### PR TITLE
feat: #56 상품 테이블 다국어 필드 추가 (en/ja/zh)

### DIFF
--- a/backend/src/database/migrations/1775700000000-AddProductI18nFields.ts
+++ b/backend/src/database/migrations/1775700000000-AddProductI18nFields.ts
@@ -1,0 +1,100 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductI18nFields1775700000000 implements MigrationInterface {
+  name = 'AddProductI18nFields1775700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // name_en
+    const nameEnExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'name_en'
+    `);
+    if ((nameEnExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`name_en\` VARCHAR(255) NULL AFTER \`name\``);
+    }
+
+    // name_ja
+    const nameJaExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'name_ja'
+    `);
+    if ((nameJaExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`name_ja\` VARCHAR(255) NULL AFTER \`name_en\``);
+    }
+
+    // name_zh
+    const nameZhExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'name_zh'
+    `);
+    if ((nameZhExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`name_zh\` VARCHAR(255) NULL AFTER \`name_ja\``);
+    }
+
+    // description_en
+    const descEnExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'description_en'
+    `);
+    if ((descEnExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`description_en\` TEXT NULL AFTER \`description\``);
+    }
+
+    // description_ja
+    const descJaExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'description_ja'
+    `);
+    if ((descJaExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`description_ja\` TEXT NULL AFTER \`description_en\``);
+    }
+
+    // description_zh
+    const descZhExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'description_zh'
+    `);
+    if ((descZhExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`description_zh\` TEXT NULL AFTER \`description_ja\``);
+    }
+
+    // short_description_en
+    const shortDescEnExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'short_description_en'
+    `);
+    if ((shortDescEnExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`short_description_en\` VARCHAR(500) NULL AFTER \`short_description\``);
+    }
+
+    // short_description_ja
+    const shortDescJaExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'short_description_ja'
+    `);
+    if ((shortDescJaExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`short_description_ja\` VARCHAR(500) NULL AFTER \`short_description_en\``);
+    }
+
+    // short_description_zh
+    const shortDescZhExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'products' AND COLUMN_NAME = 'short_description_zh'
+    `);
+    if ((shortDescZhExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`products\` ADD \`short_description_zh\` VARCHAR(500) NULL AFTER \`short_description_ja\``);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`short_description_zh\``);
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`short_description_ja\``);
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`short_description_en\``);
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`description_zh\``);
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`description_ja\``);
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`description_en\``);
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`name_zh\``);
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`name_ja\``);
+    await queryRunner.query(`ALTER TABLE \`products\` DROP COLUMN \`name_en\``);
+  }
+}

--- a/backend/src/modules/products/dto/query-products.dto.ts
+++ b/backend/src/modules/products/dto/query-products.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsNumber, IsEnum, IsBoolean, Min, Max, MaxLength } from 'class-validator';
+import { IsOptional, IsString, IsNumber, IsEnum, IsBoolean, Min, Max, MaxLength, IsIn } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 
 export enum ProductSort {
@@ -56,4 +56,9 @@ export class QueryProductsDto {
   @IsNumber()
   @Min(0)
   price_max?: number;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['ko', 'en', 'ja', 'zh'])
+  locale?: string;
 }

