### PR TITLE
feat: #55 UI 문자열 다국어 번역 파일 구축 (en/ja/zh)

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -3,9 +3,9 @@
     "home": "Home",
     "products": "Products",
     "cart": "Cart",
-    "login": "Login",
-    "logout": "Logout",
-    "register": "Register",
+    "login": "Log In",
+    "logout": "Log Out",
+    "register": "Sign Up",
     "search": "Search",
     "loading": "Loading...",
     "error": "An error occurred",
@@ -14,29 +14,604 @@
     "cancel": "Cancel",
     "save": "Save",
     "delete": "Delete",
-    "edit": "Edit"
+    "edit": "Edit",
+    "add": "Add",
+    "close": "Close",
+    "all": "All",
+    "apply": "Apply",
+    "reset": "Reset",
+    "previous": "Previous",
+    "next": "Next",
+    "submit": "Submit",
+    "saving": "Saving...",
+    "deleting": "Deleting...",
+    "loading2": "Loading...",
+    "noResults": "No results found",
+    "required": "Required",
+    "optional": "Optional",
+    "or": "or",
+    "free": "Free",
+    "won": "KRW",
+    "items": "item(s)",
+    "cases": "case(s)",
+    "persons": "person(s)",
+    "viewAll": "View All",
+    "continueShopping": "Continue Shopping"
   },
   "navigation": {
-    "skipToContent": "Skip to main content"
+    "skipToContent": "Skip to main content",
+    "mainMenu": "Main Menu",
+    "mobileMenu": "Mobile Menu",
+    "mobileBottomNav": "Mobile Bottom Navigation",
+    "openMenu": "Open Menu",
+    "closeMenu": "Close Menu",
+    "collection": "Collection",
+    "archive": "Archive",
+    "journal": "Journal",
+    "myPage": "My Page",
+    "home": "Home"
+  },
+  "header": {
+    "searchPlaceholder": "Search products...",
+    "searchLabel": "Search products",
+    "searchButton": "Search",
+    "cartLabel": "Cart",
+    "myPage": "My Page",
+    "logout": "Log Out",
+    "login": "Log In",
+    "goBack": "Back",
+    "goHome": "Home"
+  },
+  "footer": {
+    "customerService": "Customer Service",
+    "company": "Company",
+    "shop": "Shop",
+    "okhwadang": "Okhwadang",
+    "tagline": "Yixing Teapots · Pu-erh Tea · Tea Ware",
+    "specialty": "Specialty Store",
+    "support": "Customer Support",
+    "faq": "FAQ",
+    "shipping": "Shipping Info",
+    "returns": "Returns & Exchanges",
+    "terms": "Terms of Service",
+    "privacy": "Privacy Policy",
+    "allProducts": "All Products",
+    "collection": "Collection",
+    "archive": "Archive",
+    "journal": "Journal",
+    "copyright": "© {year} Okhwadang. All rights reserved."
+  },
+  "auth": {
+    "email": "Email",
+    "emailPlaceholder": "you@example.com",
+    "password": "Password",
+    "passwordPlaceholder": "••••••••",
+    "passwordHint": "8+ characters including letters, numbers, and symbols",
+    "passwordConfirm": "Confirm Password",
+    "passwordConfirmPlaceholder": "Re-enter your password",
+    "name": "Name",
+    "namePlaceholder": "Your Name",
+    "forgotPassword": "Forgot Password",
+    "loginTitle": "Log In",
+    "registerTitle": "Sign Up",
+    "loginSubmit": "Log In",
+    "loginSubmitting": "Logging in...",
+    "registerSubmit": "Sign Up",
+    "registerSubmitting": "Creating account...",
+    "kakaoLogin": "Continue with Kakao",
+    "googleLogin": "Continue with Google",
+    "noAccount": "Don't have an account?",
+    "hasAccount": "Already have an account?",
+    "loginError": "Login failed.",
+    "registerError": "Sign up failed.",
+    "dividerOr": "or",
+    "validation": {
+      "emailInvalid": "Please enter a valid email address.",
+      "passwordTooShort": "Password must be at least 8 characters.",
+      "passwordRequirements": "Password must contain both letters and numbers.",
+      "passwordNeedsSpecial": "Password must contain at least one special character.",
+      "nameTooShort": "Name must be between 1 and 100 characters.",
+      "passwordMismatch": "Passwords do not match."
+    }
   },
   "product": {
     "addToCart": "Add to Cart",
     "buyNow": "Buy Now",
     "outOfStock": "Out of Stock",
+    "outOfStockMessage": "This item is currently out of stock.",
     "price": "Price",
-    "quantity": "Quantity"
+    "salePrice": "Sale Price",
+    "quantity": "Quantity",
+    "option": "Option",
+    "selectOption": "Please select an option.",
+    "addToCartSuccess": "Added to cart.",
+    "addToCartError": "Failed to add to cart.",
+    "buyNowError": "An error occurred during checkout.",
+    "productList": "Product List",
+    "featuredProducts": "Featured Products",
+    "searchResults": "Results for \"{query}\"",
+    "noProducts": "No products found",
+    "noProductsDescription": "No products are listed yet.",
+    "noSearchResults": "No results found for \"{query}\".",
+    "tabs": {
+      "details": "Details",
+      "reviews": "Reviews",
+      "inquiry": "Inquiry",
+      "comingSoon": "Coming soon."
+    },
+    "sort": {
+      "label": "Sort by",
+      "latest": "Newest",
+      "priceAsc": "Price: Low to High",
+      "priceDesc": "Price: High to Low",
+      "popular": "Most Popular"
+    },
+    "filter": {
+      "label": "Filter",
+      "openFilter": "Open Filter",
+      "closeFilter": "Close Filter",
+      "resetFilter": "Reset Filter",
+      "filterLabel": "Product Filter",
+      "priceRange": "Price Range",
+      "priceMin": "Min",
+      "priceMax": "Max",
+      "clayType": "Clay Type (泥料)",
+      "teapotShape": "Shape",
+      "category": "Category"
+    },
+    "status": {
+      "draft": "Draft",
+      "active": "On Sale",
+      "soldout": "Sold Out",
+      "hidden": "Hidden"
+    }
+  },
+  "cart": {
+    "title": "Cart",
+    "empty": "Your cart is empty",
+    "emptyDescription": "Add items you love to your cart.",
+    "requireLogin": "Login required",
+    "requireLoginDescription": "Please log in to use the cart.",
+    "selectAll": "Select All",
+    "orderSummary": "Order Summary",
+    "selectedItems": "Selected Items",
+    "productAmount": "Subtotal",
+    "shippingFee": "Shipping",
+    "total": "Total",
+    "orderSelected": "Order Selected Items",
+    "selectItemsToOrder": "Please select items to order.",
+    "noImage": "No image",
+    "removeItem": "Remove {name}"
+  },
+  "checkout": {
+    "title": "Order / Payment",
+    "shippingInfo": "Shipping Information",
+    "loadingAddresses": "Loading addresses...",
+    "noSavedAddress": "No saved addresses.",
+    "addAddress": "Add Address",
+    "manualEntry": "Enter Manually",
+    "recipientName": "Recipient Name",
+    "phone": "Phone Number",
+    "zipcode": "ZIP Code",
+    "address": "Address",
+    "addressDetail": "Address Detail",
+    "addressDetailPlaceholder": "Apartment, suite, etc.",
+    "shippingMemo": "Delivery Notes",
+    "shippingMemoPlaceholder": "Any special delivery instructions?",
+    "paymentMethod": "Payment Method",
+    "tossPayment": "Toss Payments (Card)",
+    "mockPayment": "Test Payment (Mock)",
+    "couponPoints": "Coupons / Points",
+    "couponPointsComingSoon": "Coupon and points support coming soon.",
+    "orderItems": "Order Items",
+    "productAmount": "Subtotal",
+    "shippingFee": "Shipping",
+    "total": "Total",
+    "pay": "Pay Now",
+    "paymentSuccess": "Payment completed successfully.",
+    "paymentError": "An error occurred during payment.",
+    "loadAddressError": "Failed to load saved addresses.",
+    "orderName": "Order {orderNumber}",
+    "steps": {
+      "idle": "Pay Now",
+      "creating_order": "Creating order...",
+      "preparing_payment": "Preparing payment...",
+      "confirming_payment": "Confirming payment...",
+      "success": "Done"
+    },
+    "validation": {
+      "recipientNameTooShort": "Please enter at least 2 characters for the name.",
+      "phoneInvalid": "Please enter a valid phone number. (e.g. 010-1234-5678)",
+      "zipcodeInvalid": "ZIP code must be 5 digits.",
+      "addressRequired": "Please enter your address."
+    }
   },
   "order": {
     "orderHistory": "Order History",
     "orderNumber": "Order Number",
     "orderDate": "Order Date",
-    "orderStatus": "Order Status"
+    "orderStatus": "Order Status",
+    "noOrders": "No orders yet.",
+    "noOrdersAction": "Continue Shopping",
+    "recentOrders": "Recent Orders",
+    "recentOrdersCount": "Last 5 Orders",
+    "orderStatusSummary": "Order Status Overview",
+    "compareYesterday": "vs. Yesterday",
+    "status": {
+      "pending": "Pending",
+      "paid": "Paid",
+      "preparing": "Preparing",
+      "shipped": "Shipped",
+      "delivered": "Delivered",
+      "cancelled": "Cancelled",
+      "refunded": "Refunded",
+      "refund_requested": "Refund Requested"
+    }
   },
