### PR TITLE
feat: #87 상품 카드 hover 인터랙션 추가

### DIFF
--- a/src/components/__tests__/HomePage.test.tsx
+++ b/src/components/__tests__/HomePage.test.tsx
@@ -14,6 +14,10 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({ isAuthenticated: false, isLoading: false, user: null, logout: vi.fn() }),
 }));
 
+vi.mock('@/contexts/CartContext', () => ({
+  useCart: () => ({ addItem: vi.fn(), items: [], itemCount: 0, totalAmount: 0, isLoading: false }),
+}));
+
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { toast } from 'sonner';
+import { wishlistApi } from '@/lib/api';
 import ProductCard from '@/components/products/ProductCard';
 
 vi.mock('next/image', () => ({
@@ -19,8 +21,19 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+const mockAddItem = vi.fn();
+vi.mock('@/contexts/CartContext', () => ({
+  useCart: () => ({ addItem: mockAddItem, items: [], itemCount: 0, totalAmount: 0, isLoading: false }),
+}));
+
+const mockUseAuth = vi.fn(() => ({
+  isAuthenticated: false,
+  isLoading: false,
+  user: null,
+  logout: vi.fn(),
+}));
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ isAuthenticated: false, isLoading: false, user: null, logout: vi.fn() }),
+  useAuth: () => mockUseAuth(),
 }));
 
 vi.mock('sonner', () => ({
@@ -45,6 +58,16 @@ describe('ProductCard', () => {
     status: 'active' as const,
     images: [{ id: 1, url: '/img/test.jpg', alt: null, sortOrder: 0, isThumbnail: true }],
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      user: null,
+      logout: vi.fn(),
+    });
+  });
 
   it('shows price only when no sale price', () => {
     render(<ProductCard {...baseProps} />);
@@ -73,5 +96,63 @@ describe('ProductCard', () => {
     render(<ProductCard {...baseProps} />);
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', '/products/1');
+  });
+
+  it('shows wishlist button', () => {
+    render(<ProductCard {...baseProps} />);
+    expect(screen.getByRole('button', { name: '찜하기' })).toBeInTheDocument();
+  });
+
+  it('shows cart button for active product', () => {
+    render(<ProductCard {...baseProps} />);
+    expect(screen.getByRole('button', { name: '장바구니 담기' })).toBeInTheDocument();
+  });
+
+  it('hides cart button when soldout', () => {
+    render(<ProductCard {...baseProps} status="soldout" />);
+    expect(screen.queryByRole('button', { name: '장바구니 담기' })).not.toBeInTheDocument();
+  });
+
+  it('calls addItem and shows toast on cart button click', async () => {
+    mockAddItem.mockResolvedValue(undefined);
+    render(<ProductCard {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: '장바구니 담기' }));
+    await waitFor(() => {
+      expect(mockAddItem).toHaveBeenCalledWith({ productId: 1, productOptionId: null, quantity: 1 });
+      expect(toast.success).toHaveBeenCalledWith('장바구니에 담았습니다.');
+    });
+  });
+
+  it('shows error toast when cart add fails', async () => {
+    mockAddItem.mockRejectedValue(new Error('fail'));
+    render(<ProductCard {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: '장바구니 담기' }));
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('장바구니 담기에 실패했습니다.');
+    });
+  });
+
+  it('shows login error toast when unauthenticated user clicks wishlist', async () => {
+    render(<ProductCard {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: '찜하기' }));
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('로그인이 필요합니다.');
+    });
+  });
+
+  it('calls wishlistApi.add and shows toast on wishlist click when authenticated', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      user: { id: 1 },
+      logout: vi.fn(),
+    });
+    vi.mocked(wishlistApi.add).mockResolvedValue({ id: 10, productId: 1, createdAt: '' });
+    render(<ProductCard {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: '찜하기' }));
+    await waitFor(() => {
+      expect(wishlistApi.add).toHaveBeenCalledWith(1);
+      expect(toast.success).toHaveBeenCalledWith('찜 목록에 추가했습니다.');
+    });
   });
 });

--- a/src/components/__tests__/SearchPage.test.tsx
+++ b/src/components/__tests__/SearchPage.test.tsx
@@ -13,6 +13,10 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({ isAuthenticated: false, isLoading: false, user: null, logout: vi.fn() }),
 }));
 
+vi.mock('@/contexts/CartContext', () => ({
+  useCart: () => ({ addItem: vi.fn(), items: [], itemCount: 0, totalAmount: 0, isLoading: false }),
+}));
+
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -1,8 +1,16 @@
+'use client';
+
+import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { Heart, ShoppingCart } from 'lucide-react';
+import { toast } from 'sonner';
 import { cn } from '@/components/ui/utils';
 import type { ProductImage } from '@/lib/api';
+import { wishlistApi } from '@/lib/api';
 import PriceDisplay from '@/components/common/PriceDisplay';
