### PR TITLE
fix: #27 파일 업로드 MIME magic byte 검증 추가

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "cookie-parser": "^1.4.7",
-        "file-type": "^22.0.0",
+        "file-type": "^16.5.4",
         "helmet": "^8.0.0",
         "ioredis": "^5.10.1",
         "multer": "^2.1.1",
@@ -4823,7 +4823,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -7011,7 +7010,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7021,7 +7019,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -7293,21 +7290,67 @@
       }
     },
     "node_modules/file-type": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.0.tgz",
-      "integrity": "sha512-cmBmnYo8Zymabm2+qAP7jTFbKF10bQpYmxoGfuZbRFRcq00BRddJdGNH/P7GA1EMpJy5yQbqa9B7yROb3z8Ziw==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/inflate": "^0.4.1",
-        "strtok3": "^10.3.5",
-        "token-types": "^6.1.2",
-        "uint8array-extras": "^1.5.0"
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/file-type/node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/file-type/node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/file-type/node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/filename-reserved-regex": {
@@ -10498,7 +10541,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -10680,7 +10722,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
       "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^4.7.0"
@@ -10697,7 +10738,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10722,7 +10762,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",
-    "file-type": "^22.0.0",
+    "file-type": "^16.5.4",
     "helmet": "^8.0.0",
     "ioredis": "^5.10.1",
     "multer": "^2.1.1",

--- a/backend/src/modules/upload/__tests__/upload.service.spec.ts
+++ b/backend/src/modules/upload/__tests__/upload.service.spec.ts
@@ -8,12 +8,27 @@ import { S3StorageAdapter } from '../adapters/s3.adapter';
 // Use mock adapter in tests
 process.env.STORAGE_PROVIDER = 'mock';
 
+// Real JPEG magic bytes: FF D8 FF
+const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00]);
+// Real PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A + IHDR chunk (25 bytes minimum)
+const PNG_MAGIC = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+  0x00, 0x00, 0x00, 0x0d,                           // IHDR chunk length
+  0x49, 0x48, 0x44, 0x52,                           // "IHDR"
+  0x00, 0x00, 0x00, 0x01,                           // width: 1
+  0x00, 0x00, 0x00, 0x01,                           // height: 1
+  0x08, 0x02, 0x00, 0x00, 0x00,                     // bit depth, color type, etc.
+  0x90, 0x77, 0x53, 0xde,                           // CRC
+]);
+// HTML content disguised as image
+const HTML_BUFFER = Buffer.from('<html><body>XSS</body></html>');
+
 const makeFile = (overrides: Partial<Express.Multer.File> = {}): Express.Multer.File => ({
   fieldname: 'file',
   originalname: 'test.jpg',
   encoding: '7bit',
   mimetype: 'image/jpeg',
-  buffer: Buffer.alloc(100),
+  buffer: JPEG_MAGIC,
   size: 100,
   stream: null as never,
   destination: '',
@@ -76,5 +91,37 @@ describe('UploadService', () => {
     expect(result.filename).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jpg$/,
     );
+  });
+
+  describe('magic byte 검증', () => {
+    it('실제 JPEG magic byte — 허용', async () => {
+      const file = makeFile({ buffer: JPEG_MAGIC, mimetype: 'image/jpeg' });
+      const result = await service.uploadImage(file);
+      expect(result.url).toBeDefined();
+    });
+
+    it('실제 PNG magic byte — 허용', async () => {
+      const file = makeFile({
+        buffer: PNG_MAGIC,
+        mimetype: 'image/png',
+        originalname: 'img.png',
+      });
+      const result = await service.uploadImage(file);
+      expect(result.url).toBeDefined();
+    });
+
+    it('Content-Type 위조 — HTML 버퍼를 image/jpeg로 업로드 시 거부', async () => {
+      const file = makeFile({ buffer: HTML_BUFFER, mimetype: 'image/jpeg' });
+      await expect(service.uploadImage(file)).rejects.toThrow(BadRequestException);
+    });
+
+    it('Content-Type 위조 — HTML 버퍼를 image/png로 업로드 시 거부', async () => {
+      const file = makeFile({
+        buffer: HTML_BUFFER,
+        mimetype: 'image/png',
+        originalname: 'evil.png',
+      });
+      await expect(service.uploadImage(file)).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/backend/src/modules/upload/upload.service.ts
+++ b/backend/src/modules/upload/upload.service.ts
@@ -7,6 +7,7 @@ import {
 import { randomUUID } from 'crypto';
 import * as path from 'path';
 import sharp from 'sharp';
+import { fromBuffer as fileTypeFromBuffer } from 'file-type';
 import { StorageAdapter, UploadedFile } from './interfaces/storage.interface';
 import { LocalStorageAdapter } from './adapters/local.adapter';
 import { MockStorageAdapter } from './adapters/mock.adapter';
@@ -50,6 +51,11 @@ export class UploadService {
 
     if (file.size > MAX_FILE_SIZE_BYTES) {
       throw new PayloadTooLargeException('파일 크기는 5MB를 초과할 수 없습니다.');
+    }
+
+    const detected = await fileTypeFromBuffer(file.buffer);
+    if (!detected || !ALLOWED_MIME_TYPES.includes(detected.mime)) {
+      throw new BadRequestException('허용되지 않는 이미지 형식입니다.');
     }
 
     const ext = path.extname(file.originalname).toLowerCase() || `.${file.mimetype.split('/')[1]}`;


### PR DESCRIPTION
## Summary
- Closes #27
- file-type v16 패키지로 업로드 파일의 magic byte 검증 추가
- Content-Type 헤더 위조를 통한 SVG/HTML 업로드 차단 (Stored XSS 방지)

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm run test (upload.service.spec.ts 9/9 통과)