### PR TITLE
feat: #2 니로별 + 모양별 이중 카테고리 필터 UI 구현

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -24,6 +24,8 @@ interface ProductsPageProps {
     price_min?: string;
     price_max?: string;
     isFeatured?: string;
+    clayType?: string;
+    shape?: string;
   }>;
 }
 

--- a/src/components/__tests__/FilterSidebar.test.tsx
+++ b/src/components/__tests__/FilterSidebar.test.tsx
@@ -32,7 +32,7 @@ describe('FilterSidebar', () => {
   it('renders 전체 and category names', async () => {
     const { default: FilterSidebar } = await import('@/components/filters/FilterSidebar');
     render(<FilterSidebar categories={mockCategories} />);
-    expect(screen.getByText('전체')).toBeInTheDocument();
+    expect(screen.getAllByText('전체').length).toBeGreaterThan(0);
     expect(screen.getByText('의류')).toBeInTheDocument();
     expect(screen.getByText('신발')).toBeInTheDocument();
   });

--- a/src/components/filters/ClayTypeFilter.tsx
+++ b/src/components/filters/ClayTypeFilter.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { cn } from '@/components/ui/utils';
+
+export type ClayType = '주니' | '단니' | '자니' | '흑니' | '청수니' | '녹니';
+
+const CLAY_TYPES: { value: ClayType; label: string }[] = [
+  { value: '주니', label: '주니(朱泥)' },
+  { value: '단니', label: '단니(段泥)' },
+  { value: '자니', label: '자니(紫泥)' },
+  { value: '흑니', label: '흑니(黑泥)' },
+  { value: '청수니', label: '청수니(靑水泥)' },
+  { value: '녹니', label: '녹니(綠泥)' },
+];
+
+interface ClayTypeFilterProps {
+  selected: ClayType | undefined;
+  onSelect: (value: ClayType | undefined) => void;
+}
+
+export default function ClayTypeFilter({ selected, onSelect }: ClayTypeFilterProps) {
+  return (
+    <div>
+      <h2 className="mb-3 text-sm font-semibold text-foreground">니로(泥料)</h2>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => onSelect(undefined)}
+          className={cn(
+            'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+            selected === undefined
+              ? 'border-primary bg-primary text-primary-foreground'
+              : 'border-border bg-background text-muted-foreground hover:border-primary hover:text-foreground',
+          )}
+        >
+          전체
+        </button>
+        {CLAY_TYPES.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            onClick={() => onSelect(selected === item.value ? undefined : item.value)}
+            className={cn(
+              'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+              selected === item.value
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border bg-background text-muted-foreground hover:border-primary hover:text-foreground',
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/filters/FilterSidebar.tsx
+++ b/src/components/filters/FilterSidebar.tsx
@@ -5,7 +5,11 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { cn } from '@/components/ui/utils';
 import CategoryTree from './CategoryTree';
 import PriceRangeFilter from './PriceRangeFilter';
+import ClayTypeFilter from './ClayTypeFilter';
+import TeapotShapeFilter from './TeapotShapeFilter';
 import type { Category } from '@/lib/api';
+import type { ClayType } from './ClayTypeFilter';
+import type { TeapotShape } from './TeapotShapeFilter';
 
 interface FilterSidebarProps {
   categories: Category[];
@@ -20,8 +24,17 @@ export default function FilterSidebar({ categories }: FilterSidebarProps) {
   const selectedCategoryId = categoryIdParam ? Number(categoryIdParam) : undefined;
   const priceMin = searchParams.get('price_min') ? Number(searchParams.get('price_min')) : undefined;
   const priceMax = searchParams.get('price_max') ? Number(searchParams.get('price_max')) : undefined;
+  const clayTypeParam = searchParams.get('clayType');
+  const selectedClayType = clayTypeParam ? (clayTypeParam as ClayType) : undefined;
+  const shapeParam = searchParams.get('shape');
+  const selectedShape = shapeParam ? (shapeParam as TeapotShape) : undefined;
 
-  const hasActiveFilters = selectedCategoryId !== undefined || priceMin !== undefined || priceMax !== undefined;
+  const hasActiveFilters =
+    selectedCategoryId !== undefined ||
+    priceMin !== undefined ||
+    priceMax !== undefined ||
+    selectedClayType !== undefined ||
+    selectedShape !== undefined;
 
   const updateParams = (updates: Record<string, string | undefined>) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -47,11 +60,21 @@ export default function FilterSidebar({ categories }: FilterSidebarProps) {
     });
   };
 
+  const handleClayTypeSelect = (value: ClayType | undefined) => {
+    updateParams({ clayType: value });
+  };
+
+  const handleShapeSelect = (value: TeapotShape | undefined) => {
+    updateParams({ shape: value });
+  };
+
   const handleReset = () => {
     const params = new URLSearchParams(searchParams.toString());
     params.delete('categoryId');
     params.delete('price_min');
     params.delete('price_max');
+    params.delete('clayType');
+    params.delete('shape');
     params.delete('page');
     router.push(`/products?${params.toString()}`);
   };
@@ -75,6 +98,16 @@ export default function FilterSidebar({ categories }: FilterSidebarProps) {
         categories={categories}
         selectedId={selectedCategoryId}
         onSelect={handleCategorySelect}
+      />
+
+      <ClayTypeFilter
+        selected={selectedClayType}
+        onSelect={handleClayTypeSelect}
+      />
+
+      <TeapotShapeFilter
+        selected={selectedShape}
+        onSelect={handleShapeSelect}
       />
 
       <PriceRangeFilter

--- a/src/components/filters/MobileFilterBar.tsx
+++ b/src/components/filters/MobileFilterBar.tsx
@@ -4,7 +4,19 @@ import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { cn } from '@/components/ui/utils';
 import PriceRangeFilter from './PriceRangeFilter';
+import TeapotShapeFilter from './TeapotShapeFilter';
 import type { Category } from '@/lib/api';
+import type { ClayType } from './ClayTypeFilter';
+import type { TeapotShape } from './TeapotShapeFilter';
+
+const CLAY_TYPES: { value: ClayType; label: string }[] = [
+  { value: '주니', label: '주니(朱泥)' },
+  { value: '단니', label: '단니(段泥)' },
+  { value: '자니', label: '자니(紫泥)' },
+  { value: '흑니', label: '흑니(黑泥)' },
+  { value: '청수니', label: '청수니(靑水泥)' },
+  { value: '녹니', label: '녹니(綠泥)' },
+];
 
 interface MobileFilterBarProps {
   categories: Category[];
@@ -19,7 +31,15 @@ export default function MobileFilterBar({ categories }: MobileFilterBarProps) {
   const selectedCategoryId = categoryIdParam ? Number(categoryIdParam) : undefined;
   const priceMin = searchParams.get('price_min') ? Number(searchParams.get('price_min')) : undefined;
   const priceMax = searchParams.get('price_max') ? Number(searchParams.get('price_max')) : undefined;
-  const hasActiveFilters = priceMin !== undefined || priceMax !== undefined;
+  const clayTypeParam = searchParams.get('clayType');
+  const selectedClayType = clayTypeParam ? (clayTypeParam as ClayType) : undefined;
+  const shapeParam = searchParams.get('shape');
+  const selectedShape = shapeParam ? (shapeParam as TeapotShape) : undefined;
+
+  const hasActiveFilters =
+    priceMin !== undefined ||
+    priceMax !== undefined ||
+    selectedShape !== undefined;
 
   const rootCategories = categories.filter((c) => c.parentId === null);
 
@@ -42,6 +62,10 @@ export default function MobileFilterBar({ categories }: MobileFilterBarProps) {
     updateParams({ categoryId: id !== undefined ? String(id) : undefined });
   };
 
+  const handleClayTypeSelect = (value: ClayType | undefined) => {
+    updateParams({ clayType: value });
+  };
+
   const handlePriceChange = (min?: number, max?: number) => {
     updateParams({
       price_min: min !== undefined ? String(min) : undefined,
@@ -49,14 +73,18 @@ export default function MobileFilterBar({ categories }: MobileFilterBarProps) {
     });
   };
 
+  const handleShapeSelect = (value: TeapotShape | undefined) => {
+    updateParams({ shape: value });
+  };
+
   const handleReset = () => {
-    updateParams({ price_min: undefined, price_max: undefined });
+    updateParams({ price_min: undefined, price_max: undefined, shape: undefined });
     setFilterOpen(false);
   };
 
   return (
     <div className="md:hidden">
-      {/* 카테고리 칩 + 필터 버튼 행 */}
+      {/* 카테고리 칩 행 */}
       <div className="flex items-center gap-2 border-b border-border pb-3">
         {/* 가로 스크롤 카테고리 칩 */}
         <div className="flex flex-1 gap-2 overflow-x-auto pb-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
@@ -104,6 +132,39 @@ export default function MobileFilterBar({ categories }: MobileFilterBarProps) {
         </button>
       </div>
 
+      {/* 니로 칩 행 */}
+      <div className="mt-2 flex gap-2 overflow-x-auto pb-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <button
+          type="button"
+          onClick={() => handleClayTypeSelect(undefined)}
+          className={cn(
+            'shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+            selectedClayType === undefined
+              ? 'border-primary bg-primary text-primary-foreground'
+              : 'border-border bg-background text-muted-foreground',
+          )}
+        >
+          전체
+        </button>
+        {CLAY_TYPES.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            onClick={() =>
+              handleClayTypeSelect(selectedClayType === item.value ? undefined : item.value)
+            }
+            className={cn(
+              'shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+              selectedClayType === item.value
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border bg-background text-muted-foreground',
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
       {/* 바텀시트 오버레이 */}
       {filterOpen && (
         <>
@@ -122,7 +183,10 @@ export default function MobileFilterBar({ categories }: MobileFilterBarProps) {
                 ✕
               </button>
             </div>
-            <PriceRangeFilter min={priceMin} max={priceMax} onChange={handlePriceChange} />
+            <div className="flex flex-col gap-6">
+              <TeapotShapeFilter selected={selectedShape} onSelect={handleShapeSelect} />
+              <PriceRangeFilter min={priceMin} max={priceMax} onChange={handlePriceChange} />
+            </div>
             <div className="mt-6 flex gap-3">
               {hasActiveFilters && (
                 <button

--- a/src/components/filters/TeapotShapeFilter.tsx
+++ b/src/components/filters/TeapotShapeFilter.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { cn } from '@/components/ui/utils';
+
+export type TeapotShape = '서시형' | '석표형' | '인왕형' | '덕종형' | '수평형';
+
+const TEAPOT_SHAPES: { value: TeapotShape; label: string }[] = [
+  { value: '서시형', label: '서시형(西施)' },
+  { value: '석표형', label: '석표형(石瓢)' },
+  { value: '인왕형', label: '인왕형(仁王)' },
+  { value: '덕종형', label: '덕종형(德鐘)' },
+  { value: '수평형', label: '수평형(水平)' },
+];
+
+interface TeapotShapeFilterProps {
+  selected: TeapotShape | undefined;
+  onSelect: (value: TeapotShape | undefined) => void;
+}
+
+export default function TeapotShapeFilter({ selected, onSelect }: TeapotShapeFilterProps) {
+  return (
+    <div>
+      <h2 className="mb-3 text-sm font-semibold text-foreground">모양</h2>
+      <div className="flex flex-col gap-2">
+        <label className="flex cursor-pointer items-center gap-2">
+          <input
+            type="radio"
+            name="teapot-shape"
+            checked={selected === undefined}
+            onChange={() => onSelect(undefined)}
+            className={cn(
+              'h-4 w-4 border-border accent-primary',
+            )}
+          />
+          <span className={cn(
+            'text-sm transition-colors',
+            selected === undefined ? 'font-medium text-foreground' : 'text-muted-foreground',
+          )}>
+            전체
+          </span>
+        </label>
+        {TEAPOT_SHAPES.map((item) => (
+          <label key={item.value} className="flex cursor-pointer items-center gap-2">
+            <input
+              type="radio"
+              name="teapot-shape"
+              checked={selected === item.value}
+              onChange={() => onSelect(item.value)}
+              className="h-4 w-4 border-border accent-primary"
+            />
+            <span className={cn(
+              'text-sm transition-colors',
+              selected === item.value ? 'font-medium text-foreground' : 'text-muted-foreground',
+            )}>
+              {item.label}
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 
 // jsdom does not implement window.matchMedia — provide a stub so tests can spy on it
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
## Summary
- Closes #2
- 니로별 칩 필터 (주니/단니/자니/흑니/청수니/녹니) 구현
- 모양별 라디오 필터 (서시/석표/인왕/덕종/수평형) 구현
- URL searchParams 기반 필터 상태 관리 (clayType, shape 파라미터)
- 정렬 드롭다운 (Featured/최신/가격) 기존 SortDropdown 활용

## Test plan
- [x] npm run build
- [x] npm run test:run (255 tests passed)