### PR TITLE
refactor: #121 파일 업로드 함수 중복 제거 (api.ts)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -15,6 +15,7 @@ globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
 - Toast errors: use `toast.error(handleApiError(err))` pattern
 - `console.log` in committed code is forbidden
 - Silent `.catch(() => {})` is forbidden — all catch blocks must handle errors (log, toast, or set error state)
+- API calls must go through `ApiClient` methods — no raw `fetch()` in feature code
 - Responsive: flex/grid based, component-level mobile branching
 - Accessibility: semantic HTML, ARIA labels, keyboard navigation
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -13,6 +13,7 @@ Next.js 15 (App Router) + React 19 + TypeScript + TailwindCSS v4 frontend rules.
 - OAuth callbacks: use shared OAuthCallbackHandler component — do not create per-provider page copies
 - `console.log` in committed code is forbidden
 - Tailwind arbitrary values (`h-[123px]`) forbidden — use theme tokens
+- File uploads: use `ApiClient.uploadFile()` — never bypass ApiClient with raw fetch + FormData
 
 ## Responsive & Accessibility
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -197,6 +197,25 @@ class ApiClient {
   delete<T>(endpoint: string, options?: RequestOptions) {
     return this.request<T>(endpoint, { ...options, method: 'DELETE' });
   }
+
+  async uploadFile<T>(endpoint: string, file: File, fieldName = 'file'): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const formData = new FormData();
+    formData.append(fieldName, file);
+    const response = await fetch(url, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
+      const message = Array.isArray(error.message)
+        ? error.message.join(', ')
+        : ((error as { message?: string }).message || `HTTP ${response.status}`);
+      throw new Error(message);
+    }
+    return response.json() as Promise<T>;
+  }
 }
 
 export const apiClient = new ApiClient(API_BASE);
@@ -936,39 +955,11 @@ export const reviewsApi = {
     apiClient.patch<ReviewItem>(`/reviews/${id}`, data),
   delete: (id: number) =>
     apiClient.delete<void>(`/reviews/${id}`),
-  uploadImage: async (file: File): Promise<UploadedFile> => {
-    const url = `${API_BASE}/reviews/upload-image`;
-    const formData = new FormData();
-    formData.append('file', file);
-    const response = await fetch(url, {
-      method: 'POST',
-      credentials: 'include',
-      body: formData,
-    });
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ message: 'An error occurred' }));
-      throw new Error((error as { message?: string }).message || `HTTP ${response.status}`);
-    }
-    return response.json() as Promise<UploadedFile>;
-  },
+  uploadImage: (file: File) => apiClient.uploadFile<UploadedFile>('/reviews/upload-image', file),
 };
 
 export const uploadApi = {
-  uploadImage: async (file: File): Promise<UploadedFile> => {
-    const url = `${API_BASE}/upload/image`;
-    const formData = new FormData();
-    formData.append('file', file);
-    const response = await fetch(url, {
-      method: 'POST',
-      credentials: 'include',
-      body: formData,
-    });
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ message: 'An error occurred' }));
-      throw new Error((error as { message?: string }).message || `HTTP ${response.status}`);
-    }
-    return response.json() as Promise<UploadedFile>;
-  },
+  uploadImage: (file: File) => apiClient.uploadFile<UploadedFile>('/upload/image', file),
 };
 
 export interface WishlistProduct {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -130,11 +130,13 @@ class ApiClient {
     const { params: _extractedParams, ...fetchOptions } = options ?? {};
 
     const { headers: optionHeaders, ...restFetchOptions } = fetchOptions ?? {};
+    const isFormData = restFetchOptions.body instanceof FormData;
+    const defaultHeaders: Record<string, string> = isFormData ? {} : { 'Content-Type': 'application/json' };
     const response = await fetch(url, {
       ...restFetchOptions,
       credentials: 'include',
       headers: {
-        'Content-Type': 'application/json',
+        ...defaultHeaders,
         ...(optionHeaders as Record<string, string> | undefined),
       },
     });
@@ -146,7 +148,7 @@ class ApiClient {
         ...restFetchOptions,
         credentials: 'include',
         headers: {
-          'Content-Type': 'application/json',
+          ...defaultHeaders,
           ...(optionHeaders as Record<string, string> | undefined),
         },
       });
@@ -198,23 +200,10 @@ class ApiClient {
     return this.request<T>(endpoint, { ...options, method: 'DELETE' });
   }
 
-  async uploadFile<T>(endpoint: string, file: File, fieldName = 'file'): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`;
+  uploadFile<T>(endpoint: string, file: File, fieldName = 'file'): Promise<T> {
     const formData = new FormData();
     formData.append(fieldName, file);
-    const response = await fetch(url, {
-      method: 'POST',
-      credentials: 'include',
-      body: formData,
-    });
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
-      const message = Array.isArray(error.message)
-        ? error.message.join(', ')
-        : ((error as { message?: string }).message || `HTTP ${response.status}`);
-      throw new Error(message);
-    }
-    return response.json() as Promise<T>;
+    return this.request<T>(endpoint, { method: 'POST', body: formData });
   }
 }
 


### PR DESCRIPTION
## Summary
- Closes #121
- `ApiClient`에 `uploadFile<T>(endpoint, file, fieldName?)` 공통 메서드 추가
- `reviewsApi.uploadImage`와 `uploadApi.uploadImage`에서 중복 fetch+FormData 로직을 제거하고 공통 메서드 호출로 교체
- `src/CLAUDE.md` 및 `.claude/rules/code-style.md`에 파일 업로드 규칙 추가

## Test plan
- [x] `npm run build` — 통과
- [x] `npm run test:run` — 316 tests passed