### PR TITLE
refactor: #129 SectionHeading 컴포넌트 공통화

### DIFF
--- a/src/app/[locale]/archive/page.tsx
+++ b/src/app/[locale]/archive/page.tsx
@@ -5,22 +5,13 @@ import { cn } from '@/components/ui/utils';
 import { fetchArchives } from '@/lib/api-server';
 import { TEAPOT_IMAGES } from '@/lib/teapot-images';
 import { SkeletonBox } from '@/components/ui/Skeleton';
+import { SectionHeading } from '@/components/common/SectionHeading';
 import type { NiloType, ProcessStep, Artist } from '@/lib/api';
 
 export const metadata: Metadata = {
   title: 'Archive — 니료 산지 기록 & 공정 스토리',
   description: '자사호의 원료인 니료(泥料) 산지 기록과 채토·연토·성형·소성 공정 스토리, 그리고 장인 인터뷰를 담은 아카이브입니다.',
 };
-
-function SectionHeading({ label, title, description }: { label: string; title: string; description?: string }) {
-  return (
-    <div className="mb-12 text-center">
-      <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">{label}</span>
-      <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground">{title}</h2>
-      {description && <p className="mt-3 max-w-xl mx-auto text-sm text-muted-foreground leading-relaxed">{description}</p>}
-    </div>
-  );
-}
 
 function NiloCard({ entry, reversed }: { entry: NiloType; reversed: boolean }) {
   return (

--- a/src/app/[locale]/collection/page.tsx
+++ b/src/app/[locale]/collection/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { fetchCollections } from '@/lib/api-server';
 import { SkeletonBox } from '@/components/ui/Skeleton';
+import { SectionHeading } from '@/components/common/SectionHeading';
 import type { Collection } from '@/lib/api';
 
 export const metadata: Metadata = {
@@ -14,34 +15,6 @@ export const metadata: Metadata = {
     description: '니료별·모양별 자사호 큐레이션 컬렉션',
   },
 };
-
-function SectionHeading({
-  id,
-  label,
-  title,
-  description,
-}: {
-  id?: string;
-  label: string;
-  title: string;
-  description?: string;
-}) {
-  return (
-    <div className="mb-12 text-center">
-      <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
-        {label}
-      </span>
-      <h2 id={id} className="mt-2 font-display-ko text-3xl font-bold tracking-tight text-foreground">
-        {title}
-      </h2>
-      {description && (
-        <p className="mt-3 max-w-xl mx-auto text-sm text-muted-foreground leading-relaxed">
-          {description}
-        </p>
-      )}
-    </div>
-  );
-}
 
 function ClayCard({ collection }: { collection: Collection }) {
   return (

--- a/src/components/common/SectionHeading.tsx
+++ b/src/components/common/SectionHeading.tsx
@@ -1,0 +1,24 @@
+interface SectionHeadingProps {
+  id?: string;
+  label: string;
+  title: string;
+  description?: string;
+}
+
+export function SectionHeading({ id, label, title, description }: SectionHeadingProps) {
+  return (
+    <div className="mb-12 text-center">
+      <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+        {label}
+      </span>
+      <h2 id={id} className="mt-2 font-display-ko text-3xl font-bold tracking-tight text-foreground">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-3 max-w-xl mx-auto text-sm text-muted-foreground leading-relaxed">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `src/components/common/SectionHeading.tsx` 공통 컴포넌트 생성
- `collection/page.tsx`와 `archive/page.tsx`의 중복 로컬 `SectionHeading` 정의 제거
- 두 페이지 모두 공통 컴포넌트 import로 교체

## Test plan
- [ ] `npm run build` 통과 확인
- [ ] `npm run test:run` 316 tests 통과 확인

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)