### PR TITLE
fix: #15 CI/CD 워크플로우 permissions + 시크릿 관리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     name: Frontend (lint + test)
@@ -46,7 +49,7 @@ jobs:
     env:
       NODE_ENV: test
       TEST_DATABASE_URL: mysql://root:testpassword@127.0.0.1:3306/commerce_test
-      JWT_SECRET: test-secret-key-for-ci
+      JWT_SECRET: ${{ secrets.TEST_JWT_SECRET || 'test-secret-key-for-ci' }}
       FRONTEND_URL: http://localhost:5173
       REDIS_URL: redis://localhost:6379
       PAYMENT_GATEWAY: mock

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   deploy-backend:
     name: Deploy Backend to EC2

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -5,6 +5,9 @@ on:
     - cron: '*/10 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   healthcheck:
     name: API Health Check

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   frontend-coverage:
     name: Frontend Coverage


### PR DESCRIPTION
## Summary
- Closes #15
- 모든 워크플로우에 최소 permissions 블록 추가
- JWT 시크릿을 GitHub Secrets 표현식으로 래핑

## Test plan
- [ ] CI 워크플로우 정상 동작 확인
- [ ] 모든 워크플로우에 permissions 블록 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)