+import { useCart } from '@/contexts/CartContext';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface ProductCardProps {
   id: number;
@@ -25,6 +33,63 @@ export default function ProductCard({
   const thumbnail = images[0]?.url;
   const isSoldout = status === 'soldout';
 
+  const { addItem } = useCart();
+  const { isAuthenticated } = useAuth();
+
+  const [isWishlisted, setIsWishlisted] = useState(false);
+  const [wishlistId, setWishlistId] = useState<number | null>(null);
+  const [isWishlistLoading, setIsWishlistLoading] = useState(false);
+  const [isCartLoading, setIsCartLoading] = useState(false);
+
+  const handleAddToCart = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (isSoldout || isCartLoading) return;
+      setIsCartLoading(true);
+      try {
+        await addItem({ productId: id, productOptionId: null, quantity: 1 });
+        toast.success('장바구니에 담았습니다.');
+      } catch {
+        toast.error('장바구니 담기에 실패했습니다.');
+      } finally {
+        setIsCartLoading(false);
+      }
+    },
+    [id, isSoldout, isCartLoading, addItem],
+  );
+
+  const handleToggleWishlist = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (isWishlistLoading) return;
+
+      if (!isAuthenticated) {
+        toast.error('로그인이 필요합니다.');
+        return;
+      }
+
+      setIsWishlistLoading(true);
+      try {
+        if (isWishlisted && wishlistId !== null) {
+          await wishlistApi.remove(wishlistId);
+          setIsWishlisted(false);
+          setWishlistId(null);
+          toast.success('찜 목록에서 제거했습니다.');
+        } else {
+          const res = await wishlistApi.add(id);
+          setIsWishlisted(true);
+          setWishlistId(res.id);
+          toast.success('찜 목록에 추가했습니다.');
+        }
+      } catch {
+        toast.error('찜하기 처리에 실패했습니다.');
+      } finally {
+        setIsWishlistLoading(false);
+      }
+    },
+    [id, isAuthenticated, isWishlisted, wishlistId, isWishlistLoading],
+  );
+
   return (
     <Link
       href={`/products/${id}`}
@@ -40,7 +105,7 @@ export default function ProductCard({
             alt={name}
             fill
             sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
-            className="object-cover"
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
             loading="lazy"
           />
         ) : (
@@ -48,10 +113,47 @@ export default function ProductCard({
             <span className="text-sm">No Image</span>
           </div>
         )}
+
         {isSoldout && (
           <div className="absolute inset-0 flex items-center justify-center bg-white/60">
             <span className="text-sm font-medium text-foreground">품절</span>
           </div>
+        )}
+
+        {/* 찜하기 버튼 — 데스크탑: hover 시 표시, 모바일: 항상 표시 */}
+        <button
+          type="button"
+          aria-label={isWishlisted ? '찜하기 취소' : '찜하기'}
+          onClick={handleToggleWishlist}
+          disabled={isWishlistLoading}
+          className={cn(
+            'absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full bg-white/80 shadow-sm transition-opacity duration-200 disabled:cursor-not-allowed',
+            'opacity-100 md:opacity-0 md:group-hover:opacity-100',
+          )}
+        >
+          <Heart
+            className={cn(
+              'h-4 w-4 transition-colors',
+              isWishlisted ? 'fill-red-500 text-red-500' : 'text-foreground',
+            )}
+          />
+        </button>
+
+        {/* 장바구니 버튼 — 데스크탑: hover 시 slide-up, 모바일: 항상 표시 */}
+        {!isSoldout && (
+          <button
+            type="button"
+            aria-label="장바구니 담기"
+            onClick={handleAddToCart}
+            disabled={isCartLoading}
+            className={cn(
+              'absolute inset-x-0 bottom-0 flex items-center justify-center gap-2 bg-foreground/90 py-2 text-sm font-medium text-background transition-transform duration-300 disabled:cursor-not-allowed',
+              'translate-y-0 md:translate-y-full md:group-hover:translate-y-0',
+            )}
+          >
+            <ShoppingCart className="h-4 w-4" />
+            {isCartLoading ? '담는 중...' : '장바구니 담기'}
+          </button>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- 상품 카드 hover 시 이미지 scale(1.05) 트랜지션 적용
- 하단 '장바구니 담기' 버튼 slide-up 애니메이션 (모바일: 항상 노출)
- 우상단 찜하기 하트 아이콘 hover 시 표시 (모바일: 항상 노출)
- CartContext.addItem 및 wishlistApi 연동, sonner toast 피드백 추가

Closes #87

## Test plan
- [ ] npm run build
- [ ] npm run test:run
- [ ] 데스크탑 hover 동작 확인 (이미지 확대, 버튼 slide-up, 하트 아이콘 표시)
- [ ] 모바일 버튼 항상 노출 확인
- [ ] 장바구니 담기 클릭 시 toast 확인
- [ ] 찜하기 클릭 시 로그인 필요 toast (비로그인) / 찜 추가 toast (로그인) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)