### PR TITLE
fix: #133 Silent .catch(() => {}) 제거 — 에러 상태 UI 추가

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -14,6 +14,7 @@ globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
 - Error extraction: always use `handleApiError(err)` from `@/utils/error` — never inline `err instanceof Error ? err.message : ...`
 - Toast errors: use `toast.error(handleApiError(err))` pattern
 - `console.log` in committed code is forbidden
+- Silent `.catch(() => {})` is forbidden — all catch blocks must handle errors (log, toast, or set error state)
 - Responsive: flex/grid based, component-level mobile branching
 - Accessibility: semantic HTML, ARIA labels, keyboard navigation
 

--- a/src/app/[locale]/my/address/page.tsx
+++ b/src/app/[locale]/my/address/page.tsx
@@ -51,19 +51,33 @@ export default function AddressPage() {
   const { isAuthenticated, isLoading } = useRequireAuth();
   const [addresses, setAddresses] = useState<UserAddress[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [form, setForm] = useState<AddressForm>(EMPTY_FORM);
   const [formErrors, setFormErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
 
-  useEffect(() => {
+  const fetchAddresses = () => {
     if (!isAuthenticated) return;
+    setLoading(true);
+    setError(null);
     usersApi
       .getAddresses()
-      .then(setAddresses)
-      .catch(() => {})
+      .then((data) => {
+        setAddresses(data);
+      })
+      .catch((err: unknown) => {
+        const message = handleApiError(err, '배송지를 불러오지 못했습니다.');
+        setError(message);
+        toast.error(message);
+      })
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchAddresses();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -196,6 +210,16 @@ export default function AddressPage() {
           {[1, 2].map((i) => (
             <SkeletonBox key={i} height="h-24" />
           ))}
+        </div>
+      ) : error !== null ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-12 text-center">
+          <p className="text-destructive">{error}</p>
+          <button
+            onClick={fetchAddresses}
+            className="mt-4 inline-block rounded-md bg-foreground px-4 py-2 text-sm text-background hover:opacity-90 transition-opacity"
+          >
+            다시 시도
+          </button>
         </div>
       ) : (
         <>

--- a/src/app/[locale]/my/orders/page.tsx
+++ b/src/app/[locale]/my/orders/page.tsx
@@ -2,9 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { toast } from 'sonner';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
+import { handleApiError } from '@/utils/error';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import StatusBadge from '@/components/common/StatusBadge';
 import { SkeletonBox } from '@/components/ui/Skeleton';
@@ -17,18 +19,29 @@ export default function OrdersPage() {
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchOrders = () => {
     if (!isAuthenticated) return;
     setLoading(true);
+    setError(null);
     ordersApi
       .getList({ page, limit: PAGE_LIMIT })
       .then((res) => {
         setOrders(res.items);
         setTotal(res.total);
       })
-      .catch(() => {})
+      .catch((err: unknown) => {
+        const message = handleApiError(err, '주문 내역을 불러오지 못했습니다.');
+        setError(message);
+        toast.error(message);
+      })
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchOrders();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, page]);
 
   const totalPages = Math.ceil(total / PAGE_LIMIT);
@@ -56,6 +69,16 @@ export default function OrdersPage() {
           {[1, 2, 3].map((i) => (
             <SkeletonBox key={i} height="h-24" />
           ))}
+        </div>
+      ) : error !== null ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-12 text-center">
+          <p className="text-destructive">{error}</p>
+          <button
+            onClick={fetchOrders}
+            className="mt-4 inline-block rounded-md bg-foreground px-4 py-2 text-sm text-background hover:opacity-90 transition-opacity"
+          >
+            다시 시도
+          </button>
         </div>
       ) : orders.length === 0 ? (
         <div className="rounded-lg border p-12 text-center">


### PR DESCRIPTION
## Summary
- Closes #133
- My Orders, My Addresses 페이지에서 Silent .catch(() => {}) 제거
- 에러 상태 UI 및 재시도 버튼 추가
- handleApiError + toast.error 패턴 적용

## Test plan
- [ ] npm run build
- [ ] npm run test:run
- [ ] API 실패 시 에러 상태 UI 표시 확인
- [ ] 재시도 버튼 동작 확인