### PR TITLE
fix: #128 ValidationPipe 배열 메시지 한국어 변환

### DIFF
--- a/backend/src/__tests__/validation-pipe-korean.spec.ts
+++ b/backend/src/__tests__/validation-pipe-korean.spec.ts
@@ -1,0 +1,84 @@
+import { ValidationPipe, BadRequestException } from '@nestjs/common';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { LoginDto } from '../modules/auth/dto/login.dto';
+import { RegisterDto } from '../modules/auth/dto/register.dto';
+
+/**
+ * ValidationPipe exceptionFactory: 배열 메시지를 단일 한국어 문자열로 변환
+ */
+function buildPipe(): ValidationPipe {
+  return new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+    exceptionFactory: (errors) => {
+      const messages = errors.flatMap((e) =>
+        Object.values(e.constraints ?? {}),
+      );
+      return new BadRequestException(messages.join(', '));
+    },
+  });
+}
+
+describe('ValidationPipe exceptionFactory', () => {
+  it('단일 문자열 메시지를 반환해야 한다', async () => {
+    const pipe = buildPipe();
+    // pipe.transform triggers validation
+    await expect(
+      pipe.transform({}, { type: 'body', metatype: LoginDto }),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({
+        message: expect.any(String),
+      }),
+    });
+  });
+
+  it('반환된 message가 배열이 아닌 문자열이어야 한다', async () => {
+    const pipe = buildPipe();
+    let caughtMessage: unknown;
+    try {
+      await pipe.transform({}, { type: 'body', metatype: LoginDto });
+    } catch (err) {
+      if (err instanceof BadRequestException) {
+        caughtMessage = (err.getResponse() as { message: unknown }).message;
+      }
+    }
+    expect(typeof caughtMessage).toBe('string');
+  });
+});
+
+describe('LoginDto 한국어 메시지', () => {
+  it('이메일 형식 오류 시 한국어 메시지를 반환해야 한다', async () => {
+    const dto = plainToInstance(LoginDto, { email: 'not-an-email', password: '1234' });
+    const errors = await validate(dto);
+    const messages = errors.flatMap((e) => Object.values(e.constraints ?? {}));
+    expect(messages.some((m) => /이메일|email/i.test(m))).toBe(true);
+    // must contain Korean
+    expect(messages.some((m) => /[가-힣]/.test(m))).toBe(true);
+  });
+});
+
+describe('RegisterDto 한국어 메시지', () => {
+  it('비밀번호 최소 길이 미달 시 한국어 메시지를 반환해야 한다', async () => {
+    const dto = plainToInstance(RegisterDto, {
+      email: 'test@test.com',
+      password: '123',
+      name: '홍길동',
+    });
+    const errors = await validate(dto);
+    const messages = errors.flatMap((e) => Object.values(e.constraints ?? {}));
+    expect(messages.some((m) => /[가-힣]/.test(m))).toBe(true);
+  });
+
+  it('이름 누락 시 한국어 메시지를 반환해야 한다', async () => {
+    const dto = plainToInstance(RegisterDto, {
+      email: 'test@test.com',
+      password: 'password123',
+      name: '',
+    });
+    const errors = await validate(dto);
+    const messages = errors.flatMap((e) => Object.values(e.constraints ?? {}));
+    expect(messages.some((m) => /[가-힣]/.test(m))).toBe(true);
+  });
+});

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, Logger } from '@nestjs/common';
+import { ValidationPipe, Logger, BadRequestException } from '@nestjs/common';
 import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
@@ -28,7 +28,7 @@ async function bootstrap() {
   if (!frontendUrl) {
     throw new Error('FRONTEND_URL environment variable is required');
   }
-  
+
   app.enableCors({
     origin: [frontendUrl, ...(process.env.FRONTEND_URLS?.split(',') || [])],
     credentials: true,
@@ -39,6 +39,12 @@ async function bootstrap() {
       whitelist: true,
       forbidNonWhitelisted: true,
       transform: true,
+      exceptionFactory: (errors) => {
+        const messages = errors.flatMap((e) =>
+          Object.values(e.constraints ?? {}),
+        );
+        return new BadRequestException(messages.join(', '));
+      },
     }),
   );
 

--- a/backend/src/modules/auth/dto/login.dto.ts
+++ b/backend/src/modules/auth/dto/login.dto.ts
@@ -1,9 +1,10 @@
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsString, IsNotEmpty } from 'class-validator';
 
 export class LoginDto {
-  @IsEmail()
+  @IsEmail({}, { message: '올바른 이메일 형식을 입력해 주세요.' })
   email!: string;
 
-  @IsString()
+  @IsString({ message: '비밀번호를 입력해 주세요.' })
+  @IsNotEmpty({ message: '비밀번호를 입력해 주세요.' })
   password!: string;
 }

