### PR TITLE
feat: #88 카테고리 내비게이션 이미지 카드 교체

### DIFF
--- a/src/components/blocks/CategoryNavBlock.tsx
+++ b/src/components/blocks/CategoryNavBlock.tsx
@@ -50,22 +50,26 @@ export default function CategoryNavBlock({ content }: Props) {
 
   if (template === 'image') {
     return (
-      <nav className="flex flex-wrap gap-4">
+      <nav className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {categories.map((cat) => (
           <Link
             key={cat.id}
             href={`/products?categoryId=${cat.id}`}
-            className="group relative h-32 w-32 overflow-hidden bg-muted"
+            className="group relative block aspect-[4/3] overflow-hidden rounded-sm bg-muted"
           >
             <Image
               src={`/images/categories/${cat.slug}.jpg`}
               alt={cat.name}
               fill
-              className="object-cover transition-opacity group-hover:opacity-80"
+              className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+              sizes="(max-width: 640px) 50vw, 25vw"
             />
-            <span className="absolute inset-0 flex items-end bg-gradient-to-t from-black/50 to-transparent p-2 text-sm font-medium text-white">
-              {cat.name}
-            </span>
+            <div className="absolute inset-0 bg-black/0 transition-colors duration-300 group-hover:bg-black/30" />
+            <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/60 via-black/10 to-transparent p-4">
+              <span className="text-sm font-medium tracking-wide text-white sm:text-base">
+                {cat.name}
+              </span>
+            </div>
           </Link>
         ))}
       </nav>

--- a/src/components/home/CategoryNav.tsx
+++ b/src/components/home/CategoryNav.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import type { Category } from '@/lib/api';
 
 interface CategoryNavProps {
@@ -6,12 +7,9 @@ interface CategoryNavProps {
   isLoading?: boolean;
 }
 
-function SkeletonItem() {
+function SkeletonCard() {
   return (
-    <div className="flex flex-col items-center gap-2">
-      <div className="h-10 w-10 animate-pulse rounded-full bg-muted" />
-      <div className="h-3 w-16 animate-pulse rounded bg-muted" />
-    </div>
+    <div className="relative aspect-[4/3] w-full animate-pulse overflow-hidden rounded-sm bg-muted" />
   );
 }
 
@@ -19,17 +17,31 @@ export default function CategoryNav({ categories, isLoading = false }: CategoryN
   if (!isLoading && categories.length === 0) return null;
 
   return (
-    <section className="border-y border-border py-6">
-      <div className="flex gap-8 overflow-x-auto pb-2 justify-center">
+    <section className="py-10">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {isLoading
-          ? Array.from({ length: 6 }).map((_, i) => <SkeletonItem key={i} />)
+          ? Array.from({ length: 4 }).map((_, i) => <SkeletonCard key={i} />)
           : categories.map((cat) => (
               <Link
                 key={cat.id}
                 href={`/products?categoryId=${cat.id}`}
-                className="shrink-0 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
+                className="group relative block aspect-[4/3] overflow-hidden rounded-sm bg-muted"
               >
-                {cat.name}
+                <Image
+                  src={`/images/categories/${cat.slug}.jpg`}
+                  alt={cat.name}
+                  fill
+                  className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+                  sizes="(max-width: 640px) 50vw, 25vw"
+                />
+                {/* dark overlay on hover */}
+                <div className="absolute inset-0 bg-black/0 transition-colors duration-300 group-hover:bg-black/30" />
+                {/* title */}
+                <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/60 via-black/10 to-transparent p-4">
+                  <span className="text-sm font-medium tracking-wide text-white sm:text-base">
+                    {cat.name}
+                  </span>
+                </div>
               </Link>
             ))}
       </div>


### PR DESCRIPTION
## Summary
- Closes #88
- 텍스트 링크를 이미지 카드로 교체, hover overlay 애니메이션
- 반응형 그리드: 모바일 2x2, 데스크탑 4열
- `CategoryNavBlock` image 템플릿도 동일 패턴으로 개선

## Test plan
- [ ] npm run build
- [ ] npm run test:run
- [ ] 4열 카드 렌더링 확인
- [ ] hover overlay 동작 확인