### PR TITLE
fix: #33 비활성 사용자 JWT 차단 및 agent 파일 gitignore 추가

### DIFF
--- a/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -1,37 +1,63 @@
 import { UnauthorizedException } from '@nestjs/common';
+import { Repository } from 'typeorm';
 import { JwtStrategy } from './jwt.strategy';
+import { User } from '../../users/entities/user.entity';
 
 describe('JwtStrategy', () => {
   let strategy: JwtStrategy;
+  let userRepository: jest.Mocked<Pick<Repository<User>, 'findOne'>>;
 
   beforeEach(() => {
     process.env.JWT_SECRET = 'test-secret';
-    strategy = new JwtStrategy();
+    userRepository = {
+      findOne: jest.fn(),
+    };
+    strategy = new JwtStrategy(userRepository as unknown as Repository<User>);
   });
 
   describe('validate()', () => {
-    it('should return user object for valid access token payload without tokenType', () => {
+    it('should return user object for valid access token payload without tokenType', async () => {
+      userRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
       const payload = { sub: 1, email: 'test@test.com', role: 'user' };
-      const result = strategy.validate(payload);
+      const result = await strategy.validate(payload);
       expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user' });
     });
 
-    it('should return user object for payload with tokenType: access', () => {
+    it('should return user object for payload with tokenType: access', async () => {
+      userRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
       const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access' };
-      const result = strategy.validate(payload);
+      const result = await strategy.validate(payload);
       expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user' });
     });
 
-    it('should throw UnauthorizedException when tokenType is refresh', () => {
+    it('should throw UnauthorizedException when tokenType is refresh', async () => {
       const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'refresh' };
-      expect(() => strategy.validate(payload)).toThrow(UnauthorizedException);
+      await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
     });
 
-    it('should throw UnauthorizedException with correct message for refresh token', () => {
+    it('should throw UnauthorizedException with correct message for refresh token', async () => {
       const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'refresh' };
-      expect(() => strategy.validate(payload)).toThrow(
+      await expect(strategy.validate(payload)).rejects.toThrow(
         'Refresh tokens cannot be used for API access',
       );
+    });
+
+    it('should throw UnauthorizedException when user is not found', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+      const payload = { sub: 99, email: 'ghost@test.com', role: 'user' };
+      await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException when user isActive is false', async () => {
+      userRepository.findOne.mockResolvedValue({ id: 1, isActive: false } as User);
+      const payload = { sub: 1, email: 'test@test.com', role: 'user' };
+      await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException with correct message for inactive user', async () => {
+      userRepository.findOne.mockResolvedValue({ id: 1, isActive: false } as User);
+      const payload = { sub: 1, email: 'test@test.com', role: 'user' };
+      await expect(strategy.validate(payload)).rejects.toThrow('비활성화된 계정입니다.');
     });
   });
 });

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,7 +1,10 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import type { Request } from 'express';
+import { User } from '../../users/entities/user.entity';
 
 export interface JwtPayload {
   sub: number;
@@ -18,7 +21,10 @@ function cookieExtractor(req: Request): string | null {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {
     const secret = process.env.JWT_SECRET;
     if (!secret) {
       throw new Error('JWT_SECRET environment variable is required');
@@ -34,10 +40,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: JwtPayload & { tokenType?: string }) {
+  async validate(payload: JwtPayload & { tokenType?: string }) {
     if (payload.tokenType === 'refresh') {
       throw new UnauthorizedException('Refresh tokens cannot be used for API access');
     }
+
+    const user = await this.userRepository.findOne({ where: { id: payload.sub } });
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException('비활성화된 계정입니다.');
+    }
+
     return { id: payload.sub, email: payload.email, role: payload.role };
   }
 }


### PR DESCRIPTION
## Summary
- Closes #33
- JwtStrategy.validate()에서 isActive 확인 추가 — 비활성 사용자의 기존 JWT를 즉시 차단
- jwt.strategy.spec.ts에 비활성 사용자/미존재 사용자 테스트 케이스 추가 (7 tests pass)
- agent-monitor.html, agent-tracker.cjs는 이미 .gitignore에 포함됨 (별도 변경 불필요)

## Test plan
- [ ] cd backend && npm run build
- [ ] cd backend && npm run test -- --testPathPattern="jwt.strategy"