### PR TITLE
feat: #1 자사호 실제 이미지 적용

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,9 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'cdn.okhwadang.com' },
       { protocol: 'https', hostname: 'shop-okhwadang.com' },
       { protocol: 'https', hostname: 'images.unsplash.com' },
+      { protocol: 'https', hostname: 'm.cbw.co.kr' },
+      { protocol: 'https', hostname: 'gdimg.gmarket.co.kr' },
+      { protocol: 'https', hostname: 'cdn-optimized.imweb.me' },
     ],
   },
   async rewrites() {

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
+import Image from 'next/image';
 import Link from 'next/link';
 import { cn } from '@/components/ui/utils';
+import { TEAPOT_IMAGES } from '@/lib/teapot-images';
 
 export const metadata: Metadata = {
   title: 'Archive — 니로 산지 기록 & 공정 스토리',
@@ -249,10 +251,12 @@ function ProcessCard({ step: s }: { step: ProcessStep }) {
 
 interface ArtistCardProps {
   artist: ArtistEntry;
+  index: number;
   reversed?: boolean;
 }
 
-function ArtistCard({ artist, reversed }: ArtistCardProps) {
+function ArtistCard({ artist, index, reversed }: ArtistCardProps) {
+  const img = TEAPOT_IMAGES[index % TEAPOT_IMAGES.length];
   return (
     <article
       className={cn(
@@ -260,13 +264,15 @@ function ArtistCard({ artist, reversed }: ArtistCardProps) {
         reversed ? 'md:flex-row-reverse' : 'md:flex-row',
       )}
     >
-      {/* 플레이스홀더 이미지 */}
-      <div
-        className="w-full md:w-2/5 aspect-square rounded-lg bg-muted shrink-0 flex items-center justify-center"
-        role="img"
-        aria-label={`${artist.name} 작가 사진`}
-      >
-        <span className="text-4xl text-muted-foreground" aria-hidden="true">匠</span>
+      {/* 작가 이미지 */}
+      <div className="relative w-full md:w-2/5 aspect-square rounded-lg bg-muted shrink-0 overflow-hidden">
+        <Image
+          src={img.src}
+          alt={`${artist.name} 작가 작품`}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 100vw, 40vw"
+        />
       </div>
 
       {/* 텍스트 */}
@@ -346,7 +352,7 @@ export default function ArchivePage() {
         />
         <div className="space-y-20" id="artist-heading">
           {ARTISTS.map((artist, i) => (
-            <ArtistCard key={artist.id} artist={artist} reversed={i % 2 === 1} />
+            <ArtistCard key={artist.id} artist={artist} index={i} reversed={i % 2 === 1} />
           ))}
         </div>
       </section>

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
+import Image from 'next/image';
 import Link from 'next/link';
 import { CLAY_COLLECTIONS, SHAPE_COLLECTIONS } from '@/lib/collections';
+import { TEAPOT_IMAGES } from '@/lib/teapot-images';
 
 export const metadata: Metadata = {
   title: 'Collection — 니로별·모양별 큐레이션',
@@ -128,24 +130,21 @@ export default function CollectionPage() {
         <div
           className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"
         >
-          {SHAPE_COLLECTIONS.map((shape) => (
+          {SHAPE_COLLECTIONS.map((shape, i) => (
             <Link
               key={shape.id}
               href={shape.productUrl}
               className="group block rounded-lg border border-border bg-background overflow-hidden transition-shadow hover:shadow-lg"
             >
-              {/* 형태 플레이스홀더 */}
-              <div
-                className="h-40 bg-muted flex items-center justify-center transition-transform duration-300 group-hover:scale-105"
-                role="img"
-                aria-label={`${shape.name} 형태`}
-              >
-                <span
-                  className="text-4xl text-muted-foreground/40"
-                  aria-hidden="true"
-                >
-                  壺
-                </span>
+              {/* 형태 이미지 */}
+              <div className="relative h-40 bg-muted overflow-hidden">
+                <Image
+                  src={TEAPOT_IMAGES[i % TEAPOT_IMAGES.length].src}
+                  alt={`${shape.name} 형태 자사호`}
+                  fill
+                  className="object-cover transition-transform duration-300 group-hover:scale-105"
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                />
               </div>
               {/* 텍스트 */}
               <div className="p-5">

--- a/src/components/__tests__/ImageGallery.test.tsx
+++ b/src/components/__tests__/ImageGallery.test.tsx
@@ -31,8 +31,10 @@ describe('ImageGallery', () => {
     expect(mainImages[0]).toHaveAttribute('src', '/img/2.jpg')
   })
 
-  it('shows 이미지 없음 when images are empty', () => {
+  it('shows fallback teapot images when images are empty', () => {
     render(<ImageGallery images={[]} />)
-    expect(screen.getByText('이미지 없음')).toBeInTheDocument()
+    const fallbackImage = screen.getAllByRole('img')[0]
+    expect(fallbackImage).toBeInTheDocument()
+    expect(fallbackImage).toHaveAttribute('alt', '자사호 — 전통 주니 자사호')
   })
 })

--- a/src/components/journal/JournalListClient.tsx
+++ b/src/components/journal/JournalListClient.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { cn } from '@/components/ui/utils';
+import { TEAPOT_IMAGES } from '@/lib/teapot-images';
 import {
   JOURNAL_ENTRIES,
   JOURNAL_CATEGORIES,
@@ -50,16 +52,21 @@ function CategoryFilter({
   );
 }
 
-function JournalCard({ entry }: { entry: JournalEntry }) {
+function JournalCard({ entry, index }: { entry: JournalEntry; index: number }) {
+  const img = TEAPOT_IMAGES[index % TEAPOT_IMAGES.length];
   return (
     <Link
       href={`/journal/${entry.slug}`}
       className="group block rounded-lg border border-border bg-background overflow-hidden transition-shadow hover:shadow-lg"
     >
-      <div className="h-48 bg-muted flex items-center justify-center transition-transform duration-300 group-hover:scale-105">
-        <span className="text-5xl text-muted-foreground/30" aria-hidden="true">
-          茶
-        </span>
+      <div className="relative h-48 bg-muted overflow-hidden">
+        <Image
+          src={img.src}
+          alt={entry.title}
+          fill
+          className="object-cover transition-transform duration-300 group-hover:scale-105"
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+        />
       </div>
       <div className="p-5">
         <div className="flex items-center gap-2 mb-2">
@@ -101,8 +108,8 @@ export default function JournalListClient() {
         </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filtered.map((entry) => (
-            <JournalCard key={entry.slug} entry={entry} />
+          {filtered.map((entry, i) => (
+            <JournalCard key={entry.slug} entry={entry} index={i} />
           ))}
         </div>
       )}

--- a/src/components/products/ImageGallery.tsx
+++ b/src/components/products/ImageGallery.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import Image from 'next/image'
 import { cn } from '@/components/ui/utils'
 import { ZoomIn, ZoomOut, X, ChevronLeft, ChevronRight } from 'lucide-react'
+import { TEAPOT_IMAGES } from '@/lib/teapot-images'
 
 interface ProductImage {
   id: number
@@ -13,11 +14,20 @@ interface ProductImage {
   isThumbnail: boolean
 }
 
+const FALLBACK_IMAGES: ProductImage[] = TEAPOT_IMAGES.map((img, i) => ({
+  id: -(i + 1),
+  url: img.src,
+  alt: img.alt,
+  sortOrder: i,
+  isThumbnail: i === 0,
+}))
+
 interface ImageGalleryProps {
   images: ProductImage[]
 }
 
-export default function ImageGallery({ images }: ImageGalleryProps) {
+export default function ImageGallery({ images: rawImages }: ImageGalleryProps) {
+  const images = rawImages.length > 0 ? rawImages : FALLBACK_IMAGES
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [isZoomed, setIsZoomed] = useState(false)
   const [zoomPos, setZoomPos] = useState({ x: 50, y: 50 })

--- a/src/lib/teapot-images.ts
+++ b/src/lib/teapot-images.ts
@@ -1,0 +1,14 @@
+export const TEAPOT_IMAGES = [
+  {
+    src: 'https://m.cbw.co.kr/web/product/medium/202602/d4c5b28827cbcccd45a132c47225e8ae.jpg',
+    alt: '자사호 — 전통 주니 자사호',
+  },
+  {
+    src: 'https://gdimg.gmarket.co.kr/4396176149/still/280?ver=1745550133',
+    alt: '자사호 — 클래식 형태 자사호',
+  },
+  {
+    src: 'https://cdn-optimized.imweb.me/upload/S201906221c48099d08547/5d3d6b293828f.jpg?w=500',
+    alt: '자사호 — 의흥 장인 자사호',
+  },
+] as const;


### PR DESCRIPTION
## Summary
- 이슈 #1 UI/UX 리포트의 이미지 관련 권고 반영
- 자사호 이미지 3종을 Collection·Journal·Archive·상품상세에 적용
- 기존 한자 placeholder(壺·茶·匠) → 실제 자사호 사진으로 교체

## Changed Files
- `src/lib/teapot-images.ts` — 자사호 이미지 3종 상수 (신규)
- `src/app/collection/page.tsx` — 모양별 카드 이미지 적용
- `src/components/journal/JournalListClient.tsx` — 저널 카드 이미지 적용
- `src/app/archive/page.tsx` — 장인 섹션 이미지 적용
- `src/components/products/ImageGallery.tsx` — 빈 이미지 fallback
- `src/components/__tests__/ImageGallery.test.tsx` — fallback 테스트 업데이트
- `next.config.ts` — 외부 이미지 도메인 3개 추가

## Test plan
- [x] npm run build
- [x] npm run test:run (46 files, 269 tests passed)