### PR TITLE
fix: #137 API 클라이언트 영어 폴백 메시지 한국어 변환

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -14,6 +14,7 @@ globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
 - Error extraction: always use `handleApiError(err)` from `@/utils/error` — never inline `err instanceof Error ? err.message : ...`
 - Toast errors: use `toast.error(handleApiError(err))` pattern
 - `console.log` in committed code is forbidden
+- API error messages: all user-facing fallback messages must be Korean — no English fallbacks in catch blocks
 - Silent `.catch(() => {})` is forbidden — all catch blocks must handle errors (log, toast, or set error state)
 - API calls must go through `ApiClient` methods — no raw `fetch()` in feature code
 - Responsive: flex/grid based, component-level mobile branching

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -25,7 +25,7 @@ async function fetchFromBackend<T>(
   const response = await fetch(url, { cache: 'no-store' });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: 'An error occurred' }));
+    const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
     throw new Error(error.message || `HTTP ${response.status}`);
   }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -28,7 +28,7 @@ async function _ensureTokenRefreshed(): Promise<void> {
   _isRefreshing = true;
   try {
     if (!_refreshFn) {
-      throw new Error('Refresh function not registered');
+      throw new Error('토큰 갱신 함수가 등록되지 않았습니다.');
     }
     await _refreshFn();
     _refreshQueue.forEach((q) => q.resolve());
@@ -153,7 +153,7 @@ class ApiClient {
         },
       });
       if (!retryResponse.ok) {
-        const error = await retryResponse.json().catch(() => ({ message: 'An error occurred' }));
+        const error = await retryResponse.json().catch(() => ({ message: '오류가 발생했습니다.' }));
         throw new Error(error.message || `HTTP ${retryResponse.status}`);
       }
       if (retryResponse.status === 204 || retryResponse.headers.get('content-length') === '0') {


### PR DESCRIPTION
## Summary
- `src/lib/api.ts`: 토큰 갱신 재시도 블록의 `'An error occurred'` → `'오류가 발생했습니다.'`, 내부 에러 `'Refresh function not registered'` → `'토큰 갱신 함수가 등록되지 않았습니다.'`
- `src/lib/api-server.ts`: 서버사이드 fetch 폴백 `'An error occurred'` → `'오류가 발생했습니다.'`
- `.claude/rules/code-style.md`: Frontend 섹션에 API 에러 메시지 한국어 강제 규칙 추가

## Test plan
- [x] `npm run build` — 빌드 통과
- [x] `npm run test:run` — 52 파일, 316 테스트 통과

Closes #137