### PR TITLE
feat: #59 SEO hreflang 태그 및 다국어 sitemap 생성

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { Toaster } from 'sonner';
@@ -9,8 +10,36 @@ import RecentlyViewedWidget from '@/components/RecentlyViewedWidget';
 import { routing } from '@/i18n/routing';
 import type { Locale } from '@/i18n/routing';
 
+const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
+
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const safeLocale = routing.locales.includes(locale as Locale) ? (locale as Locale) : routing.defaultLocale;
+
+  const languages: Record<string, string> = {};
+  for (const loc of routing.locales) {
+    languages[loc] = `${SITE_URL}/${loc}`;
+  }
+  languages['x-default'] = `${SITE_URL}/${routing.defaultLocale}`;
+
+  return {
+    alternates: {
+      canonical: `${SITE_URL}/${safeLocale}`,
+      languages,
+    },
+    openGraph: {
+      locale: safeLocale,
+      alternateLocale: routing.locales.filter((loc) => loc !== safeLocale),
+    },
+  };
 }
 
 const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';

--- a/src/app/[locale]/products/[id]/page.tsx
+++ b/src/app/[locale]/products/[id]/page.tsx
@@ -2,21 +2,30 @@ import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import { fetchProduct } from '@/lib/api-server'
 import ProductDetailClient from '@/components/products/ProductDetailClient'
+import { routing } from '@/i18n/routing'
+import type { Locale } from '@/i18n/routing'
 
 const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
 
 interface ProductDetailProps {
-  params: Promise<{ id: string }>
+  params: Promise<{ id: string; locale: string }>
 }
 
 export async function generateMetadata({ params }: ProductDetailProps): Promise<Metadata> {
-  const { id } = await params
+  const { id, locale } = await params
+  const safeLocale = routing.locales.includes(locale as Locale) ? (locale as Locale) : routing.defaultLocale;
   const product = await fetchProduct(Number(id))
   if (!product) return { title: '상품을 찾을 수 없습니다' }
 
   const imageUrl = product.images?.[0]?.url ?? '';
   const absoluteImageUrl = imageUrl.startsWith('http') ? imageUrl : `${SITE_URL}${imageUrl}`;
   const description = product.shortDescription ?? product.description?.slice(0, 160) ?? `${product.name} 상세 페이지`;
+
+  const languages: Record<string, string> = {};
+  for (const loc of routing.locales) {
+    languages[loc] = `${SITE_URL}/${loc}/products/${id}`;
+  }
+  languages['x-default'] = `${SITE_URL}/${routing.defaultLocale}/products/${id}`;
 
   return {
     title: product.name,
@@ -26,6 +35,8 @@ export async function generateMetadata({ params }: ProductDetailProps): Promise<
       description,
       images: imageUrl ? [{ url: absoluteImageUrl, width: 1200, height: 630, alt: product.name }] : [],
       type: 'website',
+      locale: safeLocale,
+      alternateLocale: routing.locales.filter((loc) => loc !== safeLocale),
     },
     twitter: {
       card: 'summary_large_image',
@@ -33,7 +44,8 @@ export async function generateMetadata({ params }: ProductDetailProps): Promise<
       images: imageUrl ? [absoluteImageUrl] : [],
     },
     alternates: {
-      canonical: `/products/${id}`,
+      canonical: `${SITE_URL}/${safeLocale}/products/${id}`,
+      languages,
     },
   }
 }

--- a/src/app/__tests__/seo.test.ts
+++ b/src/app/__tests__/seo.test.ts
@@ -45,8 +45,10 @@ describe('SEO', () => {
       mockFetchProducts.mockResolvedValue({ items: [], total: 0, page: 1, limit: 1000 });
       const result = await sitemap();
       const urls = result.map((r) => r.url);
-      expect(urls).toContain('https://shop-okhwadang.com');
-      expect(urls).toContain('https://shop-okhwadang.com/products');
+      expect(urls).toContain('https://shop-okhwadang.com/ko');
+      expect(urls).toContain('https://shop-okhwadang.com/en');
+      expect(urls).toContain('https://shop-okhwadang.com/ko/products');
+      expect(urls).toContain('https://shop-okhwadang.com/en/products');
     });
 
     it('includes product routes', async () => {
@@ -60,14 +62,15 @@ describe('SEO', () => {
       });
       const result = await sitemap();
       const urls = result.map((r) => r.url);
-      expect(urls).toContain('https://shop-okhwadang.com/products/1');
+      expect(urls).toContain('https://shop-okhwadang.com/ko/products/1');
+      expect(urls).toContain('https://shop-okhwadang.com/en/products/1');
     });
 
     it('returns only static routes when fetchProducts fails', async () => {
       mockFetchProducts.mockRejectedValue(new Error('Network error'));
       const result = await sitemap();
       const urls = result.map((r) => r.url);
-      expect(urls).toContain('https://shop-okhwadang.com');
+      expect(urls).toContain('https://shop-okhwadang.com/ko');
       expect(urls).not.toContain(expect.stringContaining('/products/'));
     });
   });