-  "auth": {
+  "orderComplete": {
+    "loading": "Processing your order..."
+  },
+  "myPage": {
+    "title": "My Page",
+    "editProfile": "Edit Profile",
+    "orderHistory": "Order History",
+    "wishlist": "Wishlist",
+    "addressManagement": "Address Book",
+    "coupons": "Coupons",
+    "recentlyViewed": "Recently Viewed",
+    "noRecentOrders": "No orders yet.",
+    "myOrders": "My Orders",
+    "previousPage": "Previous",
+    "nextPage": "Next"
+  },
+  "profile": {
+    "title": "Edit Profile",
     "email": "Email",
-    "password": "Password",
-    "loginTitle": "Login",
-    "registerTitle": "Register",
-    "forgotPassword": "Forgot Password"
+    "emailReadOnly": "Email cannot be changed.",
+    "name": "Name",
+    "phone": "Phone Number",
+    "save": "Save Changes",
+    "saving": "Saving...",
+    "updateSuccess": "Profile updated successfully.",
+    "updateError": "An error occurred while updating.",
+    "validation": {
+      "nameRequired": "Please enter your name.",
+      "phoneInvalid": "Please enter a valid phone number. (e.g. 010-1234-5678)"
+    }
+  },
+  "address": {
+    "title": "Address Book",
+    "noSavedAddresses": "No saved addresses.",
+    "addAddress": "+ Add Address",
+    "defaultBadge": "Default",
+    "setDefault": "Set as Default",
+    "edit": "Edit",
+    "delete": "Delete",
+    "newAddress": "New Address",
+    "editAddress": "Edit Address",
+    "recipientName": "Recipient",
+    "phone": "Phone Number",
+    "zipcode": "ZIP Code",
+    "address": "Address",
+    "addressDetail": "Address Detail",
+    "label": "Label",
+    "labelPlaceholder": "Home, Office, etc.",
+    "setAsDefault": "Set as default address",
+    "save": "Save",
+    "saving": "Saving...",
+    "cancel": "Cancel",
+    "addSuccess": "Address added successfully.",
+    "updateSuccess": "Address updated successfully.",
+    "deleteSuccess": "Address deleted successfully.",
+    "setDefaultSuccess": "Default address updated.",
+    "deleteConfirm": "Are you sure you want to delete this address?",
+    "validation": {
+      "recipientNameRequired": "Please enter the recipient's name.",
+      "phoneInvalid": "Please enter a valid phone number. (e.g. 010-1234-5678)",
+      "zipcodeInvalid": "ZIP code must be 5 digits.",
+      "addressRequired": "Please enter your address."
+    }
+  },
+  "review": {
+    "title": "Write a Review",
+    "rating": "Rating",
+    "contentPlaceholder": "Share your thoughts about this product.",
+    "attachPhoto": "Attach Photo",
+    "uploading": "Uploading...",
+    "deleteImage": "Delete Image",
+    "attachedImage": "Attached image {index}",
+    "submit": "Submit Review",
+    "submitting": "Submitting...",
+    "cancel": "Cancel",
+    "noReviews": "No reviews yet.",
+    "sortRecent": "Newest",
+    "sortRatingHigh": "Highest Rated",
+    "sortRatingLow": "Lowest Rated",
+    "uploadSuccess": "Image uploaded successfully",
+    "uploadError": "Failed to upload image.",
+    "maxImagesError": "You can upload up to 5 images.",
+    "ratingRequired": "Please select a rating.",
+    "submitSuccess": "Review submitted successfully.",
+    "submitError": "Failed to submit review."
+  },
+  "shipping": {
+    "title": "Register Tracking Number",
+    "orderNumber": "Order: {orderNumber}",
+    "carrier": "Carrier",
+    "trackingNumber": "Tracking Number",
+    "trackingNumberPlaceholder": "Enter tracking number",
+    "cancel": "Cancel",
+    "submit": "Register",
+    "submitting": "Registering...",
+    "submitSuccess": "Tracking number registered successfully.",
+    "submitError": "Failed to register tracking number.",
+    "trackingNumberRequired": "Please enter a tracking number.",
+    "carriers": {
+      "cj": "CJ Logistics",
+      "hanjin": "Hanjin Express",
+      "lotte": "Lotte Logistics",
+      "mock": "Test (Mock)"
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "Dashboard",
+      "todayRevenue": "Today's Revenue",
+      "todayOrders": "Today's Orders",
+      "newMembers": "New Members",
+      "productViews": "Product Views",
+      "compareYesterday": "vs. Yesterday",
+      "orderStatusSummary": "Order Status Overview",
+      "recentOrders": "Last 5 Orders",
+      "noOrders": "No orders",
+      "chartLoading": "Loading chart...",
+      "period": {
+        "today": "Today",
+        "7d": "7 Days",
+        "30d": "30 Days",
+        "90d": "90 Days",
+        "custom": "Custom"
+      },
+      "columns": {
+        "orderNumber": "Order #",
+        "customerName": "Customer",
+        "paymentAmount": "Amount",
+        "status": "Status",
+        "orderDate": "Order Date"
+      },
+      "orderStatus": {
+        "pending": "Pending",
+        "paid": "Paid",
+        "preparing": "Preparing",
+        "shipped": "Shipped",
+        "delivered": "Delivered",
+        "cancelled": "Cancelled",
+        "refunded": "Refunded"
+      }
+    },
+    "orders": {
+      "title": "Order Management",
+      "searchPlaceholder": "Search by order #, recipient, or email",
+      "search": "Search",
+      "loading": "Loading...",
+      "noOrders": "No orders found.",
+      "loadError": "Failed to load orders.",
+      "columns": {
+        "orderNumber": "Order #",
+        "orderer": "Customer",
+        "product": "Product",
+        "amount": "Amount",
+        "status": "Status",
+        "orderDate": "Order Date",
+        "action": "Action"
+      },
+      "trackingSlip": "Tracking",
+      "statusFilter": {
+        "all": "All",
+        "pending": "Pending",
+        "paid": "Paid",
+        "preparing": "Preparing",
+        "shipped": "Shipped",
+        "delivered": "Delivered",
+        "cancelled": "Cancelled",
+        "refunded": "Refunded"
+      },
+      "status": {
+        "pending": "Pending",
+        "paid": "Paid",
+        "preparing": "Preparing",
+        "shipped": "Shipped",
+        "delivered": "Delivered",
+        "cancelled": "Cancelled",
+        "refunded": "Refunded"
+      }
+    },
+    "products": {
+      "title": "Product Management",
+      "addProduct": "+ Add Product",
+      "loading": "Loading...",
+      "noProducts": "No products found.",
+      "loadError": "Failed to load products.",
+      "statusChangeError": "Failed to change status.",
+      "deleteError": "Failed to delete.",
+      "deleteConfirm": "Are you sure you want to delete \"{name}\"?",
+      "deleteSuccess": "Product deleted successfully.",
+      "columns": {
+        "id": "ID",
+        "name": "Product Name",
+        "price": "Price",
+        "status": "Status",
+        "featured": "Featured",
+        "action": "Action"
+      },
+      "actions": {
+        "hide": "Hide",
+        "show": "Show",
+        "edit": "Edit",
+        "delete": "Delete"
+      },
+      "statusFilter": {
+        "all": "All",
+        "active": "On Sale",
+        "draft": "Draft",
+        "soldout": "Sold Out",
+        "hidden": "Hidden"
+      },
+      "status": {
+        "draft": "Draft",
+        "active": "On Sale",
+        "soldout": "Sold Out",
+        "hidden": "Hidden"
+      }
+    },
+    "productForm": {
+      "createTitle": "Add Product",
+      "editTitle": "Edit Product",
+      "imageSection": "Product Images",
+      "basicInfoSection": "Basic Information",
+      "pricingSection": "Pricing / Stock",
+      "displaySection": "Display Settings",
+      "optionsSection": "Options",
+      "productName": "Product Name *",
+      "productNamePlaceholder": "Enter product name",
+      "slug": "Slug *",
+      "shortDescription": "Short Description",
+      "shortDescriptionPlaceholder": "Brief product summary",
+      "description": "Description",
+      "descriptionPlaceholder": "Full product description",
+      "salePrice": "Sale Price (KRW) *",
+      "discountPrice": "Discount Price (KRW)",
+      "stock": "Stock",
+      "sku": "SKU",
+      "skuPlaceholder": "Inventory management code",
+      "status": "Status",
+      "featuredProduct": "Mark as featured product",
+      "cancel": "Cancel",
+      "create": "Add Product",
+      "update": "Save Changes",
+      "saving": "Saving...",
+      "createSuccess": "Product added successfully.",
+      "updateSuccess": "Product updated successfully.",
+      "saveError": "Failed to save.",
+      "validation": {
+        "nameRequired": "Please enter a product name.",
+        "slugRequired": "Please enter a slug.",
+        "priceRequired": "Please enter a valid price."
+      }
+    },
+    "members": {
+      "title": "Member Management",
+      "searchPlaceholder": "Search by email or name",
+      "search": "Search",
+      "loading": "Loading...",
+      "noMembers": "No members found.",
+      "loadError": "Failed to load members.",
+      "statusLabel": "Status:",
+      "cannotChange": "Cannot change",
+      "columns": {
+        "id": "ID",
+        "email": "Email",
+        "name": "Name",
+        "role": "Role",
+        "status": "Status",
+        "joinDate": "Joined",
+        "changeRole": "Change Role"
+      },
+      "roles": {
+        "user": "Member",
+        "admin": "Admin",
+        "super_admin": "Super Admin"
+      },
+      "memberStatus": {
+        "active": "Active",
+        "inactive": "Inactive"
+      },
+      "roleFilter": {
+        "all": "All",
+        "user": "Member",
+        "admin": "Admin",
+        "super_admin": "Super Admin"
+      },
+      "statusFilter": {
+        "all": "All",
+        "active": "Active",
+        "inactive": "Inactive"
+      }
+    },
+    "sidebar": {
+      "dashboard": "Dashboard",
+      "orders": "Orders",
+      "products": "Products",
+      "categories": "Categories",
+      "members": "Members",
+      "navigation": "Navigation",
+      "pages": "Pages",
+      "theme": "Theme",
+      "settings": "Settings",
+      "shopName": "Okhwadang",
+      "adminPanel": "Admin Panel",
+      "backToShop": "Back to Shop"
+    },
+    "navigation": {
+      "title": "Navigation Management"
+    },
+    "categories": {
+      "title": "Category Management"
+    }
+  },
+  "search": {
+    "title": "Search",
+    "placeholder": "Search for products...",
+    "recentSearches": "Recent Searches",
+    "clearAll": "Clear All",
+    "noResults": "No results found",
+    "noResultsDescription": "No results found for \"{query}\".",
+    "results": "Results for \"{query}\""
+  },
+  "wishlist": {
+    "add": "Add to Wishlist",
+    "remove": "Remove from Wishlist",
+    "addSuccess": "Added to wishlist.",
+    "removeSuccess": "Removed from wishlist.",
+    "loginRequired": "Please log in.",
+    "noItems": "Your wishlist is empty.",
+    "noItemsDescription": "Add items you love to your wishlist."
+  },
+  "recentlyViewed": {
+    "title": "Recently Viewed",
+    "noItems": "No recently viewed items."
+  },
+  "payment": {
+    "successTitle": "Payment Complete",
+    "failTitle": "Payment Failed",
+    "backToHome": "Back to Home",
+    "tryAgain": "Try Again"
+  },
+  "pages": {
+    "adminPages": "Page Management"
+  },
+  "errors": {
+    "generic": "An error occurred.",
+    "notFound": "Page not found.",
+    "loadFailed": "Failed to load data.",
+    "saveFailed": "Failed to save.",
+    "deleteFailed": "Failed to delete.",
+    "networkError": "A network error occurred.",
+    "serverError": "A server error occurred.",
+    "unauthorized": "Please log in.",
+    "forbidden": "You do not have permission to access this.",
+    "dashboardLoadError": "Failed to load dashboard data"
+  },
+  "clayTypes": {
+    "all": "All",
+    "zhuni": "Zhuni (朱泥)",
+    "duanni": "Duanni (段泥)",
+    "zini": "Zini (紫泥)",
+    "heini": "Heini (黑泥)",
+    "qingshuini": "Qingshuini (靑水泥)",
+    "luni": "Luni (綠泥)"
+  },
+  "teapotShapes": {
+    "all": "All"
   }
 }

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -14,29 +14,604 @@
     "cancel": "キャンセル",
     "save": "保存",
     "delete": "削除",
