### PR TITLE
fix: #32 로컬 스토리지 경로 탐색 방지 및 리뷰 업로드 제한 추가

### DIFF
--- a/backend/src/modules/reviews/reviews.controller.ts
+++ b/backend/src/modules/reviews/reviews.controller.ts
@@ -13,6 +13,7 @@ import {
   UploadedFile,
   BadRequestException,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
@@ -51,6 +52,7 @@ export class ReviewsController {
   }
 
   @Post('upload-image')
+  @Throttle({ global: { limit: 5, ttl: 60000 } })
   @UseInterceptors(FileInterceptor('file'))
   async uploadImage(
     @UploadedFile() file: Express.Multer.File,

--- a/backend/src/modules/upload/adapters/__tests__/local.adapter.spec.ts
+++ b/backend/src/modules/upload/adapters/__tests__/local.adapter.spec.ts
@@ -1,0 +1,63 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { BadRequestException } from '@nestjs/common';
+import { LocalStorageAdapter } from '../local.adapter';
+
+jest.mock('fs/promises');
+
+const mockMkdir = fs.mkdir as jest.MockedFunction<typeof fs.mkdir>;
+const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>;
+
+describe('LocalStorageAdapter', () => {
+  let adapter: LocalStorageAdapter;
+  const uploadDir = path.join(process.cwd(), 'uploads');
+
+  beforeEach(() => {
+    adapter = new LocalStorageAdapter();
+    jest.clearAllMocks();
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+  });
+
+  describe('save()', () => {
+    it('정상 파일명 → 저장 성공 후 url/filename 반환', async () => {
+      const result = await adapter.save('image.jpg', Buffer.from('data'), 'image/jpeg');
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        path.join(uploadDir, 'image.jpg'),
+        Buffer.from('data'),
+      );
+      expect(result.url).toBe('/uploads/image.jpg');
+      expect(result.filename).toBe('image.jpg');
+    });
+
+    it('../ 경로 탐색 → BadRequestException', async () => {
+      await expect(
+        adapter.save('../etc/passwd', Buffer.from('data'), 'text/plain'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('../../ 중첩 경로 탐색 → BadRequestException', async () => {
+      await expect(
+        adapter.save('../../etc/shadow', Buffer.from('data'), 'text/plain'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('슬래시 포함 경로 → BadRequestException', async () => {
+      await expect(
+        adapter.save('subdir/image.jpg', Buffer.from('data'), 'image/jpeg'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('백슬래시 포함 경로 → BadRequestException', async () => {
+      await expect(
+        adapter.save('subdir\\image.jpg', Buffer.from('data'), 'image/jpeg'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('url에 safeName 사용 (원본 파일명 그대로)', async () => {
+      const result = await adapter.save('photo.png', Buffer.from(''), 'image/png');
+      expect(result.url).toBe('/uploads/photo.png');
+      expect(result.filename).toBe('photo.png');
+    });
+  });
+});

--- a/backend/src/modules/upload/adapters/local.adapter.ts
+++ b/backend/src/modules/upload/adapters/local.adapter.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { StorageAdapter, UploadedFile } from '../interfaces/storage.interface';
@@ -8,14 +8,19 @@ export class LocalStorageAdapter implements StorageAdapter {
   private readonly uploadDir = path.join(process.cwd(), 'uploads');
 
   async save(filename: string, buffer: Buffer, _mimetype: string): Promise<UploadedFile> {
+    if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+      throw new BadRequestException('잘못된 파일명입니다.');
+    }
     await fs.mkdir(this.uploadDir, { recursive: true });
     const safeName = path.basename(filename);
     const filePath = path.join(this.uploadDir, safeName);
-    if (!filePath.startsWith(this.uploadDir)) throw new Error('Invalid filename');
+    if (!filePath.startsWith(path.resolve(this.uploadDir))) {
+      throw new BadRequestException('잘못된 파일명입니다.');
+    }
     await fs.writeFile(filePath, buffer);
     return {
-      url: `/uploads/${filename}`,
-      filename,
+      url: `/uploads/${safeName}`,
+      filename: safeName,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Closes #32
- LocalStorageAdapter에 경로 탐색 방지 추가: `../`, `/`, `\` 포함 파일명 즉시 거부 + `path.basename()` 이중 방어
- `startsWith(path.resolve(...))` 로 resolve된 절대경로 기준 검증
- url/filename 반환 시 원본 filename 대신 safeName 사용
- 리뷰 이미지 업로드 엔드포인트에 `@Throttle({ global: { limit: 5, ttl: 60000 } })` 추가 (분당 5회 제한)

## Test plan
- [x] `backend/src/modules/upload/adapters/__tests__/local.adapter.spec.ts` — 6개 신규 테스트 (경로 탐색 거부, 정상 저장, url safeName 검증)
- [x] cd backend && npm run test — 기존 9개 실패 그대로, 신규 실패 없음 (36 suites, 263 tests)