### PR TITLE
fix: #17 로그인 redirect 파라미터 소비 + query string 보존

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -45,6 +45,24 @@ describe('middleware', () => {
     expect(location).toContain('redirect=%2Fcheckout');
   });
 
+  it('redirects sub-paths like /admin/products and /my/orders', () => {
+    for (const path of ['/admin/products', '/admin/settings', '/my/orders', '/checkout/success']) {
+      const req = makeRequest(path);
+      const res = middleware(req);
+      expect(res.status).toBe(307);
+      const location = res.headers.get('location');
+      expect(location).toContain('/login');
+    }
+  });
+
+  it('preserves query string in redirect param', () => {
+    const req = makeRequest('/checkout?coupon=ABC');
+    const res = middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('redirect=%2Fcheckout%3Fcoupon%3DABC');
+  });
+
   it('passes through public routes without cookie', () => {
     for (const path of ['/', '/products', '/login']) {
       const req = makeRequest(path);

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, type FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
@@ -10,6 +10,8 @@ import { cn } from '@/components/ui/utils';
 
 export default function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get('redirect') || '/';
   const { login, loginWithKakao, loginWithGoogle } = useAuth();
 
   const [email, setEmail] = useState('');
@@ -21,7 +23,7 @@ export default function LoginForm() {
     setIsSubmitting(true);
     try {
       await login(email, password);
-      router.push('/');
+      router.push(redirectTo);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : '로그인에 실패했습니다.');
     } finally {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,7 @@ export function middleware(request: NextRequest) {
   if (pathname.startsWith('/admin')) {
     if (!token) {
       const loginUrl = new URL('/login', request.url);
-      loginUrl.searchParams.set('redirect', pathname);
+      loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
       return NextResponse.redirect(loginUrl);
     }
     // Note: We can't fully verify JWT or role at the edge without the secret,
@@ -21,7 +21,7 @@ export function middleware(request: NextRequest) {
   if (pathname.startsWith('/my') || pathname.startsWith('/checkout')) {
     if (!token) {
       const loginUrl = new URL('/login', request.url);
-      loginUrl.searchParams.set('redirect', pathname);
+      loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
       return NextResponse.redirect(loginUrl);
     }
   }


### PR DESCRIPTION
## Summary
- #17 코드 리뷰 후속 수정
- LoginForm에서 redirect 쿼리 파라미터 읽어서 로그인 후 원래 페이지로 이동
- middleware에서 pathname + query string 모두 redirect에 포함
- sub-path 및 query string 보존 테스트 추가

## Test plan
- [ ] npm run build && npm run test:run
- [ ] /admin 비인증 → /login?redirect=/admin → 로그인 → /admin 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)