### PR TITLE
fix: #17 Admin 라우트 서버사이드 보호 middleware 추가

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { middleware } from '@/middleware';
+import { NextRequest } from 'next/server';
+
+function makeRequest(pathname: string, hasToken = false): NextRequest {
+  const url = `http://localhost${pathname}`;
+  const req = new NextRequest(url);
+  if (hasToken) {
+    req.cookies.set('accessToken', 'test-token');
+  }
+  return req;
+}
+
+describe('middleware', () => {
+  it('redirects /admin to /login when no accessToken cookie', () => {
+    const req = makeRequest('/admin');
+    const res = middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/login');
+    expect(location).toContain('redirect=%2Fadmin');
+  });
+
+  it('passes through /admin when accessToken cookie is present', () => {
+    const req = makeRequest('/admin', true);
+    const res = middleware(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('redirects /my to /login when no accessToken cookie', () => {
+    const req = makeRequest('/my');
+    const res = middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/login');
+    expect(location).toContain('redirect=%2Fmy');
+  });
+
+  it('redirects /checkout to /login when no accessToken cookie', () => {
+    const req = makeRequest('/checkout');
+    const res = middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/login');
+    expect(location).toContain('redirect=%2Fcheckout');
+  });
+
+  it('passes through public routes without cookie', () => {
+    for (const path of ['/', '/products', '/login']) {
+      const req = makeRequest(path);
+      const res = middleware(req);
+      expect(res.status).toBe(200);
+    }
+  });
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -11,6 +11,8 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   const { user, isLoading } = useAuth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
+  // Server-side auth check is handled by middleware.ts
+  // This client-side check is defense-in-depth for role verification
   useEffect(() => {
     if (isLoading) return;
     if (!user) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const token = request.cookies.get('accessToken')?.value;
+
+  // Protect admin routes — require authentication
+  if (pathname.startsWith('/admin')) {
+    if (!token) {
+      const loginUrl = new URL('/login', request.url);
+      loginUrl.searchParams.set('redirect', pathname);
+      return NextResponse.redirect(loginUrl);
+    }
+    // Note: We can't fully verify JWT or role at the edge without the secret,
+    // but blocking unauthenticated users prevents HTML exposure.
+    // Role-based checks remain server-side in the backend API.
+  }
+
+  // Protect user-only routes
+  if (pathname.startsWith('/my') || pathname.startsWith('/checkout')) {
+    if (!token) {
+      const loginUrl = new URL('/login', request.url);
+      loginUrl.searchParams.set('redirect', pathname);
+      return NextResponse.redirect(loginUrl);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*', '/my/:path*', '/checkout/:path*'],
+};


### PR DESCRIPTION
## Summary
- Closes #17
- Next.js middleware.ts 생성 — /admin, /my, /checkout 라우트 보호
- 쿠키에 accessToken 없으면 /login으로 리다이렉트 (redirect 파라미터 포함)
- 기존 클라이언트 사이드 체크는 defense-in-depth로 유지

## Test plan
- [ ] npm run build && npm run test:run
- [ ] /admin 비인증 접근 시 /login 리다이렉트 확인
- [ ] /admin 인증 접근 시 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)