### PR TITLE
fix: #132 401 글로벌 인터셉터 및 토큰 자동 갱신

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -33,6 +33,7 @@ globs: ["**/*.ts", "**/*.tsx"]
 - Sonner for toast notifications — **all mutations must show toast feedback**
 - Template system: pages as blocks (hero-banner, product-grid, carousel, category-nav, etc.)
 - CMS: navigation and categories managed in DB
+- Auth: ApiClient must intercept 401 responses globally — auto-refresh token or redirect to login
 
 ## SEO
 - SSR via React Server Components

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -11,6 +11,8 @@ CORS validation → Rate Limiting → JWT Guard → ValidationPipe → Controlle
 - RBAC: `user` / `admin` / `super_admin` with `@Roles()` decorator
 - OAuth: Kakao, Google
 - bcrypt hashing (salt rounds 10+)
+- Frontend 401 handling: global interceptor in ApiClient — no per-component 401 checks
+- Token refresh: silent refresh via refresh token before redirect
 
 ## Rate Limiting
 - Global: 200 requests/minute (ThrottlerModule, name: `global`)

--- a/src/lib/__tests__/api-interceptor.test.ts
+++ b/src/lib/__tests__/api-interceptor.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+// Mock window.location for redirect tests
+Object.defineProperty(window, 'location', {
+  writable: true,
+  value: { href: '' },
+});
+
+import { apiClient, authApi } from '@/lib/api';
+
+function makeResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('ApiClient 401 interceptor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.href = '';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('401 응답 시 refresh 호출 후 원래 요청 재시도', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+
+    fetchMock
+      .mockResolvedValueOnce(makeResponse(401, { message: 'Unauthorized' }))
+      .mockResolvedValueOnce(makeResponse(200, { id: 1, name: 'test' }));
+
+    const result = await apiClient.get<{ id: number; name: string }>('/products/1');
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ id: 1, name: 'test' });
+  });
+
+  it('refresh 실패 시 로그인 페이지로 리다이렉트', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockRejectedValue(new Error('Refresh failed'));
+
+    fetchMock.mockResolvedValue(makeResponse(401, { message: 'Unauthorized' }));
+
+    await expect(apiClient.get('/products/1')).rejects.toThrow();
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toMatch(/\/login/);
+  });
+
+  it('동시 다중 401 요청 시 refresh는 1번만 호출', async () => {
+    let refreshResolve!: () => void;
+    const refreshPromise = new Promise<void>((resolve) => {
+      refreshResolve = resolve;
+    });
+
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockImplementation(() => {
+      return refreshPromise.then(() => ({ message: 'ok' }));
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(makeResponse(401, { message: 'Unauthorized' }))
+      .mockResolvedValueOnce(makeResponse(401, { message: 'Unauthorized' }))
+      .mockResolvedValueOnce(makeResponse(401, { message: 'Unauthorized' }))
+      .mockResolvedValueOnce(makeResponse(200, { id: 1 }))
+      .mockResolvedValueOnce(makeResponse(200, { id: 2 }))
+      .mockResolvedValueOnce(makeResponse(200, { id: 3 }));
+
+    const p1 = apiClient.get<{ id: number }>('/products/1');
+    const p2 = apiClient.get<{ id: number }>('/products/2');
+    const p3 = apiClient.get<{ id: number }>('/products/3');
+
+    refreshResolve();
+
+    const results = await Promise.all([p1, p2, p3]);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(results[0].id).toBe(1);
+    expect(results[1].id).toBe(2);
+    expect(results[2].id).toBe(3);
+  });
+
+  it('403 응답 시 한국어 에러 메시지 throw', async () => {
+    fetchMock.mockResolvedValue(makeResponse(403, { message: 'Forbidden' }));
+
+    await expect(apiClient.get('/admin/dashboard')).rejects.toThrow('접근 권한이 없습니다.');
+  });
+
+  it('401이 아닌 다른 4xx 에러는 그대로 throw', async () => {
+    fetchMock.mockResolvedValue(makeResponse(400, { message: '잘못된 요청입니다.' }));
+
+    await expect(apiClient.get('/products/99')).rejects.toThrow('잘못된 요청입니다.');
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,47 @@
 const API_BASE = '/api';
 
+// 401 interceptor state — shared across all ApiClient instances
+let _isRefreshing = false;
+let _refreshQueue: Array<{ resolve: () => void; reject: (err: unknown) => void }> = [];
+
+function _redirectToLogin(): void {
+  if (typeof window !== 'undefined') {
+    const locale = document.documentElement.lang || 'ko';
+    window.location.href = `/${locale}/login`;
+  }
+}
+
+// Late-bound refresh function — set after authApi is created to avoid circular dependency
+let _refreshFn: (() => Promise<unknown>) | null = null;
+
+export function _setRefreshFn(fn: () => Promise<unknown>): void {
+  _refreshFn = fn;
+}
+
+async function _ensureTokenRefreshed(): Promise<void> {
+  if (_isRefreshing) {
+    return new Promise<void>((resolve, reject) => {
+      _refreshQueue.push({ resolve, reject });
+    });
+  }
+
+  _isRefreshing = true;
+  try {
+    if (!_refreshFn) {
+      throw new Error('Refresh function not registered');
+    }
+    await _refreshFn();
+    _refreshQueue.forEach((q) => q.resolve());
+  } catch (err) {
+    _refreshQueue.forEach((q) => q.reject(err));
+    _redirectToLogin();
+    throw err;
+  } finally {
+    _isRefreshing = false;
+    _refreshQueue = [];
+  }
+}
+
 export interface ProductImage {
   id: number;
   url: string;
@@ -97,9 +139,37 @@ class ApiClient {
       },
     });
 
+    if (response.status === 401) {
+      await _ensureTokenRefreshed();
+      // Retry original request after token refresh
+      const retryResponse = await fetch(url, {
+        ...restFetchOptions,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(optionHeaders as Record<string, string> | undefined),
+        },
+      });
+      if (!retryResponse.ok) {
+        const error = await retryResponse.json().catch(() => ({ message: 'An error occurred' }));
+        throw new Error(error.message || `HTTP ${retryResponse.status}`);
+      }
+      if (retryResponse.status === 204 || retryResponse.headers.get('content-length') === '0') {
+        return undefined as T;
+      }
+      return retryResponse.json() as Promise<T>;
+    }
+
+    if (response.status === 403) {
+      throw new Error('접근 권한이 없습니다.');
+    }
+
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ message: 'An error occurred' }));
-      throw new Error(error.message || `HTTP ${response.status}`);
+      const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
+      const message = Array.isArray(error.message)
+        ? error.message.join(', ')
+        : (error.message || `HTTP ${response.status}`);
+      throw new Error(message);
     }
 
     if (response.status === 204 || response.headers.get('content-length') === '0') {
@@ -439,6 +509,9 @@ export const authApi = {
   googleCallback: (code: string) =>
     apiClient.post<AuthTokenResponse>('/auth/google', { code }),
 };
+
+// Register the refresh function after authApi is created
+_setRefreshFn(() => authApi.refresh());
 
 export interface AdminProductsParams {
   page?: number;


### PR DESCRIPTION
## Summary

- `ApiClient.request()`에 401 응답 인터셉터 추가 — JWT 만료 시 자동 갱신 후 재시도
- 동시 다중 401 요청 시 refresh 1회만 실행 (큐잉 처리)
- refresh 실패 시 `/{locale}/login`으로 리다이렉트
- 403 응답 시 `'접근 권한이 없습니다.'` 한국어 메시지
- `architecture.md`, `security.md` 규칙 업데이트

## Test plan

- [x] `401 응답 시 refresh 호출 후 원래 요청 재시도`
- [x] `refresh 실패 시 로그인 페이지로 리다이렉트`
- [x] `동시 다중 401 요청 시 refresh는 1번만 호출`
- [x] `403 응답 시 한국어 에러 메시지 throw`
- [x] `401이 아닌 다른 4xx 에러는 그대로 throw`
- [x] `npm run build && npm run test:run` — 303 tests passed

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)