### PR TITLE
fix: #14 GitHub Actions SHA 고정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     name: Frontend (lint + test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -52,8 +52,8 @@ jobs:
       PAYMENT_GATEWAY: mock
       STORAGE_PROVIDER: local
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: Close related issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,9 @@ jobs:
     name: Deploy Backend to EC2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Deploy to EC2
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -11,8 +11,8 @@ jobs:
     name: Frontend Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -54,8 +54,8 @@ jobs:
       PAYMENT_GATEWAY: mock
       STORAGE_PROVIDER: local
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Summary
- Closes #14
- 모든 GitHub Actions를 mutable 버전 태그에서 immutable SHA로 고정
- 특히 appleboy/ssh-action (프로덕션 SSH 접근) 공급망 공격 방지

## Changes
| Action | Before | After |
|--------|--------|-------|
| actions/checkout | @v4 | @34e114876b0b (v4.3.1) |
| actions/setup-node | @v4 | @49933ea5288c (v4.4.0) |
| actions/github-script | @v7 | @f28e40c7f34b (v7.1.0) |
| appleboy/ssh-action | @v1 | @0ff4204d59e8 (v1.2.5) |

## Test plan
- [ ] CI 워크플로우 정상 동작 확인
- [ ] 모든 uses: 라인이 SHA로 고정되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)