### PR TITLE
feat: #83 Collection 페이지 — 니로별·모양별 큐레이션 시리즈

### DIFF
--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -13,10 +13,12 @@ export const metadata: Metadata = {
 };
 
 function SectionHeading({
+  id,
   label,
   title,
   description,
 }: {
+  id?: string;
   label: string;
   title: string;
   description?: string;
@@ -26,7 +28,7 @@ function SectionHeading({
       <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
         {label}
       </span>
-      <h2 className="mt-2 font-display-ko text-3xl font-bold tracking-tight text-foreground">
+      <h2 id={id} className="mt-2 font-display-ko text-3xl font-bold tracking-tight text-foreground">
         {title}
       </h2>
       {description && (
@@ -61,12 +63,12 @@ export default function CollectionPage() {
         aria-labelledby="clay-collection-heading"
       >
         <SectionHeading
+          id="clay-collection-heading"
           label="니로별"
           title="흙의 색으로 찾기"
           description="6종의 니로는 각기 다른 색상, 질감, 차 궁합을 지닙니다. 관심 있는 니로를 선택해보세요."
         />
         <div
-          id="clay-collection-heading"
           className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"
         >
           {CLAY_COLLECTIONS.map((clay) => (
@@ -118,12 +120,12 @@ export default function CollectionPage() {
         aria-labelledby="shape-collection-heading"
       >
         <SectionHeading
+          id="shape-collection-heading"
           label="모양별"
           title="형태의 선으로 찾기"
           description="자사호의 대표적인 5가지 형태. 각 형태가 지닌 미학과 기능을 탐색해보세요."
         />
         <div
-          id="shape-collection-heading"
           className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"
         >
           {SHAPE_COLLECTIONS.map((shape) => (

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -1,0 +1,182 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { CLAY_COLLECTIONS, SHAPE_COLLECTIONS } from '@/lib/collections';
+
+export const metadata: Metadata = {
+  title: 'Collection — 니로별·모양별 큐레이션',
+  description:
+    '자사호를 니로(泥料)별, 모양별로 탐색하세요. 주니·단니·자니·흑니·청수니·녹니 컬렉션과 서시·석표·인왕·덕종·수평 형태별 큐레이션.',
+  openGraph: {
+    title: 'Collection — 옥화당',
+    description: '니로별·모양별 자사호 큐레이션 컬렉션',
+  },
+};
+
+function SectionHeading({
+  label,
+  title,
+  description,
+}: {
+  label: string;
+  title: string;
+  description?: string;
+}) {
+  return (
+    <div className="mb-12 text-center">
+      <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+        {label}
+      </span>
+      <h2 className="mt-2 font-display-ko text-3xl font-bold tracking-tight text-foreground">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-3 max-w-xl mx-auto text-sm text-muted-foreground leading-relaxed">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function CollectionPage() {
+  return (
+    <div className="min-h-screen">
+      {/* Hero */}
+      <section className="bg-foreground text-background py-20 px-4 text-center">
+        <p className="text-xs font-semibold tracking-widest uppercase text-background/60 mb-3">
+          Collection
+        </p>
+        <h1 className="font-display-ko text-4xl font-bold tracking-tight mb-4">
+          니로별 · 모양별 큐레이션
+        </h1>
+        <p className="max-w-xl mx-auto text-sm text-background/70 leading-relaxed">
+          자사호의 개성은 흙과 형태에서 비롯됩니다. 니로의 색과 질감, 형태의 선과
+          비례로 나만의 자사호를 찾아보세요.
+        </p>
+      </section>
+
+      {/* 니로별 컬렉션 */}
+      <section
+        className="py-20 px-4 max-w-6xl mx-auto"
+        aria-labelledby="clay-collection-heading"
+      >
+        <SectionHeading
+          label="니로별"
+          title="흙의 색으로 찾기"
+          description="6종의 니로는 각기 다른 색상, 질감, 차 궁합을 지닙니다. 관심 있는 니로를 선택해보세요."
+        />
+        <div
+          id="clay-collection-heading"
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"
+        >
+          {CLAY_COLLECTIONS.map((clay) => (
+            <Link
+              key={clay.id}
+              href={clay.productUrl}
+              className="group block rounded-lg border border-border bg-background overflow-hidden transition-shadow hover:shadow-lg"
+            >
+              {/* 컬러 블록 */}
+              <div
+                className="h-40 transition-transform duration-300 group-hover:scale-105"
+                style={{ backgroundColor: clay.color }}
+                role="img"
+                aria-label={`${clay.nameKo} 색상`}
+              />
+              {/* 텍스트 */}
+              <div className="p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span
+                    className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: clay.color }}
+                    aria-hidden="true"
+                  />
+                  <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+                    {clay.name}
+                  </span>
+                </div>
+                <h3 className="text-lg font-bold text-foreground mb-1">
+                  {clay.nameKo}
+                </h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {clay.description}
+                </p>
+                <span className="inline-block mt-4 text-xs font-medium text-foreground border-b border-foreground pb-0.5 group-hover:border-foreground/60 transition-colors">
+                  컬렉션 보기 →
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* 구분선 */}
+      <hr className="border-border" />
+
+      {/* 모양별 컬렉션 */}
+      <section
+        className="py-20 px-4 max-w-6xl mx-auto"
+        aria-labelledby="shape-collection-heading"
+      >
+        <SectionHeading
+          label="모양별"
+          title="형태의 선으로 찾기"
+          description="자사호의 대표적인 5가지 형태. 각 형태가 지닌 미학과 기능을 탐색해보세요."
+        />
+        <div
+          id="shape-collection-heading"
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"
+        >
+          {SHAPE_COLLECTIONS.map((shape) => (
+            <Link
+              key={shape.id}
+              href={shape.productUrl}
+              className="group block rounded-lg border border-border bg-background overflow-hidden transition-shadow hover:shadow-lg"
+            >
+              {/* 형태 플레이스홀더 */}
+              <div
+                className="h-40 bg-muted flex items-center justify-center transition-transform duration-300 group-hover:scale-105"
+                role="img"
+                aria-label={`${shape.name} 형태`}
+              >
+                <span
+                  className="text-4xl text-muted-foreground/40"
+                  aria-hidden="true"
+                >
+                  壺
+                </span>
+              </div>
+              {/* 텍스트 */}
+              <div className="p-5">
+                <h3 className="text-lg font-bold text-foreground mb-1">
+                  {shape.name}
+                </h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {shape.description}
+                </p>
+                <span className="inline-block mt-4 text-xs font-medium text-foreground border-b border-foreground pb-0.5 group-hover:border-foreground/60 transition-colors">
+                  컬렉션 보기 →
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA 푸터 */}
+      <section className="bg-muted py-16 px-4 text-center">
+        <p className="text-xs font-semibold tracking-widest uppercase text-muted-foreground mb-3">
+          Shop
+        </p>
+        <h2 className="font-display-ko text-2xl font-bold text-foreground mb-4">
+          전체 상품을 둘러보세요
+        </h2>
+        <Link
+          href="/products"
+          className="inline-flex items-center gap-2 text-sm font-medium bg-foreground text-background rounded px-6 py-3 hover:opacity-80 transition-opacity"
+        >
+          전체 상품 보기 →
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, Search, BookOpen, ShoppingCart, User } from 'lucide-react';
+import { Home, LayoutGrid, BookOpen, ShoppingCart, User } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import { useCart } from '@/contexts/CartContext';
 
@@ -15,7 +15,7 @@ interface NavTab {
 
 const NAV_TABS: NavTab[] = [
   { href: '/', label: '홈', icon: Home, matchExact: true },
-  { href: '/search', label: '검색', icon: Search },
+  { href: '/collection', label: '컬렉션', icon: LayoutGrid },
   { href: '/archive', label: 'Archive', icon: BookOpen },
   { href: '/cart', label: '장바구니', icon: ShoppingCart },
   { href: '/my', label: '마이', icon: User },

--- a/src/components/__tests__/MobileBottomNav.test.tsx
+++ b/src/components/__tests__/MobileBottomNav.test.tsx
@@ -30,7 +30,7 @@ describe('MobileBottomNav', () => {
   it('바텀 네비 렌더링 - 5개 탭 표시', () => {
     render(<MobileBottomNav />);
     expect(screen.getByRole('link', { name: '홈' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: '검색' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '컬렉션' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Archive' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '장바구니' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '마이' })).toBeInTheDocument();

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,0 +1,99 @@
+export interface ClayCollection {
+  id: string;
+  name: string;
+  nameKo: string;
+  color: string;
+  description: string;
+  productUrl: string;
+}
+
+export interface ShapeCollection {
+  id: string;
+  name: string;
+  description: string;
+  productUrl: string;
+}
+
+export const CLAY_COLLECTIONS: ClayCollection[] = [
+  {
+    id: 'zuni',
+    name: '朱泥',
+    nameKo: '주니',
+    color: '#8B4513',
+    description: '철분 함량이 높아 소성 후 선명한 붉은색을 띠는 니로. 홍차·우롱에 최적.',
+    productUrl: '/products?clayType=주니',
+  },
+  {
+    id: 'danni',
+    name: '段泥',
+    nameKo: '단니',
+    color: '#C4A882',
+    description: '베이지·황토 계열의 온화한 색상. 기공이 균일하여 녹차·백차에 최적.',
+    productUrl: '/products?clayType=단니',
+  },
+  {
+    id: 'zini',
+    name: '紫泥',
+    nameKo: '자니',
+    color: '#6B3A5C',
+    description: '자사호의 대표 니로. 보라빛 갈색으로 보이차·암차에 최적.',
+    productUrl: '/products?clayType=자니',
+  },
+  {
+    id: 'heukni',
+    name: '黑泥',
+    nameKo: '흑니',
+    color: '#2A2520',
+    description: '희귀한 짙은 흑갈색 니로. 강한 흡착력으로 숙성 보이차에 최적.',
+    productUrl: '/products?clayType=흑니',
+  },
+  {
+    id: 'chunsuni',
+    name: '青水泥',
+    nameKo: '청수니',
+    color: '#3D6B6B',
+    description: '회록색·청회색의 섬세한 질감. 깔끔한 차 맛으로 녹차·화차에 최적.',
+    productUrl: '/products?clayType=청수니',
+  },
+  {
+    id: 'nokni',
+    name: '綠泥',
+    nameKo: '녹니',
+    color: '#4A6741',
+    description: '극히 희귀한 담록색 니로. 낮은 수축률로 정밀 조형에 적합.',
+    productUrl: '/products?clayType=녹니',
+  },
+];
+
+export const SHAPE_COLLECTIONS: ShapeCollection[] = [
+  {
+    id: 'seosi',
+    name: '서시형 (西施)',
+    description: '둥글고 풍만한 곡선이 특징. 우아한 여성미를 담은 대표적 형태.',
+    productUrl: '/products?shape=서시형',
+  },
+  {
+    id: 'seokpyo',
+    name: '석표형 (石瓢)',
+    description: '삼각 구도의 안정적 형태. 넓은 바닥과 직선적 라인이 특징.',
+    productUrl: '/products?shape=석표형',
+  },
+  {
+    id: 'inwang',
+    name: '인왕형 (仁王)',
+    description: '근엄하고 힘 있는 형태. 두툼한 벽과 넓은 주구가 특징.',
+    productUrl: '/products?shape=인왕형',
+  },
+  {
+    id: 'deokjong',
+    name: '덕종형 (德鍾)',
+    description: '단정하고 격조 있는 전통 형태. 균형 잡힌 비례가 특징.',
+    productUrl: '/products?shape=덕종형',
+  },
+  {
+    id: 'supyeong',
+    name: '수평형 (水平)',
+    description: '수평으로 뜨는 구조. 기능적이며 실용적인 우림에 최적.',
+    productUrl: '/products?shape=수평형',
+  },
+];


### PR DESCRIPTION
## Summary
- Closes #83
- `/collection` 라우트 생성 — 니로 6종 + 모양 5종 카드 그리드 레이아웃
- 카드 클릭 시 해당 필터가 적용된 `/products` 페이지로 이동
- MobileBottomNav: 검색 탭 → 컬렉션 탭 교체 (이슈 #1 IA 구조 반영)
- SEO 메타데이터 (title, description, OpenGraph)

## Changed Files
- `src/app/collection/page.tsx` — Collection 페이지 (신규)
- `src/lib/collections.ts` — 니로·모양 컬렉션 데이터 (신규)
- `src/components/MobileBottomNav.tsx` — 컬렉션 탭 추가
- `src/components/__tests__/MobileBottomNav.test.tsx` — 테스트 업데이트

## Test plan
- [x] npm run build
- [x] npm run test:run (46 files, 262 tests passed)