@@ -146,13 +149,13 @@ describe('SEO', () => {
       });
 
       const { generateMetadata } = await import('@/app/[locale]/products/[id]/page');
-      const metadata = await generateMetadata({ params: Promise.resolve({ id: '1' }) });
+      const metadata = await generateMetadata({ params: Promise.resolve({ id: '1', locale: 'ko' }) });
 
       expect(metadata.title).toBe('Test Product');
       expect(metadata.description).toBe('Short desc');
       expect(metadata.openGraph).toBeDefined();
       expect(metadata.twitter).toBeDefined();
-      expect(metadata.alternates?.canonical).toBe('/products/1');
+      expect(metadata.alternates?.canonical).toBe('https://shop-okhwadang.com/ko/products/1');
     });
 
     it('returns fallback when product not found', async () => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,24 +1,39 @@
 import type { MetadataRoute } from 'next';
 import { fetchProducts } from '@/lib/api-server';
+import { routing } from '@/i18n/routing';
 
 const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
+const locales = routing.locales;
+
+const staticPaths = [
+  { path: '', changeFrequency: 'daily' as const, priority: 1 },
+  { path: '/products', changeFrequency: 'daily' as const, priority: 0.9 },
+  { path: '/faq', changeFrequency: 'monthly' as const, priority: 0.5 },
+  { path: '/notice', changeFrequency: 'weekly' as const, priority: 0.5 },
+];
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const staticRoutes: MetadataRoute.Sitemap = [
-    { url: `${SITE_URL}`, lastModified: new Date(), changeFrequency: 'daily', priority: 1 },
-    { url: `${SITE_URL}/products`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
-    { url: `${SITE_URL}/faq`, changeFrequency: 'monthly', priority: 0.5 },
-    { url: `${SITE_URL}/notice`, changeFrequency: 'weekly', priority: 0.5 },
-  ];
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = staticPaths.flatMap(({ path, changeFrequency, priority }) =>
+    locales.map((locale) => ({
+      url: `${SITE_URL}/${locale}${path}`,
+      lastModified: now,
+      changeFrequency,
+      priority,
+    }))
+  );
 
   try {
     const result = await fetchProducts({ limit: 1000 });
-    const productRoutes: MetadataRoute.Sitemap = result.items.map((p) => ({
-      url: `${SITE_URL}/products/${p.id}`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly' as const,
-      priority: 0.8,
-    }));
+    const productRoutes: MetadataRoute.Sitemap = result.items.flatMap((p) =>
+      locales.map((locale) => ({
+        url: `${SITE_URL}/${locale}/products/${p.id}`,
+        lastModified: now,
+        changeFrequency: 'weekly' as const,
+        priority: 0.8,
+      }))
+    );
     return [...staticRoutes, ...productRoutes];
   } catch {
     return staticRoutes;


### PR DESCRIPTION
## Summary

- `src/app/[locale]/layout.tsx`에 `generateMetadata` 추가: `alternates.languages`로 모든 로케일(ko/en/ja/zh)에 대한 hreflang `<link rel="alternate">` 태그 및 `x-default` 자동 생성
- `src/app/sitemap.ts`를 로케일별 URL 포함하도록 업데이트: 정적 페이지 및 상품 페이지 모두 `/{locale}/path` 형식으로 생성
- `src/app/[locale]/products/[id]/page.tsx`에 hreflang alternates 및 OG `locale` / `alternateLocale` 태그 추가
- `src/app/__tests__/seo.test.ts`를 새 로케일 인식 URL 형식에 맞게 업데이트

## Test plan

- [ ] HTML source에 `<link rel="alternate" hreflang="ko" href="https://shop-okhwadang.com/ko">` 등 존재 확인
- [ ] `/sitemap.xml`에 `/ko/products`, `/en/products`, `/ja/products`, `/zh/products` 포함 확인
- [ ] 상품 상세 페이지에 hreflang alternates 및 OG locale 태그 확인
- [ ] `npm run build && npm run test:run` 통과 (285 tests passed)
- [ ] Google Search Console에서 hreflang 인식 가능

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)