### PR TITLE
fix: #31 웹훅 페이로드 민감 금융정보 로깅 제거

### DIFF
--- a/backend/src/common/interceptors/logging.interceptor.spec.ts
+++ b/backend/src/common/interceptors/logging.interceptor.spec.ts
@@ -122,4 +122,66 @@ describe('LoggingInterceptor', () => {
       complete: () => done(),
     });
   });
+
+  it('should redact cardnumber field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      cardnumber: '4111111111111111',
+      amount: 30000,
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('4111111111111111'));
+        done();
+      },
+    });
+  });
+
+  it('should redact accountnumber field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      accountnumber: '987654321',
+      bank: 'KB',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('987654321'));
+        done();
+      },
+    });
+  });
+
+  it('should redact bankaccount field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      bankaccount: '111-222-333',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('111-222-333'));
+        done();
+      },
+    });
+  });
+
+  it('should redact cardno field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      cardno: '5500005555555559',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('5500005555555559'));
+        done();
+      },
+    });
+  });
 });

--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -14,6 +14,10 @@ const SENSITIVE_FIELDS = [
   'authorization',
   'credit_card',
   'cvv',
+  'cardnumber',
+  'accountnumber',
+  'bankaccount',
+  'cardno',
 ];
 
 @Injectable()

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -51,4 +51,35 @@ describe('PaymentsService — webhook', () => {
       UnauthorizedException,
     );
   });
+
+  it('웹훅 로그에 민감 필드(cardNumber 등) 포함 안 됨', async () => {
+    mockGateway.verifyWebhook.mockReturnValue(true);
+    const logSpy = jest.spyOn(service['logger'], 'log');
+    const payload = {
+      orderId: 42,
+      status: 'DONE',
+      type: 'PAYMENT',
+      cardNumber: '4111111111111111',
+      accountNumber: '123456789',
+    };
+    await service.handleWebhook(payload, 'valid_sig');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('42'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('DONE'));
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('4111111111111111'),
+    );
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('123456789'),
+    );
+  });
+
+  it('웹훅 로그에 orderId, status, type 필드만 포함', async () => {
+    mockGateway.verifyWebhook.mockReturnValue(true);
+    const logSpy = jest.spyOn(service['logger'], 'log');
+    const payload = { orderId: 7, status: 'CANCELLED', type: 'CANCEL' };
+    await service.handleWebhook(payload, 'valid_sig');
+    const logArg: string = logSpy.mock.calls[0][0] as string;
+    const logged = JSON.parse(logArg.replace('Webhook received: ', '')) as Record<string, unknown>;
+    expect(Object.keys(logged)).toEqual(['orderId', 'status', 'type']);
+  });
 });

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -157,6 +157,7 @@ export class PaymentsService {
     if (!this.gateway.verifyWebhook(payload, signature)) {
       throw new UnauthorizedException('웹훅 서명 검증 실패');
     }
-    this.logger.log(`Webhook received: ${JSON.stringify(payload)}`);
+    const safe = { orderId: (payload as Record<string, unknown>)?.orderId, status: (payload as Record<string, unknown>)?.status, type: (payload as Record<string, unknown>)?.type };
+    this.logger.log(`Webhook received: ${JSON.stringify(safe)}`);
   }
 }


### PR DESCRIPTION
## Summary
- Closes #31
- 웹훅 페이로드 전체 로깅을 안전한 필드만 로깅으로 변경 (orderId, status, type)
- LoggingInterceptor 민감 필드 목록에 금융정보 필드 추가 (cardnumber, accountnumber, bankaccount, cardno)
- TDD: 웹훅 안전 로깅 검증 테스트 2개, 금융정보 마스킹 테스트 4개 추가

## Test plan
- [ ] cd backend && npm run build
- [ ] cd backend && npm run test (payments.webhook, logging.interceptor 모두 PASS 확인)