### PR TITLE
fix: #37 로깅 민감 필드 확장 및 검색 키워드 옥화당 관련으로 변경

### DIFF
--- a/backend/src/common/interceptors/logging.interceptor.spec.ts
+++ b/backend/src/common/interceptors/logging.interceptor.spec.ts
@@ -100,14 +100,14 @@ describe('LoggingInterceptor', () => {
   it('should pass through normal fields unchanged', (done) => {
     const logSpy = jest.spyOn(interceptor['logger'], 'log');
     const context = createMockContext({
-      email: 'test@test.com',
       name: 'John',
+      quantity: 2,
     });
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('test@test.com'));
         expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('John'));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('2'));
         done();
       },
     });
@@ -180,6 +180,102 @@ describe('LoggingInterceptor', () => {
       complete: () => {
         expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
         expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('5500005555555559'));
+        done();
+      },
+    });
+  });
+
+  it('should redact refreshtoken field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      refreshToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'),
+        );
+        done();
+      },
+    });
+  });
+
+  it('should redact secret field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      clientSecret: 'my-client-secret-value',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining('my-client-secret-value'),
+        );
+        done();
+      },
+    });
+  });
+
+  it('should redact ssn field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      ssn: '900101-1234567',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('900101-1234567'));
+        done();
+      },
+    });
+  });
+
+  it('should redact phone field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      phone: '010-1234-5678',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('010-1234-5678'));
+        done();
+      },
+    });
+  });
+
+  it('should redact address field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      address: '서울특별시 강남구 테헤란로 123',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining('서울특별시 강남구 테헤란로 123'),
+        );
+        done();
+      },
+    });
+  });
+
+  it('should redact email field', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext({
+      email: 'user@example.com',
+    });
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('user@example.com'));
         done();
       },
     });

--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -18,6 +18,12 @@ const SENSITIVE_FIELDS = [
   'accountnumber',
   'bankaccount',
   'cardno',
+  'refreshtoken',
+  'secret',
+  'ssn',
+  'phone',
+  'address',
+  'email',
 ];
 
 @Injectable()

--- a/backend/src/modules/search/search.controller.spec.ts
+++ b/backend/src/modules/search/search.controller.spec.ts
@@ -1,0 +1,34 @@
+import { SearchController } from './search.controller';
+
+describe('SearchController', () => {
+  let controller: SearchController;
+
+  beforeEach(() => {
+    controller = new SearchController();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return 옥화당-relevant popular keywords', () => {
+    const result = controller.popular();
+    expect(result.keywords).toContain('자사호');
+    expect(result.keywords).toContain('보이차');
+    expect(result.keywords).toContain('다구');
+    expect(result.keywords).toContain('찻잔');
+    expect(result.keywords).toContain('개완');
+  });
+
+  it('should not contain Nike/Adidas/jeans keywords', () => {
+    const result = controller.popular();
+    expect(result.keywords).not.toContain('Nike');
+    expect(result.keywords).not.toContain('Adidas');
+    expect(result.keywords).not.toContain('jeans');
+  });
+
+  it('should return non-empty keywords array', () => {
+    const result = controller.popular();
+    expect(result.keywords.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/modules/search/search.controller.ts
+++ b/backend/src/modules/search/search.controller.ts
@@ -6,6 +6,6 @@ export class SearchController {
   @Get('popular')
   @Public()
   popular(): { keywords: string[] } {
-    return { keywords: [] };
+    return { keywords: ['자사호', '보이차', '다구', '찻잔', '개완', '숙차', '생차', '다반'] };
   }
 }


### PR DESCRIPTION
## Summary
- Closes #37
- LoggingInterceptor에 PIPA 대상 PII 필드 추가 (refreshtoken, secret, ssn, phone, address, email)
- 인기 검색어를 옥화당 관련 키워드로 교체 (자사호, 보이차, 다구, 찻잔, 개완, 숙차, 생차, 다반)

## Test plan
- [ ] cd backend && npm run build
- [ ] cd backend && npm run test