--- a/backend/src/modules/products/entities/product.entity.ts
+++ b/backend/src/modules/products/entities/product.entity.ts
@@ -34,14 +34,41 @@ export class Product {
   @Column({ length: 255 })
   name!: string;
 
+  @Column({ name: 'name_en', length: 255, nullable: true })
+  nameEn!: string | null;
+
+  @Column({ name: 'name_ja', length: 255, nullable: true })
+  nameJa!: string | null;
+
+  @Column({ name: 'name_zh', length: 255, nullable: true })
+  nameZh!: string | null;
+
   @Column({ length: 255, unique: true })
   slug!: string;
 
   @Column({ type: 'text', nullable: true })
   description!: string | null;
 
+  @Column({ name: 'description_en', type: 'text', nullable: true })
+  descriptionEn!: string | null;
+
+  @Column({ name: 'description_ja', type: 'text', nullable: true })
+  descriptionJa!: string | null;
+
+  @Column({ name: 'description_zh', type: 'text', nullable: true })
+  descriptionZh!: string | null;
+
   @Column({ name: 'short_description', type: 'varchar', length: 500, nullable: true })
   shortDescription!: string | null;
+
+  @Column({ name: 'short_description_en', type: 'varchar', length: 500, nullable: true })
+  shortDescriptionEn!: string | null;
+
+  @Column({ name: 'short_description_ja', type: 'varchar', length: 500, nullable: true })
+  shortDescriptionJa!: string | null;
+
+  @Column({ name: 'short_description_zh', type: 'varchar', length: 500, nullable: true })
+  shortDescriptionZh!: string | null;
 
   @Column({ type: 'decimal', precision: 12, scale: 2 })
   price!: number;

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -42,10 +42,11 @@ export class ProductsController {
   @Public()
   findOne(
     @Param('id', ParseIntPipe) id: number,
+    @Query('locale') locale: string | undefined,
     @Request() req: RequestWithUser,
   ) {
     const isAdmin = req.user?.role === 'admin';
-    return this.productsService.findOne(id, isAdmin);
+    return this.productsService.findOne(id, isAdmin, locale);
   }
 
   @Post()

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -40,6 +40,24 @@ export class ProductsService {
     return `products:list:${hash}`;
   }
 
+  private applyLocale(product: Product, locale?: string): Product {
+    if (!locale || locale === 'ko') return product;
+    const localeMap: Record<string, 'En' | 'Ja' | 'Zh'> = { en: 'En', ja: 'Ja', zh: 'Zh' };
+    const suffix = localeMap[locale];
+    if (!suffix) return product;
+
+    const nameKey = `name${suffix}` as keyof Product;
+    const descKey = `description${suffix}` as keyof Product;
+    const shortDescKey = `shortDescription${suffix}` as keyof Product;
+
+    return {
+      ...product,
+      name: (product[nameKey] as string | null) ?? product.name,
+      description: (product[descKey] as string | null) ?? product.description,
+      shortDescription: (product[shortDescKey] as string | null) ?? product.shortDescription,
+    };
+  }
+
   async findAll(
     query: QueryProductsDto,
     isAdmin = false,
@@ -58,6 +76,7 @@ export class ProductsService {
       isFeatured,
       price_min,
       price_max,
+      locale,
     } = query;
 
     if (price_min !== undefined && price_max !== undefined && price_min > price_max) {
@@ -125,7 +144,7 @@ export class ProductsService {
 
     try {
       const [items, total] = await qb.getManyAndCount();
-      const result = { items, total, page, limit };
+      const result = { items: items.map((p) => this.applyLocale(p, locale)), total, page, limit };
       await this.cacheService.set(cacheKey, result, CACHE_TTL_LIST);
       return result;
     } catch (err) {
@@ -170,7 +189,7 @@ export class ProductsService {
         likeQb.skip((page - 1) * limit).take(limit);
 
         const [items, total] = await likeQb.getManyAndCount();
-        const result = { items, total, page, limit };
+        const result = { items: items.map((p) => this.applyLocale(p, locale)), total, page, limit };
         await this.cacheService.set(cacheKey, result, CACHE_TTL_LIST);
         return result;
       }
@@ -178,7 +197,7 @@ export class ProductsService {
     }
   }
 
-  async findOne(id: number, isAdmin = false): Promise<Product> {
+  async findOne(id: number, isAdmin = false, locale?: string): Promise<Product> {
     const cacheKey = `products:detail:${id}`;
     const cached = await this.cacheService.get<Product>(cacheKey);
     if (cached) {
@@ -188,7 +207,7 @@ export class ProductsService {
       ) {
         throw new NotFoundException('상품을 찾을 수 없습니다.');
       }
-      return cached;
+      return this.applyLocale(cached, locale);
     }
 
     const product = await this.productRepository
@@ -220,7 +239,7 @@ export class ProductsService {
         this.logger.warn(`view_count increment failed: ${err.message}`),
       );
 
-    return product;
+    return this.applyLocale(product, locale);
   }
 
   private async findById(id: number): Promise<Product> {


### PR DESCRIPTION
## Summary

- Product 엔티티에 다국어 필드 9개 추가: `name_en/ja/zh`, `description_en/ja/zh`, `short_description_en/ja/zh`
- `GET /api/products?locale=en` → 영어 name/description 반환
- `GET /api/products/:id?locale=ja` → 일본어 name/description 반환
- locale 미지정 시 한국어 기본값 유지 (하위 호환)

## Changes

- `product.entity.ts`: 다국어 필드 9개 추가 (VARCHAR 255, TEXT, VARCHAR 500, 모두 nullable)
- `query-products.dto.ts`: `locale` 파라미터 추가 (`ko|en|ja|zh` 유효성 검사)
- `products.service.ts`: `applyLocale()` 메서드 추가 — locale에 따라 name/description/shortDescription 오버라이드 (fallback: 한국어)
- `products.controller.ts`: `findOne`에 `@Query('locale')` 파라미터 추가
- `1775700000000-AddProductI18nFields.ts`: TypeORM 마이그레이션 (INFORMATION_SCHEMA 존재 체크로 멱등성 보장)

## Test plan

- [x] `npm run build` — 빌드 성공
- [x] `npm run test` — 335 tests passed
- [ ] E2E: DB 연결 시 `npm run test:e2e` 실행 필요 (SSH 터널 필요)
- [ ] 마이그레이션: `LOCAL_DATABASE_URL=... npm run migration:run` (SSH 터널 port 3307)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)