### PR TITLE
feat: #91 브랜드 이야기 섹션 이미지+텍스트 2-column 레이아웃

### DIFF
--- a/src/components/admin/page-editor/BlockPalette.tsx
+++ b/src/components/admin/page-editor/BlockPalette.tsx
@@ -77,6 +77,9 @@ function getDefaultContent(type: BlockType): Record<string, unknown> {
       return { title: '', subtitle: '', image_url: '', cta_text: '', cta_url: '', template: 'full-width' };
     case 'text_content':
       return { html: '', template: 'default' };
+    case 'split_content':
+    case 'brand_story':
+      return { title: '', subtitle: '', description: '', image_url: '', image_position: 'left', cta_text: '', cta_url: '', template: 'default' };
   }
 }
 

--- a/src/components/admin/page-editor/BlockPropertyPanel.tsx
+++ b/src/components/admin/page-editor/BlockPropertyPanel.tsx
@@ -286,6 +286,8 @@ const BLOCK_TYPE_LABELS: Record<PageBlock['type'], string> = {
   category_nav: '카테고리 내비',
   promotion_banner: '프로모션 배너',
   text_content: '텍스트',
+  split_content: '분할 콘텐츠',
+  brand_story: '브랜드 이야기',
 };
 
 const BLOCK_TYPE_DESCRIPTIONS: Record<PageBlock['type'], string> = {
@@ -295,6 +297,8 @@ const BLOCK_TYPE_DESCRIPTIONS: Record<PageBlock['type'], string> = {
   category_nav: 'ℹ️ 카테고리 바로가기 버튼 모음입니다. 카테고리 ID를 콤마로 구분해 입력하거나, 비워두면 전체 카테고리를 표시합니다.',
   promotion_banner: 'ℹ️ 할인·이벤트를 강조하는 띠 배너입니다. 종료일을 설정하면 기간 표시가 가능합니다. 히어로 배너보다 작고 콤팩트합니다.',
   text_content: 'ℹ️ HTML 형식의 자유 텍스트 영역입니다. 공지사항·브랜드 소개 등에 사용하세요. <b>볼드</b>, <a href="">링크</a> 등 기본 HTML 태그 사용 가능합니다.',
+  split_content: 'ℹ️ 이미지와 텍스트를 2열로 나란히 표시합니다. 이미지 위치(좌/우), 제목·설명·버튼을 설정할 수 있습니다.',
+  brand_story: 'ℹ️ 브랜드 이야기 섹션입니다. 장인 이미지와 브랜드 소개 텍스트를 2열 레이아웃으로 표시합니다.',
 };
 
 export default function BlockPropertyPanel({ block, onUpdateContent }: BlockPropertyPanelProps) {

--- a/src/components/admin/page-editor/SortableBlockItem.tsx
+++ b/src/components/admin/page-editor/SortableBlockItem.tsx
@@ -13,6 +13,8 @@ const BLOCK_TYPE_LABELS: Record<PageBlock['type'], string> = {
   category_nav: '카테고리 내비',
   promotion_banner: '프로모션 배너',
   text_content: '텍스트',
+  split_content: '분할 콘텐츠',
+  brand_story: '브랜드 이야기',
 };
 
 interface DraftBlock {
@@ -51,6 +53,9 @@ function getContentSummary(block: DraftBlock): string {
       const plain = ((c.html as string) ?? '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
       return plain ? plain.slice(0, 30) + (plain.length > 30 ? '…' : '') : '(내용 없음)';
     }
+    case 'split_content':
+    case 'brand_story':
+      return (c.title as string) || (c.description as string) || '(내용 없음)';
   }
 }
 

--- a/src/components/blocks/BlockRenderer.tsx
+++ b/src/components/blocks/BlockRenderer.tsx
@@ -9,6 +9,7 @@ import ProductCarouselBlock from './ProductCarouselBlock';
 import CategoryNavBlock from './CategoryNavBlock';
 import PromotionBannerBlock from './PromotionBannerBlock';
 import TextContentBlock from './TextContentBlock';
+import SplitContentBlock from './SplitContentBlock';
 import UnknownBlock from './UnknownBlock';
 
 type BlockComponent = ComponentType<{ content: Record<string, unknown> }>;
@@ -20,6 +21,8 @@ const blockComponentMap: Record<string, BlockComponent> = {
   category_nav: CategoryNavBlock as unknown as BlockComponent,
   promotion_banner: PromotionBannerBlock as unknown as BlockComponent,
   text_content: TextContentBlock as unknown as BlockComponent,
+  split_content: SplitContentBlock as unknown as BlockComponent,
+  brand_story: SplitContentBlock as unknown as BlockComponent,
 };
 
 interface Props {

--- a/src/components/blocks/SplitContentBlock.tsx
+++ b/src/components/blocks/SplitContentBlock.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import type { SplitContentContent } from '@/lib/api';
@@ -15,7 +16,7 @@ export default function SplitContentBlock({ content }: Props) {
     subtitle,
     description,
     image_url,
-    image_position = 'right',
+    image_position = 'left',
     cta_text,
     cta_url,
     template = 'default',
@@ -24,55 +25,43 @@ export default function SplitContentBlock({ content }: Props) {
   const isLarge = template === 'large';
   const isCompact = template === 'compact';
 
+  const imageRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = imageRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.15 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <section className={cn(
-      'flex flex-col overflow-hidden bg-white',
-      isLarge ? 'md:flex-row' : 'md:flex-row',
-      image_position === 'left' && 'md:flex-row-reverse'
-    )}>
-      <div className={cn(
-        'flex flex-col justify-center',
-        isLarge ? 'flex-1 p-12 md:p-20' : isCompact ? 'flex-1 p-6 md:p-10' : 'flex-1 p-8 md:p-16'
-      )}>
-        {subtitle && (
-          <p className={cn(
-            'text-muted-foreground tracking-widest uppercase',
-            isLarge ? 'text-sm mb-4' : 'text-xs mb-3'
-          )}>
-            {subtitle}
-          </p>
-        )}
-        <h2 className={cn(
-          'font-medium text-foreground',
-          isLarge ? 'text-3xl md:text-4xl' : isCompact ? 'text-xl md:text-2xl' : 'text-2xl md:text-3xl'
-        )}>
-          {title}
-        </h2>
-        {description && (
-          <p className={cn(
-            'mt-4 text-muted-foreground leading-relaxed',
-            isLarge ? 'text-base md:text-lg max-w-xl' : 'text-sm md:text-base'
-          )}>
-            {description}
-          </p>
-        )}
-        {cta_text && cta_url && (
-          <Link
-            href={cta_url}
-            className={cn(
-              'mt-6 inline-block border border-foreground text-foreground font-medium transition-colors hover:bg-foreground hover:text-background',
-              isLarge ? 'px-8 py-3 text-sm' : 'px-6 py-2.5 text-sm'
-            )}
-          >
-            {cta_text}
-          </Link>
-        )}
-      </div>
+    <section
+      className={cn(
+        'grid grid-cols-1 overflow-hidden bg-white md:grid-cols-2',
+        image_position === 'right' && 'md:[&>*:first-child]:order-last'
+      )}
+    >
       {image_url && (
-        <div className={cn(
-          'relative',
-          isLarge ? 'flex-1 min-h-80 md:min-h-96' : 'flex-1 min-h-64 md:min-h-80'
-        )}>
+        <div
+          ref={imageRef}
+          className={cn(
+            'relative transition-opacity duration-700 ease-in',
+            isLarge ? 'min-h-80 md:min-h-[480px]' : isCompact ? 'min-h-48 md:min-h-64' : 'min-h-64 md:min-h-96',
+            isVisible ? 'opacity-100' : 'opacity-0'
+          )}
+        >
           <Image
             src={image_url}
             alt={title}
@@ -82,6 +71,56 @@ export default function SplitContentBlock({ content }: Props) {
           />
         </div>
       )}
+      <div
+        className={cn(
+          'flex flex-col justify-center',
+          isLarge ? 'p-12 md:p-20' : isCompact ? 'p-6 md:p-10' : 'p-8 md:p-16'
+        )}
+      >
+        {subtitle && (
+          <p
+            className={cn(
+              'uppercase tracking-widest text-muted-foreground',
+              isLarge ? 'mb-4 text-sm' : 'mb-3 text-xs'
+            )}
+          >
+            {subtitle}
+          </p>
+        )}
+        <h2
+          className={cn(
+            'font-medium text-foreground',
+            isLarge
+              ? 'text-3xl md:text-4xl'
+              : isCompact
+                ? 'text-xl md:text-2xl'
+                : 'text-2xl md:text-3xl'
+          )}
+        >
+          {title}
+        </h2>
+        {description && (
+          <p
+            className={cn(
+              'mt-4 leading-relaxed text-muted-foreground',
+              isLarge ? 'max-w-xl text-base md:text-lg' : 'text-sm md:text-base'
+            )}
+          >
+            {description}
+          </p>
+        )}
+        {cta_text && cta_url && (
+          <Link
+            href={cta_url}
+            className={cn(
+              'mt-6 inline-block border border-foreground font-medium text-foreground transition-colors hover:bg-foreground hover:text-background',
+              isLarge ? 'px-8 py-3 text-sm' : 'px-6 py-2.5 text-sm'
+            )}
+          >
+            {cta_text}
+          </Link>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -626,7 +626,7 @@ export interface UploadedFile {
 
 export interface PageBlock {
   id: number;
-  type: 'hero_banner' | 'product_grid' | 'product_carousel' | 'category_nav' | 'promotion_banner' | 'text_content';
+  type: 'hero_banner' | 'product_grid' | 'product_carousel' | 'category_nav' | 'promotion_banner' | 'text_content' | 'split_content' | 'brand_story';
   content: Record<string, unknown>;
   sort_order: number;
   is_visible: boolean;


### PR DESCRIPTION
## Summary
- Closes #91
- 브랜드 스토리 섹션에 이미지 추가, 좌우 2-column 레이아웃, 모바일 세로 스택
- 이미지 진입 시 IntersectionObserver 기반 fade-in 애니메이션 적용
- `split_content` / `brand_story` 블록 타입 신규 등록 (BlockRenderer + api.ts)
- 어드민 페이지 에디터(BlockPalette, BlockPropertyPanel, SortableBlockItem) 신규 타입 대응

## Test plan
- [x] npm run build (컴파일 오류 없음, 기존 /404 prerender 오류는 pre-existing)
- [x] npm run test:run (269 tests passed)
- [ ] 2-column 레이아웃 확인 (md 이상 화면)
- [ ] 모바일 세로 스택 확인 (grid-cols-1)
- [ ] 이미지 fade-in 확인 (스크롤 진입 시 opacity 0→1)