### PR TITLE
refactor: 가격 포맷팅 formatCurrency 단일화 (#124 #136)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -15,6 +15,7 @@ globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
 - Toast errors: use `toast.error(handleApiError(err))` pattern
 - `console.log` in committed code is forbidden
 - API error messages: all user-facing fallback messages must be Korean — no English fallbacks in catch blocks
+- Price formatting: always use `formatCurrency()` from `@/utils/currency` — no inline `.toLocaleString() + '원'`, no local format functions
 - Silent `.catch(() => {})` is forbidden — all catch blocks must handle errors (log, toast, or set error state)
 - API calls must go through `ApiClient` methods — no raw `fetch()` in feature code
 - Responsive: flex/grid based, component-level mobile branching

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -45,4 +45,5 @@ components/                     # Reusable UI + shadcn/ui wrappers
 lib/api.ts                      # API client
 contexts/                       # AuthContext, CartContext
 hooks/useWishlistToggle.ts      # Wishlist toggle with optimistic update
+utils/currency.ts               # Price formatting utility (formatCurrency) — single source of truth
 ```

--- a/src/app/[locale]/admin/dashboard/page.tsx
+++ b/src/app/[locale]/admin/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import { handleApiError } from '@/utils/error';
+import { formatCurrency } from '@/utils/currency';
 import {
   adminDashboardApi,
   type DashboardResponse,
@@ -256,7 +257,7 @@ export default function DashboardPage() {
                         </td>
                         <td className="px-3 py-2">{order.user_name}</td>
                         <td className="px-3 py-2 text-right">
-                          {order.total_amount.toLocaleString()}원
+                          {formatCurrency(order.total_amount)}
                         </td>
                         <td className="px-3 py-2">
                           <span className="rounded-full bg-muted px-2 py-0.5 text-xs">

--- a/src/app/[locale]/my/page.tsx
+++ b/src/app/[locale]/my/page.tsx
@@ -8,6 +8,7 @@ import type { OrderResponse } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { ORDER_STATUS_LABELS } from '@/constants/orderStatus';
 import { SkeletonBox } from '@/components/ui/Skeleton';
+import { formatCurrency } from '@/utils/currency';
 
 export default function MyPage() {
   const { isAuthenticated, isLoading } = useRequireAuth();
@@ -135,7 +136,7 @@ export default function MyPage() {
                     </p>
                   </div>
                   <div className="text-right">
-                    <p className="font-medium">{Number(order.totalAmount).toLocaleString()}원</p>
+                    <p className="font-medium">{formatCurrency(Number(order.totalAmount))}</p>
                     <p className="text-xs text-muted-foreground">
                       {ORDER_STATUS_LABELS[order.status] ?? order.status}
                     </p>

--- a/src/app/[locale]/my/recently-viewed/page.tsx
+++ b/src/app/[locale]/my/recently-viewed/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { toast } from 'sonner';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
 import EmptyState from '@/components/EmptyState';
+import { formatCurrency } from '@/utils/currency';
 
 export default function RecentlyViewedPage() {
   const { items, clear } = useRecentlyViewed();
@@ -56,7 +57,7 @@ export default function RecentlyViewedPage() {
               <div className="p-3">
                 <p className="line-clamp-2 text-sm font-medium">{item.name}</p>
                 <p className="mt-1 text-sm font-semibold">
-                  {(item.salePrice ?? item.price).toLocaleString()}원
+                  {formatCurrency(item.salePrice ?? item.price)}
                 </p>
               </div>
             </Link>

--- a/src/components/RecentlyViewedWidget.tsx
+++ b/src/components/RecentlyViewedWidget.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
+import { formatCurrency } from '@/utils/currency';
 
 export default function RecentlyViewedWidget() {
   const { items } = useRecentlyViewed();
@@ -43,7 +44,7 @@ export default function RecentlyViewedWidget() {
               <div className="max-w-32 text-xs">
                 <p className="line-clamp-1 font-medium">{item.name}</p>
                 <p className="text-muted-foreground">
-                  {(item.salePrice ?? item.price).toLocaleString()}원
+                  {formatCurrency(item.salePrice ?? item.price)}
                 </p>
               </div>
             </Link>

--- a/src/components/admin/DashboardCharts.tsx
+++ b/src/components/admin/DashboardCharts.tsx
@@ -12,16 +12,10 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import type { RevenueChartItem } from '@/lib/api';
+import { formatCurrency } from '@/utils/currency';
 
 interface DashboardChartsProps {
   data: RevenueChartItem[];
-}
-
-function formatCurrency(value: number): string {
-  if (value >= 10000) {
-    return `${(value / 10000).toFixed(0)}만`;
-  }
-  return value.toLocaleString();
 }
 
 function formatDate(dateStr: string): string {
@@ -37,10 +31,10 @@ export function RevenueLineChart({ data }: DashboardChartsProps) {
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" tickFormatter={formatDate} fontSize={12} />
-          <YAxis tickFormatter={formatCurrency} fontSize={12} />
+          <YAxis tickFormatter={(value: number) => formatCurrency(value, 'ko', { abbreviated: true })} fontSize={12} />
           <Tooltip
             formatter={(value) => [
-              `${Number(value).toLocaleString()}원`,
+              formatCurrency(Number(value)),
               '매출',
             ]}
             labelFormatter={(label) => `날짜: ${String(label)}`}

--- a/src/components/common/PriceDisplay.tsx
+++ b/src/components/common/PriceDisplay.tsx
@@ -1,5 +1,4 @@
-import { calcDiscount } from '@/utils/price';
-import { formatCurrency, type Locale } from '@/utils/currency';
+import { calcDiscount, formatCurrency, type Locale } from '@/utils/currency';
 
 interface PriceDisplayProps {
   price: number;

--- a/src/components/products/OptionSelector.tsx
+++ b/src/components/products/OptionSelector.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/components/ui/utils'
 import type { ProductOption } from '@/lib/api'
+import { formatCurrency } from '@/utils/currency'
 
 interface OptionSelectorProps {
   options: ProductOption[]
@@ -46,7 +47,7 @@ export default function OptionSelector({ options, selectedOptionId, onSelect }: 
                   {option.priceAdjustment !== 0 && (
                     <span className="ml-1 text-xs">
                       ({option.priceAdjustment > 0 ? '+' : ''}
-                      {option.priceAdjustment.toLocaleString('ko-KR')}원)
+                      {formatCurrency(option.priceAdjustment)})
                     </span>
                   )}
                 </button>

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -47,21 +47,48 @@ const CURRENCY_FORMAT: Record<Currency, { locale: string; currency: string }> = 
  * @param amount KRW 기준 금액
  * @param to 대상 통화
  */
+/**
+ * 할인율을 계산합니다 (0~100 정수).
+ * @param price 원가
+ * @param salePrice 판매가
+ */
+export function calcDiscount(price: number, salePrice: number): number {
+  if (price <= 0) return 0;
+  return Math.round((1 - salePrice / price) * 100);
+}
+
 export function convertPrice(amount: number, to: Currency): number {
   if (to === 'KRW') return amount;
   const rates = getExchangeRates();
   return amount / rates[to];
 }
 
+export interface FormatCurrencyOptions {
+  /** abbreviated: true이면 만 단위 축약 표기 (예: 150000 → '15만'). KRW 전용. */
+  abbreviated?: boolean;
+}
+
 /**
  * KRW 금액을 로케일에 맞는 통화 형식으로 포맷합니다.
  * @param amount KRW 기준 금액
  * @param locale 표시 로케일
+ * @param options 포맷 옵션
  */
-export function formatCurrency(amount: number, locale: Locale = 'ko'): string {
+export function formatCurrency(
+  amount: number,
+  locale: Locale = 'ko',
+  options: FormatCurrencyOptions = {},
+): string {
   const currency = LOCALE_TO_CURRENCY[locale];
   const converted = convertPrice(amount, currency);
   const { locale: intlLocale, currency: intlCurrency } = CURRENCY_FORMAT[currency];
+
+  if (options.abbreviated && currency === 'KRW') {
+    if (converted >= 10000) {
+      return `${(converted / 10000).toFixed(0)}만`;
+    }
+    return converted.toLocaleString();
+  }
 
   return new Intl.NumberFormat(intlLocale, {
     style: 'currency',

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -1,8 +1,0 @@
-export function formatPrice(value: number | string): string {
-  return Math.floor(Number(value)).toLocaleString('ko-KR') + '원';
-}
-
-export function calcDiscount(price: number, salePrice: number): number {
-  if (price <= 0) return 0;
-  return Math.round((1 - salePrice / price) * 100);
-}


### PR DESCRIPTION
## Summary

- `src/utils/price.ts` 삭제 (미사용 파일)
- `calcDiscount` 함수를 `src/utils/currency.ts`로 이전
- `formatCurrency`에 `{ abbreviated?: boolean }` 옵션 추가 — 만 단위 축약 표기 지원 (DashboardCharts YAxis 전용)
- `DashboardCharts.tsx` 로컬 `formatCurrency` 제거, 글로벌 유틸로 교체
- 7개 인라인 `.toLocaleString() + '원'` → `formatCurrency()` 호출로 교체
- `.claude/rules/code-style.md` Frontend 섹션에 가격 포맷팅 규칙 추가
- `src/CLAUDE.md` Key Files에 `utils/currency.ts` 항목 추가

## Test plan

- [x] `npm run build` — 빌드 성공
- [x] `npm run test:run` — 52 test files, 316 tests 전부 통과
- [x] `@/utils/price` 잔여 임포트 없음 확인

Closes #124
Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)