### PR TITLE
fix: #130 Shipping 서비스 에러 포맷 통일

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -25,6 +25,8 @@ globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
 - Cursor-based pagination for lists
 - Redis caching for hot data
 - N+1 prevention with TypeORM relations
+- Error response format: consistent structure `{ statusCode, message, error }` across all services — shipping included
+- ValidationPipe error messages: must be Korean — configure exceptionFactory to translate class-validator messages
 
 ## Backend Decorator Order
 컨트롤러 메서드 데코레이터 순서: Route → Modifier → Status → Guard → Param

--- a/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
+++ b/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
@@ -69,10 +69,10 @@ describe('ShippingService', () => {
       ).not.toThrow();
     });
 
-    it('DELIVERED → PREPARING 역방향 전이 → BadRequestException(INVALID_STATUS_TRANSITION)', () => {
+    it('DELIVERED → PREPARING 역방향 전이 → BadRequestException(유효하지 않은 배송 상태 변경입니다.)', () => {
       expect(() =>
         service.validateTransition(ShippingStatus.DELIVERED, ShippingStatus.PREPARING),
-      ).toThrow(BadRequestException);
+      ).toThrow(new BadRequestException('유효하지 않은 배송 상태 변경입니다.'));
     });
 
     it('shipped → preparing 역방향 전이 → BadRequestException', () => {
@@ -83,20 +83,26 @@ describe('ShippingService', () => {
   });
 
   describe('getByOrderId', () => {
-    it('orderId 없음 → 404 SHIPPING_NOT_FOUND', async () => {
+    it('orderId 없음 → 404 배송 정보를 찾을 수 없습니다.', async () => {
       mockOrderRepo.findOne.mockResolvedValue(null);
-      await expect(service.getByOrderId(999, 10)).rejects.toThrow(NotFoundException);
+      await expect(service.getByOrderId(999, 10)).rejects.toThrow(
+        new NotFoundException('배송 정보를 찾을 수 없습니다.'),
+      );
     });
 
-    it('타인 주문 접근 → 403 FORBIDDEN', async () => {
+    it('타인 주문 접근 → 403 접근 권한이 없습니다.', async () => {
       mockOrderRepo.findOne.mockResolvedValue(makeOrder({ userId: 99 }));
-      await expect(service.getByOrderId(1, 10)).rejects.toThrow(ForbiddenException);
+      await expect(service.getByOrderId(1, 10)).rejects.toThrow(
+        new ForbiddenException('접근 권한이 없습니다.'),
+      );
     });
 
-    it('shipping 없음 → 404 SHIPPING_NOT_FOUND', async () => {
+    it('shipping 없음 → 404 배송 정보를 찾을 수 없습니다.', async () => {
       mockOrderRepo.findOne.mockResolvedValue(makeOrder());
       mockShippingRepo.findOne.mockResolvedValue(null);
-      await expect(service.getByOrderId(1, 10)).rejects.toThrow(NotFoundException);
+      await expect(service.getByOrderId(1, 10)).rejects.toThrow(
+        new NotFoundException('배송 정보를 찾을 수 없습니다.'),
+      );
     });
 
     it('tracking_number 없음 → tracking null 반환', async () => {
@@ -121,23 +127,29 @@ describe('ShippingService', () => {
   describe('registerTracking', () => {
     const dto = { carrier: 'mock' as const, trackingNumber: '9999999' };
 
-    it('주문 없음 → 404 ORDER_NOT_FOUND', async () => {
+    it('주문 없음 → 404 주문 정보를 찾을 수 없습니다.', async () => {
       mockOrderRepo.findOne.mockResolvedValue(null);
-      await expect(service.registerTracking(999, dto)).rejects.toThrow(NotFoundException);
+      await expect(service.registerTracking(999, dto)).rejects.toThrow(
+        new NotFoundException('주문 정보를 찾을 수 없습니다.'),
+      );
     });
 
-    it('shipping 없음 → 404 SHIPPING_NOT_FOUND', async () => {
+    it('shipping 없음 → 404 배송 정보를 찾을 수 없습니다.', async () => {
       mockOrderRepo.findOne.mockResolvedValue(makeOrder());
       mockShippingRepo.findOne.mockResolvedValueOnce(null);
-      await expect(service.registerTracking(1, dto)).rejects.toThrow(NotFoundException);
+      await expect(service.registerTracking(1, dto)).rejects.toThrow(
+        new NotFoundException('배송 정보를 찾을 수 없습니다.'),
+      );
     });
 
-    it('이미 preparing 상태에서 preparing 전이 시도 → BadRequestException', async () => {
+    it('이미 preparing 상태에서 preparing 전이 시도 → BadRequestException(유효하지 않은 배송 상태 변경입니다.)', async () => {
       mockOrderRepo.findOne.mockResolvedValue(makeOrder());
       mockShippingRepo.findOne.mockResolvedValueOnce(
         makeShipping({ status: ShippingStatus.PREPARING }),
       );
-      await expect(service.registerTracking(1, dto)).rejects.toThrow(BadRequestException);
+      await expect(service.registerTracking(1, dto)).rejects.toThrow(
+        new BadRequestException('유효하지 않은 배송 상태 변경입니다.'),
+      );
     });
 
     it('payment_confirmed 상태에서 운송장 등록 성공', async () => {

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -36,11 +36,11 @@ export class ShippingService {
 
   async getByOrderId(orderId: number, userId: number) {
     const order = await this.orderRepository.findOne({ where: { id: orderId } });
-    if (!order) throw new NotFoundException({ code: 'SHIPPING_NOT_FOUND' });
-    if (Number(order.userId) !== Number(userId)) throw new ForbiddenException({ code: 'FORBIDDEN' });
+    if (!order) throw new NotFoundException('배송 정보를 찾을 수 없습니다.');
+    if (Number(order.userId) !== Number(userId)) throw new ForbiddenException('접근 권한이 없습니다.');
 
     const shipping = await this.shippingRepository.findOne({ where: { orderId } });
-    if (!shipping) throw new NotFoundException({ code: 'SHIPPING_NOT_FOUND' });
+    if (!shipping) throw new NotFoundException('배송 정보를 찾을 수 없습니다.');
 
     let tracking: TrackingResult | null = null;
     if (shipping.trackingNumber) {
@@ -76,16 +76,16 @@ export class ShippingService {
         steps: result.steps,
       };
     } catch {
-      throw new BadRequestException({ code: 'CARRIER_API_ERROR' });
+      throw new BadRequestException('배송 추적 중 오류가 발생했습니다.');
     }
   }
 
   async registerTracking(orderId: number, dto: RegisterTrackingDto) {
     const order = await this.orderRepository.findOne({ where: { id: orderId } });
-    if (!order) throw new NotFoundException({ code: 'ORDER_NOT_FOUND' });
+    if (!order) throw new NotFoundException('주문 정보를 찾을 수 없습니다.');
 
     const shipping = await this.shippingRepository.findOne({ where: { orderId } });
-    if (!shipping) throw new NotFoundException({ code: 'SHIPPING_NOT_FOUND' });
+    if (!shipping) throw new NotFoundException('배송 정보를 찾을 수 없습니다.');
 
     this.validateTransition(shipping.status, ShippingStatus.PREPARING);
 
@@ -105,7 +105,7 @@ export class ShippingService {
   validateTransition(current: ShippingStatus, next: ShippingStatus): void {
     const allowed = ALLOWED_TRANSITIONS[current] ?? [];
     if (!allowed.includes(next)) {
-      throw new BadRequestException({ code: 'INVALID_STATUS_TRANSITION' });
+      throw new BadRequestException('유효하지 않은 배송 상태 변경입니다.');
     }
   }
 }


### PR DESCRIPTION
## Summary
- `shipping.service.ts`의 모든 예외를 객체(`{ code: '...' }`)에서 한국어 문자열 메시지로 변경
- 프론트엔드에서 `[object Object]` 대신 한국어 에러 메시지가 표시됨
- 테스트를 한국어 메시지 검증으로 업데이트 (16개 모두 통과)
- `.claude/rules/code-style.md` Backend 섹션에 에러 포맷 규칙 추가

## Changes
- `SHIPPING_NOT_FOUND` → `'배송 정보를 찾을 수 없습니다.'`
- `FORBIDDEN` → `'접근 권한이 없습니다.'`
- `INVALID_STATUS_TRANSITION` → `'유효하지 않은 배송 상태 변경입니다.'`
- `ORDER_NOT_FOUND` → `'주문 정보를 찾을 수 없습니다.'`
- `CARRIER_API_ERROR` → `'배송 추적 중 오류가 발생했습니다.'`

## Test plan
- [x] `cd backend && npm run build` — 통과
- [x] `cd backend && npm run test -- --testPathPattern="shipping"` — 16/16 통과
- [x] `cd backend && npm run test` — 349/349 통과

Closes #130