### PR TITLE
feat: #58 통화 변환 유틸리티 구현

### DIFF
--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { toast } from 'sonner';
 import { adminProductsApi } from '@/lib/api';
 import type { Product } from '@/lib/api';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 
 const STATUS_LABELS: Record<string, string> = {
   draft: '임시저장',
@@ -130,7 +130,7 @@ export default function AdminProductsPage() {
                 <tr key={p.id} className="hover:bg-secondary/30">
                   <td className="px-4 py-3 text-muted-foreground">{p.id}</td>
                   <td className="px-4 py-3 font-medium">{p.name}</td>
-                  <td className="px-4 py-3">{formatPrice(p.price)}</td>
+                  <td className="px-4 py-3">{formatCurrency(p.price)}</td>
                   <td className="px-4 py-3">
                     <span
                       className={`rounded-full px-2 py-0.5 text-xs ${

--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -7,7 +7,7 @@ import { useCart } from '@/contexts/CartContext';
 import { useAuth } from '@/contexts/AuthContext';
 import EmptyState from '@/components/EmptyState';
 import CartItemRow from '@/components/cart/CartItemRow';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 
 export default function CartPage() {
@@ -142,7 +142,7 @@ export default function CartPage() {
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">상품 금액</span>
-              <span>{formatPrice(selectedTotal)}</span>
+              <span>{formatCurrency(selectedTotal)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">배송비</span>
@@ -154,7 +154,7 @@ export default function CartPage() {
             <div className="flex justify-between font-bold">
               <span>합계</span>
               <span>
-                {formatPrice(
+                {formatCurrency(
                   selectedTotal +
                   (selectedTotal >= 30000 || selectedTotal === 0 ? 0 : 3000)
                 )}

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useCart } from '@/contexts/CartContext';
 import type { CartItem, PreparePaymentResponse, UserAddress } from '@/lib/api';
 import { ordersApi, paymentsApi, usersApi } from '@/lib/api';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 
 type PaymentStep = 'idle' | 'creating_order' | 'preparing_payment' | 'confirming_payment' | 'success';
 
@@ -434,8 +434,8 @@ export default function CheckoutPage() {
                       </p>
                     )}
                     <p className="text-muted-foreground">
-                      {formatPrice(item.unitPrice)} × {item.quantity}개 ={' '}
-                      {formatPrice(item.subtotal)}
+                      {formatCurrency(item.unitPrice)} × {item.quantity}개 ={' '}
+                      {formatCurrency(item.subtotal)}
                     </p>
                   </li>
                 ))}
@@ -444,18 +444,18 @@ export default function CheckoutPage() {
               <div className="border-t pt-4 space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">상품 금액</span>
-                  <span>{formatPrice(totalAmount)}</span>
+                  <span>{formatCurrency(totalAmount)}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">배송비</span>
-                  <span>{shippingFee === 0 ? '무료' : formatPrice(shippingFee)}</span>
+                  <span>{shippingFee === 0 ? '무료' : formatCurrency(shippingFee)}</span>
                 </div>
               </div>
 
               <div className="border-t pt-4">
                 <div className="flex justify-between font-bold">
                   <span>합계</span>
-                  <span>{formatPrice(grandTotal)}</span>
+                  <span>{formatCurrency(grandTotal)}</span>
                 </div>
               </div>
 

--- a/src/app/[locale]/my/coupons/page.tsx
+++ b/src/app/[locale]/my/coupons/page.tsx
@@ -6,7 +6,7 @@ import type { CouponItem } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { cn } from '@/components/ui/utils';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 
 type TabStatus = 'available' | 'used' | 'expired';
 
@@ -19,8 +19,8 @@ const TAB_LABELS: Record<TabStatus, string> = {
 function CouponCard({ coupon }: { coupon: CouponItem }) {
   const discountText =
     coupon.type === 'percentage'
-      ? `${coupon.value}% 할인${coupon.maxDiscount ? ` (최대 ${formatPrice(coupon.maxDiscount)}원)` : ''}`
-      : `${formatPrice(coupon.value)}원 할인`;
+      ? `${coupon.value}% 할인${coupon.maxDiscount ? ` (최대 ${formatCurrency(coupon.maxDiscount)}원)` : ''}`
+      : `${formatCurrency(coupon.value)}원 할인`;
 
   return (
     <div
@@ -45,7 +45,7 @@ function CouponCard({ coupon }: { coupon: CouponItem }) {
       <p className="text-sm font-medium text-primary">{discountText}</p>
       {coupon.minOrderAmount > 0 && (
         <p className="text-xs text-muted-foreground">
-          {formatPrice(coupon.minOrderAmount)}원 이상 구매 시 사용 가능
+          {formatCurrency(coupon.minOrderAmount)}원 이상 구매 시 사용 가능
         </p>
       )}
       <p className="text-xs text-muted-foreground">
@@ -90,7 +90,7 @@ export default function MyCouponsPage() {
       {/* 적립금 잔액 */}
       <div className="mb-6 rounded-lg border p-4 flex items-center justify-between">
         <span className="text-sm font-medium">보유 적립금</span>
-        <span className="text-lg font-bold">{formatPrice(pointBalance)}원</span>
+        <span className="text-lg font-bold">{formatCurrency(pointBalance)}원</span>
       </div>
 
       {/* 탭 */}

--- a/src/app/[locale]/my/orders/[id]/page.tsx
+++ b/src/app/[locale]/my/orders/[id]/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { ORDER_STATUS_LABELS } from '@/constants/orderStatus';
 import { SkeletonBox } from '@/components/ui/Skeleton';
@@ -123,11 +123,11 @@ export default function OrderDetailPage() {
                       <p className="text-xs text-muted-foreground">{item.optionName}</p>
                     )}
                     <p className="text-xs text-muted-foreground">
-                      {formatPrice(item.price)} × {item.quantity}개
+                      {formatCurrency(item.price)} × {item.quantity}개
                     </p>
                   </div>
                   <p className="font-medium shrink-0">
-                    {formatPrice(Number(item.price) * item.quantity)}
+                    {formatCurrency(Number(item.price) * item.quantity)}
                   </p>
                 </div>
               </li>
@@ -141,24 +141,24 @@ export default function OrderDetailPage() {
           <dl className="space-y-2 text-sm">
             <div className="flex justify-between">
               <dt className="text-muted-foreground">상품 금액</dt>
-              <dd>{formatPrice(order.totalAmount)}</dd>
+              <dd>{formatCurrency(order.totalAmount)}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-muted-foreground">할인 금액</dt>
-              <dd>-{formatPrice(order.discountAmount)}</dd>
+              <dd>-{formatCurrency(order.discountAmount)}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-muted-foreground">배송비</dt>
               <dd>
                 {Number(order.shippingFee) === 0
                   ? '무료'
-                  : formatPrice(order.shippingFee)}
+                  : formatCurrency(order.shippingFee)}
               </dd>
             </div>
             <div className="flex justify-between border-t pt-2 font-bold">
               <dt>합계</dt>
               <dd>
-                {formatPrice(
+                {formatCurrency(
                   Number(order.totalAmount) -
                   Number(order.discountAmount) +
                   Number(order.shippingFee)

--- a/src/app/[locale]/my/orders/page.tsx
+++ b/src/app/[locale]/my/orders/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import StatusBadge from '@/components/common/StatusBadge';
 import { SkeletonBox } from '@/components/ui/Skeleton';
@@ -95,7 +95,7 @@ export default function OrdersPage() {
                       </p>
                     </div>
                     <div className="text-right shrink-0">
-                      <p className="font-semibold">{formatPrice(order.totalAmount)}</p>
+                      <p className="font-semibold">{formatCurrency(order.totalAmount)}</p>
                     </div>
                   </div>
                 </Link>

--- a/src/app/[locale]/order/complete/page.tsx
+++ b/src/app/[locale]/order/complete/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import { CheckCircle } from 'lucide-react';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 
 function OrderCompleteContent() {
   const router = useRouter();
@@ -85,7 +85,7 @@ function OrderCompleteContent() {
                 <p className="text-muted-foreground">수량 {item.quantity}개</p>
               </div>
               <p className="font-medium shrink-0">
-                {formatPrice(item.price * item.quantity)}
+                {formatCurrency(item.price * item.quantity)}
               </p>
             </li>
           ))}
@@ -94,19 +94,19 @@ function OrderCompleteContent() {
         <div className="border-t pt-4 space-y-2 text-sm">
           <div className="flex justify-between">
             <span className="text-muted-foreground">배송비</span>
-            <span>{order.shippingFee === 0 ? '무료' : formatPrice(order.shippingFee)}</span>
+            <span>{order.shippingFee === 0 ? '무료' : formatCurrency(order.shippingFee)}</span>
           </div>
           {order.discountAmount > 0 && (
             <div className="flex justify-between">
               <span className="text-muted-foreground">할인</span>
-              <span className="text-destructive">-{formatPrice(order.discountAmount)}</span>
+              <span className="text-destructive">-{formatCurrency(order.discountAmount)}</span>
             </div>
           )}
         </div>
 
         <div className="border-t pt-4 flex justify-between font-bold">
           <span>결제 금액</span>
-          <span>{formatPrice(order.totalAmount)}</span>
+          <span>{formatCurrency(order.totalAmount)}</span>
         </div>
       </section>
 

--- a/src/components/__tests__/CartItemRow.test.tsx
+++ b/src/components/__tests__/CartItemRow.test.tsx
@@ -45,9 +45,9 @@ describe('CartItemRow', () => {
       />,
     );
     expect(screen.getByText('테스트 상품')).toBeInTheDocument();
-    expect(screen.getByText('15,000원')).toBeInTheDocument();
+    expect(screen.getByText('₩15,000')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('30,000원')).toBeInTheDocument();
+    expect(screen.getByText('₩30,000')).toBeInTheDocument();
   });
 
   it('renders option text when option is provided', () => {

--- a/src/components/__tests__/CartPage.test.tsx
+++ b/src/components/__tests__/CartPage.test.tsx
@@ -134,7 +134,7 @@ describe('CartPage', () => {
     const item1Checkbox = checkboxes[1];
     await user.click(item1Checkbox);
 
-    expect(screen.getByText('20,000원', { selector: 'span' })).toBeInTheDocument();
+    expect(screen.getByText('₩20,000', { selector: 'span' })).toBeInTheDocument();
   });
 
   it('shows toast warning when order button clicked with no selection', async () => {

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -71,14 +71,14 @@ describe('ProductCard', () => {
 
   it('shows price only when no sale price', () => {
     render(<ProductCard {...baseProps} />);
-    expect(screen.getByText('29,000원')).toBeInTheDocument();
+    expect(screen.getByText('₩29,000')).toBeInTheDocument();
     expect(screen.queryByText(/%/)).not.toBeInTheDocument();
   });
 
   it('shows sale price, original price strikethrough, and discount percentage', () => {
     render(<ProductCard {...baseProps} salePrice={24000} />);
-    expect(screen.getByText('24,000원')).toBeInTheDocument();
-    expect(screen.getByText('29,000원')).toBeInTheDocument();
+    expect(screen.getByText('₩24,000')).toBeInTheDocument();
+    expect(screen.getByText('₩29,000')).toBeInTheDocument();
     expect(screen.getByText('17%')).toBeInTheDocument();
   });
 

--- a/src/components/admin/AdminOrdersTable.tsx
+++ b/src/components/admin/AdminOrdersTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { AdminOrder } from '@/lib/api';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 import { OrderStatusSelect } from './OrderStatusSelect';
 
 const STATUS_COLORS: Record<string, string> = {
@@ -66,7 +66,7 @@ export function AdminOrdersTable({ orders, onStatusChange, onShippingRegister }:
                     : `${order.items[0].productName} 외 ${order.items.length - 1}건`
                   : '-'}
               </td>
-              <td className="px-4 py-3 text-right">{formatPrice(order.totalAmount)}</td>
+              <td className="px-4 py-3 text-right">{formatCurrency(order.totalAmount)}</td>
               <td className="px-4 py-3">
                 <span className={`rounded-full px-2 py-0.5 text-xs ${STATUS_COLORS[order.status] ?? 'bg-secondary'}`}>
                   {STATUS_LABELS[order.status] ?? order.status}

--- a/src/components/cart/CartItemRow.tsx
+++ b/src/components/cart/CartItemRow.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { Trash2 } from 'lucide-react';
 import { CartItem } from '@/lib/api';
 import { cn } from '@/components/ui/utils';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 import QuantitySelector from '@/components/products/QuantitySelector';
 
 interface CartItemRowProps {
@@ -57,7 +57,7 @@ export default function CartItemRow({
             {item.option.name}: {item.option.value}
           </p>
         )}
-        <p className="text-sm font-semibold">{formatPrice(item.unitPrice)}</p>
+        <p className="text-sm font-semibold">{formatCurrency(item.unitPrice)}</p>
       </div>
 
       <div className="flex flex-col items-end gap-2 shrink-0">
@@ -68,7 +68,7 @@ export default function CartItemRow({
           onDecrease={() => onQuantityChange(item.id, item.quantity - 1)}
         />
 
-        <p className="text-sm font-bold">{formatPrice(item.subtotal)}</p>
+        <p className="text-sm font-bold">{formatCurrency(item.subtotal)}</p>
 
         <button
           type="button"

--- a/src/components/checkout/CouponSelector.tsx
+++ b/src/components/checkout/CouponSelector.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { couponsApi } from '@/lib/api';
 import type { CouponItem, CalculateDiscountResponse } from '@/lib/api';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 import { cn } from '@/components/ui/utils';
 
 interface CouponSelectorProps {
@@ -74,8 +74,8 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
           <option key={c.id} value={c.id}>
             {c.name} (
             {c.type === 'percentage'
-              ? `${c.value}% 할인${c.maxDiscount ? ` / 최대 ${formatPrice(c.maxDiscount)}원` : ''}`
-              : `${formatPrice(c.value)}원 할인`}
+              ? `${c.value}% 할인${c.maxDiscount ? ` / 최대 ${formatCurrency(c.maxDiscount)}원` : ''}`
+              : `${formatCurrency(c.value)}원 할인`}
             )
           </option>
         ))}
@@ -83,7 +83,7 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
 
       {selected && (
         <p className="text-xs text-muted-foreground">
-          최소 주문금액: {formatPrice(selected.minOrderAmount)}원 &middot; 만료:{' '}
+          최소 주문금액: {formatCurrency(selected.minOrderAmount)}원 &middot; 만료:{' '}
           {new Date(selected.expiresAt).toLocaleDateString('ko-KR')}
         </p>
       )}

--- a/src/components/checkout/PointInput.tsx
+++ b/src/components/checkout/PointInput.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { couponsApi } from '@/lib/api';
-import { formatPrice } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 import { cn } from '@/components/ui/utils';
 
 interface PointInputProps {
@@ -45,7 +45,7 @@ export default function PointInput({ onPointsChange }: PointInputProps) {
           적립금 사용
         </label>
         <span className="text-xs text-muted-foreground">
-          보유 적립금: <strong>{formatPrice(balance)}원</strong>
+          보유 적립금: <strong>{formatCurrency(balance)}원</strong>
         </span>
       </div>
       <div className="flex gap-2">

--- a/src/components/common/PriceDisplay.tsx
+++ b/src/components/common/PriceDisplay.tsx
@@ -1,4 +1,5 @@
-import { formatPrice, calcDiscount } from '@/utils/price';
+import { calcDiscount } from '@/utils/price';
+import { formatCurrency } from '@/utils/currency';
 
 interface PriceDisplayProps {
   price: number;
@@ -17,15 +18,15 @@ export default function PriceDisplay({ price, salePrice, size = 'sm' }: PriceDis
         <span className={`${discountClass} text-destructive`}>
           {calcDiscount(price, salePrice)}%
         </span>
-        <span className={`${priceClass} text-foreground`}>{formatPrice(salePrice)}</span>
+        <span className={`${priceClass} text-foreground`}>{formatCurrency(salePrice)}</span>
         <span className={`${originalClass} text-muted-foreground line-through`}>
-          {formatPrice(price)}
+          {formatCurrency(price)}
         </span>
       </div>
     );
   }
 
   return (
-    <span className={`${priceClass} text-foreground`}>{formatPrice(price)}</span>
+    <span className={`${priceClass} text-foreground`}>{formatCurrency(price)}</span>
   );
 }

--- a/src/utils/__tests__/currency.test.ts
+++ b/src/utils/__tests__/currency.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { convertPrice, formatCurrency } from '@/utils/currency';
+
+describe('convertPrice', () => {
+  it('KRW는 그대로 반환', () => {
+    expect(convertPrice(15000, 'KRW')).toBe(15000);
+  });
+
+  it('USD 변환: 15000 KRW / 1350 = 11.111...', () => {
+    expect(convertPrice(15000, 'USD')).toBeCloseTo(11.111, 2);
+  });
+
+  it('JPY 변환: 15000 KRW / 9 = 1666.666...', () => {
+    expect(convertPrice(15000, 'JPY')).toBeCloseTo(1666.67, 1);
+  });
+
+  it('CNY 변환: 15000 KRW / 190 = 78.947...', () => {
+    expect(convertPrice(15000, 'CNY')).toBeCloseTo(78.947, 2);
+  });
+});
+
+describe('formatCurrency', () => {
+  it('ko 로케일: ₩15,000', () => {
+    expect(formatCurrency(15000, 'ko')).toBe('₩15,000');
+  });
+
+  it('en 로케일: $11.11 (KRW 1,350 기준)', () => {
+    expect(formatCurrency(15000, 'en')).toBe('$11.11');
+  });
+
+  it('ja 로케일: ￥1,667 (ja-JP Intl 출력)', () => {
+    expect(formatCurrency(15000, 'ja')).toBe('￥1,667');
+  });
+
+  it('zh 로케일: ¥78.95', () => {
+    expect(formatCurrency(15000, 'zh')).toBe('¥78.95');
+  });
+
+  it('기본 로케일은 ko', () => {
+    expect(formatCurrency(15000)).toBe('₩15,000');
+  });
+
+  it('0원은 ₩0으로 포맷', () => {
+    expect(formatCurrency(0, 'ko')).toBe('₩0');
+  });
+});
+
+describe('NEXT_PUBLIC_EXCHANGE_RATES 환경변수', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('환경변수로 환율 오버라이드 가능', () => {
+    vi.stubEnv('NEXT_PUBLIC_EXCHANGE_RATES', JSON.stringify({ USD: 1000, JPY: 10, CNY: 200 }));
+    // 환율 오버라이드: 15000 / 1000 = 15 USD
+    expect(convertPrice(15000, 'USD')).toBeCloseTo(15, 2);
+  });
+
+  it('잘못된 환경변수는 기본값 사용', () => {
+    vi.stubEnv('NEXT_PUBLIC_EXCHANGE_RATES', 'invalid-json');
+    expect(convertPrice(15000, 'USD')).toBeCloseTo(11.111, 2);
+  });
+});

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,0 +1,72 @@
+export type Currency = 'KRW' | 'USD' | 'JPY' | 'CNY';
+export type Locale = 'ko' | 'en' | 'ja' | 'zh';
+
+/** KRW 기준 환율 (1 단위 외화 = N KRW) */
+const DEFAULT_RATES: Record<Exclude<Currency, 'KRW'>, number> = {
+  USD: 1350,
+  JPY: 9,
+  CNY: 190,
+};
+
+function getExchangeRates(): Record<Exclude<Currency, 'KRW'>, number> {
+  const envRaw =
+    typeof process !== 'undefined'
+      ? process.env.NEXT_PUBLIC_EXCHANGE_RATES
+      : undefined;
+
+  if (!envRaw) return DEFAULT_RATES;
+
+  try {
+    const parsed = JSON.parse(envRaw) as Partial<Record<Exclude<Currency, 'KRW'>, number>>;
+    return {
+      USD: parsed.USD ?? DEFAULT_RATES.USD,
+      JPY: parsed.JPY ?? DEFAULT_RATES.JPY,
+      CNY: parsed.CNY ?? DEFAULT_RATES.CNY,
+    };
+  } catch {
+    return DEFAULT_RATES;
+  }
+}
+
+const LOCALE_TO_CURRENCY: Record<Locale, Currency> = {
+  ko: 'KRW',
+  en: 'USD',
+  ja: 'JPY',
+  zh: 'CNY',
+};
+
+const CURRENCY_FORMAT: Record<Currency, { locale: string; currency: string }> = {
+  KRW: { locale: 'ko-KR', currency: 'KRW' },
+  USD: { locale: 'en-US', currency: 'USD' },
+  JPY: { locale: 'ja-JP', currency: 'JPY' },
+  CNY: { locale: 'zh-CN', currency: 'CNY' },
+};
+
+/**
+ * KRW 금액을 대상 통화로 변환합니다.
+ * @param amount KRW 기준 금액
+ * @param to 대상 통화
+ */
+export function convertPrice(amount: number, to: Currency): number {
+  if (to === 'KRW') return amount;
+  const rates = getExchangeRates();
+  return amount / rates[to];
+}
+
+/**
+ * KRW 금액을 로케일에 맞는 통화 형식으로 포맷합니다.
+ * @param amount KRW 기준 금액
+ * @param locale 표시 로케일
+ */
+export function formatCurrency(amount: number, locale: Locale = 'ko'): string {
+  const currency = LOCALE_TO_CURRENCY[locale];
+  const converted = convertPrice(amount, currency);
+  const { locale: intlLocale, currency: intlCurrency } = CURRENCY_FORMAT[currency];
+
+  return new Intl.NumberFormat(intlLocale, {
+    style: 'currency',
+    currency: intlCurrency,
+    maximumFractionDigits: currency === 'KRW' || currency === 'JPY' ? 0 : 2,
+    minimumFractionDigits: currency === 'KRW' || currency === 'JPY' ? 0 : 2,
+  }).format(converted);
+}


### PR DESCRIPTION
## Summary

- `src/utils/currency.ts` 생성: `Currency`/`Locale` 타입, `convertPrice`, `formatCurrency` 함수 구현
- 기본 환율: 1 USD = 1,350 KRW, 1 JPY = 9 KRW, 1 CNY = 190 KRW
- `NEXT_PUBLIC_EXCHANGE_RATES` 환경변수로 정적 환율 오버라이드 지원
- Cart, Checkout, OrderComplete, MyOrders, Coupons, Admin 등 13개 파일의 `formatPrice` → `formatCurrency` 교체
- `src/utils/__tests__/currency.test.ts` 테스트 추가 (acceptance criteria 포함)

## Acceptance Criteria 검증

| 호출 | 결과 |
|---|---|
| `formatCurrency(15000, 'ko')` | `₩15,000` |
| `formatCurrency(15000, 'en')` | `$11.11` |
| `formatCurrency(15000, 'ja')` | `￥1,667` |
| `formatCurrency(15000, 'zh')` | `¥78.95` |

## Test plan

- [x] `npm run test:run` — 285/285 passed
- [x] `npm run build` — 빌드 성공
- [x] currency 유틸 단위 테스트 통과
- [x] 기존 CartItemRow, CartPage, ProductCard 테스트 업데이트 및 통과

Closes #58