### PR TITLE
fix: #135 에러 메시지 삼킴 방지 — handleApiError 활용

### DIFF
--- a/src/app/[locale]/my/inquiries/new/page.tsx
+++ b/src/app/[locale]/my/inquiries/new/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { inquiriesApi } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
+import { handleApiError } from '@/utils/error';
 
 const INQUIRY_TYPES = ['상품', '배송', '결제', '교환/반품', '기타'];
 
@@ -28,8 +29,8 @@ export default function NewInquiryPage() {
       await inquiriesApi.create({ type, title: title.trim(), content: content.trim() });
       toast.success('문의가 접수되었습니다.');
       router.push('/my/inquiries');
-    } catch {
-      toast.error('문의 접수에 실패했습니다.');
+    } catch (err) {
+      toast.error(handleApiError(err, '문의 접수에 실패했습니다.'));
     } finally {
       setSubmitting(false);
     }

--- a/src/app/[locale]/my/wishlist/page.tsx
+++ b/src/app/[locale]/my/wishlist/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { wishlistApi, cartApi } from '@/lib/api';
 import type { WishlistItem } from '@/lib/api';
+import { handleApiError } from '@/utils/error';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import EmptyState from '@/components/EmptyState';
@@ -33,8 +34,8 @@ export default function WishlistPage() {
       await wishlistApi.remove(wishlistId);
       setItems((prev) => prev.filter((item) => item.id !== wishlistId));
       toast.success('위시리스트에서 삭제되었습니다.');
-    } catch {
-      toast.error('삭제에 실패했습니다.');
+    } catch (err) {
+      toast.error(handleApiError(err, '삭제에 실패했습니다.'));
     }
   };
 
@@ -42,8 +43,8 @@ export default function WishlistPage() {
     try {
       await cartApi.add({ productId, productOptionId: null, quantity: 1 });
       toast.success('장바구니에 추가되었습니다.');
-    } catch {
-      toast.error('장바구니 추가에 실패했습니다.');
+    } catch (err) {
+      toast.error(handleApiError(err, '장바구니 추가에 실패했습니다.'));
     }
   };
 

--- a/src/components/admin/OrderStatusSelect.tsx
+++ b/src/components/admin/OrderStatusSelect.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { adminOrdersApi } from '@/lib/api';
+import { handleApiError } from '@/utils/error';
 
 const STATUS_LABELS: Record<string, string> = {
   pending: '결제대기',
@@ -42,8 +43,8 @@ export function OrderStatusSelect({ orderId, currentStatus, onStatusChange }: Or
       await adminOrdersApi.updateStatus(orderId, nextStatus);
       toast.success(`주문 상태가 ${STATUS_LABELS[nextStatus]}(으)로 변경되었습니다.`);
       onStatusChange();
-    } catch {
-      toast.error('상태 변경에 실패했습니다.');
+    } catch (err) {
+      toast.error(handleApiError(err, '상태 변경에 실패했습니다.'));
     } finally {
       setUpdating(false);
     }

--- a/src/components/admin/ProductImageUploader.tsx
+++ b/src/components/admin/ProductImageUploader.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { uploadApi } from '@/lib/api';
+import { handleApiError } from '@/utils/error';
 
 interface ProductImageUploaderProps {
   imageUrl: string;
@@ -23,8 +24,8 @@ export default function ProductImageUploader({
       const result = await uploadApi.uploadImage(file);
       onChange(result.url);
       toast.success('이미지가 업로드되었습니다.');
-    } catch {
-      toast.error('이미지 업로드에 실패했습니다.');
+    } catch (err) {
+      toast.error(handleApiError(err, '이미지 업로드에 실패했습니다.'));
     } finally {
       setUploading(false);
     }

--- a/src/components/admin/ShippingModal.tsx
+++ b/src/components/admin/ShippingModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { adminOrdersApi } from '@/lib/api';
+import { handleApiError } from '@/utils/error';
 
 interface ShippingModalProps {
   orderId: number;
@@ -38,8 +39,8 @@ export function ShippingModal({ orderId, orderNumber, onClose, onSuccess }: Ship
       });
       toast.success('운송장이 등록되었습니다.');
       onSuccess();
-    } catch {
-      toast.error('운송장 등록에 실패했습니다.');
+    } catch (err) {
+      toast.error(handleApiError(err, '운송장 등록에 실패했습니다.'));
     } finally {
       setSubmitting(false);
     }

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -12,6 +12,7 @@ import {
 import { toast } from 'sonner';
 import { cartApi, CartItem, CartResponse } from '@/lib/api';
 import { useAuth } from './AuthContext';
+import { handleApiError } from '@/utils/error';
 
 const GUEST_CART_KEY = 'guest_cart';
 
@@ -177,8 +178,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
       }));
       try {
         await cartApi.updateQuantity(id, { quantity });
-      } catch {
-        toast.error('수량 변경에 실패했습니다.');
+      } catch (err) {
+        toast.error(handleApiError(err, '수량 변경에 실패했습니다.'));
         await fetchCart();
       }
     },

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -30,7 +30,7 @@ export function useAsyncAction<T>(
       optRef.current.onSuccess?.();
       return result;
     } catch (err) {
-      const message = optRef.current.errorMessage ?? handleApiError(err, '오류가 발생했습니다.');
+      const message = handleApiError(err, optRef.current.errorMessage ?? '오류가 발생했습니다.');
       toast.error(message);
       throw err;
     } finally {


### PR DESCRIPTION
## Summary
- Closes #135
- 백엔드 구체적 에러 메시지를 삼키던 패턴 전체 수정
- CartContext, WishlistButton, ProductImageUploader, OrderStatusSelect, ShippingModal, inquiries, wishlist 페이지
- catch {} → catch (err) { toast.error(handleApiError(err)) } 패턴 적용
- useAsyncAction errorMessage 옵션 백엔드 메시지 우선 처리

## Test plan
- [ ] npm run build
- [ ] npm run test:run
- [ ] 각 컴포넌트에서 백엔드 에러 메시지 표시 확인