-    "edit": "編集"
+    "edit": "編集",
+    "add": "追加",
+    "close": "閉じる",
+    "all": "すべて",
+    "apply": "適用",
+    "reset": "リセット",
+    "previous": "前へ",
+    "next": "次へ",
+    "submit": "送信",
+    "saving": "保存中...",
+    "deleting": "削除中...",
+    "loading2": "読み込み中...",
+    "noResults": "結果がありません",
+    "required": "必須",
+    "optional": "任意",
+    "or": "または",
+    "free": "無料",
+    "won": "ウォン",
+    "items": "点",
+    "cases": "件",
+    "persons": "名",
+    "viewAll": "すべて見る",
+    "continueShopping": "お買い物を続ける"
   },
   "navigation": {
-    "skipToContent": "メインコンテンツへスキップ"
+    "skipToContent": "メインコンテンツへスキップ",
+    "mainMenu": "メインメニュー",
+    "mobileMenu": "モバイルメニュー",
+    "mobileBottomNav": "モバイル下部ナビゲーション",
+    "openMenu": "メニューを開く",
+    "closeMenu": "メニューを閉じる",
+    "collection": "コレクション",
+    "archive": "Archive",
+    "journal": "Journal",
+    "myPage": "マイページ",
+    "home": "ホーム"
+  },
+  "header": {
+    "searchPlaceholder": "商品を検索...",
+    "searchLabel": "商品を検索",
+    "searchButton": "検索",
+    "cartLabel": "カート",
+    "myPage": "マイページ",
+    "logout": "ログアウト",
+    "login": "ログイン",
+    "goBack": "戻る",
+    "goHome": "ホーム"
+  },
+  "footer": {
+    "customerService": "カスタマーサービス",
+    "company": "会社情報",
+    "shop": "ショップ",
+    "okhwadang": "玉花堂",
+    "tagline": "紫砂急須 · プーアル茶 · 茶器",
+    "specialty": "専門ショップ",
+    "support": "カスタマーサポート",
+    "faq": "よくある質問",
+    "shipping": "配送について",
+    "returns": "返品・交換",
+    "terms": "利用規約",
+    "privacy": "プライバシーポリシー",
+    "allProducts": "全商品",
+    "collection": "コレクション",
+    "archive": "Archive",
+    "journal": "Journal",
+    "copyright": "© {year} 玉花堂. All rights reserved."
+  },
+  "auth": {
+    "email": "メールアドレス",
+    "emailPlaceholder": "you@example.com",
+    "password": "パスワード",
+    "passwordPlaceholder": "••••••••",
+    "passwordHint": "英字・数字・記号を含む8文字以上",
+    "passwordConfirm": "パスワード確認",
+    "passwordConfirmPlaceholder": "パスワードを再入力",
+    "name": "お名前",
+    "namePlaceholder": "お名前",
+    "forgotPassword": "パスワードをお忘れの方",
+    "loginTitle": "ログイン",
+    "registerTitle": "会員登録",
+    "loginSubmit": "ログイン",
+    "loginSubmitting": "ログイン中...",
+    "registerSubmit": "会員登録",
+    "registerSubmitting": "登録中...",
+    "kakaoLogin": "Kakaoでログイン",
+    "googleLogin": "Googleでログイン",
+    "noAccount": "アカウントをお持ちでない方は",
+    "hasAccount": "すでにアカウントをお持ちの方は",
+    "loginError": "ログインに失敗しました。",
+    "registerError": "会員登録に失敗しました。",
+    "dividerOr": "または",
+    "validation": {
+      "emailInvalid": "正しいメールアドレスの形式で入力してください。",
+      "passwordTooShort": "パスワードは8文字以上で入力してください。",
+      "passwordRequirements": "パスワードには英字と数字の両方を含める必要があります。",
+      "passwordNeedsSpecial": "パスワードには特殊文字を含める必要があります。",
+      "nameTooShort": "お名前は1〜100文字で入力してください。",
+      "passwordMismatch": "パスワードが一致しません。"
+    }
   },
   "product": {
     "addToCart": "カートに追加",
     "buyNow": "今すぐ購入",
     "outOfStock": "在庫切れ",
+    "outOfStockMessage": "現在、在庫切れの商品です。",
     "price": "価格",
-    "quantity": "数量"
+    "salePrice": "セール価格",
+    "quantity": "数量",
+    "option": "オプション",
+    "selectOption": "オプションを選択してください。",
+    "addToCartSuccess": "カートに追加しました。",
+    "addToCartError": "カートへの追加に失敗しました。",
+    "buyNowError": "購入処理中にエラーが発生しました。",
+    "productList": "商品一覧",
+    "featuredProducts": "おすすめ商品",
+    "searchResults": "「{query}」の検索結果",
+    "noProducts": "商品がありません",
+    "noProductsDescription": "登録された商品がありません。",
+    "noSearchResults": "「{query}」に関する検索結果がありません。",
+    "tabs": {
+      "details": "詳細情報",
+      "reviews": "レビュー",
+      "inquiry": "お問い合わせ",
+      "comingSoon": "準備中です。"
+    },
+    "sort": {
+      "label": "並び替え",
+      "latest": "新着順",
+      "priceAsc": "価格が安い順",
+      "priceDesc": "価格が高い順",
+      "popular": "人気順"
+    },
+    "filter": {
+      "label": "フィルター",
+      "openFilter": "フィルターを開く",
+      "closeFilter": "フィルターを閉じる",
+      "resetFilter": "フィルターをリセット",
+      "filterLabel": "商品フィルター",
+      "priceRange": "価格帯",
+      "priceMin": "最低価格",
+      "priceMax": "最高価格",
+      "clayType": "泥料",
+      "teapotShape": "形状",
+      "category": "カテゴリー"
+    },
+    "status": {
+      "draft": "下書き",
+      "active": "販売中",
+      "soldout": "在庫切れ",
+      "hidden": "非表示"
+    }
+  },
+  "cart": {
+    "title": "カート",
+    "empty": "カートが空です",
+    "emptyDescription": "気に入った商品をカートに追加してください。",
+    "requireLogin": "ログインが必要です",
+    "requireLoginDescription": "カートをご利用になるにはログインしてください。",
+    "selectAll": "すべて選択",
+    "orderSummary": "注文概要",
+    "selectedItems": "選択商品",
+    "productAmount": "商品金額",
+    "shippingFee": "送料",
+    "total": "合計",
+    "orderSelected": "選択商品を注文する",
+    "selectItemsToOrder": "注文する商品を選択してください。",
+    "noImage": "画像なし",
+    "removeItem": "{name} を削除"
+  },
+  "checkout": {
+    "title": "注文 / お支払い",
+    "shippingInfo": "配送情報",
+    "loadingAddresses": "住所を読み込み中...",
+    "noSavedAddress": "保存された配送先がありません。",
+    "addAddress": "配送先を追加",
+    "manualEntry": "手動で入力",
+    "recipientName": "お受け取り人のお名前",
+    "phone": "電話番号",
+    "zipcode": "郵便番号",
+    "address": "住所",
+    "addressDetail": "住所詳細",
+    "addressDetailPlaceholder": "部屋番号など",
+    "shippingMemo": "配送メモ",
+    "shippingMemoPlaceholder": "配送時のご要望をご記入ください。",
+    "paymentMethod": "お支払い方法",
+    "tossPayment": "Tossペイメンツ（カード）",
+    "mockPayment": "テスト決済（Mock）",
+    "couponPoints": "クーポン / ポイント",
+    "couponPointsComingSoon": "クーポン・ポイントのご利用は近日対応予定です。",
+    "orderItems": "注文商品",
+    "productAmount": "商品金額",
+    "shippingFee": "送料",
+    "total": "合計",
+    "pay": "お支払いへ進む",
+    "paymentSuccess": "お支払いが完了しました。",
+    "paymentError": "お支払い中にエラーが発生しました。",
+    "loadAddressError": "保存された住所の読み込みに失敗しました。",
+    "orderName": "注文 {orderNumber}",
+    "steps": {
+      "idle": "お支払いへ進む",
+      "creating_order": "注文を作成中...",
+      "preparing_payment": "お支払いを準備中...",
+      "confirming_payment": "お支払いを確認中...",
+      "success": "完了"
+    },
+    "validation": {
+      "recipientNameTooShort": "お名前は2文字以上で入力してください。",
+      "phoneInvalid": "正しい電話番号の形式で入力してください。（例: 010-1234-5678）",
+      "zipcodeInvalid": "郵便番号は5桁の数字で入力してください。",
+      "addressRequired": "住所を入力してください。"
+    }
   },
   "order": {
     "orderHistory": "注文履歴",
     "orderNumber": "注文番号",
     "orderDate": "注文日",
-    "orderStatus": "注文状態"
+    "orderStatus": "注文状態",
+    "noOrders": "注文履歴がありません。",
+    "noOrdersAction": "お買い物を続ける",
+    "recentOrders": "最近の注文",
+    "recentOrdersCount": "直近5件の注文",
+    "orderStatusSummary": "注文状態別の状況",
+    "compareYesterday": "前日比",
+    "status": {
+      "pending": "お支払い待ち",
+      "paid": "お支払い完了",
+      "preparing": "商品準備中",
+      "shipped": "配送中",
+      "delivered": "配送完了",
+      "cancelled": "注文キャンセル",
+      "refunded": "返金完了",
+      "refund_requested": "返金申請中"
+    }
   },
