### PR TITLE
feat: #7 Artist(장인) 독립 페이지 구현

### DIFF
--- a/src/app/artist/[slug]/page.tsx
+++ b/src/app/artist/[slug]/page.tsx
@@ -1,0 +1,125 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getArtistBySlug, ARTISTS } from '@/lib/artists';
+
+interface ArtistDetailProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return ARTISTS.map((a) => ({ slug: a.slug }));
+}
+
+export async function generateMetadata({ params }: ArtistDetailProps): Promise<Metadata> {
+  const { slug } = await params;
+  const artist = getArtistBySlug(slug);
+  if (!artist) return { title: '장인을 찾을 수 없습니다' };
+
+  return {
+    title: `${artist.nameKo} ${artist.name} | 옥화당 장인`,
+    description: artist.bio,
+  };
+}
+
+export default async function ArtistDetailPage({ params }: ArtistDetailProps) {
+  const { slug } = await params;
+  const artist = getArtistBySlug(slug);
+
+  if (!artist) notFound();
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      {/* 뒤로가기 */}
+      <Link
+        href="/artist"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8"
+      >
+        ← 장인 목록
+      </Link>
+
+      {/* 에디토리얼 헤더 */}
+      <header className="grid grid-cols-1 gap-8 md:grid-cols-2 md:gap-12">
+        {/* 프로파일 이미지 placeholder */}
+        <div className="aspect-square w-full max-w-sm rounded-lg bg-muted flex items-center justify-center mx-auto md:mx-0">
+          <span className="text-8xl font-bold text-muted-foreground/20 select-none">
+            {artist.name.slice(0, 1)}
+          </span>
+        </div>
+
+        <div className="flex flex-col justify-center">
+          <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground mb-2">
+            {artist.workshop} 공방
+          </p>
+          <h1 className="text-3xl font-bold text-foreground md:text-4xl">
+            {artist.nameKo}
+          </h1>
+          <p className="mt-1 text-xl text-muted-foreground">{artist.name}</p>
+
+          <dl className="mt-6 grid grid-cols-2 gap-4 border-t border-border pt-6">
+            <div>
+              <dt className="text-xs text-muted-foreground">대표 니로</dt>
+              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.clay}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">전문 분야</dt>
+              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.specialty}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">작품 수</dt>
+              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.productCount}점</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">공방 소재지</dt>
+              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.workshop}</dd>
+            </div>
+          </dl>
+        </div>
+      </header>
+
+      {/* 장인 스토리 */}
+      <section aria-labelledby="story-heading" className="mt-14">
+        <h2 id="story-heading" className="text-lg font-bold text-foreground mb-6">
+          장인 이야기
+        </h2>
+        <div className="space-y-4 border-l-2 border-border pl-6">
+          {artist.story.map((paragraph, index) => (
+            <p key={index} className="text-sm leading-relaxed text-muted-foreground">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+      </section>
+
+      {/* 대표 작품 갤러리 */}
+      <section aria-labelledby="gallery-heading" className="mt-14">
+        <h2 id="gallery-heading" className="text-lg font-bold text-foreground mb-6">
+          대표 작품
+        </h2>
+        <ul className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          {Array.from({ length: 6 }, (_, i) => (
+            <li key={i} className="aspect-square rounded-lg bg-muted flex items-center justify-center">
+              <span className="text-xs text-muted-foreground/50">작품 {i + 1}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* CTA */}
+      <section className="mt-14 rounded-lg border border-border bg-muted/40 p-8 text-center">
+        <h2 className="text-base font-bold text-foreground">
+          {artist.nameKo}의 작품 컬렉션
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {artist.nameKo} 장인이 빚은 {artist.clay} 자사호를 만나보세요.
+        </p>
+        <Link
+          href={`/products?artist=${encodeURIComponent(artist.nameKo)}`}
+          className="mt-6 inline-flex items-center justify-center rounded-md bg-foreground px-6 py-2.5 text-sm font-medium text-background hover:opacity-90 transition-opacity"
+        >
+          이 장인의 작품 보기
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/src/app/artist/page.tsx
+++ b/src/app/artist/page.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ARTISTS, CLAY_FILTERS } from '@/lib/artists';
+import type { ClayFilter } from '@/lib/artists';
+
+export const metadata: Metadata = {
+  title: '장인 | 옥화당',
+  description: '옥화당 자사호를 빚는 장인들을 만나보세요.',
+};
+
+interface ArtistPageProps {
+  searchParams: Promise<{ clay?: string }>;
+}
+
+export default async function ArtistPage({ searchParams }: ArtistPageProps) {
+  const params = await searchParams;
+  const clay = (CLAY_FILTERS as readonly string[]).includes(params.clay ?? '')
+    ? (params.clay as ClayFilter)
+    : '전체';
+
+  const filtered = clay === '전체' ? ARTISTS : ARTISTS.filter((a) => a.clay === clay);
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-10">
+      <header className="mb-8">
+        <h1 className="text-2xl font-bold text-foreground md:text-3xl">장인</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          옥화당의 자사호를 빚는 의흥 장인들
+        </p>
+      </header>
+
+      {/* 니로 필터 */}
+      <nav aria-label="니로 필터" className="mb-8 flex flex-wrap gap-2">
+        {CLAY_FILTERS.map((filter) => {
+          const isActive = clay === filter;
+          const href = filter === '전체' ? '/artist' : `/artist?clay=${encodeURIComponent(filter)}`;
+          return (
+            <Link
+              key={filter}
+              href={href}
+              className={
+                isActive
+                  ? 'rounded-full border border-foreground bg-foreground px-4 py-1.5 text-sm font-medium text-background'
+                  : 'rounded-full border border-border bg-background px-4 py-1.5 text-sm font-medium text-muted-foreground hover:border-foreground hover:text-foreground transition-colors'
+              }
+            >
+              {filter}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* 장인 카드 그리드 */}
+      <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {filtered.map((artist) => (
+          <li key={artist.slug}>
+            <Link
+              href={`/artist/${artist.slug}`}
+              className="group block overflow-hidden rounded-lg border border-border bg-background transition-shadow hover:shadow-md"
+            >
+              {/* 프로파일 이미지 placeholder */}
+              <div className="aspect-square w-full bg-muted flex items-center justify-center">
+                <span className="text-5xl font-bold text-muted-foreground/30 select-none">
+                  {artist.name.slice(0, 1)}
+                </span>
+              </div>
+
+              <div className="p-4">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-lg font-bold text-foreground">{artist.nameKo}</span>
+                  <span className="text-sm text-muted-foreground">{artist.name}</span>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {artist.clay} · {artist.workshop}
+                </p>
+                <p className="mt-2 text-sm text-foreground">{artist.specialty}</p>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  작품 {artist.productCount}점
+                </p>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      {filtered.length === 0 && (
+        <p className="mt-12 text-center text-sm text-muted-foreground">
+          해당 니로의 장인이 없습니다.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/__tests__/useNavigation.test.ts
+++ b/src/hooks/__tests__/useNavigation.test.ts
@@ -39,7 +39,7 @@ describe('useNavigation', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items).toHaveLength(2);
     expect(result.current.items[0].label).toBe('상품목록');
   });
 
@@ -52,7 +52,7 @@ describe('useNavigation', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items).toHaveLength(2);
     expect(result.current.items[0].label).toBe('상품목록');
   });
 

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -15,6 +15,16 @@ const STATIC_GNB: NavigationItem[] = [
     parent_id: null,
     children: [],
   },
+  {
+    id: -1,
+    group: 'gnb',
+    label: '장인',
+    url: '/artist',
+    sort_order: 1,
+    is_active: true,
+    parent_id: null,
+    children: [],
+  },
 ];
 
 const STATIC_FOOTER: NavigationItem[] = [];

--- a/src/lib/artists.ts
+++ b/src/lib/artists.ts
@@ -1,0 +1,81 @@
+export interface Artist {
+  slug: string;
+  name: string;
+  nameKo: string;
+  clay: string;
+  workshop: string;
+  productCount: number;
+  bio: string;
+  story: string[];
+  specialty: string;
+}
+
+export const ARTISTS: Artist[] = [
+  {
+    slug: 'master-chen',
+    name: '陳師傅',
+    nameKo: '진사부',
+    clay: '주니',
+    workshop: '의흥',
+    productCount: 12,
+    bio: '40년 경력의 의흥 주니 전문 장인',
+    story: [
+      '진사부는 의흥 도예 명가에서 태어나 열다섯 살부터 아버지 곁에서 흙을 배웠습니다.',
+      '주니(朱泥)의 붉은 기운을 가장 잘 살린다는 평가를 받으며, 그의 호는 자연의 결을 따른다는 뜻의 순결(順結)입니다.',
+      '현재 의흥 공방에서 전통 방식만을 고집하며, 한 점 한 점 손으로 빚어냅니다.',
+    ],
+    specialty: '주니 자사호',
+  },
+  {
+    slug: 'master-li',
+    name: '李師傅',
+    nameKo: '이사부',
+    clay: '단니',
+    workshop: '의흥',
+    productCount: 8,
+    bio: '단니 재료 연구 30년, 의흥 단니의 권위자',
+    story: [
+      '이사부는 단니(段泥)의 황금빛 토질을 연구하는 데 30년을 바쳤습니다.',
+      '광산 선별부터 배합, 소성 온도까지 직접 관리하며, 균일하고 깊은 발색을 구현합니다.',
+      '그의 다관은 뚜껑과 본체의 유격이 머리카락 한 올 수준으로 알려져 있습니다.',
+    ],
+    specialty: '단니 다관',
+  },
+  {
+    slug: 'master-wang',
+    name: '王師傅',
+    nameKo: '왕사부',
+    clay: '자니',
+    workshop: '의흥',
+    productCount: 15,
+    bio: '자니 명장, 전통 형태 복원 프로젝트 주도',
+    story: [
+      '왕사부는 명나라 시대 고전 형태를 현대적으로 복원하는 작업에 전념해 왔습니다.',
+      '자니(紫泥)의 깊은 보라빛을 최대한 끌어내기 위해 이중 소성 기법을 개발했습니다.',
+      '의흥 박물관과 협력하여 전통 형태 자료집 편찬에도 참여한 학자적 장인입니다.',
+    ],
+    specialty: '자니 고전형 자사호',
+  },
+  {
+    slug: 'master-zhao',
+    name: '趙師傅',
+    nameKo: '조사부',
+    clay: '흑니',
+    workshop: '의흥',
+    productCount: 6,
+    bio: '흑니 전문 신예 장인, 현대적 감각의 전통 계승',
+    story: [
+      '조사부는 의흥 도예 학교 수석 졸업 후 흑니(黑泥) 연구에 전념한 신예 장인입니다.',
+      '전통 형태에 현대적 선을 접목하는 시도로 젊은 다인들 사이에서 주목받고 있습니다.',
+      '스승 왕사부에게 소성 기술을 전수받아 독자적인 광택 처리 기법을 발전시켰습니다.',
+    ],
+    specialty: '흑니 현대형 자사호',
+  },
+];
+
+export function getArtistBySlug(slug: string): Artist | undefined {
+  return ARTISTS.find((a) => a.slug === slug);
+}
+
+export const CLAY_FILTERS = ['전체', '주니', '단니', '자니', '흑니'] as const;
+export type ClayFilter = (typeof CLAY_FILTERS)[number];

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 
 // jsdom does not implement window.matchMedia — provide a stub so tests can spy on it
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
## Summary
- Closes #7
- /artist 장인 목록 페이지 (프로파일 카드 + 니로별 필터)
- /artist/[slug] 장인 상세 페이지 (에디토리얼 레이아웃 + 작품 갤러리 + CTA)
- 네비게이션 GNB에 장인 탭 추가

## Test plan
- [x] npm run build
- [x] npm run test:run (255 passed)