### PR TITLE
feat: #90 캐러셀 좌우 화살표 네비게이션 버튼 추가

### DIFF
--- a/src/components/blocks/ProductCarouselBlock.tsx
+++ b/src/components/blocks/ProductCarouselBlock.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { productsApi } from '@/lib/api';
 import type { Product, ProductCarouselContent } from '@/lib/api';
 import ProductCard from '@/components/products/ProductCard';
 import { cn } from '@/components/ui/utils';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface Props {
   content: ProductCarouselContent;
@@ -14,6 +15,9 @@ export default function ProductCarouselBlock({ content }: Props) {
   const { product_ids, category_id, limit, template, title } = content;
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -48,6 +52,36 @@ export default function ProductCarouselBlock({ content }: Props) {
     return () => { cancelled = true; };
   }, [product_ids, category_id, limit]);
 
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener('scroll', updateScrollState, { passive: true });
+    const ro = new ResizeObserver(updateScrollState);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener('scroll', updateScrollState);
+      ro.disconnect();
+    };
+  }, [products, updateScrollState]);
+
+  const cardWidth = template === 'large' ? 288 : 224; // w-72 = 288px, w-56 = 224px
+  const gap = 24; // gap-6 = 24px
+
+  function scrollBy(direction: 'left' | 'right') {
+    const el = scrollRef.current;
+    if (!el) return;
+    const amount = cardWidth + gap;
+    el.scrollBy({ left: direction === 'left' ? -amount : amount, behavior: 'smooth' });
+  }
+
   const isLarge = template === 'large';
 
   if (loading) {
@@ -74,15 +108,54 @@ export default function ProductCarouselBlock({ content }: Props) {
   return (
     <section className="py-12">
       {title && <h2 className="text-2xl font-medium mb-8">{title}</h2>}
-      <div className="flex gap-6 overflow-x-auto pb-4">
-        {products.map((product) => (
-          <div
-            key={product.id}
-            className={cn('shrink-0', isLarge ? 'w-72' : 'w-56')}
-          >
-            <ProductCard {...product} />
-          </div>
-        ))}
+      <div className="relative group">
+        {/* Left arrow */}
+        <button
+          type="button"
+          onClick={() => scrollBy('left')}
+          disabled={!canScrollLeft}
+          aria-label="이전 상품"
+          className={cn(
+            'absolute left-0 top-1/2 -translate-y-1/2 -translate-x-4 z-10',
+            'hidden md:flex items-center justify-center',
+            'w-10 h-10 rounded-full bg-background border border-border shadow-md',
+            'opacity-0 group-hover:opacity-100 transition-opacity duration-200',
+            !canScrollLeft && 'opacity-0 pointer-events-none',
+          )}
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+
+        <div
+          ref={scrollRef}
+          className="flex gap-6 overflow-x-auto pb-4 scrollbar-hide"
+        >
+          {products.map((product) => (
+            <div
+              key={product.id}
+              className={cn('shrink-0', isLarge ? 'w-72' : 'w-56')}
+            >
+              <ProductCard {...product} />
+            </div>
+          ))}
+        </div>
+
+        {/* Right arrow */}
+        <button
+          type="button"
+          onClick={() => scrollBy('right')}
+          disabled={!canScrollRight}
+          aria-label="다음 상품"
+          className={cn(
+            'absolute right-0 top-1/2 -translate-y-1/2 translate-x-4 z-10',
+            'hidden md:flex items-center justify-center',
+            'w-10 h-10 rounded-full bg-background border border-border shadow-md',
+            'opacity-0 group-hover:opacity-100 transition-opacity duration-200',
+            !canScrollRight && 'opacity-0 pointer-events-none',
+          )}
+        >
+          <ChevronRight className="w-5 h-5" />
+        </button>
       </div>
     </section>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -135,3 +135,11 @@ h3 {
   font-weight: 400;
   letter-spacing: 0.025em;
 }
+
+/* ── Scrollbar utilities ────────────────────────────────────────── */
+@utility scrollbar-hide {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #90
- 수평 스크롤 캐러셀에 좌/우 화살표 버튼 추가, 양 끝 비활성화
- hover 시 표시, 평소 숨김 (group-hover opacity 전환)
- `scrollbar-hide` utility 추가 (globals.css `@utility`)

## Test plan
- [ ] npm run build
- [ ] npm run test:run
- [ ] 화살표 클릭 스크롤 동작 확인
- [ ] 첫/마지막에서 버튼 비활성화 확인
- [ ] 모바일에서 버튼 숨김 확인 (hidden md:flex)