-  "auth": {
+  "orderComplete": {
+    "loading": "注文完了処理中..."
+  },
+  "myPage": {
+    "title": "マイページ",
+    "editProfile": "会員情報の編集",
+    "orderHistory": "注文履歴",
+    "wishlist": "ウィッシュリスト",
+    "addressManagement": "配送先管理",
+    "coupons": "クーポン",
+    "recentlyViewed": "最近見た商品",
+    "noRecentOrders": "注文履歴がありません。",
+    "myOrders": "注文履歴",
+    "previousPage": "前へ",
+    "nextPage": "次へ"
+  },
+  "profile": {
+    "title": "会員情報の編集",
     "email": "メールアドレス",
-    "password": "パスワード",
-    "loginTitle": "ログイン",
-    "registerTitle": "会員登録",
-    "forgotPassword": "パスワードを忘れた方"
+    "emailReadOnly": "メールアドレスは変更できません。",
+    "name": "お名前",
+    "phone": "電話番号",
+    "save": "保存する",
+    "saving": "保存中...",
+    "updateSuccess": "会員情報を更新しました。",
+    "updateError": "更新中にエラーが発生しました。",
+    "validation": {
+      "nameRequired": "お名前を入力してください。",
+      "phoneInvalid": "正しい電話番号の形式で入力してください。（例: 010-1234-5678）"
+    }
+  },
+  "address": {
+    "title": "配送先管理",
+    "noSavedAddresses": "保存された配送先がありません。",
+    "addAddress": "+ 配送先を追加",
+    "defaultBadge": "デフォルト",
+    "setDefault": "デフォルトに設定",
+    "edit": "編集",
+    "delete": "削除",
+    "newAddress": "新しい配送先",
+    "editAddress": "配送先を編集",
+    "recipientName": "お受け取り人",
+    "phone": "電話番号",
+    "zipcode": "郵便番号",
+    "address": "住所",
+    "addressDetail": "住所詳細",
+    "label": "ラベル",
+    "labelPlaceholder": "自宅、会社など",
+    "setAsDefault": "デフォルトの配送先に設定",
+    "save": "保存",
+    "saving": "保存中...",
+    "cancel": "キャンセル",
+    "addSuccess": "配送先を追加しました。",
+    "updateSuccess": "配送先を更新しました。",
+    "deleteSuccess": "配送先を削除しました。",
+    "setDefaultSuccess": "デフォルトの配送先に設定しました。",
+    "deleteConfirm": "この配送先を削除してよろしいですか？",
+    "validation": {
+      "recipientNameRequired": "お受け取り人のお名前を入力してください。",
+      "phoneInvalid": "正しい電話番号の形式で入力してください。（例: 010-1234-5678）",
+      "zipcodeInvalid": "郵便番号は5桁の数字で入力してください。",
+      "addressRequired": "住所を入力してください。"
+    }
+  },
+  "review": {
+    "title": "レビューを書く",
+    "rating": "評価",
+    "contentPlaceholder": "この商品についてのレビューをご記入ください。",
+    "attachPhoto": "写真を添付",
+    "uploading": "アップロード中...",
+    "deleteImage": "画像を削除",
+    "attachedImage": "添付画像 {index}",
+    "submit": "レビューを投稿",
+    "submitting": "投稿中...",
+    "cancel": "キャンセル",
+    "noReviews": "まだレビューがありません。",
+    "sortRecent": "新着順",
+    "sortRatingHigh": "評価が高い順",
+    "sortRatingLow": "評価が低い順",
+    "uploadSuccess": "画像のアップロードが完了しました",
+    "uploadError": "画像のアップロードに失敗しました。",
+    "maxImagesError": "画像は最大5枚までアップロードできます。",
+    "ratingRequired": "評価を選択してください。",
+    "submitSuccess": "レビューを投稿しました。",
+    "submitError": "レビューの投稿に失敗しました。"
+  },
+  "shipping": {
+    "title": "追跡番号の登録",
+    "orderNumber": "注文番号: {orderNumber}",
+    "carrier": "運送会社",
+    "trackingNumber": "追跡番号",
+    "trackingNumberPlaceholder": "追跡番号を入力",
+    "cancel": "キャンセル",
+    "submit": "登録",
+    "submitting": "登録中...",
+    "submitSuccess": "追跡番号を登録しました。",
+    "submitError": "追跡番号の登録に失敗しました。",
+    "trackingNumberRequired": "追跡番号を入力してください。",
+    "carriers": {
+      "cj": "CJ大韓通運",
+      "hanjin": "韓進宅配",
+      "lotte": "ロッテ宅配",
+      "mock": "テスト（Mock）"
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "ダッシュボード",
+      "todayRevenue": "本日の売上",
+      "todayOrders": "本日の注文数",
+      "newMembers": "新規会員数",
+      "productViews": "商品閲覧数",
+      "compareYesterday": "前日比",
+      "orderStatusSummary": "注文状態別の状況",
+      "recentOrders": "直近5件の注文",
+      "noOrders": "注文履歴がありません",
+      "chartLoading": "チャートを読み込み中...",
+      "period": {
+        "today": "今日",
+        "7d": "7日間",
+        "30d": "30日間",
+        "90d": "90日間",
+        "custom": "カスタム"
+      },
+      "columns": {
+        "orderNumber": "注文番号",
+        "customerName": "お客様名",
+        "paymentAmount": "お支払い金額",
+        "status": "状態",
+        "orderDate": "注文日時"
+      },
+      "orderStatus": {
+        "pending": "待機中",
+        "paid": "お支払い完了",
+        "preparing": "準備中",
+        "shipped": "配送中",
+        "delivered": "配送完了",
+        "cancelled": "キャンセル",
+        "refunded": "返金済み"
+      }
+    },
+    "orders": {
+      "title": "注文管理",
+      "searchPlaceholder": "注文番号・受取人・メールアドレスで検索",
+      "search": "検索",
+      "loading": "読み込み中...",
+      "noOrders": "注文がありません。",
+      "loadError": "注文一覧の読み込みに失敗しました。",
+      "columns": {
+        "orderNumber": "注文番号",
+        "orderer": "注文者",
+        "product": "商品",
+        "amount": "金額",
+        "status": "状態",
+        "orderDate": "注文日",
+        "action": "アクション"
+      },
+      "trackingSlip": "追跡番号",
+      "statusFilter": {
+        "all": "すべて",
+        "pending": "お支払い待ち",
+        "paid": "お支払い完了",
+        "preparing": "商品準備中",
+        "shipped": "配送中",
+        "delivered": "配送完了",
+        "cancelled": "注文キャンセル",
+        "refunded": "返金完了"
+      },
+      "status": {
+        "pending": "お支払い待ち",
+        "paid": "お支払い完了",
+        "preparing": "商品準備中",
+        "shipped": "配送中",
+        "delivered": "配送完了",
+        "cancelled": "注文キャンセル",
+        "refunded": "返金完了"
+      }
+    },
+    "products": {
+      "title": "商品管理",
+      "addProduct": "+ 商品を登録",
+      "loading": "読み込み中...",
+      "noProducts": "商品がありません。",
+      "loadError": "商品一覧の読み込みに失敗しました。",
+      "statusChangeError": "ステータスの変更に失敗しました。",
+      "deleteError": "削除に失敗しました。",
+      "deleteConfirm": "「{name}」を削除してよろしいですか？",
+      "deleteSuccess": "商品を削除しました。",
+      "columns": {
+        "id": "ID",
+        "name": "商品名",
+        "price": "価格",
+        "status": "状態",
+        "featured": "おすすめ",
+        "action": "アクション"
+      },
+      "actions": {
+        "hide": "非表示",
+        "show": "表示",
+        "edit": "編集",
+        "delete": "削除"
+      },
+      "statusFilter": {
+        "all": "すべて",
+        "active": "販売中",
+        "draft": "下書き",
+        "soldout": "在庫切れ",
+        "hidden": "非表示"
+      },
+      "status": {
+        "draft": "下書き",
+        "active": "販売中",
+        "soldout": "在庫切れ",
+        "hidden": "非表示"
+      }
+    },
+    "productForm": {
+      "createTitle": "商品登録",
+      "editTitle": "商品編集",
+      "imageSection": "商品画像",
+      "basicInfoSection": "基本情報",
+      "pricingSection": "価格 / 在庫",
+      "displaySection": "表示設定",
+      "optionsSection": "オプション",
+      "productName": "商品名 *",
+      "productNamePlaceholder": "商品名を入力してください",
+      "slug": "スラッグ *",
+      "shortDescription": "短い説明",
+      "shortDescriptionPlaceholder": "商品の概要説明",
+      "description": "詳細説明",
+      "descriptionPlaceholder": "商品の詳細説明",
+      "salePrice": "販売価格（ウォン） *",
+      "discountPrice": "割引価格（ウォン）",
+      "stock": "在庫数",
+      "sku": "SKU",
+      "skuPlaceholder": "在庫管理コード",
+      "status": "状態",
+      "featuredProduct": "おすすめ商品として表示",
+      "cancel": "キャンセル",
+      "create": "登録する",
+      "update": "更新する",
+      "saving": "保存中...",
+      "createSuccess": "商品を登録しました。",
+      "updateSuccess": "商品を更新しました。",
+      "saveError": "保存に失敗しました。",
+      "validation": {
+        "nameRequired": "商品名を入力してください。",
+        "slugRequired": "スラッグを入力してください。",
+        "priceRequired": "正しい価格を入力してください。"
+      }
+    },
+    "members": {
+      "title": "会員管理",
+      "searchPlaceholder": "メールアドレス・お名前で検索",
+      "search": "検索",
+      "loading": "読み込み中...",
+      "noMembers": "会員がいません。",
+      "loadError": "会員一覧の読み込みに失敗しました。",
+      "statusLabel": "状態：",
+      "cannotChange": "変更不可",
+      "columns": {
+        "id": "ID",
+        "email": "メールアドレス",
+        "name": "お名前",
+        "role": "役割",
+        "status": "状態",
+        "joinDate": "登録日",
+        "changeRole": "役割変更"
+      },
+      "roles": {
+        "user": "一般会員",
+        "admin": "管理者",
+        "super_admin": "最高管理者"
+      },
+      "memberStatus": {
+        "active": "有効",
+        "inactive": "無効"
+      },
+      "roleFilter": {
+        "all": "すべて",
+        "user": "一般会員",
+        "admin": "管理者",
+        "super_admin": "最高管理者"
+      },
+      "statusFilter": {
+        "all": "すべて",
+        "active": "有効",
+        "inactive": "無効"
+      }
+    },
+    "sidebar": {
+      "dashboard": "ダッシュボード",
+      "orders": "注文管理",
+      "products": "商品管理",
+      "categories": "カテゴリー",
+      "members": "会員管理",
+      "navigation": "ナビゲーション",
+      "pages": "ページ管理",
+      "theme": "テーマ設定",
+      "settings": "設定",
+      "shopName": "玉花堂",
+      "adminPanel": "管理者パネル",
+      "backToShop": "ショップに戻る"
+    },
+    "navigation": {
+      "title": "ナビゲーション管理"
+    },
+    "categories": {
+      "title": "カテゴリー管理"
+    }
+  },
+  "search": {
+    "title": "検索",
+    "placeholder": "商品を検索してみてください...",
+    "recentSearches": "最近の検索",
+    "clearAll": "すべて削除",
+    "noResults": "検索結果がありません",
+    "noResultsDescription": "「{query}」の検索結果が見つかりませんでした。",
+    "results": "「{query}」の検索結果"
+  },
+  "wishlist": {
+    "add": "ウィッシュリストに追加",
+    "remove": "ウィッシュリストから削除",
+    "addSuccess": "ウィッシュリストに追加しました。",
+    "removeSuccess": "ウィッシュリストから削除しました。",
+    "loginRequired": "ログインが必要です。",
+    "noItems": "ウィッシュリストが空です。",
+    "noItemsDescription": "気に入った商品をウィッシュリストに追加してください。"
+  },
+  "recentlyViewed": {
+    "title": "最近見た商品",
+    "noItems": "最近見た商品がありません。"
+  },
+  "payment": {
+    "successTitle": "お支払い完了",
+    "failTitle": "お支払い失敗",
+    "backToHome": "ホームに戻る",
+    "tryAgain": "もう一度試す"
+  },
+  "pages": {
+    "adminPages": "ページ管理"
+  },
+  "errors": {
+    "generic": "エラーが発生しました。",
+    "notFound": "ページが見つかりません。",
+    "loadFailed": "データの読み込みに失敗しました。",
+    "saveFailed": "保存に失敗しました。",
+    "deleteFailed": "削除に失敗しました。",
+    "networkError": "ネットワークエラーが発生しました。",
+    "serverError": "サーバーエラーが発生しました。",
+    "unauthorized": "ログインが必要です。",
+    "forbidden": "アクセス権限がありません。",
+    "dashboardLoadError": "ダッシュボードのデータを読み込めません"
+  },
+  "clayTypes": {
+    "all": "すべて",
+    "zhuni": "朱泥（ジュニ）",
+    "duanni": "段泥（ドアンニ）",
+    "zini": "紫泥（ジニ）",
+    "heini": "黒泥（ヘイニ）",
+    "qingshuini": "青水泥（チンスイニ）",
+    "luni": "緑泥（ルーニ）"
+  },
+  "teapotShapes": {
+    "all": "すべて"
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -14,29 +14,604 @@
     "cancel": "취소",
     "save": "저장",
     "delete": "삭제",
-    "edit": "수정"
+    "edit": "수정",
+    "add": "추가",
+    "close": "닫기",
+    "all": "전체",
+    "apply": "적용",
+    "reset": "초기화",
+    "previous": "이전",
+    "next": "다음",
+    "submit": "제출",
+    "saving": "저장 중...",
+    "deleting": "삭제 중...",
+    "loading2": "불러오는 중...",
+    "noResults": "결과가 없습니다",
+    "required": "필수",
+    "optional": "선택",
+    "or": "또는",
+    "free": "무료",
+    "won": "원",
+    "items": "개",
+    "cases": "건",
+    "persons": "명",
+    "viewAll": "전체 보기",
+    "continueShopping": "쇼핑 계속하기"
   },
   "navigation": {
-    "skipToContent": "본문으로 바로가기"
+    "skipToContent": "본문으로 바로가기",
+    "mainMenu": "메인 메뉴",
+    "mobileMenu": "모바일 메뉴",
+    "mobileBottomNav": "모바일 하단 네비게이션",
+    "openMenu": "메뉴 열기",
+    "closeMenu": "메뉴 닫기",
+    "collection": "컬렉션",
+    "archive": "Archive",
+    "journal": "Journal",
+    "myPage": "마이",
+    "home": "홈"
+  },
+  "header": {
+    "searchPlaceholder": "상품 검색...",
+    "searchLabel": "상품 검색",
+    "searchButton": "검색",
+    "cartLabel": "장바구니",
+    "myPage": "마이페이지",
+    "logout": "로그아웃",
+    "login": "로그인",
+    "goBack": "뒤로가기",
+    "goHome": "홈"
+  },
+  "footer": {
+    "customerService": "고객센터",
+    "company": "회사",
+    "shop": "쇼핑",
+    "okhwadang": "옥화당",
+    "tagline": "자사호 · 보이차 · 다구",
+    "specialty": "전문 쇼핑몰",
+    "support": "고객센터",
+    "faq": "자주 묻는 질문",
+    "shipping": "배송 안내",
+    "returns": "반품 및 교환",
+    "terms": "이용약관",
+    "privacy": "개인정보처리방침",
+    "allProducts": "전체 상품",
+    "collection": "컬렉션",
+    "archive": "Archive",
+    "journal": "Journal",
+    "copyright": "© {year} 옥화당. All rights reserved."
+  },
+  "auth": {
+    "email": "이메일",
+    "emailPlaceholder": "you@example.com",
+    "password": "비밀번호",
+    "passwordPlaceholder": "••••••••",
+    "passwordHint": "영문+숫자+특수문자 8자 이상",
+    "passwordConfirm": "비밀번호 확인",
+    "passwordConfirmPlaceholder": "비밀번호 재입력",
+    "name": "이름",
+    "namePlaceholder": "홍길동",
+    "forgotPassword": "비밀번호 찾기",
+    "loginTitle": "로그인",
+    "registerTitle": "회원가입",
+    "loginSubmit": "로그인",
+    "loginSubmitting": "로그인 중...",
+    "registerSubmit": "회원가입",
+    "registerSubmitting": "가입 중...",
+    "kakaoLogin": "카카오로 로그인",
+    "googleLogin": "Google로 로그인",
+    "noAccount": "계정이 없으신가요?",
+    "hasAccount": "이미 계정이 있으신가요?",
+    "loginError": "로그인에 실패했습니다.",
+    "registerError": "회원가입에 실패했습니다.",
+    "dividerOr": "또는",
+    "validation": {
+      "emailInvalid": "올바른 이메일 형식이 아닙니다.",
+      "passwordTooShort": "비밀번호는 8자 이상이어야 합니다.",
+      "passwordRequirements": "비밀번호는 영문과 숫자를 모두 포함해야 합니다.",
+      "passwordNeedsSpecial": "비밀번호는 특수문자를 포함해야 합니다.",
+      "nameTooShort": "이름은 1~100자 사이여야 합니다.",
+      "passwordMismatch": "비밀번호가 일치하지 않습니다."
+    }
   },
   "product": {
     "addToCart": "장바구니 담기",
     "buyNow": "바로 구매",
     "outOfStock": "품절",
+    "outOfStockMessage": "현재 품절된 상품입니다.",
     "price": "가격",
-    "quantity": "수량"
+    "salePrice": "할인가",
+    "quantity": "수량",
+    "option": "옵션",
+    "selectOption": "옵션을 선택해 주세요.",
+    "addToCartSuccess": "장바구니에 담았습니다.",
+    "addToCartError": "장바구니 담기에 실패했습니다.",
+    "buyNowError": "구매 처리 중 오류가 발생했습니다.",
+    "productList": "상품 목록",
+    "featuredProducts": "추천 상품",
+    "searchResults": "\"{query}\" 검색 결과",
+    "noProducts": "상품이 없습니다",
+    "noProductsDescription": "등록된 상품이 없습니다.",
+    "noSearchResults": "\"{query}\"에 대한 검색 결과가 없습니다.",
+    "tabs": {
+      "details": "상세정보",
+      "reviews": "리뷰",
+      "inquiry": "문의",
+      "comingSoon": "준비 중입니다."
+    },
+    "sort": {
+      "label": "정렬 기준",
+      "latest": "최신순",
+      "priceAsc": "가격낮은순",
+      "priceDesc": "가격높은순",
+      "popular": "인기순"
+    },
+    "filter": {
+      "label": "필터",
+      "openFilter": "필터 열기",
+      "closeFilter": "필터 닫기",
+      "resetFilter": "필터 초기화",
+      "filterLabel": "상품 필터",
+      "priceRange": "가격 범위",
+      "priceMin": "최소",
+      "priceMax": "최대",
+      "clayType": "니로(泥料)",
+      "teapotShape": "형태",
+      "category": "카테고리"
+    },
+    "status": {
+      "draft": "임시저장",
+      "active": "판매중",
+      "soldout": "품절",
+      "hidden": "숨김"
+    }
+  },
+  "cart": {
+    "title": "장바구니",
+    "empty": "장바구니가 비었습니다",
+    "emptyDescription": "마음에 드는 상품을 장바구니에 담아보세요.",
+    "requireLogin": "로그인이 필요합니다",
+    "requireLoginDescription": "장바구니를 이용하려면 로그인해주세요.",
+    "selectAll": "전체 선택",
+    "orderSummary": "주문 요약",
+    "selectedItems": "선택 상품",
+    "productAmount": "상품 금액",
+    "shippingFee": "배송비",
+    "total": "합계",
+    "orderSelected": "선택 상품 주문하기",
+    "selectItemsToOrder": "주문할 상품을 선택해주세요.",
+    "noImage": "No image",
+    "removeItem": "{name} 삭제"
+  },
+  "checkout": {
+    "title": "주문 / 결제",
+    "shippingInfo": "배송 정보",
+    "loadingAddresses": "주소 불러오는 중...",
+    "noSavedAddress": "저장된 배송지가 없습니다.",
+    "addAddress": "배송지 추가",
+    "manualEntry": "직접 입력",
+    "recipientName": "받는 분 이름",
+    "phone": "연락처",
+    "zipcode": "우편번호",
+    "address": "주소",
+    "addressDetail": "상세 주소",
+    "addressDetailPlaceholder": "동/호수 등",
+    "shippingMemo": "배송 메모",
+    "shippingMemoPlaceholder": "배송 시 요청사항을 입력해주세요.",
+    "paymentMethod": "결제 수단",
+    "tossPayment": "토스페이먼츠 (카드)",
+    "mockPayment": "테스트 결제 (Mock)",
+    "couponPoints": "쿠폰 / 적립금",
+    "couponPointsComingSoon": "쿠폰/적립금 적용은 추후 지원 예정입니다.",
+    "orderItems": "주문 상품",
+    "productAmount": "상품 금액",
+    "shippingFee": "배송비",
+    "total": "합계",
+    "pay": "결제하기",
+    "paymentSuccess": "결제가 완료되었습니다.",
+    "paymentError": "결제 중 오류가 발생했습니다.",
+    "loadAddressError": "저장된 주소를 불러오는데 실패했습니다.",
+    "orderName": "주문 {orderNumber}",
+    "steps": {
+      "idle": "결제하기",
+      "creating_order": "주문 생성 중...",
+      "preparing_payment": "결제 준비 중...",
+      "confirming_payment": "결제 확인 중...",
+      "success": "완료"
+    },
+    "validation": {
+      "recipientNameTooShort": "이름은 2자 이상 입력해주세요.",
+      "phoneInvalid": "올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)",
+      "zipcodeInvalid": "우편번호는 5자리 숫자로 입력해주세요.",
+      "addressRequired": "주소를 입력해주세요."
+    }
   },
   "order": {
     "orderHistory": "주문 내역",
     "orderNumber": "주문 번호",
     "orderDate": "주문일",
-    "orderStatus": "주문 상태"
+    "orderStatus": "주문 상태",
+    "noOrders": "주문 내역이 없습니다.",
+    "noOrdersAction": "쇼핑 계속하기",
+    "recentOrders": "최근 주문",
+    "recentOrdersCount": "최근 주문 5건",
+    "orderStatusSummary": "주문 상태별 현황",
+    "compareYesterday": "전일 대비",
+    "status": {
+      "pending": "결제대기",
+      "paid": "결제완료",
+      "preparing": "상품준비중",
+      "shipped": "배송중",
+      "delivered": "배송완료",
+      "cancelled": "주문취소",
+      "refunded": "환불완료",
+      "refund_requested": "환불요청"
+    }
   },
-  "auth": {
+  "orderComplete": {
+    "loading": "주문 완료 처리 중..."
+  },
+  "myPage": {
+    "title": "마이페이지",
+    "editProfile": "회원정보 수정",
+    "orderHistory": "주문 내역",
+    "wishlist": "위시리스트",
+    "addressManagement": "배송지 관리",
+    "coupons": "쿠폰함",
+    "recentlyViewed": "최근 본 상품",
+    "noRecentOrders": "주문 내역이 없습니다.",
+    "myOrders": "주문 내역",
+    "previousPage": "이전",
+    "nextPage": "다음"
+  },
+  "profile": {
+    "title": "회원정보 수정",
     "email": "이메일",
-    "password": "비밀번호",
-    "loginTitle": "로그인",
-    "registerTitle": "회원가입",
-    "forgotPassword": "비밀번호 찾기"
+    "emailReadOnly": "이메일은 변경할 수 없습니다.",
+    "name": "이름",
+    "phone": "전화번호",
+    "save": "저장하기",
+    "saving": "저장 중...",
+    "updateSuccess": "회원정보가 수정되었습니다.",
+    "updateError": "수정 중 오류가 발생했습니다.",
+    "validation": {
+      "nameRequired": "이름을 입력해주세요.",
+      "phoneInvalid": "올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)"
+    }
+  },
+  "address": {
+    "title": "배송지 관리",
+    "noSavedAddresses": "저장된 배송지가 없습니다.",
+    "addAddress": "+ 배송지 추가",
+    "defaultBadge": "기본",
+    "setDefault": "기본 설정",
+    "edit": "수정",
+    "delete": "삭제",
+    "newAddress": "새 배송지",
+    "editAddress": "배송지 수정",
+    "recipientName": "받는 분",
+    "phone": "전화번호",
+    "zipcode": "우편번호",
+    "address": "주소",
+    "addressDetail": "상세 주소",
+    "label": "라벨",
+    "labelPlaceholder": "집, 회사 등",
+    "setAsDefault": "기본 배송지로 설정",
+    "save": "저장",
+    "saving": "저장 중...",
+    "cancel": "취소",
+    "addSuccess": "배송지가 추가되었습니다.",
+    "updateSuccess": "배송지가 수정되었습니다.",
+    "deleteSuccess": "배송지가 삭제되었습니다.",
+    "setDefaultSuccess": "기본 배송지로 설정되었습니다.",
+    "deleteConfirm": "배송지를 삭제하시겠습니까?",
+    "validation": {
+      "recipientNameRequired": "받는 분 이름을 입력해주세요.",
+      "phoneInvalid": "올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)",
+      "zipcodeInvalid": "우편번호는 5자리 숫자로 입력해주세요.",
+      "addressRequired": "주소를 입력해주세요."
+    }
+  },
+  "review": {
+    "title": "리뷰 작성",
+    "rating": "별점",
+    "contentPlaceholder": "상품에 대한 리뷰를 작성해 주세요.",
+    "attachPhoto": "사진 첨부",
+    "uploading": "업로드 중...",
+    "deleteImage": "이미지 삭제",
+    "attachedImage": "첨부 이미지 {index}",
+    "submit": "리뷰 등록",
+    "submitting": "등록 중...",
+    "cancel": "취소",
+    "noReviews": "아직 리뷰가 없습니다.",
+    "sortRecent": "최신순",
+    "sortRatingHigh": "별점 높은순",
+    "sortRatingLow": "별점 낮은순",
+    "uploadSuccess": "이미지 업로드 완료",
+    "uploadError": "이미지 업로드에 실패했습니다.",
+    "maxImagesError": "이미지는 최대 5장까지 업로드 가능합니다.",
+    "ratingRequired": "별점을 선택해 주세요.",
+    "submitSuccess": "리뷰가 등록되었습니다.",
+    "submitError": "리뷰 작성에 실패했습니다."
+  },
+  "shipping": {
+    "title": "운송장 등록",
+    "orderNumber": "주문번호: {orderNumber}",
+    "carrier": "택배사",
+    "trackingNumber": "운송장 번호",
+    "trackingNumberPlaceholder": "운송장 번호 입력",
+    "cancel": "취소",
+    "submit": "등록",
+    "submitting": "등록 중...",
+    "submitSuccess": "운송장이 등록되었습니다.",
+    "submitError": "운송장 등록에 실패했습니다.",
+    "trackingNumberRequired": "운송장 번호를 입력해주세요.",
+    "carriers": {
+      "cj": "CJ대한통운",
+      "hanjin": "한진택배",
+      "lotte": "롯데택배",
+      "mock": "테스트(Mock)"
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "대시보드",
+      "todayRevenue": "오늘 매출",
+      "todayOrders": "오늘 주문수",
+      "newMembers": "신규 회원수",
+      "productViews": "상품 조회수",
+      "compareYesterday": "전일 대비",
+      "orderStatusSummary": "주문 상태별 현황",
+      "recentOrders": "최근 주문 5건",
+      "noOrders": "주문 내역이 없습니다",
+      "chartLoading": "차트 로딩 중...",
+      "period": {
+        "today": "오늘",
+        "7d": "7일",
+        "30d": "30일",
+        "90d": "90일",
+        "custom": "직접입력"
+      },
+      "columns": {
+        "orderNumber": "주문번호",
+        "customerName": "고객명",
+        "paymentAmount": "결제금액",
+        "status": "상태",
+        "orderDate": "주문일시"
+      },
+      "orderStatus": {
+        "pending": "대기",
+        "paid": "결제완료",
+        "preparing": "준비중",
+        "shipped": "배송중",
+        "delivered": "배송완료",
+        "cancelled": "취소",
+        "refunded": "환불"
+      }
+    },
+    "orders": {
+      "title": "주문 관리",
+      "searchPlaceholder": "주문번호, 수령인, 이메일 검색",
+      "search": "검색",
+      "loading": "불러오는 중...",
+      "noOrders": "주문이 없습니다.",
+      "loadError": "주문 목록을 불러오지 못했습니다.",
+      "columns": {
+        "orderNumber": "주문번호",
+        "orderer": "주문자",
+        "product": "상품",
+        "amount": "금액",
+        "status": "상태",
+        "orderDate": "주문일",
+        "action": "액션"
+      },
+      "trackingSlip": "운송장",
+      "statusFilter": {
+        "all": "전체",
+        "pending": "결제대기",
+        "paid": "결제완료",
+        "preparing": "상품준비중",
+        "shipped": "배송중",
+        "delivered": "배송완료",
+        "cancelled": "주문취소",
+        "refunded": "환불완료"
+      },
+      "status": {
+        "pending": "결제대기",
+        "paid": "결제완료",
+        "preparing": "상품준비중",
+        "shipped": "배송중",
+        "delivered": "배송완료",
+        "cancelled": "주문취소",
+        "refunded": "환불완료"
+      }
+    },
+    "products": {
+      "title": "상품 관리",
+      "addProduct": "+ 상품 등록",
+      "loading": "불러오는 중...",
+      "noProducts": "상품이 없습니다.",
+      "loadError": "상품 목록을 불러오지 못했습니다.",
+      "statusChangeError": "상태 변경에 실패했습니다.",
+      "deleteError": "삭제에 실패했습니다.",
+      "deleteConfirm": "\"{name}\"을(를) 삭제하시겠습니까?",
+      "deleteSuccess": "상품이 삭제되었습니다.",
+      "columns": {
+        "id": "ID",
+        "name": "상품명",
+        "price": "가격",
+        "status": "상태",
+        "featured": "추천",
+        "action": "액션"
+      },
+      "actions": {
+        "hide": "숨기기",
+        "show": "노출",
+        "edit": "수정",
+        "delete": "삭제"
+      },
+      "statusFilter": {
+        "all": "전체",
+        "active": "판매중",
+        "draft": "임시저장",
+        "soldout": "품절",
+        "hidden": "숨김"
+      },
+      "status": {
+        "draft": "임시저장",
+        "active": "판매중",
+        "soldout": "품절",
+        "hidden": "숨김"
+      }
+    },
+    "productForm": {
+      "createTitle": "상품 등록",
+      "editTitle": "상품 수정",
+      "imageSection": "상품 이미지",
+      "basicInfoSection": "기본 정보",
+      "pricingSection": "가격 / 재고",
+      "displaySection": "노출 설정",
+      "optionsSection": "옵션",
+      "productName": "상품명 *",
+      "productNamePlaceholder": "상품명을 입력하세요",
+      "slug": "슬러그 *",
+      "shortDescription": "짧은 설명",
+      "shortDescriptionPlaceholder": "상품 요약 설명",
+      "description": "상세 설명",
+      "descriptionPlaceholder": "상품 상세 설명",
+      "salePrice": "판매가 (원) *",
+      "discountPrice": "할인가 (원)",
+      "stock": "재고",
+      "sku": "SKU",
+      "skuPlaceholder": "재고 관리 코드",
+      "status": "상태",
+      "featuredProduct": "추천 상품으로 표시",
+      "cancel": "취소",
+      "create": "등록하기",
+      "update": "수정하기",
+      "saving": "저장 중...",
+      "createSuccess": "상품이 등록되었습니다.",
+      "updateSuccess": "상품이 수정되었습니다.",
+      "saveError": "저장에 실패했습니다.",
+      "validation": {
+        "nameRequired": "상품명을 입력해주세요.",
+        "slugRequired": "슬러그를 입력해주세요.",
+        "priceRequired": "가격을 올바르게 입력해주세요."
+      }
+    },
+    "members": {
+      "title": "회원 관리",
+      "searchPlaceholder": "이메일, 이름 검색",
+      "search": "검색",
+      "loading": "불러오는 중...",
+      "noMembers": "회원이 없습니다.",
+      "loadError": "회원 목록을 불러오지 못했습니다.",
+      "statusLabel": "상태:",
+      "cannotChange": "변경 불가",
+      "columns": {
+        "id": "ID",
+        "email": "이메일",
+        "name": "이름",
+        "role": "역할",
+        "status": "상태",
+        "joinDate": "가입일",
+        "changeRole": "역할 변경"
+      },
+      "roles": {
+        "user": "일반회원",
+        "admin": "관리자",
+        "super_admin": "최고관리자"
+      },
+      "memberStatus": {
+        "active": "활성",
+        "inactive": "비활성"
+      },
+      "roleFilter": {
+        "all": "전체",
+        "user": "일반회원",
+        "admin": "관리자",
+        "super_admin": "최고관리자"
+      },
+      "statusFilter": {
+        "all": "전체",
+        "active": "활성",
+        "inactive": "비활성"
+      }
+    },
+    "sidebar": {
+      "dashboard": "대시보드",
+      "orders": "주문 관리",
+      "products": "상품 관리",
+      "categories": "카테고리",
+      "members": "회원 관리",
+      "navigation": "네비게이션",
+      "pages": "페이지 관리",
+      "theme": "테마 설정",
+      "settings": "설정",
+      "shopName": "옥화당",
+      "adminPanel": "관리자 패널",
+      "backToShop": "쇼핑몰로 돌아가기"
+    },
+    "navigation": {
+      "title": "네비게이션 관리"
+    },
+    "categories": {
+      "title": "카테고리 관리"
+    }
+  },
+  "search": {
+    "title": "검색",
+    "placeholder": "상품을 검색해보세요...",
+    "recentSearches": "최근 검색어",
+    "clearAll": "전체 삭제",
+    "noResults": "검색 결과가 없습니다",
+    "noResultsDescription": "\"{query}\"에 대한 검색 결과를 찾을 수 없습니다.",
+    "results": "\"{query}\" 검색 결과"
+  },
+  "wishlist": {
+    "add": "위시리스트에 추가",
+    "remove": "위시리스트에서 제거",
+    "addSuccess": "위시리스트에 추가되었습니다.",
+    "removeSuccess": "위시리스트에서 제거되었습니다.",
+    "loginRequired": "로그인이 필요합니다.",
+    "noItems": "위시리스트가 비었습니다.",
+    "noItemsDescription": "마음에 드는 상품을 위시리스트에 담아보세요."
+  },
+  "recentlyViewed": {
+    "title": "최근 본 상품",
+    "noItems": "최근 본 상품이 없습니다."
+  },
+  "payment": {
+    "successTitle": "결제 완료",
+    "failTitle": "결제 실패",
+    "backToHome": "홈으로 돌아가기",
+    "tryAgain": "다시 시도하기"
+  },
+  "pages": {
+    "adminPages": "페이지 관리"
+  },
+  "errors": {
+    "generic": "오류가 발생했습니다.",
+    "notFound": "페이지를 찾을 수 없습니다.",
+    "loadFailed": "데이터를 불러오는데 실패했습니다.",
+    "saveFailed": "저장에 실패했습니다.",
+    "deleteFailed": "삭제에 실패했습니다.",
+    "networkError": "네트워크 오류가 발생했습니다.",
+    "serverError": "서버 오류가 발생했습니다.",
+    "unauthorized": "로그인이 필요합니다.",
+    "forbidden": "접근 권한이 없습니다.",
+    "dashboardLoadError": "대시보드 데이터를 불러올 수 없습니다"
+  },
+  "clayTypes": {
+    "all": "전체",
+    "zhuni": "주니(朱泥)",
+    "duanni": "단니(段泥)",
+    "zini": "자니(紫泥)",
+    "heini": "흑니(黑泥)",
+    "qingshuini": "청수니(靑水泥)",
+    "luni": "녹니(綠泥)"
+  },
+  "teapotShapes": {
+    "all": "전체"
   }
 }

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -14,29 +14,604 @@
     "cancel": "取消",
     "save": "保存",
     "delete": "删除",
-    "edit": "编辑"
+    "edit": "编辑",
+    "add": "添加",
+    "close": "关闭",
+    "all": "全部",
+    "apply": "应用",
+    "reset": "重置",
+    "previous": "上一页",
+    "next": "下一页",
+    "submit": "提交",
+    "saving": "保存中...",
+    "deleting": "删除中...",
+    "loading2": "加载中...",
+    "noResults": "暂无结果",
+    "required": "必填",
+    "optional": "选填",
+    "or": "或",
+    "free": "免费",
+    "won": "韩元",
+    "items": "件",
+    "cases": "条",
+    "persons": "人",
+    "viewAll": "查看全部",
+    "continueShopping": "继续购物"
   },
   "navigation": {
-    "skipToContent": "跳转到主要内容"
+    "skipToContent": "跳转到主要内容",
+    "mainMenu": "主菜单",
+    "mobileMenu": "移动端菜单",
+    "mobileBottomNav": "移动端底部导航",
+    "openMenu": "打开菜单",
+    "closeMenu": "关闭菜单",
+    "collection": "系列",
+    "archive": "Archive",
+    "journal": "Journal",
+    "myPage": "我的",
+    "home": "首页"
+  },
+  "header": {
+    "searchPlaceholder": "搜索商品...",
+    "searchLabel": "搜索商品",
+    "searchButton": "搜索",
+    "cartLabel": "购物车",
+    "myPage": "我的页面",
+    "logout": "退出登录",
+    "login": "登录",
+    "goBack": "返回",
+    "goHome": "首页"
+  },
+  "footer": {
+    "customerService": "客户服务",
+    "company": "公司",
+    "shop": "购物",
+    "okhwadang": "玉花堂",
+    "tagline": "紫砂壶 · 普洱茶 · 茶具",
+    "specialty": "专业商城",
+    "support": "客户支持",
+    "faq": "常见问题",
+    "shipping": "配送说明",
+    "returns": "退换货",
+    "terms": "服务条款",
+    "privacy": "隐私政策",
+    "allProducts": "全部商品",
+    "collection": "系列",
+    "archive": "Archive",
+    "journal": "Journal",
+    "copyright": "© {year} 玉花堂. 保留所有权利。"
+  },
+  "auth": {
+    "email": "电子邮箱",
+    "emailPlaceholder": "you@example.com",
+    "password": "密码",
+    "passwordPlaceholder": "••••••••",
+    "passwordHint": "8位以上，包含字母、数字及特殊字符",
+    "passwordConfirm": "确认密码",
+    "passwordConfirmPlaceholder": "请再次输入密码",
+    "name": "姓名",
+    "namePlaceholder": "您的姓名",
+    "forgotPassword": "忘记密码",
+    "loginTitle": "登录",
+    "registerTitle": "注册",
+    "loginSubmit": "登录",
+    "loginSubmitting": "登录中...",
+    "registerSubmit": "注册",
+    "registerSubmitting": "注册中...",
+    "kakaoLogin": "使用Kakao登录",
+    "googleLogin": "使用Google登录",
+    "noAccount": "还没有账号？",
+    "hasAccount": "已有账号？",
+    "loginError": "登录失败。",
+    "registerError": "注册失败。",
+    "dividerOr": "或",
+    "validation": {
+      "emailInvalid": "请输入正确的电子邮箱格式。",
+      "passwordTooShort": "密码须至少8位。",
+      "passwordRequirements": "密码须同时包含字母和数字。",
+      "passwordNeedsSpecial": "密码须包含至少一个特殊字符。",
+      "nameTooShort": "姓名须在1到100个字符之间。",
+      "passwordMismatch": "两次输入的密码不一致。"
+    }
   },
   "product": {
     "addToCart": "加入购物车",
     "buyNow": "立即购买",
     "outOfStock": "缺货",
+    "outOfStockMessage": "该商品当前缺货。",
     "price": "价格",
-    "quantity": "数量"
+    "salePrice": "优惠价",
+    "quantity": "数量",
+    "option": "规格",
+    "selectOption": "请选择规格。",
+    "addToCartSuccess": "已加入购物车。",
+    "addToCartError": "加入购物车失败。",
+    "buyNowError": "结算过程中发生错误。",
+    "productList": "商品列表",
+    "featuredProducts": "推荐商品",
+    "searchResults": "\"{query}\"的搜索结果",
+    "noProducts": "暂无商品",
+    "noProductsDescription": "暂无上架商品。",
+    "noSearchResults": "未找到\"{query}\"的相关结果。",
+    "tabs": {
+      "details": "详细信息",
+      "reviews": "评价",
+      "inquiry": "咨询",
+      "comingSoon": "即将上线。"
+    },
+    "sort": {
+      "label": "排序",
+      "latest": "最新",
+      "priceAsc": "价格从低到高",
+      "priceDesc": "价格从高到低",
+      "popular": "最受欢迎"
+    },
+    "filter": {
+      "label": "筛选",
+      "openFilter": "打开筛选",
+      "closeFilter": "关闭筛选",
+      "resetFilter": "重置筛选",
+      "filterLabel": "商品筛选",
+      "priceRange": "价格区间",
+      "priceMin": "最低价",
+      "priceMax": "最高价",
+      "clayType": "泥料",
+      "teapotShape": "形制",
+      "category": "分类"
+    },
+    "status": {
+      "draft": "草稿",
+      "active": "在售",
+      "soldout": "缺货",
+      "hidden": "已隐藏"
+    }
+  },
+  "cart": {
+    "title": "购物车",
+    "empty": "购物车为空",
+    "emptyDescription": "将您喜欢的商品加入购物车吧。",
+    "requireLogin": "请先登录",
+    "requireLoginDescription": "请登录后使用购物车。",
+    "selectAll": "全选",
+    "orderSummary": "订单摘要",
+    "selectedItems": "已选商品",
+    "productAmount": "商品金额",
+    "shippingFee": "运费",
+    "total": "合计",
+    "orderSelected": "结算已选商品",
+    "selectItemsToOrder": "请选择要结算的商品。",
+    "noImage": "暂无图片",
+    "removeItem": "删除 {name}"
+  },
+  "checkout": {
+    "title": "下单 / 支付",
+    "shippingInfo": "收货信息",
+    "loadingAddresses": "正在加载地址...",
+    "noSavedAddress": "暂无保存的收货地址。",
+    "addAddress": "添加地址",
+    "manualEntry": "手动输入",
+    "recipientName": "收件人姓名",
+    "phone": "联系电话",
+    "zipcode": "邮政编码",
+    "address": "地址",
+    "addressDetail": "详细地址",
+    "addressDetailPlaceholder": "楼号/房间号等",
+    "shippingMemo": "配送备注",
+    "shippingMemoPlaceholder": "请填写配送时的特殊要求。",
+    "paymentMethod": "支付方式",
+    "tossPayment": "Toss支付（信用卡）",
+    "mockPayment": "测试支付（Mock）",
+    "couponPoints": "优惠券 / 积分",
+    "couponPointsComingSoon": "优惠券及积分功能即将上线。",
+    "orderItems": "订单商品",
+    "productAmount": "商品金额",
+    "shippingFee": "运费",
+    "total": "合计",
+    "pay": "立即支付",
+    "paymentSuccess": "支付成功。",
+    "paymentError": "支付过程中发生错误。",
+    "loadAddressError": "加载已保存地址失败。",
+    "orderName": "订单 {orderNumber}",
+    "steps": {
+      "idle": "立即支付",
+      "creating_order": "正在创建订单...",
+      "preparing_payment": "正在准备支付...",
+      "confirming_payment": "正在确认支付...",
+      "success": "完成"
+    },
+    "validation": {
+      "recipientNameTooShort": "收件人姓名须至少2个字符。",
+      "phoneInvalid": "请输入正确的电话号码格式。（例：010-1234-5678）",
+      "zipcodeInvalid": "邮政编码须为5位数字。",
+      "addressRequired": "请输入地址。"
+    }
   },
   "order": {
-    "orderHistory": "订单历史",
-    "orderNumber": "订单号",
+    "orderHistory": "订单记录",
+    "orderNumber": "订单编号",
     "orderDate": "下单日期",
-    "orderStatus": "订单状态"
+    "orderStatus": "订单状态",
+    "noOrders": "暂无订单记录。",
+    "noOrdersAction": "继续购物",
+    "recentOrders": "最近订单",
+    "recentOrdersCount": "最近5笔订单",
+    "orderStatusSummary": "各状态订单概况",
+    "compareYesterday": "较昨日",
+    "status": {
+      "pending": "待付款",
+      "paid": "已付款",
+      "preparing": "备货中",
+      "shipped": "配送中",
+      "delivered": "已送达",
+      "cancelled": "已取消",
+      "refunded": "已退款",
+      "refund_requested": "申请退款"
+    }
   },