--- a/backend/src/modules/auth/dto/register.dto.ts
+++ b/backend/src/modules/auth/dto/register.dto.ts
@@ -1,16 +1,16 @@
 import { IsEmail, IsString, MinLength, MaxLength } from 'class-validator';
 
 export class RegisterDto {
-  @IsEmail()
+  @IsEmail({}, { message: '올바른 이메일 형식을 입력해 주세요.' })
   email!: string;
 
-  @IsString()
-  @MinLength(8)
-  @MaxLength(100)
+  @IsString({ message: '비밀번호를 입력해 주세요.' })
+  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+  @MaxLength(100, { message: '비밀번호는 최대 100자까지 입력 가능합니다.' })
   password!: string;
 
-  @IsString()
-  @MinLength(1)
-  @MaxLength(100)
+  @IsString({ message: '이름을 입력해 주세요.' })
+  @MinLength(1, { message: '이름을 입력해 주세요.' })
+  @MaxLength(100, { message: '이름은 최대 100자까지 입력 가능합니다.' })
   name!: string;
 }

--- a/backend/src/modules/orders/dto/create-order.dto.ts
+++ b/backend/src/modules/orders/dto/create-order.dto.ts
@@ -5,57 +5,57 @@ import {
 } from 'class-validator';
 
 export class OrderItemDto {
-  @IsInt()
+  @IsInt({ message: '상품 ID는 정수여야 합니다.' })
   productId!: number;
 
   @IsOptional()
   @ValidateIf((o: OrderItemDto) => o.productOptionId !== null)
-  @IsInt()
+  @IsInt({ message: '상품 옵션 ID는 정수여야 합니다.' })
   productOptionId?: number | null;
 
-  @IsInt()
-  @Min(1)
+  @IsInt({ message: '수량은 정수여야 합니다.' })
+  @Min(1, { message: '수량은 최소 1개 이상이어야 합니다.' })
   quantity!: number;
 }
 
 export class CreateOrderDto {
-  @IsArray()
+  @IsArray({ message: '주문 상품 목록은 배열이어야 합니다.' })
   @ValidateNested({ each: true })
   @Type(() => OrderItemDto)
   items!: OrderItemDto[];
 
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(100)
+  @IsString({ message: '수령인 이름을 입력해 주세요.' })
+  @IsNotEmpty({ message: '수령인 이름을 입력해 주세요.' })
+  @MaxLength(100, { message: '수령인 이름은 최대 100자까지 입력 가능합니다.' })
   recipientName!: string;
 
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(20)
+  @IsString({ message: '수령인 연락처를 입력해 주세요.' })
+  @IsNotEmpty({ message: '수령인 연락처를 입력해 주세요.' })
+  @MaxLength(20, { message: '수령인 연락처는 최대 20자까지 입력 가능합니다.' })
   recipientPhone!: string;
 
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(10)
+  @IsString({ message: '우편번호를 입력해 주세요.' })
+  @IsNotEmpty({ message: '우편번호를 입력해 주세요.' })
+  @MaxLength(10, { message: '우편번호는 최대 10자까지 입력 가능합니다.' })
   zipcode!: string;
 
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(255)
+  @IsString({ message: '주소를 입력해 주세요.' })
+  @IsNotEmpty({ message: '주소를 입력해 주세요.' })
+  @MaxLength(255, { message: '주소는 최대 255자까지 입력 가능합니다.' })
   address!: string;
 
   @IsOptional()
-  @IsString()
-  @MaxLength(255)
+  @IsString({ message: '상세 주소는 문자열이어야 합니다.' })
+  @MaxLength(255, { message: '상세 주소는 최대 255자까지 입력 가능합니다.' })
   addressDetail?: string | null;
 
   @IsOptional()
-  @IsString()
-  @MaxLength(500)
+  @IsString({ message: '배송 메모는 문자열이어야 합니다.' })
+  @MaxLength(500, { message: '배송 메모는 최대 500자까지 입력 가능합니다.' })
   memo?: string | null;
 
   @IsOptional()
-  @IsInt()
-  @Min(0)
+  @IsInt({ message: '포인트 사용량은 정수여야 합니다.' })
+  @Min(0, { message: '포인트 사용량은 0 이상이어야 합니다.' })
   pointsUsed?: number;
 }

