### PR TITLE
fix: #12 JWT 토큰 시크릿 분리 + tokenType 검증

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,7 @@ TEST_DATABASE_URL=mysql://root:changeme_root_password@127.0.0.1:3307/commerce_te
 DB_SYNCHRONIZE=false
 DB_SSL_ENABLED=false
 JWT_SECRET=  # REQUIRED: generate with: openssl rand -hex 32
+JWT_REFRESH_SECRET=  # REQUIRED in production: must be different from JWT_SECRET. generate with: openssl rand -hex 32
 JWT_EXPIRES_IN=1h
 JWT_REFRESH_EXPIRES_IN=7d
 FRONTEND_URL=http://localhost:5173

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -133,7 +133,7 @@ describe('AuthService', () => {
     it('유효한 refreshToken으로 새 토큰 쌍 발급', async () => {
       const rawRefresh = 'mock-token';
       const hashedRefresh = await bcrypt.hash(rawRefresh, 10);
-      mockJwtService.verify.mockReturnValueOnce({ sub: 1, email: 'test@example.com', role: 'user' });
+      mockJwtService.verify.mockReturnValueOnce({ sub: 1, email: 'test@example.com', role: 'user', tokenType: 'refresh' });
       mockUserRepository.findOne.mockResolvedValue(makeUser({ refreshToken: hashedRefresh }));
       mockUserRepository.update.mockResolvedValue(undefined);
 
@@ -145,7 +145,7 @@ describe('AuthService', () => {
 
     it('DB의 refresh_token과 불일치 시 UnauthorizedException', async () => {
       const hashedRefresh = await bcrypt.hash('correct-token', 10);
-      mockJwtService.verify.mockReturnValueOnce({ sub: 1, email: 'test@example.com', role: 'user' });
+      mockJwtService.verify.mockReturnValueOnce({ sub: 1, email: 'test@example.com', role: 'user', tokenType: 'refresh' });
       mockUserRepository.findOne.mockResolvedValue(makeUser({ refreshToken: hashedRefresh }));
 
       await expect(service.refresh('wrong-token')).rejects.toThrow(UnauthorizedException);
@@ -168,18 +168,14 @@ describe('AuthService', () => {
     });
   });
 
-  describe('generateTokens (JWT_REFRESH_SECRET)', () => {
-    it('JWT_REFRESH_SECRET 미설정 시 경고 로그 출력', async () => {
+  describe('onModuleInit (JWT_REFRESH_SECRET warning)', () => {
+    it('JWT_REFRESH_SECRET 미설정 시 시작 경고 로그 출력', () => {
       const originalRefreshSecret = process.env.JWT_REFRESH_SECRET;
       delete process.env.JWT_REFRESH_SECRET;
 
-      const hashed = await bcrypt.hash('Test1234!', 10);
-      mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed }));
-      mockUserRepository.update.mockResolvedValue(undefined);
-
       const warnSpy = jest.spyOn(service['logger'], 'warn');
 
-      await service.login({ email: 'test@example.com', password: 'Test1234!' });
+      service.onModuleInit();
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('JWT_REFRESH_SECRET is not set'),
@@ -188,16 +184,12 @@ describe('AuthService', () => {
       process.env.JWT_REFRESH_SECRET = originalRefreshSecret;
     });
 
-    it('JWT_REFRESH_SECRET 설정 시 경고 로그 미출력', async () => {
+    it('JWT_REFRESH_SECRET 설정 시 경고 로그 미출력', () => {
       process.env.JWT_REFRESH_SECRET = 'separate-refresh-secret';
-
-      const hashed = await bcrypt.hash('Test1234!', 10);
-      mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed }));
-      mockUserRepository.update.mockResolvedValue(undefined);
 
       const warnSpy = jest.spyOn(service['logger'], 'warn');
 
-      await service.login({ email: 'test@example.com', password: 'Test1234!' });
+      service.onModuleInit();
 
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('JWT_REFRESH_SECRET is not set'),

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -167,4 +167,43 @@ describe('AuthService', () => {
       expect(mockUserRepository.update).toHaveBeenCalledWith(1, { refreshToken: null });
     });
   });
+
+  describe('generateTokens (JWT_REFRESH_SECRET)', () => {
+    it('JWT_REFRESH_SECRET 미설정 시 경고 로그 출력', async () => {
+      const originalRefreshSecret = process.env.JWT_REFRESH_SECRET;
+      delete process.env.JWT_REFRESH_SECRET;
+
+      const hashed = await bcrypt.hash('Test1234!', 10);
+      mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed }));
+      mockUserRepository.update.mockResolvedValue(undefined);
+
+      const warnSpy = jest.spyOn(service['logger'], 'warn');
+
+      await service.login({ email: 'test@example.com', password: 'Test1234!' });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('JWT_REFRESH_SECRET is not set'),
+      );
+
+      process.env.JWT_REFRESH_SECRET = originalRefreshSecret;
+    });
+
+    it('JWT_REFRESH_SECRET 설정 시 경고 로그 미출력', async () => {
+      process.env.JWT_REFRESH_SECRET = 'separate-refresh-secret';
+
+      const hashed = await bcrypt.hash('Test1234!', 10);
+      mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed }));
+      mockUserRepository.update.mockResolvedValue(undefined);
+
+      const warnSpy = jest.spyOn(service['logger'], 'warn');
+
+      await service.login({ email: 'test@example.com', password: 'Test1234!' });
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('JWT_REFRESH_SECRET is not set'),
+      );
+
+      delete process.env.JWT_REFRESH_SECRET;
+    });
+  });
 });

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -139,14 +139,20 @@ export class AuthService {
 
   private generateTokens(user: User): TokenPair {
     const payload = { sub: user.id, email: user.email, role: user.role };
-    // accessToken uses the module-level signOptions (JWT_EXPIRES_IN default via JwtModule)
-    const accessToken = this.jwtService.sign(payload);
+    // accessToken includes tokenType: 'access' to prevent refresh tokens from being used as access tokens
+    const accessToken = this.jwtService.sign({ ...payload, tokenType: 'access' });
     // refreshToken uses longer expiry; cast to ms.StringValue required by jsonwebtoken types
     const refreshExpiresIn = (process.env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue;
+    const refreshSecret = process.env.JWT_REFRESH_SECRET;
+    if (!refreshSecret) {
+      this.logger.warn(
+        'JWT_REFRESH_SECRET is not set. Using JWT_SECRET as fallback. Set a separate secret in production.',
+      );
+    }
     const refreshToken = this.jwtService.sign(
       { ...payload, tokenType: 'refresh' },
       {
-        secret: process.env.JWT_REFRESH_SECRET ?? process.env.JWT_SECRET,
+        secret: refreshSecret ?? process.env.JWT_SECRET,
         expiresIn: refreshExpiresIn,
       },
     );

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -4,6 +4,7 @@ import {
   UnauthorizedException,
   ForbiddenException,
   Logger,
+  OnModuleInit,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -29,7 +30,7 @@ export interface AuthResponse extends TokenPair {
 }
 
 @Injectable()
-export class AuthService {
+export class AuthService implements OnModuleInit {
   private readonly logger = new Logger(AuthService.name);
 
   constructor(
@@ -37,6 +38,14 @@ export class AuthService {
     private readonly userRepository: Repository<User>,
     private readonly jwtService: JwtService,
   ) {}
+
+  onModuleInit() {
+    if (!process.env.JWT_REFRESH_SECRET) {
+      this.logger.warn(
+        'JWT_REFRESH_SECRET is not set. Using JWT_SECRET as fallback. Set a separate secret in production.',
+      );
+    }
+  }
 
   async register(dto: RegisterDto): Promise<AuthResponse> {
     const existing = await this.userRepository.findOne({
@@ -105,12 +114,16 @@ export class AuthService {
   }
 
   async refresh(rawRefreshToken: string): Promise<TokenPair> {
-    let payload: { sub: number; email: string; role: string };
+    let payload: { sub: number; email: string; role: string; tokenType?: string };
     try {
       payload = this.jwtService.verify(rawRefreshToken, {
         secret: process.env.JWT_REFRESH_SECRET ?? process.env.JWT_SECRET,
       });
     } catch {
+      throw new UnauthorizedException('유효하지 않은 리프레시 토큰입니다.');
+    }
+
+    if (payload.tokenType !== 'refresh') {
       throw new UnauthorizedException('유효하지 않은 리프레시 토큰입니다.');
     }
 
@@ -144,11 +157,6 @@ export class AuthService {
     // refreshToken uses longer expiry; cast to ms.StringValue required by jsonwebtoken types
     const refreshExpiresIn = (process.env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue;
     const refreshSecret = process.env.JWT_REFRESH_SECRET;
-    if (!refreshSecret) {
-      this.logger.warn(
-        'JWT_REFRESH_SECRET is not set. Using JWT_SECRET as fallback. Set a separate secret in production.',
-      );
-    }
     const refreshToken = this.jwtService.sign(
       { ...payload, tokenType: 'refresh' },
       {

--- a/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,37 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { JwtStrategy } from './jwt.strategy';
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy;
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'test-secret';
+    strategy = new JwtStrategy();
+  });
+
+  describe('validate()', () => {
+    it('should return user object for valid access token payload without tokenType', () => {
+      const payload = { sub: 1, email: 'test@test.com', role: 'user' };
+      const result = strategy.validate(payload);
+      expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user' });
+    });
+
+    it('should return user object for payload with tokenType: access', () => {
+      const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access' };
+      const result = strategy.validate(payload);
+      expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user' });
+    });
+
+    it('should throw UnauthorizedException when tokenType is refresh', () => {
+      const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'refresh' };
+      expect(() => strategy.validate(payload)).toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException with correct message for refresh token', () => {
+      const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'refresh' };
+      expect(() => strategy.validate(payload)).toThrow(
+        'Refresh tokens cannot be used for API access',
+      );
+    });
+  });
+});

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import type { Request } from 'express';
@@ -34,7 +34,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: JwtPayload) {
+  validate(payload: JwtPayload & { tokenType?: string }) {
+    if (payload.tokenType === 'refresh') {
+      throw new UnauthorizedException('Refresh tokens cannot be used for API access');
+    }
     return { id: payload.sub, email: payload.email, role: payload.role };
   }
 }


### PR DESCRIPTION
## Summary
- Closes #12
- JwtStrategy.validate()에서 refresh token 사용 차단 (tokenType 검증)
- Access token에 tokenType: 'access' 추가
- JWT_REFRESH_SECRET 미설정 시 경고 로그
- .env.example에 JWT_REFRESH_SECRET 추가

## Test plan
- [ ] cd backend && npm run build && npm run test
- [ ] refresh token으로 API 접근 시 401 반환 확인
- [ ] access token으로 정상 접근 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)