### PR TITLE
refactor: #127 위시리스트 토글 로직을 useWishlistToggle 훅으로 통합

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -38,8 +38,9 @@ Next.js 15 (App Router) + React 19 + TypeScript + TailwindCSS v4 frontend rules.
 ## Key Files
 
 ```
-app/                # Pages & layouts (App Router)
-components/         # Reusable UI + shadcn/ui wrappers
-lib/api.ts          # API client
-contexts/           # AuthContext, CartContext
+app/                            # Pages & layouts (App Router)
+components/                     # Reusable UI + shadcn/ui wrappers
+lib/api.ts                      # API client
+contexts/                       # AuthContext, CartContext
+hooks/useWishlistToggle.ts      # Wishlist toggle with optimistic update
 ```

--- a/src/components/WishlistButton.tsx
+++ b/src/components/WishlistButton.tsx
@@ -1,12 +1,8 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { Heart } from 'lucide-react';
-import { toast } from 'sonner';
 import { cn } from '@/components/ui/utils';
-import { wishlistApi } from '@/lib/api';
-import { useAuth } from '@/contexts/AuthContext';
+import { useWishlistToggle } from '@/hooks/useWishlistToggle';
 
 interface WishlistButtonProps {
   productId: number;
@@ -21,58 +17,20 @@ export default function WishlistButton({
   initialWishlistId = null,
   className,
 }: WishlistButtonProps) {
-  const router = useRouter();
-  const { isAuthenticated } = useAuth();
-  const [isWishlisted, setIsWishlisted] = useState(initialIsWishlisted);
-  const [wishlistId, setWishlistId] = useState<number | null>(initialWishlistId);
-  const [isPending, setIsPending] = useState(false);
-
-  const handleClick = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (!isAuthenticated) {
-      router.push('/login');
-      return;
-    }
-
-    if (isPending) return;
-    setIsPending(true);
-
-    // Optimistic update
-    const prevIsWishlisted = isWishlisted;
-    const prevWishlistId = wishlistId;
-    setIsWishlisted(!isWishlisted);
-
-    try {
-      if (isWishlisted && wishlistId != null) {
-        await wishlistApi.remove(wishlistId);
-        setWishlistId(null);
-        toast.success('위시리스트에서 삭제되었습니다.');
-      } else {
-        const result = await wishlistApi.add(productId);
-        setWishlistId(result.id);
-        toast.success('위시리스트에 추가되었습니다.');
-      }
-    } catch {
-      // Rollback on failure
-      setIsWishlisted(prevIsWishlisted);
-      setWishlistId(prevWishlistId);
-      toast.error('위시리스트 처리에 실패했습니다.');
-    } finally {
-      setIsPending(false);
-    }
-  };
+  const { isWishlisted, loading, toggle } = useWishlistToggle(productId, {
+    initialIsWishlisted,
+    initialWishlistId,
+  });
 
   return (
     <button
       type="button"
-      onClick={handleClick}
+      onClick={toggle}
       aria-label={isWishlisted ? '위시리스트에서 삭제' : '위시리스트에 추가'}
       className={cn(
         'flex items-center justify-center rounded-full p-1.5 transition-colors',
         'hover:bg-muted',
-        isPending && 'opacity-60 cursor-not-allowed',
+        loading && 'opacity-60 cursor-not-allowed',
         className,
       )}
     >

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -17,8 +17,9 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+const mockRouterPush = vi.fn();
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockRouterPush }),
 }));
 
 const mockAddItem = vi.fn();
@@ -61,6 +62,7 @@ describe('ProductCard', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRouterPush.mockReset();
     mockUseAuth.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -132,12 +134,13 @@ describe('ProductCard', () => {
     });
   });
 