--- a/backend/src/modules/payments/dto/cancel-payment.dto.ts
+++ b/backend/src/modules/payments/dto/cancel-payment.dto.ts
@@ -1,11 +1,11 @@
 import { IsInt, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CancelPaymentDto {
-  @IsInt()
+  @IsInt({ message: '주문 ID는 정수여야 합니다.' })
   orderId!: number;
 
   @IsOptional()
-  @IsString()
-  @MaxLength(500)
+  @IsString({ message: '취소 사유는 문자열이어야 합니다.' })
+  @MaxLength(500, { message: '취소 사유는 최대 500자까지 입력 가능합니다.' })
   reason?: string;
 }

--- a/backend/src/modules/payments/dto/confirm-payment.dto.ts
+++ b/backend/src/modules/payments/dto/confirm-payment.dto.ts
@@ -1,13 +1,13 @@
 import { IsInt, IsString, IsNotEmpty } from 'class-validator';
 
 export class ConfirmPaymentDto {
-  @IsInt()
+  @IsInt({ message: '주문 ID는 정수여야 합니다.' })
   orderId!: number;
 
-  @IsString()
-  @IsNotEmpty()
+  @IsString({ message: '결제 키를 입력해 주세요.' })
+  @IsNotEmpty({ message: '결제 키를 입력해 주세요.' })
   paymentKey!: string;
 
-  @IsInt()
+  @IsInt({ message: '결제 금액은 정수여야 합니다.' })
   amount!: number;
 }

--- a/backend/src/modules/payments/dto/prepare-payment.dto.ts
+++ b/backend/src/modules/payments/dto/prepare-payment.dto.ts
@@ -1,10 +1,10 @@
 import { IsInt, IsOptional, IsString } from 'class-validator';
 
 export class PreparePaymentDto {
-  @IsInt()
+  @IsInt({ message: '주문 ID는 정수여야 합니다.' })
   orderId!: number;
 
   @IsOptional()
-  @IsString()
+  @IsString({ message: '로케일은 문자열이어야 합니다.' })
   locale?: string;
 }

--- a/backend/src/modules/products/dto/create-product.dto.ts
+++ b/backend/src/modules/products/dto/create-product.dto.ts
@@ -5,50 +5,50 @@ export { ProductStatus };
 
 export class CreateProductDto {
   @IsOptional()
-  @IsNumber()
+  @IsNumber({}, { message: '카테고리 ID는 숫자여야 합니다.' })
   categoryId?: number;
 
-  @IsString()
-  @MaxLength(255)
+  @IsString({ message: '상품명을 입력해 주세요.' })
+  @MaxLength(255, { message: '상품명은 최대 255자까지 입력 가능합니다.' })
   name!: string;
 
-  @IsString()
-  @MaxLength(255)
+  @IsString({ message: '슬러그를 입력해 주세요.' })
+  @MaxLength(255, { message: '슬러그는 최대 255자까지 입력 가능합니다.' })
   slug!: string;
 
   @IsOptional()
-  @IsString()
+  @IsString({ message: '상품 설명은 문자열이어야 합니다.' })
   description?: string;
 
   @IsOptional()
-  @IsString()
-  @MaxLength(500)
+  @IsString({ message: '짧은 설명은 문자열이어야 합니다.' })
+  @MaxLength(500, { message: '짧은 설명은 최대 500자까지 입력 가능합니다.' })
   shortDescription?: string;
 
-  @IsNumber()
-  @Min(1)
+  @IsNumber({}, { message: '가격은 숫자여야 합니다.' })
+  @Min(1, { message: '가격은 최소 1원 이상이어야 합니다.' })
   price!: number;
 
   @IsOptional()
-  @IsNumber()
-  @Min(0)
+  @IsNumber({}, { message: '할인가는 숫자여야 합니다.' })
+  @Min(0, { message: '할인가는 0 이상이어야 합니다.' })
   salePrice?: number;
 
   @IsOptional()
-  @IsNumber()
-  @Min(0)
+  @IsNumber({}, { message: '재고는 숫자여야 합니다.' })
+  @Min(0, { message: '재고는 0 이상이어야 합니다.' })
   stock?: number;
 
   @IsOptional()
-  @IsString()
-  @MaxLength(100)
+  @IsString({ message: 'SKU는 문자열이어야 합니다.' })
+  @MaxLength(100, { message: 'SKU는 최대 100자까지 입력 가능합니다.' })
   sku?: string;
 
   @IsOptional()
-  @IsEnum(ProductStatus)
+  @IsEnum(ProductStatus, { message: '올바른 상품 상태를 선택해 주세요.' })
   status?: ProductStatus;
 
   @IsOptional()
-  @IsBoolean()
+  @IsBoolean({ message: '추천 상품 여부는 불리언이어야 합니다.' })
   isFeatured?: boolean;
 }

--- a/backend/src/modules/reviews/dto/create-review.dto.ts
+++ b/backend/src/modules/reviews/dto/create-review.dto.ts
@@ -1,24 +1,24 @@
 import { IsInt, IsOptional, IsString, Max, Min, IsArray, ArrayMaxSize } from 'class-validator';
 
 export class CreateReviewDto {
-  @IsInt()
+  @IsInt({ message: '상품 ID는 정수여야 합니다.' })
   productId!: number;
 
-  @IsInt()
+  @IsInt({ message: '주문 상품 ID는 정수여야 합니다.' })
   orderItemId!: number;
 
-  @IsInt()
-  @Min(1)
-  @Max(5)
+  @IsInt({ message: '별점은 정수여야 합니다.' })
+  @Min(1, { message: '별점은 최소 1점 이상이어야 합니다.' })
+  @Max(5, { message: '별점은 최대 5점까지 입력 가능합니다.' })
   rating!: number;
 
   @IsOptional()
-  @IsString()
+  @IsString({ message: '리뷰 내용은 문자열이어야 합니다.' })
   content?: string | null;
 
   @IsOptional()
-  @IsArray()
-  @ArrayMaxSize(5)
-  @IsString({ each: true })
+  @IsArray({ message: '이미지 URL 목록은 배열이어야 합니다.' })
+  @ArrayMaxSize(5, { message: '이미지는 최대 5개까지 첨부 가능합니다.' })
+  @IsString({ each: true, message: '이미지 URL은 문자열이어야 합니다.' })
   imageUrls?: string[];
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -98,8 +98,11 @@ class ApiClient {
     });
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ message: 'An error occurred' }));
-      throw new Error(error.message || `HTTP ${response.status}`);
+      const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
+      const message = Array.isArray(error.message)
+        ? error.message.join(', ')
+        : (error.message || `HTTP ${response.status}`);
+      throw new Error(message);
     }
 
     if (response.status === 204 || response.headers.get('content-length') === '0') {


### PR DESCRIPTION
## Summary

- `backend/src/main.ts`: ValidationPipe에 `exceptionFactory` 추가 — 배열 에러 메시지를 단일 한국어 문자열로 변환
- `backend/src/modules/auth/dto/`: LoginDto, RegisterDto에 한국어 `message` 옵션 추가
- `backend/src/modules/orders/payments/products/reviews/dto/`: 주요 DTO 한국어 에러 메시지 추가
- `src/lib/api.ts`: `error.message`가 배열일 경우 join 처리로 프론트엔드 표시 개선
- `backend/src/__tests__/validation-pipe-korean.spec.ts`: TDD 테스트 5개 추가

## Test plan

- [x] `cd backend && npm run build && npm run test` — 39 suites, 349 tests 전체 통과
- [x] `validation-pipe-korean.spec.ts` 5개 케이스 통과 (exceptionFactory 단일 문자열 반환, LoginDto/RegisterDto 한국어 메시지)
- [x] `npm run test:run` — 프론트엔드 49 test files, 298 tests 통과

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)