### PR TITLE
feat: #63 언어 선택기 UI 구현

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -17,6 +17,10 @@ vi.mock('@/i18n/navigation', () => ({
   usePathname: () => '/',
 }));
 
+vi.mock('next-intl', () => ({
+  useLocale: () => 'ko',
+}));
+
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
     isAuthenticated: false,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useCart } from '@/contexts/CartContext';
 import { useNavigation } from '@/hooks/useNavigation';
 import type { NavigationItem } from '@/lib/api';
+import LanguageSelector from '@/components/LanguageSelector';
 
 // ─── Sub-components ──────────────────────────────────────────────
 
@@ -76,6 +77,7 @@ interface DesktopActionsProps {
 function DesktopActions({ isAuthenticated, userName, itemCount, onLogout }: DesktopActionsProps) {
   return (
     <div className="hidden md:flex items-center gap-4">
+      <LanguageSelector />
       <CartBadge itemCount={itemCount} />
       {isAuthenticated ? (
         <>
@@ -176,6 +178,9 @@ function MobileMenu({ isAuthenticated, userName, navItems, sidebarItems, onClose
             로그인
           </Link>
         )}
+        <div className="py-2">
+          <LanguageSelector />
+        </div>
       </div>
     </nav>
   );

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useRouter, usePathname } from '@/i18n/navigation';
+import { useLocale } from 'next-intl';
+import { cn } from '@/components/ui/utils';
+import { routing } from '@/i18n/routing';
+import type { Locale } from '@/i18n/routing';
+
+interface LangOption {
+  locale: Locale;
+  flag: string;
+  label: string;
+}
+
+const LANG_OPTIONS: LangOption[] = [
+  { locale: 'ko', flag: '🇰🇷', label: '한국어' },
+  { locale: 'en', flag: '🇺🇸', label: 'English' },
+  { locale: 'ja', flag: '🇯🇵', label: '日本語' },
+  { locale: 'zh', flag: '🇨🇳', label: '中文' },
+];
+
+interface LanguageSelectorProps {
+  className?: string;
+  /** compact: flag only; full: flag + label (default full) */
+  compact?: boolean;
+}
+
+export default function LanguageSelector({ className, compact = false }: LanguageSelectorProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentLocale = useLocale() as Locale;
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const current = LANG_OPTIONS.find((o) => o.locale === currentLocale) ?? LANG_OPTIONS[0];
+
+  const handleSelect = (locale: Locale) => {
+    setIsOpen(false);
+    if (locale === currentLocale) return;
+    // Save to cookie (NEXT_LOCALE) — next-intl reads this automatically
+    document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
+    router.replace(pathname, { locale });
+  };
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label="언어 선택"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className={cn(
+          'flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm',
+        )}
+      >
+        <span aria-hidden="true">{current.flag}</span>
+        {!compact && <span>{current.label}</span>}
+      </button>
+
+      {isOpen && (
+        <ul
+          role="listbox"
+          aria-label="언어 목록"
+          className={cn(
+            'absolute right-0 top-full mt-1 z-50',
+            'min-w-[8rem] rounded-md border border-border bg-background shadow-md',
+            'py-1',
+          )}
+        >
+          {LANG_OPTIONS.map((option) => {
+            const isSelected = option.locale === currentLocale;
+            return (
+              <li key={option.locale} role="option" aria-selected={isSelected}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(option.locale)}
+                  className={cn(
+                    'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left transition-colors',
+                    isSelected
+                      ? 'text-foreground font-medium bg-muted'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                  )}
+                >
+                  <span aria-hidden="true">{option.flag}</span>
+                  <span>{option.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// Re-export for tree-shaking convenience
+export { LANG_OPTIONS, routing };

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -20,6 +20,10 @@ vi.mock('@/i18n/navigation', () => ({
   usePathname: () => mockPathname,
 }));
 
+vi.mock('next-intl', () => ({
+  useLocale: () => 'ko',
+}));
+
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
     isAuthenticated: false,

--- a/src/components/__tests__/LanguageSelector.test.tsx
+++ b/src/components/__tests__/LanguageSelector.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import LanguageSelector from '@/components/LanguageSelector';
+
+const mockReplace = vi.fn();
+let mockPathname = '/';
+let mockLocale = 'ko';
+
+vi.mock('@/i18n/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('next-intl', () => ({
+  useLocale: () => mockLocale,
+}));
+
+beforeEach(() => {
+  mockReplace.mockClear();
+  mockPathname = '/';
+  mockLocale = 'ko';
+  // Reset document.cookie
+  document.cookie = 'NEXT_LOCALE=; max-age=0; path=/';
+});
+
+describe('LanguageSelector', () => {
+  it('renders current language flag and label', () => {
+    render(<LanguageSelector />);
+    expect(screen.getByRole('button', { name: '언어 선택' })).toBeInTheDocument();
+    expect(screen.getByText('한국어')).toBeInTheDocument();
+  });
+
+  it('opens dropdown on button click', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector />);
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    expect(screen.getByRole('listbox', { name: '언어 목록' })).toBeInTheDocument();
+  });
+
+  it('shows all 4 language options', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector />);
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.getByText('日本語')).toBeInTheDocument();
+    expect(screen.getByText('中文')).toBeInTheDocument();
+    expect(screen.getAllByText('한국어').length).toBeGreaterThan(0);
+  });
+
+  it('selecting a different language calls router.replace and closes dropdown', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector />);
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    await user.click(screen.getByText('English'));
+    expect(mockReplace).toHaveBeenCalledWith('/', { locale: 'en' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('selecting current locale does not call router.replace', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector />);
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    // Click 한국어 (current locale is 'ko')
+    const options = screen.getAllByText('한국어');
+    await user.click(options[options.length - 1]);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('sets NEXT_LOCALE cookie on language change', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector />);
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    await user.click(screen.getByText('日本語'));
+    expect(document.cookie).toContain('NEXT_LOCALE=ja');
+  });
+
+  it('closes dropdown on Escape key', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector />);
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes dropdown on outside click', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <LanguageSelector />
+        <div data-testid="outside">outside</div>
+      </div>,
+    );
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('compact mode shows only flag (no label)', () => {
+    render(<LanguageSelector compact />);
+    // label is not rendered
+    expect(screen.queryByText('한국어')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '언어 선택' })).toBeInTheDocument();
+  });
+
+  it('shows English as current language when locale is en', () => {
+    mockLocale = 'en';
+    render(<LanguageSelector />);
+    expect(screen.getByText('English')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- `LanguageSelector` 컴포넌트 신규 추가 — 🇰🇷 한국어 / 🇺🇸 English / 🇯🇵 日本語 / 🇨🇳 中文 드롭다운
- Header 데스크탑(`DesktopActions`) 우측 및 모바일 메뉴 하단에 통합
- 언어 변경 시 `NEXT_LOCALE` 쿠키 저장(1년) + `router.replace(pathname, { locale })` 으로 동일 페이지 이동
- Escape 키 / 외부 클릭 시 드롭다운 자동 닫힘
- `compact` prop으로 플래그만 표시하는 압축 모드 지원

## Test plan
- [x] `LanguageSelector` 단위 테스트 10개 추가 (드롭다운 열기/닫기, 언어 선택, 쿠키, compact 모드 등)
- [x] `Header.test.tsx`, `App.test.tsx`에 `next-intl` mock 추가
- [x] `npm run build` 통과
- [x] `npm run test:run` — 295 tests passed

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)