### PR TITLE
feat: #61 결제 페이지 locale별 게이트웨이 분기

### DIFF
--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -6,6 +6,8 @@ import { Payment, PaymentStatus, PaymentMethod, PaymentGatewayType } from '../en
 import { Shipping, ShippingStatus } from '../entities/shipping.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { MockPaymentAdapter, MOCK_TEST_SIGNATURE } from '../adapters/mock.adapter';
+import { TossPaymentAdapter } from '../adapters/toss.adapter';
+import { StripePaymentAdapter } from '../adapters/stripe.adapter';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order =>
   ({
@@ -103,6 +105,8 @@ describe('PaymentsService', () => {
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockShippingRepo },
         { provide: 'PaymentGateway', useValue: mockGateway },
+        { provide: TossPaymentAdapter, useValue: mockGateway },
+        { provide: StripePaymentAdapter, useValue: mockGateway },
       ],
     }).compile();
 

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -5,6 +5,8 @@ import { PaymentsService } from '../payments.service';
 import { Payment } from '../entities/payment.entity';
 import { Order } from '../../orders/entities/order.entity';
 import { Shipping } from '../entities/shipping.entity';
+import { TossPaymentAdapter } from '../adapters/toss.adapter';
+import { StripePaymentAdapter } from '../adapters/stripe.adapter';
 
 describe('PaymentsService — webhook', () => {
   let service: PaymentsService;
@@ -29,6 +31,8 @@ describe('PaymentsService — webhook', () => {
         { provide: getRepositoryToken(Order), useValue: mockRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockRepo },
         { provide: 'PaymentGateway', useValue: mockGateway },
+        { provide: TossPaymentAdapter, useValue: mockGateway },
+        { provide: StripePaymentAdapter, useValue: mockGateway },
       ],
     }).compile();
 

--- a/backend/src/modules/payments/dto/prepare-payment.dto.ts
+++ b/backend/src/modules/payments/dto/prepare-payment.dto.ts
@@ -1,6 +1,10 @@
-import { IsInt } from 'class-validator';
+import { IsInt, IsOptional, IsString } from 'class-validator';
 
 export class PreparePaymentDto {
   @IsInt()
   orderId!: number;
+
+  @IsOptional()
+  @IsString()
+  locale?: string;
 }

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -12,6 +12,9 @@ import { PaymentGateway } from './interfaces/payment-gateway.interface';
 import { PreparePaymentDto } from './dto/prepare-payment.dto';
 import { ConfirmPaymentDto } from './dto/confirm-payment.dto';
 import { CancelPaymentDto } from './dto/cancel-payment.dto';
+import { TossPaymentAdapter } from './adapters/toss.adapter';
+import { StripePaymentAdapter } from './adapters/stripe.adapter';
+import { resolveGatewayByLocale } from './payments.module';
 
 @Injectable()
 export class PaymentsService {
@@ -26,7 +29,17 @@ export class PaymentsService {
     private readonly shippingRepository: Repository<Shipping>,
     @Inject('PaymentGateway')
     private readonly gateway: PaymentGateway,
+    private readonly tossAdapter: TossPaymentAdapter,
+    private readonly stripeAdapter: StripePaymentAdapter,
   ) {}
+
+  private resolveGateway(locale?: string): PaymentGateway {
+    if (!locale) return this.gateway;
+    const name = resolveGatewayByLocale(locale);
+    if (name === 'toss') return this.tossAdapter;
+    if (name === 'stripe') return this.stripeAdapter;
+    return this.gateway;
+  }
 
   async prepare(dto: PreparePaymentDto, userId: number) {
     const order = await this.orderRepository.findOne({ where: { id: dto.orderId } });
@@ -35,6 +48,9 @@ export class PaymentsService {
     if (order.status !== OrderStatus.PENDING) {
       throw new ConflictException('이미 처리된 주문입니다.');
     }
+
+    const selectedGateway = this.resolveGateway(dto.locale);
+    const gatewayName = dto.locale ? resolveGatewayByLocale(dto.locale) : 'mock';
 
     let payment = await this.paymentRepository.findOne({ where: { orderId: dto.orderId } });
     if (!payment) {
@@ -48,14 +64,14 @@ export class PaymentsService {
       payment = await this.paymentRepository.save(payment);
     }
 
-    const result = await this.gateway.prepare(String(dto.orderId), Number(order.totalAmount));
+    const result = await selectedGateway.prepare(String(dto.orderId), Number(order.totalAmount));
 
     return {
       paymentId: Number(payment.id),
       orderId: dto.orderId,
       orderNumber: order.orderNumber,
       amount: Number(order.totalAmount),
-      gateway: 'mock',
+      gateway: gatewayName,
       clientKey: result.clientKey,
     };
   }

--- a/src/app/[locale]/checkout/fail/page.tsx
+++ b/src/app/[locale]/checkout/fail/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, use } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
+import type { Locale } from '@/i18n/routing';
 
-function CheckoutFailContent() {
+function CheckoutFailContent({ locale }: { locale: Locale }) {
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -25,7 +26,7 @@ function CheckoutFailContent() {
       )}
       <p className="mb-6 text-sm text-muted-foreground">{message}</p>
       <button
-        onClick={() => router.back()}
+        onClick={() => router.replace(`/${locale}/checkout`)}
         className="rounded-md bg-foreground px-6 py-2 text-sm font-semibold text-background hover:opacity-90 transition-opacity"
       >
         돌아가기
@@ -34,7 +35,13 @@ function CheckoutFailContent() {
   );
 }
 
-export default function CheckoutFailPage() {
+export default function CheckoutFailPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = use(params);
+
   return (
     <Suspense
       fallback={
@@ -43,7 +50,7 @@ export default function CheckoutFailPage() {
         </div>
       }
     >
-      <CheckoutFailContent />
+      <CheckoutFailContent locale={locale} />
     </Suspense>
   );
 }

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, use } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
@@ -8,6 +8,8 @@ import { useCart } from '@/contexts/CartContext';
 import type { CartItem, PreparePaymentResponse, UserAddress } from '@/lib/api';
 import { ordersApi, paymentsApi, usersApi } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
+import type { Locale } from '@/i18n/routing';
+import PaymentGateway from '@/components/checkout/PaymentGateway';
 
 type PaymentStep = 'idle' | 'creating_order' | 'preparing_payment' | 'confirming_payment' | 'success';
 
@@ -52,13 +54,21 @@ function validateForm(form: ShippingForm): FormErrors {
   return errors;
 }
 
-export default function CheckoutPage() {
+export default function CheckoutPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = use(params);
   const router = useRouter();
   const { isAuthenticated, isLoading } = useAuth();
   const { refetch } = useCart();
 
   const [checkoutItems, setCheckoutItems] = useState<CartItem[]>([]);
   const [step, setStep] = useState<PaymentStep>('idle');
+  const [prepareResult, setPrepareResult] = useState<PreparePaymentResponse | null>(null);
+  const [currentOrderId, setCurrentOrderId] = useState<number | null>(null);
+  const [currentOrderNumber, setCurrentOrderNumber] = useState<string>('');
   const [form, setForm] = useState<ShippingForm>({
     recipientName: '',
     recipientPhone: '',
@@ -86,23 +96,23 @@ export default function CheckoutPage() {
   useEffect(() => {
     if (isLoading) return;
     if (!isAuthenticated) {
-      router.replace('/login');
+      router.replace(`/${locale}/login`);
       return;
     }
     const raw = sessionStorage.getItem('checkoutItems');
     if (!raw) {
-      router.replace('/cart');
+      router.replace(`/${locale}/cart`);
       return;
     }
     try {
       const parsed = JSON.parse(raw) as CartItem[];
       if (!Array.isArray(parsed) || parsed.length === 0) {
-        router.replace('/cart');
+        router.replace(`/${locale}/cart`);
         return;
       }
       setCheckoutItems(parsed);
     } catch {
-      router.replace('/cart');
+      router.replace(`/${locale}/cart`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, isLoading]);
@@ -153,32 +163,30 @@ export default function CheckoutPage() {
     }
   };
 
-  const handleTossPayment = async (
-    prepareResult: PreparePaymentResponse,
-    orderId: number,
-    orderNumber: string,
-  ) => {
-    const { loadTossPayments } = await import('@tosspayments/tosspayments-sdk');
-    const tossPayments = await loadTossPayments(prepareResult.clientKey);
-    const payment = tossPayments.payment({ customerKey: `user_${orderId}` });
-
-    sessionStorage.setItem(
-      'tossPaymentContext',
-      JSON.stringify({ orderId, orderNumber, amount: grandTotal }),
-    );
-
-    await payment.requestPayment({
-      method: 'CARD',
-      amount: { currency: 'KRW', value: grandTotal },
-      orderId: orderNumber,
-      orderName: `주문 ${orderNumber}`,
-      successUrl: `${window.location.origin}/checkout/success`,
-      failUrl: `${window.location.origin}/checkout/fail`,
-    });
+  const handlePaymentError = (message: string) => {
+    toast.error(message);
+    setStep('idle');
+    setPrepareResult(null);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // If already prepared (Stripe), trigger stripe confirm
+    if (prepareResult && prepareResult.gateway === 'stripe') {
+      const stripeConfirm = (window as Window & { __stripeConfirm?: () => Promise<void> }).__stripeConfirm;
+      if (stripeConfirm) {
+        setStep('confirming_payment');
+        try {
+          await stripeConfirm();
+          // Stripe redirects on success — if we reach here it means redirect pending
+        } catch (err) {
+          handlePaymentError(err instanceof Error ? err.message : '결제에 실패했습니다.');
+        }
+        return;
+      }
+    }
+
     const validationErrors = validateForm(form);
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
@@ -204,15 +212,47 @@ export default function CheckoutPage() {
       );
 
       setStep('preparing_payment');
-      const prepareResult: PreparePaymentResponse = await paymentsApi.prepare(
-        { orderId: order.id },
+      const result: PreparePaymentResponse = await paymentsApi.prepare(
+        { orderId: order.id, locale },
       );
 
-      if (prepareResult.clientKey && prepareResult.clientKey !== 'mock_client_key') {
-        await handleTossPayment(prepareResult, order.id, order.orderNumber);
+      // Toss flow: invoke __tossPayHandler
+      const isToss =
+        locale === 'ko' &&
+        result.clientKey &&
+        result.clientKey !== 'mock_client_key';
+
+      if (isToss) {
+        setCurrentOrderId(order.id);
+        setCurrentOrderNumber(order.orderNumber);
+        setPrepareResult(result);
+        // PaymentGateway component registers __tossPayHandler in useEffect
+        // Give it a tick to register, then call it
+        setTimeout(async () => {
+          const tossHandler = (window as Window & { __tossPayHandler?: () => Promise<void> }).__tossPayHandler;
+          if (tossHandler) {
+            await tossHandler();
+          }
+        }, 100);
         return;
       }
 
+      // Stripe flow: render Payment Element
+      const isStripe =
+        result.gateway === 'stripe' &&
+        result.clientKey &&
+        result.clientKey !== 'mock_client_key';
+
+      if (isStripe) {
+        setCurrentOrderId(order.id);
+        setCurrentOrderNumber(order.orderNumber);
+        setPrepareResult(result);
+        setStep('idle');
+        toast.info('카드 정보를 입력하고 결제하기를 눌러주세요.');
+        return;
+      }
+
+      // Mock flow
       setStep('confirming_payment');
       await paymentsApi.confirm(
         { orderId: order.id, paymentKey: `mock-${order.orderNumber}`, amount: grandTotal },
@@ -222,7 +262,7 @@ export default function CheckoutPage() {
       toast.success('결제가 완료되었습니다.');
       sessionStorage.removeItem('checkoutItems');
       await refetch();
-      router.replace(`/order/complete?orderId=${order.id}&orderNumber=${order.orderNumber}`);
+      router.replace(`/${locale}/order/complete?orderId=${order.id}&orderNumber=${order.orderNumber}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : '결제 중 오류가 발생했습니다.';
       toast.error(message);
@@ -254,7 +294,7 @@ export default function CheckoutPage() {
                   <p className="text-sm text-muted-foreground">저장된 배송지가 없습니다.</p>
                   <button
                     type="button"
-                    onClick={() => router.push('/my/address')}
+                    onClick={() => router.push(`/${locale}/my/address`)}
                     className="text-sm font-medium underline underline-offset-2 hover:opacity-70 transition-opacity"
                   >
                     배송지 추가
@@ -402,14 +442,20 @@ export default function CheckoutPage() {
             {/* Payment method */}
             <section className="rounded-lg border p-6 space-y-4">
               <h2 className="text-lg font-semibold">결제 수단</h2>
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input type="radio" name="paymentMethod" value="mock" defaultChecked readOnly className="accent-foreground" />
-                <span className="text-sm">
-                  {process.env.NEXT_PUBLIC_PAYMENT_GATEWAY === 'toss'
-                    ? '토스페이먼츠 (카드)'
-                    : '테스트 결제 (Mock)'}
-                </span>
-              </label>
+              {prepareResult ? (
+                <PaymentGateway
+                  prepareResult={prepareResult}
+                  orderId={currentOrderId!}
+                  orderNumber={currentOrderNumber}
+                  amount={grandTotal}
+                  locale={locale}
+                  onError={handlePaymentError}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  주문 정보 입력 후 결제 수단이 표시됩니다.
+                </p>
+              )}
             </section>
 
             {/* Coupon / points placeholder */}
@@ -434,8 +480,8 @@ export default function CheckoutPage() {
                       </p>
                     )}
                     <p className="text-muted-foreground">
-                      {formatCurrency(item.unitPrice)} × {item.quantity}개 ={' '}
-                      {formatCurrency(item.subtotal)}
+                      {formatCurrency(item.unitPrice, locale)} × {item.quantity}개 ={' '}
+                      {formatCurrency(item.subtotal, locale)}
                     </p>
                   </li>
                 ))}
@@ -444,18 +490,18 @@ export default function CheckoutPage() {
               <div className="border-t pt-4 space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">상품 금액</span>
-                  <span>{formatCurrency(totalAmount)}</span>
+                  <span>{formatCurrency(totalAmount, locale)}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">배송비</span>
-                  <span>{shippingFee === 0 ? '무료' : formatCurrency(shippingFee)}</span>
+                  <span>{shippingFee === 0 ? '무료' : formatCurrency(shippingFee, locale)}</span>
                 </div>
               </div>
 
               <div className="border-t pt-4">
                 <div className="flex justify-between font-bold">
                   <span>합계</span>
-                  <span>{formatCurrency(grandTotal)}</span>
+                  <span>{formatCurrency(grandTotal, locale)}</span>
                 </div>
               </div>
 

--- a/src/app/[locale]/checkout/success/page.tsx
+++ b/src/app/[locale]/checkout/success/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, use } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { useCart } from '@/contexts/CartContext';
 import { paymentsApi } from '@/lib/api';
+import type { Locale } from '@/i18n/routing';
 
-function CheckoutSuccessContent() {
+function CheckoutSuccessContent({ locale }: { locale: Locale }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { refetch } = useCart();
@@ -19,14 +21,14 @@ function CheckoutSuccessContent() {
 
     if (!paymentKey || !tossOrderId || !amountParam) {
       toast.error('결제 정보가 올바르지 않습니다.');
-      router.replace('/cart');
+      router.replace(`/${locale}/cart`);
       return;
     }
 
     const raw = sessionStorage.getItem('tossPaymentContext');
     if (!raw) {
       toast.error('결제 컨텍스트를 찾을 수 없습니다.');
-      router.replace('/cart');
+      router.replace(`/${locale}/cart`);
       return;
     }
 
@@ -39,21 +41,19 @@ function CheckoutSuccessContent() {
     const amount = Number(amountParam);
     if (amount !== ctx.amount) {
       toast.error('결제 금액이 일치하지 않습니다.');
-      router.replace('/cart');
+      router.replace(`/${locale}/cart`);
       return;
     }
 
     paymentsApi
-      .confirm(
-        { orderId: ctx.orderId, paymentKey, amount },
-      )
+      .confirm({ orderId: ctx.orderId, paymentKey, amount })
       .then(async () => {
         toast.success('결제가 완료되었습니다.');
         sessionStorage.removeItem('checkoutItems');
         sessionStorage.removeItem('tossPaymentContext');
         await refetch();
         router.replace(
-          `/order/complete?orderId=${ctx.orderId}&orderNumber=${ctx.orderNumber}`,
+          `/${locale}/order/complete?orderId=${ctx.orderId}&orderNumber=${ctx.orderNumber}`,
         );
       })
       .catch((err: unknown) => {
@@ -73,7 +73,7 @@ function CheckoutSuccessContent() {
           결제 확인 중 문제가 발생했습니다. 고객센터에 문의해주세요.
         </p>
         <button
-          onClick={() => router.replace('/cart')}
+          onClick={() => router.replace(`/${locale}/cart`)}
           className="rounded-md bg-foreground px-6 py-2 text-sm font-semibold text-background hover:opacity-90 transition-opacity"
         >
           장바구니로 돌아가기
@@ -90,7 +90,13 @@ function CheckoutSuccessContent() {
   );
 }
 
-export default function CheckoutSuccessPage() {
+export default function CheckoutSuccessPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = use(params);
+
   return (
     <Suspense
       fallback={
@@ -100,7 +106,7 @@ export default function CheckoutSuccessPage() {
         </div>
       }
     >
-      <CheckoutSuccessContent />
+      <CheckoutSuccessContent locale={locale} />
     </Suspense>
   );
 }

--- a/src/components/__tests__/CheckoutPage.test.tsx
+++ b/src/components/__tests__/CheckoutPage.test.tsx
@@ -1,9 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import CheckoutPage from '@/app/[locale]/checkout/page';
 import { ordersApi, paymentsApi, usersApi } from '@/lib/api';
 import type { CartItem, UserAddress } from '@/lib/api';
+
+const makeParams = () => Promise.resolve({ locale: 'ko' as const });
 
 // ---- next/navigation ----
 const mockReplace = vi.fn();
@@ -33,6 +35,16 @@ vi.mock('@/contexts/CartContext', () => ({
   CartProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// ---- i18n/routing ----
+vi.mock('@/i18n/routing', () => ({
+  routing: { locales: ['ko', 'en', 'ja', 'zh'], defaultLocale: 'ko' },
+}));
+
+// ---- PaymentGateway ----
+vi.mock('@/components/checkout/PaymentGateway', () => ({
+  default: () => <div data-testid="payment-gateway">PaymentGateway</div>,
+}));
+
 // ---- api ----
 vi.mock('@/lib/api', () => ({
   ordersApi: { create: vi.fn(), getById: vi.fn() },
@@ -54,22 +66,22 @@ describe('CheckoutPage', () => {
     sessionStorage.clear();
   });
 
-  it('redirects to /login when not authenticated', () => {
+  it('redirects to /login when not authenticated', async () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false, token: null, user: null, isLoading: false });
-    render(<CheckoutPage />);
-    expect(mockReplace).toHaveBeenCalledWith('/login');
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
+    expect(mockReplace).toHaveBeenCalledWith('/ko/login');
   });
 
-  it('redirects to /cart when no sessionStorage items', () => {
+  it('redirects to /cart when no sessionStorage items', async () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
-    render(<CheckoutPage />);
-    expect(mockReplace).toHaveBeenCalledWith('/cart');
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
+    expect(mockReplace).toHaveBeenCalledWith('/ko/cart');
   });
 
   it('renders form fields and order summary with valid items', async () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
     expect(await screen.findByLabelText(/받는 분 이름/)).toBeInTheDocument();
     expect(screen.getByLabelText(/연락처/)).toBeInTheDocument();
     expect(screen.getByText('테스트 상품')).toBeInTheDocument();
@@ -79,7 +91,7 @@ describe('CheckoutPage', () => {
     const user = userEvent.setup();
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
     await screen.findByLabelText(/받는 분 이름/);
     await user.type(screen.getByLabelText(/받는 분 이름/), '홍길동');
     await user.type(screen.getByLabelText(/연락처/), '01012345678');
@@ -110,7 +122,7 @@ describe('CheckoutPage', () => {
       status: 'paid', method: 'card', amount: 40000, paidAt: new Date().toISOString(),
     });
 
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
     await screen.findByLabelText(/받는 분 이름/);
     await user.type(screen.getByLabelText(/받는 분 이름/), '홍길동');
     await user.type(screen.getByLabelText(/연락처/), '010-1234-5678');
@@ -119,7 +131,7 @@ describe('CheckoutPage', () => {
     await user.click(screen.getByRole('button', { name: '결제하기' }));
 
     await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith('/order/complete?orderId=1&orderNumber=ORD-001');
+      expect(mockReplace).toHaveBeenCalledWith('/ko/order/complete?orderId=1&orderNumber=ORD-001');
     });
     expect(ordersApi.create).toHaveBeenCalledOnce();
     expect(paymentsApi.prepare).toHaveBeenCalledOnce();
@@ -161,7 +173,7 @@ describe('CheckoutPage', () => {
     );
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
 
     expect(await screen.findByText('주소 불러오는 중...')).toBeInTheDocument();
 
@@ -175,7 +187,7 @@ describe('CheckoutPage', () => {
     vi.mocked(usersApi.getAddresses).mockResolvedValue([defaultAddress, secondAddress]);
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
 
     await waitFor(() => {
       expect(screen.getByLabelText(/받는 분 이름/)).toHaveValue('김기본');
@@ -190,7 +202,7 @@ describe('CheckoutPage', () => {
     vi.mocked(usersApi.getAddresses).mockResolvedValue([defaultAddress, secondAddress]);
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
 
     await waitFor(() => {
       expect(screen.getByLabelText(/집/)).toBeInTheDocument();
@@ -204,7 +216,7 @@ describe('CheckoutPage', () => {
     vi.mocked(usersApi.getAddresses).mockResolvedValue([defaultAddress, secondAddress]);
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
 
     await waitFor(() => {
       expect(screen.getByLabelText(/회사/)).toBeInTheDocument();
@@ -225,7 +237,7 @@ describe('CheckoutPage', () => {
     vi.mocked(usersApi.getAddresses).mockResolvedValue([defaultAddress, secondAddress]);
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
 
     await waitFor(() => {
       expect(screen.getByLabelText(/받는 분 이름/)).toHaveValue('김기본');
@@ -245,7 +257,7 @@ describe('CheckoutPage', () => {
     vi.mocked(usersApi.getAddresses).mockResolvedValue([]);
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
 
     await waitFor(() => {
       expect(screen.getByText('저장된 배송지가 없습니다.')).toBeInTheDocument();
@@ -258,7 +270,7 @@ describe('CheckoutPage', () => {
     vi.mocked(usersApi.getAddresses).mockRejectedValue(new Error('Network error'));
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
-    render(<CheckoutPage />);
+    await act(async () => { render(<CheckoutPage params={makeParams()} />) });
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalled();

--- a/src/components/checkout/PaymentGateway.tsx
+++ b/src/components/checkout/PaymentGateway.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { Locale } from '@/i18n/routing';
+import type { PreparePaymentResponse } from '@/lib/api';
+
+interface PaymentGatewayProps {
+  prepareResult: PreparePaymentResponse;
+  orderId: number;
+  orderNumber: string;
+  amount: number;
+  locale: Locale;
+  onError: (message: string) => void;
+}
+
+// ─── Toss Payments (ko) ───────────────────────────────────────────────────────
+
+function TossPaymentGateway({
+  prepareResult,
+  orderId,
+  orderNumber,
+  amount,
+  locale,
+  onError,
+}: PaymentGatewayProps) {
+  useEffect(() => {
+    const origin = window.location.origin;
+
+    const handler = async () => {
+      try {
+        const { loadTossPayments } = await import('@tosspayments/tosspayments-sdk');
+        const tossPayments = await loadTossPayments(prepareResult.clientKey);
+        const payment = tossPayments.payment({ customerKey: `user_${orderId}` });
+
+        sessionStorage.setItem(
+          'tossPaymentContext',
+          JSON.stringify({ orderId, orderNumber, amount }),
+        );
+
+        await payment.requestPayment({
+          method: 'CARD',
+          amount: { currency: 'KRW', value: amount },
+          orderId: orderNumber,
+          orderName: `주문 ${orderNumber}`,
+          successUrl: `${origin}/${locale}/checkout/success`,
+          failUrl: `${origin}/${locale}/checkout/fail`,
+        });
+      } catch (err) {
+        onError(err instanceof Error ? err.message : '결제 초기화 오류');
+      }
+    };
+
+    (window as Window & { __tossPayHandler?: () => Promise<void> }).__tossPayHandler = handler;
+
+    return () => {
+      delete (window as Window & { __tossPayHandler?: () => Promise<void> }).__tossPayHandler;
+    };
+  }, [prepareResult.clientKey, orderId, orderNumber, amount, locale, onError]);
+
+  return (
+    <label className="flex items-center gap-3 cursor-pointer">
+      <input
+        type="radio"
+        name="paymentMethod"
+        value="toss"
+        defaultChecked
+        readOnly
+        className="accent-foreground"
+      />
+      <span className="text-sm">토스페이먼츠 (카드)</span>
+    </label>
+  );
+}
+
+// ─── Stripe Payment Element (en / ja / zh) ────────────────────────────────────
+
+function StripePaymentGateway({
+  clientSecret,
+  publishableKey,
+  locale,
+  onError,
+}: {
+  clientSecret: string;
+  publishableKey: string;
+  locale: string;
+  onError: (msg: string) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [loading, setLoading] = useState(true);
+  const [mountError, setMountError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!clientSecret || !publishableKey) {
+      setMountError('Stripe 설정이 올바르지 않습니다.');
+      setLoading(false);
+      return;
+    }
+
+    const stripeLocaleMap: Record<string, string> = {
+      en: 'en',
+      ja: 'ja',
+      zh: 'zh',
+    };
+    const stripeLocale = stripeLocaleMap[locale] ?? 'auto';
+
+    let mounted = true;
+
+    import('@stripe/stripe-js').then(async ({ loadStripe }) => {
+      if (!mounted || !containerRef.current) return;
+
+      const stripeInstance = await loadStripe(publishableKey);
+      if (!stripeInstance || !mounted || !containerRef.current) return;
+
+      const elements = stripeInstance.elements({
+        clientSecret,
+        locale: stripeLocale as import('@stripe/stripe-js').StripeElementLocale,
+      });
+
+      const paymentElement = elements.create('payment');
+      paymentElement.mount(containerRef.current);
+      paymentElement.on('ready', () => {
+        if (mounted) setLoading(false);
+      });
+      paymentElement.on('loaderror', () => {
+        if (mounted) {
+          setMountError('결제 수단을 불러오는데 실패했습니다.');
+          setLoading(false);
+        }
+      });
+
+      (window as Window & { __stripeConfirm?: () => Promise<void> }).__stripeConfirm = async () => {
+        const { error } = await stripeInstance.confirmPayment({
+          elements,
+          confirmParams: {
+            return_url: `${window.location.origin}/${locale}/checkout/success`,
+          },
+        });
+        if (error) {
+          throw new Error(error.message ?? '결제에 실패했습니다.');
+        }
+      };
+    });
+
+    return () => {
+      mounted = false;
+      delete (window as Window & { __stripeConfirm?: () => Promise<void> }).__stripeConfirm;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientSecret, publishableKey]);
+
+  return (
+    <div className="space-y-3">
+      <label className="flex items-center gap-3">
+        <input
+          type="radio"
+          name="paymentMethod"
+          value="stripe"
+          defaultChecked
+          readOnly
+          className="accent-foreground"
+        />
+        <span className="text-sm">Stripe (International Card)</span>
+      </label>
+      {loading && !mountError && (
+        <p className="text-xs text-muted-foreground">결제 수단 불러오는 중...</p>
+      )}
+      {mountError && <p className="text-xs text-destructive">{mountError}</p>}
+      <div ref={containerRef} className={loading ? 'sr-only' : undefined} />
+    </div>
+  );
+}
+
+// ─── Mock / fallback ──────────────────────────────────────────────────────────
+
+function MockPaymentGateway() {
+  return (
+    <label className="flex items-center gap-3 cursor-pointer">
+      <input
+        type="radio"
+        name="paymentMethod"
+        value="mock"
+        defaultChecked
+        readOnly
+        className="accent-foreground"
+      />
+      <span className="text-sm">테스트 결제 (Mock)</span>
+    </label>
+  );
+}
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+export default function PaymentGateway(props: PaymentGatewayProps) {
+  const { prepareResult, locale } = props;
+
+  const isToss =
+    locale === 'ko' &&
+    prepareResult.clientKey &&
+    prepareResult.clientKey !== 'mock_client_key';
+
+  if (isToss) {
+    return <TossPaymentGateway {...props} />;
+  }
+
+  const isStripe =
+    prepareResult.gateway === 'stripe' &&
+    prepareResult.clientKey &&
+    prepareResult.clientKey !== 'mock_client_key';
+
+  if (isStripe) {
+    const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '';
+    return (
+      <StripePaymentGateway
+        clientSecret={prepareResult.clientKey}
+        publishableKey={publishableKey}
+        locale={locale}
+        onError={props.onError}
+      />
+    );
+  }
+
+  return <MockPaymentGateway />;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -286,7 +286,7 @@ export interface ConfirmPaymentResponse {
 }
 
 export const paymentsApi = {
-  prepare: (body: { orderId: number }, options?: RequestOptions) =>
+  prepare: (body: { orderId: number; locale?: string }, options?: RequestOptions) =>
     apiClient.post<PreparePaymentResponse>('/payments/prepare', body, options),
   confirm: (body: { orderId: number; paymentKey: string; amount: number }, options?: RequestOptions) =>
     apiClient.post<ConfirmPaymentResponse>('/payments/confirm', body, options),


### PR DESCRIPTION
## Summary
- Closes #61
- PaymentGateway 컴포넌트: ko→Toss Payments, 그 외→Stripe Payment Element 분기
- Backend locale 기반 게이트웨이 선택 로직
- 결제 콜백 URL에 locale prefix 유지

## Test plan
- [x] npm run build
- [x] npm run test:run (47 files, 285 tests passed)
- [x] cd backend && npm run build && npm run test (344 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)