-  "auth": {
-    "email": "邮箱",
-    "password": "密码",
-    "loginTitle": "登录",
-    "registerTitle": "注册",
-    "forgotPassword": "忘记密码"
+  "orderComplete": {
+    "loading": "正在处理订单..."
+  },
+  "myPage": {
+    "title": "我的页面",
+    "editProfile": "修改个人信息",
+    "orderHistory": "订单记录",
+    "wishlist": "心愿单",
+    "addressManagement": "地址管理",
+    "coupons": "优惠券",
+    "recentlyViewed": "最近浏览",
+    "noRecentOrders": "暂无订单记录。",
+    "myOrders": "我的订单",
+    "previousPage": "上一页",
+    "nextPage": "下一页"
+  },
+  "profile": {
+    "title": "修改个人信息",
+    "email": "电子邮箱",
+    "emailReadOnly": "电子邮箱不可修改。",
+    "name": "姓名",
+    "phone": "电话号码",
+    "save": "保存",
+    "saving": "保存中...",
+    "updateSuccess": "个人信息已更新。",
+    "updateError": "更新过程中发生错误。",
+    "validation": {
+      "nameRequired": "请输入姓名。",
+      "phoneInvalid": "请输入正确的电话号码格式。（例：010-1234-5678）"
+    }
+  },
+  "address": {
+    "title": "地址管理",
+    "noSavedAddresses": "暂无保存的收货地址。",
+    "addAddress": "+ 添加地址",
+    "defaultBadge": "默认",
+    "setDefault": "设为默认",
+    "edit": "编辑",
+    "delete": "删除",
+    "newAddress": "新增地址",
+    "editAddress": "编辑地址",
+    "recipientName": "收件人",
+    "phone": "电话号码",
+    "zipcode": "邮政编码",
+    "address": "地址",
+    "addressDetail": "详细地址",
+    "label": "标签",
+    "labelPlaceholder": "家、公司等",
+    "setAsDefault": "设为默认收货地址",
+    "save": "保存",
+    "saving": "保存中...",
+    "cancel": "取消",
+    "addSuccess": "地址添加成功。",
+    "updateSuccess": "地址更新成功。",
+    "deleteSuccess": "地址删除成功。",
+    "setDefaultSuccess": "已设为默认收货地址。",
+    "deleteConfirm": "确定要删除该地址吗？",
+    "validation": {
+      "recipientNameRequired": "请输入收件人姓名。",
+      "phoneInvalid": "请输入正确的电话号码格式。（例：010-1234-5678）",
+      "zipcodeInvalid": "邮政编码须为5位数字。",
+      "addressRequired": "请输入地址。"
+    }
+  },
+  "review": {
+    "title": "撰写评价",
+    "rating": "评分",
+    "contentPlaceholder": "请分享您对该商品的看法。",
+    "attachPhoto": "上传图片",
+    "uploading": "上传中...",
+    "deleteImage": "删除图片",
+    "attachedImage": "上传图片 {index}",
+    "submit": "提交评价",
+    "submitting": "提交中...",
+    "cancel": "取消",
+    "noReviews": "暂无评价。",
+    "sortRecent": "最新",
+    "sortRatingHigh": "好评优先",
+    "sortRatingLow": "差评优先",
+    "uploadSuccess": "图片上传成功",
+    "uploadError": "图片上传失败。",
+    "maxImagesError": "最多可上传5张图片。",
+    "ratingRequired": "请选择评分。",
+    "submitSuccess": "评价提交成功。",
+    "submitError": "评价提交失败。"
+  },
+  "shipping": {
+    "title": "登记快递单号",
+    "orderNumber": "订单编号：{orderNumber}",
+    "carrier": "快递公司",
+    "trackingNumber": "快递单号",
+    "trackingNumberPlaceholder": "请输入快递单号",
+    "cancel": "取消",
+    "submit": "登记",
+    "submitting": "登记中...",
+    "submitSuccess": "快递单号登记成功。",
+    "submitError": "快递单号登记失败。",
+    "trackingNumberRequired": "请输入快递单号。",
+    "carriers": {
+      "cj": "CJ大韩通运",
+      "hanjin": "韩进快递",
+      "lotte": "乐天快递",
+      "mock": "测试（Mock）"
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "控制台",
+      "todayRevenue": "今日销售额",
+      "todayOrders": "今日订单数",
+      "newMembers": "新增会员数",
+      "productViews": "商品浏览量",
+      "compareYesterday": "较昨日",
+      "orderStatusSummary": "各状态订单概况",
+      "recentOrders": "最近5笔订单",
+      "noOrders": "暂无订单",
+      "chartLoading": "图表加载中...",
+      "period": {
+        "today": "今日",
+        "7d": "7天",
+        "30d": "30天",
+        "90d": "90天",
+        "custom": "自定义"
+      },
+      "columns": {
+        "orderNumber": "订单编号",
+        "customerName": "客户姓名",
+        "paymentAmount": "支付金额",
+        "status": "状态",
+        "orderDate": "下单时间"
+      },
+      "orderStatus": {
+        "pending": "待处理",
+        "paid": "已付款",
+        "preparing": "备货中",
+        "shipped": "配送中",
+        "delivered": "已送达",
+        "cancelled": "已取消",
+        "refunded": "已退款"
+      }
+    },
+    "orders": {
+      "title": "订单管理",
+      "searchPlaceholder": "按订单号、收件人或邮箱搜索",
+      "search": "搜索",
+      "loading": "加载中...",
+      "noOrders": "暂无订单。",
+      "loadError": "订单列表加载失败。",
+      "columns": {
+        "orderNumber": "订单编号",
+        "orderer": "下单人",
+        "product": "商品",
+        "amount": "金额",
+        "status": "状态",
+        "orderDate": "下单日期",
+        "action": "操作"
+      },
+      "trackingSlip": "快递单",
+      "statusFilter": {
+        "all": "全部",
+        "pending": "待付款",
+        "paid": "已付款",
+        "preparing": "备货中",
+        "shipped": "配送中",
+        "delivered": "已送达",
+        "cancelled": "已取消",
+        "refunded": "已退款"
+      },
+      "status": {
+        "pending": "待付款",
+        "paid": "已付款",
+        "preparing": "备货中",
+        "shipped": "配送中",
+        "delivered": "已送达",
+        "cancelled": "已取消",
+        "refunded": "已退款"
+      }
+    },
+    "products": {
+      "title": "商品管理",
+      "addProduct": "+ 添加商品",
+      "loading": "加载中...",
+      "noProducts": "暂无商品。",
+      "loadError": "商品列表加载失败。",
+      "statusChangeError": "状态修改失败。",
+      "deleteError": "删除失败。",
+      "deleteConfirm": "确定要删除\"{name}\"吗？",
+      "deleteSuccess": "商品已删除。",
+      "columns": {
+        "id": "ID",
+        "name": "商品名称",
+        "price": "价格",
+        "status": "状态",
+        "featured": "推荐",
+        "action": "操作"
+      },
+      "actions": {
+        "hide": "隐藏",
+        "show": "显示",
+        "edit": "编辑",
+        "delete": "删除"
+      },
+      "statusFilter": {
+        "all": "全部",
+        "active": "在售",
+        "draft": "草稿",
+        "soldout": "缺货",
+        "hidden": "已隐藏"
+      },
+      "status": {
+        "draft": "草稿",
+        "active": "在售",
+        "soldout": "缺货",
+        "hidden": "已隐藏"
+      }
+    },
+    "productForm": {
+      "createTitle": "添加商品",
+      "editTitle": "编辑商品",
+      "imageSection": "商品图片",
+      "basicInfoSection": "基本信息",
+      "pricingSection": "价格 / 库存",
+      "displaySection": "展示设置",
+      "optionsSection": "规格选项",
+      "productName": "商品名称 *",
+      "productNamePlaceholder": "请输入商品名称",
+      "slug": "Slug *",
+      "shortDescription": "简短描述",
+      "shortDescriptionPlaceholder": "商品简要说明",
+      "description": "详细描述",
+      "descriptionPlaceholder": "商品详细说明",
+      "salePrice": "售价（韩元） *",
+      "discountPrice": "折扣价（韩元）",
+      "stock": "库存",
+      "sku": "SKU",
+      "skuPlaceholder": "库存管理编码",
+      "status": "状态",
+      "featuredProduct": "标记为推荐商品",
+      "cancel": "取消",
+      "create": "添加商品",
+      "update": "保存修改",
+      "saving": "保存中...",
+      "createSuccess": "商品添加成功。",
+      "updateSuccess": "商品更新成功。",
+      "saveError": "保存失败。",
+      "validation": {
+        "nameRequired": "请输入商品名称。",
+        "slugRequired": "请输入Slug。",
+        "priceRequired": "请输入正确的价格。"
+      }
+    },
+    "members": {
+      "title": "会员管理",
+      "searchPlaceholder": "按邮箱或姓名搜索",
+      "search": "搜索",
+      "loading": "加载中...",
+      "noMembers": "暂无会员。",
+      "loadError": "会员列表加载失败。",
+      "statusLabel": "状态：",
+      "cannotChange": "不可修改",
+      "columns": {
+        "id": "ID",
+        "email": "电子邮箱",
+        "name": "姓名",
+        "role": "角色",
+        "status": "状态",
+        "joinDate": "注册日期",
+        "changeRole": "修改角色"
+      },
+      "roles": {
+        "user": "普通会员",
+        "admin": "管理员",
+        "super_admin": "超级管理员"
+      },
+      "memberStatus": {
+        "active": "活跃",
+        "inactive": "停用"
+      },
+      "roleFilter": {
+        "all": "全部",
+        "user": "普通会员",
+        "admin": "管理员",
+        "super_admin": "超级管理员"
+      },
+      "statusFilter": {
+        "all": "全部",
+        "active": "活跃",
+        "inactive": "停用"
+      }
+    },
+    "sidebar": {
+      "dashboard": "控制台",
+      "orders": "订单管理",
+      "products": "商品管理",
+      "categories": "分类",
+      "members": "会员管理",
+      "navigation": "导航",
+      "pages": "页面管理",
+      "theme": "主题设置",
+      "settings": "设置",
+      "shopName": "玉花堂",
+      "adminPanel": "管理后台",
+      "backToShop": "返回商城"
+    },
+    "navigation": {
+      "title": "导航管理"
+    },
+    "categories": {
+      "title": "分类管理"
+    }
+  },
+  "search": {
+    "title": "搜索",
+    "placeholder": "搜索商品...",
+    "recentSearches": "最近搜索",
+    "clearAll": "全部清除",
+    "noResults": "暂无搜索结果",
+    "noResultsDescription": "未找到\"{query}\"的相关结果。",
+    "results": "\"{query}\"的搜索结果"
+  },
+  "wishlist": {
+    "add": "加入心愿单",
+    "remove": "从心愿单移除",
+    "addSuccess": "已加入心愿单。",
+    "removeSuccess": "已从心愿单移除。",
+    "loginRequired": "请先登录。",
+    "noItems": "心愿单为空。",
+    "noItemsDescription": "将您喜欢的商品加入心愿单吧。"
+  },
+  "recentlyViewed": {
+    "title": "最近浏览",
+    "noItems": "暂无最近浏览的商品。"
+  },
+  "payment": {
+    "successTitle": "支付成功",
+    "failTitle": "支付失败",
+    "backToHome": "返回首页",
+    "tryAgain": "重新尝试"
+  },
+  "pages": {
+    "adminPages": "页面管理"
+  },
+  "errors": {
+    "generic": "发生错误。",
+    "notFound": "页面未找到。",
+    "loadFailed": "数据加载失败。",
+    "saveFailed": "保存失败。",
+    "deleteFailed": "删除失败。",
+    "networkError": "发生网络错误。",
+    "serverError": "发生服务器错误。",
+    "unauthorized": "请先登录。",
+    "forbidden": "您没有访问权限。",
+    "dashboardLoadError": "控制台数据加载失败"
+  },
+  "clayTypes": {
+    "all": "全部",
+    "zhuni": "朱泥",
+    "duanni": "段泥",
+    "zini": "紫泥",
+    "heini": "黑泥",
+    "qingshuini": "青水泥",
+    "luni": "绿泥"
+  },
+  "teapotShapes": {
+    "all": "全部"
   }
 }


### PR DESCRIPTION
## Summary
- ko.json(617줄) 기반으로 en/ja/zh 번역 파일을 완성하여 동일한 키 구조 유지
- English: 자연스러운 상업적 어조 (polite commercial tone)
- Japanese: 경어(敬語/Keigo) 전체 적용
- Chinese: 간체자(简体中文) 격식체 상업 어조

## Changes
- `src/i18n/messages/en.json` — 완전한 영문 번역 (617줄)
- `src/i18n/messages/ja.json` — 완전한 일문 번역 (617줄)
- `src/i18n/messages/zh.json` — 완전한 중문 번역 (617줄)
- `src/i18n/messages/ko.json` — 기존 617줄 전체 키 반영

## Test plan
- [x] `node -e "require('./src/i18n/messages/[en|ja|zh].json')"` — JSON 유효성 확인
- [x] `npx next build` — 빌드 성공
- [x] `npm run test:run` — 273 tests passed (46 files)

Closes #55