-  it('shows login error toast when unauthenticated user clicks wishlist', async () => {
+  it('redirects to login when unauthenticated user clicks wishlist', async () => {
     render(<ProductCard {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: '찜하기' }));
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('로그인이 필요합니다.');
+      expect(mockRouterPush).toHaveBeenCalledWith('/login');
     });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it('calls wishlistApi.add and shows toast on wishlist click when authenticated', async () => {
@@ -152,7 +155,7 @@ describe('ProductCard', () => {
     fireEvent.click(screen.getByRole('button', { name: '찜하기' }));
     await waitFor(() => {
       expect(wishlistApi.add).toHaveBeenCalledWith(1);
-      expect(toast.success).toHaveBeenCalledWith('찜 목록에 추가했습니다.');
+      expect(toast.success).toHaveBeenCalledWith('위시리스트에 추가되었습니다.');
     });
   });
 });

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -7,10 +7,9 @@ import { Heart, ShoppingCart } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/components/ui/utils';
 import type { ProductImage } from '@/lib/api';
-import { wishlistApi } from '@/lib/api';
 import PriceDisplay from '@/components/common/PriceDisplay';
 import { useCart } from '@/contexts/CartContext';
-import { useAuth } from '@/contexts/AuthContext';
+import { useWishlistToggle } from '@/hooks/useWishlistToggle';
 import type { Locale } from '@/utils/currency';
 
 interface ProductCardProps {
@@ -37,11 +36,8 @@ export default function ProductCard({
   const isSoldout = status === 'soldout';
 
   const { addItem } = useCart();
-  const { isAuthenticated } = useAuth();
+  const { isWishlisted, loading: isWishlistLoading, toggle: handleToggleWishlist } = useWishlistToggle(id);
 
-  const [isWishlisted, setIsWishlisted] = useState(false);
-  const [wishlistId, setWishlistId] = useState<number | null>(null);
-  const [isWishlistLoading, setIsWishlistLoading] = useState(false);
   const [isCartLoading, setIsCartLoading] = useState(false);
 
   const handleAddToCart = useCallback(
@@ -59,38 +55,6 @@ export default function ProductCard({
       }
     },
     [id, isSoldout, isCartLoading, addItem],
-  );
-
-  const handleToggleWishlist = useCallback(
-    async (e: React.MouseEvent) => {
-      e.preventDefault();
-      if (isWishlistLoading) return;
-
-      if (!isAuthenticated) {
-        toast.error('로그인이 필요합니다.');
-        return;
-      }
-
-      setIsWishlistLoading(true);
-      try {
-        if (isWishlisted && wishlistId !== null) {
-          await wishlistApi.remove(wishlistId);
-          setIsWishlisted(false);
-          setWishlistId(null);
-          toast.success('찜 목록에서 제거했습니다.');
-        } else {
-          const res = await wishlistApi.add(id);
-          setIsWishlisted(true);
-          setWishlistId(res.id);
-          toast.success('찜 목록에 추가했습니다.');
-        }
-      } catch {
-        toast.error('찜하기 처리에 실패했습니다.');
-      } finally {
-        setIsWishlistLoading(false);
-      }
-    },
-    [id, isAuthenticated, isWishlisted, wishlistId, isWishlistLoading],
   );
 
   return (

--- a/src/hooks/__tests__/useWishlistToggle.test.ts
+++ b/src/hooks/__tests__/useWishlistToggle.test.ts
@@ -1,0 +1,137 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWishlistToggle } from '../useWishlistToggle';
+
+const mockAdd = vi.fn();
+const mockRemove = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  wishlistApi: {
+    add: (...args: unknown[]) => mockAdd(...args),
+    remove: (...args: unknown[]) => mockRemove(...args),
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockIsAuthenticated = vi.fn(() => true);
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: mockIsAuthenticated() }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('useWishlistToggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAuthenticated.mockReturnValue(true);
+  });
+
+  it('초기 상태를 반환한다', () => {
+    const { result } = renderHook(() => useWishlistToggle(1));
+
+    expect(result.current.isWishlisted).toBe(false);
+    expect(result.current.loading).toBe(false);
+    expect(typeof result.current.toggle).toBe('function');
+  });
+
+  it('initialIsWishlisted와 initialWishlistId를 반영한다', () => {
+    const { result } = renderHook(() =>
+      useWishlistToggle(1, { initialIsWishlisted: true, initialWishlistId: 42 }),
+    );
+
+    expect(result.current.isWishlisted).toBe(true);
+  });
+
+  it('미인증 상태에서 toggle 호출 시 로그인 페이지로 이동한다', async () => {
+    mockIsAuthenticated.mockReturnValue(false);
+
+    const { result } = renderHook(() => useWishlistToggle(1));
+
+    const fakeEvent = { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as React.MouseEvent;
+
+    await act(async () => {
+      await result.current.toggle(fakeEvent);
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/login');
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('위시리스트에 없는 상품을 추가한다 (optimistic update)', async () => {
+    mockAdd.mockResolvedValue({ id: 99 });
+
+    const { result } = renderHook(() => useWishlistToggle(1));
+
+    const fakeEvent = { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as React.MouseEvent;
+
+    await act(async () => {
+      await result.current.toggle(fakeEvent);
+    });
+
+    expect(mockAdd).toHaveBeenCalledWith(1);
+    expect(result.current.isWishlisted).toBe(true);
+  });
+
+  it('위시리스트에 있는 상품을 제거한다', async () => {
+    mockRemove.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useWishlistToggle(1, { initialIsWishlisted: true, initialWishlistId: 42 }),
+    );
+
+    const fakeEvent = { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as React.MouseEvent;
+
+    await act(async () => {
+      await result.current.toggle(fakeEvent);
+    });
+
+    expect(mockRemove).toHaveBeenCalledWith(42);
+    expect(result.current.isWishlisted).toBe(false);
+  });
+
+  it('API 실패 시 낙관적 업데이트를 롤백한다', async () => {
+    mockAdd.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useWishlistToggle(1));
+
+    const fakeEvent = { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as React.MouseEvent;
+
+    await act(async () => {
+      await result.current.toggle(fakeEvent);
+    });
+
+    expect(result.current.isWishlisted).toBe(false);
+  });
+
+  it('이미 처리 중이면 중복 호출을 무시한다', async () => {
+    let resolve: (value: { id: number }) => void;
+    mockAdd.mockReturnValue(new Promise<{ id: number }>((r) => { resolve = r; }));
+
+    const { result } = renderHook(() => useWishlistToggle(1));
+
+    const fakeEvent = { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as React.MouseEvent;
+
+    // First call — not awaited yet
+    act(() => {
+      void result.current.toggle(fakeEvent);
+    });
+
+    // Second call should be ignored
+    await act(async () => {
+      await result.current.toggle(fakeEvent);
+    });
+
+    resolve!({ id: 99 });
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useWishlistToggle.ts
+++ b/src/hooks/useWishlistToggle.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { wishlistApi } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface UseWishlistToggleOptions {
+  initialIsWishlisted?: boolean;
+  initialWishlistId?: number | null;
+}
+
+interface UseWishlistToggleReturn {
+  isWishlisted: boolean;
+  loading: boolean;
+  toggle: (e: React.MouseEvent) => Promise<void>;
+}
+
+export function useWishlistToggle(
+  productId: number,
+  options: UseWishlistToggleOptions = {},
+): UseWishlistToggleReturn {
+  const { initialIsWishlisted = false, initialWishlistId = null } = options;
+
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+  const [isWishlisted, setIsWishlisted] = useState(initialIsWishlisted);
+  const [wishlistId, setWishlistId] = useState<number | null>(initialWishlistId);
+  const [loading, setLoading] = useState(false);
+
+  const toggle = async (e: React.MouseEvent): Promise<void> => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!isAuthenticated) {
+      router.push('/login');
+      return;
+    }
+
+    if (loading) return;
+    setLoading(true);
+
+    // Optimistic update
+    const prevIsWishlisted = isWishlisted;
+    const prevWishlistId = wishlistId;
+    setIsWishlisted(!isWishlisted);
+
+    try {
+      if (isWishlisted && wishlistId != null) {
+        await wishlistApi.remove(wishlistId);
+        setWishlistId(null);
+        toast.success('위시리스트에서 삭제되었습니다.');
+      } else {
+        const result = await wishlistApi.add(productId);
+        setWishlistId(result.id);
+        toast.success('위시리스트에 추가되었습니다.');
+      }
+    } catch {
+      // Rollback on failure
+      setIsWishlisted(prevIsWishlisted);
+      setWishlistId(prevWishlistId);
+      toast.error('위시리스트 처리에 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { isWishlisted, loading, toggle };
+}


### PR DESCRIPTION
## Summary

- `src/hooks/useWishlistToggle.ts` 커스텀 훅 생성 — WishlistButton의 optimistic update + rollback 패턴을 표준으로 채택
- `WishlistButton` → 훅 사용으로 리팩토링 (95줄 → 40줄)
- `ProductCard` → 훅 사용으로 리팩토링, 인라인 위시리스트 상태 제거
- toast 메시지 통일: '위시리스트에 추가되었습니다.' / '위시리스트에서 삭제되었습니다.' / '위시리스트 처리에 실패했습니다.'
- 미인증 사용자: toast.error 대신 `/login` 리디렉션으로 통일 (WishlistButton 기존 패턴 채택)
- `src/CLAUDE.md` Key Files에 `hooks/useWishlistToggle.ts` 추가
- `.claude/rules/code-style.md` Frontend 섹션에 위시리스트 훅 사용 규칙 추가

## Test plan

- [x] `useWishlistToggle` 훅 단위 테스트 7개 (TDD) — 모두 통과
- [x] `ProductCard` 기존 테스트 2개 업데이트 (새 동작 반영)
- [x] `npm run build` — 타입 오류 없음
- [x] `npm run test:run` — 310/310 통과

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)