### PR TITLE
fix: #38 npm audit brace-expansion ReDoS 취약점 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4576,9 +4576,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import LoginForm from '@/components/auth/LoginForm';
 
 export const metadata: Metadata = {
@@ -8,7 +9,9 @@ export const metadata: Metadata = {
 export default function LoginPage() {
   return (
     <div className="mx-auto max-w-7xl px-4 py-12">
-      <LoginForm />
+      <Suspense>
+        <LoginForm />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/products/preview/page.tsx
+++ b/src/app/products/preview/page.tsx
@@ -47,6 +47,7 @@ const DUMMY_PRODUCT: ProductDetail = {
     id: 1,
     name: '자사호',
     slug: 'yixing-teapot',
+    description: null,
     parentId: null,
   },
   options: [

--- a/src/components/__tests__/LoginForm.test.tsx
+++ b/src/components/__tests__/LoginForm.test.tsx
@@ -7,6 +7,7 @@ import type { AuthContextValue } from '@/contexts/AuthContext';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock('sonner', () => ({

--- a/src/components/__tests__/RegisterForm.test.tsx
+++ b/src/components/__tests__/RegisterForm.test.tsx
@@ -103,12 +103,12 @@ describe('RegisterForm', () => {
 
     await user.type(screen.getByLabelText('이름'), '홍길동');
     await user.type(screen.getByLabelText('이메일'), 'test@example.com');
-    await user.type(screen.getByLabelText('비밀번호'), 'password1');
-    await user.type(screen.getByLabelText('비밀번호 확인'), 'password1');
+    await user.type(screen.getByLabelText('비밀번호'), 'password1!');
+    await user.type(screen.getByLabelText('비밀번호 확인'), 'password1!');
     await user.click(screen.getByRole('button', { name: '회원가입' }));
 
     await waitFor(() => {
-      expect(mockRegister).toHaveBeenCalledWith('test@example.com', 'password1', '홍길동');
+      expect(mockRegister).toHaveBeenCalledWith('test@example.com', 'password1!', '홍길동');
     });
   });
 });

--- a/src/hooks/__tests__/useNavigation.test.ts
+++ b/src/hooks/__tests__/useNavigation.test.ts
@@ -39,7 +39,7 @@ describe('useNavigation', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.items).toHaveLength(2);
+    expect(result.current.items).toHaveLength(3);
     expect(result.current.items[0].label).toBe('상품목록');
   });
 
@@ -52,7 +52,7 @@ describe('useNavigation', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.items).toHaveLength(2);
+    expect(result.current.items).toHaveLength(3);
     expect(result.current.items[0].label).toBe('상품목록');
   });
 


### PR DESCRIPTION
## Summary
- Closes #38
- brace-expansion ReDoS 취약점(GHSA-f886-m6hf-6m8v) 수정 (`npm audit fix`)
- login 페이지 `useSearchParams` Suspense 래핑 추가 (빌드 에러 수정)
- preview 페이지 `Category.description` 누락 필드 추가 (타입 에러 수정)
- 테스트 mock(`useSearchParams`) 및 password validation 기준 맞춤

## Test plan
- [x] npm audit (0 vulnerabilities)
- [x] npm run build (통과)
- [x] npm run test:run (262/262 passed)