### PR TITLE
refactor: #156 findOrThrow 유틸리티 추출 — 30+ 중복 제거

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -97,7 +97,7 @@ Security pipeline: CORS → Rate Limiting → JWT Guard → ValidationPipe → C
 - **`findOrThrow(repo, where, message, relations?)`** — 엔티티 조회 + NotFoundException. 인라인 `findOne → if (!x) throw` 패턴 금지, 반드시 이 유틸리티 사용.
   ```typescript
   import { findOrThrow } from '../common/utils/repository.util';
-  const product = await findOrThrow(this.productRepo, { id } as any, '상품을 찾을 수 없습니다.');
+  const product = await findOrThrow(this.productRepo, { id }, '상품을 찾을 수 없습니다.');
   ```
 
 ## Key Directories

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -92,6 +92,14 @@ Security pipeline: CORS → Rate Limiting → JWT Guard → ValidationPipe → C
 - Unit tests: `npm run build && npm run test`
 - E2E tests: `npm run test:e2e` — **required for any entity/migration/DB change**
 
+## Common Utilities (`src/common/utils/`)
+
+- **`findOrThrow(repo, where, message, relations?)`** — 엔티티 조회 + NotFoundException. 인라인 `findOne → if (!x) throw` 패턴 금지, 반드시 이 유틸리티 사용.
+  ```typescript
+  import { findOrThrow } from '../common/utils/repository.util';
+  const product = await findOrThrow(this.productRepo, { id } as any, '상품을 찾을 수 없습니다.');
+  ```
+
 ## Key Directories
 
 ```

--- a/backend/src/common/utils/repository.util.ts
+++ b/backend/src/common/utils/repository.util.ts
@@ -1,17 +1,17 @@
-import { Repository, FindOptionsWhere, ObjectLiteral } from 'typeorm';
+import { Repository, ObjectLiteral } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 
 /**
- * Repository에서 엔티티를 ID로 조회하고, 없으면 NotFoundException을 던진다.
+ * Repository에서 엔티티를 조회하고, 없으면 NotFoundException을 던진다.
  */
 export async function findOrThrow<T extends ObjectLiteral>(
   repo: Repository<T>,
-  where: FindOptionsWhere<T>,
+  where: Record<string, unknown>,
   message: string,
   relations?: string[],
 ): Promise<T> {
   const entity = await repo.findOne({
-    where,
+    where: where as any,
     ...(relations ? { relations } : {}),
   });
   if (!entity) {

--- a/backend/src/common/utils/repository.util.ts
+++ b/backend/src/common/utils/repository.util.ts
@@ -1,0 +1,21 @@
+import { Repository, FindOptionsWhere, ObjectLiteral } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+
+/**
+ * Repository에서 엔티티를 ID로 조회하고, 없으면 NotFoundException을 던진다.
+ */
+export async function findOrThrow<T extends ObjectLiteral>(
+  repo: Repository<T>,
+  where: FindOptionsWhere<T>,
+  message: string,
+  relations?: string[],
+): Promise<T> {
+  const entity = await repo.findOne({
+    where,
+    ...(relations ? { relations } : {}),
+  });
+  if (!entity) {
+    throw new NotFoundException(message);
+  }
+  return entity;
+}

--- a/backend/src/modules/admin/admin-members.service.ts
+++ b/backend/src/modules/admin/admin-members.service.ts
@@ -88,7 +88,7 @@ export class AdminMembersService {
       throw new BadRequestException('자기 자신의 역할은 변경할 수 없습니다.');
     }
 
-    const target = await findOrThrow(this.userRepository, { id: targetId } as any, '회원을 찾을 수 없습니다.');
+    const target = await findOrThrow(this.userRepository, { id: targetId }, '회원을 찾을 수 없습니다.');
 
     if (!target.isActive) {
       throw new BadRequestException('비활성 회원의 역할은 변경할 수 없습니다.');

--- a/backend/src/modules/admin/admin-members.service.ts
+++ b/backend/src/modules/admin/admin-members.service.ts
@@ -1,6 +1,5 @@
 import {
   Injectable,
-  NotFoundException,
   BadRequestException,
   ForbiddenException,
   Logger,
@@ -9,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User, UserRole } from '../users/entities/user.entity';
 import { AdminMembersQueryDto } from './dto/admin-members-query.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 export interface SafeUser {
   id: number;
@@ -88,10 +88,7 @@ export class AdminMembersService {
       throw new BadRequestException('자기 자신의 역할은 변경할 수 없습니다.');
     }
 
-    const target = await this.userRepository.findOne({ where: { id: targetId } });
-    if (!target) {
-      throw new NotFoundException('회원을 찾을 수 없습니다.');
-    }
+    const target = await findOrThrow(this.userRepository, { id: targetId } as any, '회원을 찾을 수 없습니다.');
 
     if (!target.isActive) {
       throw new BadRequestException('비활성 회원의 역할은 변경할 수 없습니다.');

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -71,7 +71,7 @@ export class AdminOrdersService {
   }
 
   async updateStatus(orderId: number, nextStatus: OrderStatus) {
-    const order = await findOrThrow(this.orderRepository, { id: orderId } as any, '주문을 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
 
     const currentStatus = order.status;
     const allowed = ALLOWED_ORDER_TRANSITIONS[currentStatus] ?? [];
@@ -111,7 +111,7 @@ export class AdminOrdersService {
   }
 
   async registerShipping(orderId: number, dto: RegisterShippingDto) {
-    const order = await findOrThrow(this.orderRepository, { id: orderId } as any, '주문을 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
 
     const existing = await this.shippingRepository.findOne({ where: { orderId } });
     if (existing && existing.trackingNumber) {

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -1,5 +1,5 @@
 import {
-  Injectable, NotFoundException, BadRequestException,
+  Injectable, BadRequestException,
   ConflictException, Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -9,6 +9,7 @@ import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
 import { Shipping, ShippingStatus } from '../payments/entities/shipping.entity';
 import { AdminOrderQueryDto } from './dto/admin-order-query.dto';
 import { RegisterShippingDto } from './dto/register-shipping.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 const ALLOWED_ORDER_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   [OrderStatus.PENDING]: [OrderStatus.PAID],
@@ -70,10 +71,7 @@ export class AdminOrdersService {
   }
 
   async updateStatus(orderId: number, nextStatus: OrderStatus) {
-    const order = await this.orderRepository.findOne({ where: { id: orderId } });
-    if (!order) {
-      throw new NotFoundException('주문을 찾을 수 없습니다.');
-    }
+    const order = await findOrThrow(this.orderRepository, { id: orderId } as any, '주문을 찾을 수 없습니다.');
 
     const currentStatus = order.status;
     const allowed = ALLOWED_ORDER_TRANSITIONS[currentStatus] ?? [];
@@ -113,10 +111,7 @@ export class AdminOrdersService {
   }
 
   async registerShipping(orderId: number, dto: RegisterShippingDto) {
-    const order = await this.orderRepository.findOne({ where: { id: orderId } });
-    if (!order) {
-      throw new NotFoundException('주문을 찾을 수 없습니다.');
-    }
+    const order = await findOrThrow(this.orderRepository, { id: orderId } as any, '주문을 찾을 수 없습니다.');
 
     const existing = await this.shippingRepository.findOne({ where: { orderId } });
     if (existing && existing.trackingNumber) {

--- a/backend/src/modules/archives/archives.service.ts
+++ b/backend/src/modules/archives/archives.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { NiloType, ProcessStep, Artist } from './entities/archive.entity';
+import { findOrThrow } from '../../common/utils/repository.util';
 import {
   CreateNiloTypeDto,
   UpdateNiloTypeDto,
@@ -43,11 +44,7 @@ export class ArchivesService {
   }
 
   async findNiloTypeById(id: number): Promise<NiloType> {
-    const niloType = await this.niloTypeRepository.findOne({ where: { id } });
-    if (!niloType) {
-      throw new NotFoundException('니로타입을 찾을 수 없습니다.');
-    }
-    return niloType;
+    return findOrThrow(this.niloTypeRepository, { id } as any, '니로타입을 찾을 수 없습니다.');
   }
 
   async createNiloType(dto: CreateNiloTypeDto): Promise<NiloType> {
@@ -73,11 +70,7 @@ export class ArchivesService {
   }
 
   async findProcessStepById(id: number): Promise<ProcessStep> {
-    const processStep = await this.processStepRepository.findOne({ where: { id } });
-    if (!processStep) {
-      throw new NotFoundException('공정 단계를 찾을 수 없습니다.');
-    }
-    return processStep;
+    return findOrThrow(this.processStepRepository, { id } as any, '공정 단계를 찾을 수 없습니다.');
   }
 
   async createProcessStep(dto: CreateProcessStepDto): Promise<ProcessStep> {
@@ -97,11 +90,7 @@ export class ArchivesService {
   }
 
   async findArtistById(id: number): Promise<Artist> {
-    const artist = await this.artistRepository.findOne({ where: { id } });
-    if (!artist) {
-      throw new NotFoundException('아티스트를 찾을 수 없습니다.');
-    }
-    return artist;
+    return findOrThrow(this.artistRepository, { id } as any, '아티스트를 찾을 수 없습니다.');
   }
 
   async createArtist(dto: CreateArtistDto): Promise<Artist> {

--- a/backend/src/modules/archives/archives.service.ts
+++ b/backend/src/modules/archives/archives.service.ts
@@ -44,7 +44,7 @@ export class ArchivesService {
   }
 
   async findNiloTypeById(id: number): Promise<NiloType> {
-    return findOrThrow(this.niloTypeRepository, { id } as any, '니로타입을 찾을 수 없습니다.');
+    return findOrThrow(this.niloTypeRepository, { id }, '니로타입을 찾을 수 없습니다.');
   }
 
   async createNiloType(dto: CreateNiloTypeDto): Promise<NiloType> {
@@ -70,7 +70,7 @@ export class ArchivesService {
   }
 
   async findProcessStepById(id: number): Promise<ProcessStep> {
-    return findOrThrow(this.processStepRepository, { id } as any, '공정 단계를 찾을 수 없습니다.');
+    return findOrThrow(this.processStepRepository, { id }, '공정 단계를 찾을 수 없습니다.');
   }
 
   async createProcessStep(dto: CreateProcessStepDto): Promise<ProcessStep> {
@@ -90,7 +90,7 @@ export class ArchivesService {
   }
 
   async findArtistById(id: number): Promise<Artist> {
-    return findOrThrow(this.artistRepository, { id } as any, '아티스트를 찾을 수 없습니다.');
+    return findOrThrow(this.artistRepository, { id }, '아티스트를 찾을 수 없습니다.');
   }
 
   async createArtist(dto: CreateArtistDto): Promise<Artist> {

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -7,6 +7,7 @@ import {
   Logger,
   OnModuleInit,
 } from '@nestjs/common';
+import { findOrThrow } from '../../common/utils/repository.util';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
@@ -144,10 +145,7 @@ export class AuthService implements OnModuleInit {
   }
 
   async getProfile(userId: number): Promise<Omit<User, 'password' | 'refreshToken'>> {
-    const user = await this.userRepository.findOne({ where: { id: userId } });
-    if (!user) {
-      throw new UnauthorizedException('사용자를 찾을 수 없습니다.');
-    }
+    const user = await findOrThrow(this.userRepository, { id: userId } as any, '사용자를 찾을 수 없습니다.');
     const { password, refreshToken, ...profile } = user;
     void password;
     void refreshToken;

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -7,7 +7,6 @@ import {
   Logger,
   OnModuleInit,
 } from '@nestjs/common';
-import { findOrThrow } from '../../common/utils/repository.util';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
@@ -145,7 +144,10 @@ export class AuthService implements OnModuleInit {
   }
 
   async getProfile(userId: number): Promise<Omit<User, 'password' | 'refreshToken'>> {
-    const user = await findOrThrow(this.userRepository, { id: userId } as any, '사용자를 찾을 수 없습니다.');
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new UnauthorizedException('사용자를 찾을 수 없습니다.');
+    }
     const { password, refreshToken, ...profile } = user;
     void password;
     void refreshToken;

--- a/backend/src/modules/cart/cart.service.ts
+++ b/backend/src/modules/cart/cart.service.ts
@@ -151,7 +151,7 @@ export class CartService {
     userId: number,
     dto: UpdateCartQuantityDto,
   ): Promise<CartItem> {
-    const item = await findOrThrow(this.cartItemRepository, { id } as any, '장바구니 항목을 찾을 수 없습니다.');
+    const item = await findOrThrow(this.cartItemRepository, { id }, '장바구니 항목을 찾을 수 없습니다.');
     if (Number(item.userId) !== Number(userId)) {
       throw new ForbiddenException('접근 권한이 없습니다.');
     }
@@ -161,7 +161,7 @@ export class CartService {
   }
 
   async remove(id: number, userId: number): Promise<{ message: string }> {
-    const item = await findOrThrow(this.cartItemRepository, { id } as any, '장바구니 항목을 찾을 수 없습니다.');
+    const item = await findOrThrow(this.cartItemRepository, { id }, '장바구니 항목을 찾을 수 없습니다.');
     if (Number(item.userId) !== Number(userId)) {
       throw new ForbiddenException('접근 권한이 없습니다.');
     }

--- a/backend/src/modules/cart/cart.service.ts
+++ b/backend/src/modules/cart/cart.service.ts
@@ -12,6 +12,7 @@ import { Product } from '../products/entities/product.entity';
 import { ProductOption } from '../products/entities/product-option.entity';
 import { AddToCartDto } from './dto/add-to-cart.dto';
 import { UpdateCartQuantityDto } from './dto/update-cart-quantity.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 export interface CartItemWithPrice {
   id: number;
@@ -150,10 +151,7 @@ export class CartService {
     userId: number,
     dto: UpdateCartQuantityDto,
   ): Promise<CartItem> {
-    const item = await this.cartItemRepository.findOne({ where: { id } });
-    if (!item) {
-      throw new NotFoundException('장바구니 항목을 찾을 수 없습니다.');
-    }
+    const item = await findOrThrow(this.cartItemRepository, { id } as any, '장바구니 항목을 찾을 수 없습니다.');
     if (Number(item.userId) !== Number(userId)) {
       throw new ForbiddenException('접근 권한이 없습니다.');
     }
@@ -163,10 +161,7 @@ export class CartService {
   }
 
   async remove(id: number, userId: number): Promise<{ message: string }> {
-    const item = await this.cartItemRepository.findOne({ where: { id } });
-    if (!item) {
-      throw new NotFoundException('장바구니 항목을 찾을 수 없습니다.');
-    }
+    const item = await findOrThrow(this.cartItemRepository, { id } as any, '장바구니 항목을 찾을 수 없습니다.');
     if (Number(item.userId) !== Number(userId)) {
       throw new ForbiddenException('접근 권한이 없습니다.');
     }

--- a/backend/src/modules/collections/collections.service.ts
+++ b/backend/src/modules/collections/collections.service.ts
@@ -26,7 +26,7 @@ export class CollectionsService {
   }
 
   async findById(id: number): Promise<Collection> {
-    return findOrThrow(this.collectionRepository, { id } as any, '컬렉션을 찾을 수 없습니다.');
+    return findOrThrow(this.collectionRepository, { id }, '컬렉션을 찾을 수 없습니다.');
   }
 
   async create(dto: CreateCollectionDto): Promise<Collection> {

--- a/backend/src/modules/collections/collections.service.ts
+++ b/backend/src/modules/collections/collections.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Collection, CollectionType } from './entities/collection.entity';
+import { findOrThrow } from '../../common/utils/repository.util';
 import { CreateCollectionDto, UpdateCollectionDto } from './dto/collection.dto';
 
 @Injectable()
@@ -25,11 +26,7 @@ export class CollectionsService {
   }
 
   async findById(id: number): Promise<Collection> {
-    const collection = await this.collectionRepository.findOne({ where: { id } });
-    if (!collection) {
-      throw new NotFoundException('컬렉션을 찾을 수 없습니다.');
-    }
-    return collection;
+    return findOrThrow(this.collectionRepository, { id } as any, '컬렉션을 찾을 수 없습니다.');
   }
 
   async create(dto: CreateCollectionDto): Promise<Collection> {

--- a/backend/src/modules/coupons/coupons.service.ts
+++ b/backend/src/modules/coupons/coupons.service.ts
@@ -227,7 +227,7 @@ export class CouponsService {
   }
 
   async issueCoupon(dto: IssueCouponDto): Promise<UserCoupon> {
-    const coupon = await findOrThrow(this.couponRepo, { id: dto.couponId } as any, '쿠폰을 찾을 수 없습니다.');
+    const coupon = await findOrThrow(this.couponRepo, { id: dto.couponId }, '쿠폰을 찾을 수 없습니다.');
     if (!coupon.isActive) {
       throw new BadRequestException('비활성화된 쿠폰입니다.');
     }

--- a/backend/src/modules/coupons/coupons.service.ts
+++ b/backend/src/modules/coupons/coupons.service.ts
@@ -12,6 +12,7 @@ import { PointHistory } from './entities/point-history.entity';
 import { CreateCouponDto } from './dto/create-coupon.dto';
 import { CalculateDiscountDto } from './dto/calculate-discount.dto';
 import { IssueCouponDto } from './dto/issue-coupon.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 export interface CouponResponse {
   id: number;
@@ -226,10 +227,7 @@ export class CouponsService {
   }
 
   async issueCoupon(dto: IssueCouponDto): Promise<UserCoupon> {
-    const coupon = await this.couponRepo.findOne({ where: { id: dto.couponId } });
-    if (!coupon) {
-      throw new NotFoundException('쿠폰을 찾을 수 없습니다.');
-    }
+    const coupon = await findOrThrow(this.couponRepo, { id: dto.couponId } as any, '쿠폰을 찾을 수 없습니다.');
     if (!coupon.isActive) {
       throw new BadRequestException('비활성화된 쿠폰입니다.');
     }

--- a/backend/src/modules/faqs/faqs.service.ts
+++ b/backend/src/modules/faqs/faqs.service.ts
@@ -61,13 +61,13 @@ export class FaqsService {
   }
 
   async update(id: number, dto: UpdateFaqDto): Promise<Faq> {
-    const faq = await findOrThrow(this.faqRepo, { id } as any, 'FAQ를 찾을 수 없습니다.');
+    const faq = await findOrThrow(this.faqRepo, { id }, 'FAQ를 찾을 수 없습니다.');
     Object.assign(faq, dto);
     return this.faqRepo.save(faq);
   }
 
   async remove(id: number): Promise<void> {
-    const faq = await findOrThrow(this.faqRepo, { id } as any, 'FAQ를 찾을 수 없습니다.');
+    const faq = await findOrThrow(this.faqRepo, { id }, 'FAQ를 찾을 수 없습니다.');
     await this.faqRepo.remove(faq);
     this.logger.log(`FAQ deleted: id=${id}`);
   }

--- a/backend/src/modules/faqs/faqs.service.ts
+++ b/backend/src/modules/faqs/faqs.service.ts
@@ -1,11 +1,11 @@
 import {
   Injectable,
-  NotFoundException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindOptionsWhere } from 'typeorm';
 import { Faq } from './entities/faq.entity';
+import { findOrThrow } from '../../common/utils/repository.util';
 import { CreateFaqDto } from './dto/create-faq.dto';
 import { UpdateFaqDto } from './dto/update-faq.dto';
 import { FaqQueryDto } from './dto/faq-query.dto';
@@ -61,19 +61,13 @@ export class FaqsService {
   }
 
   async update(id: number, dto: UpdateFaqDto): Promise<Faq> {
-    const faq = await this.faqRepo.findOne({ where: { id } });
-    if (!faq) {
-      throw new NotFoundException('FAQ를 찾을 수 없습니다.');
-    }
+    const faq = await findOrThrow(this.faqRepo, { id } as any, 'FAQ를 찾을 수 없습니다.');
     Object.assign(faq, dto);
     return this.faqRepo.save(faq);
   }
 
   async remove(id: number): Promise<void> {
-    const faq = await this.faqRepo.findOne({ where: { id } });
-    if (!faq) {
-      throw new NotFoundException('FAQ를 찾을 수 없습니다.');
-    }
+    const faq = await findOrThrow(this.faqRepo, { id } as any, 'FAQ를 찾을 수 없습니다.');
     await this.faqRepo.remove(faq);
     this.logger.log(`FAQ deleted: id=${id}`);
   }

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -1,6 +1,5 @@
 import {
   Injectable,
-  NotFoundException,
   ForbiddenException,
   Logger,
 } from '@nestjs/common';
@@ -9,6 +8,7 @@ import { Repository } from 'typeorm';
 import { Inquiry } from './entities/inquiry.entity';
 import { CreateInquiryDto } from './dto/create-inquiry.dto';
 import { AnswerInquiryDto } from './dto/answer-inquiry.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 @Injectable()
 export class InquiriesService {
@@ -27,10 +27,7 @@ export class InquiriesService {
   }
 
   async findOne(id: number, userId: number): Promise<Inquiry> {
-    const inquiry = await this.inquiryRepo.findOne({ where: { id } });
-    if (!inquiry) {
-      throw new NotFoundException('문의를 찾을 수 없습니다.');
-    }
+    const inquiry = await findOrThrow(this.inquiryRepo, { id } as any, '문의를 찾을 수 없습니다.');
     if (Number(inquiry.userId) !== Number(userId)) {
       throw new ForbiddenException('권한이 없습니다.');
     }
@@ -56,10 +53,7 @@ export class InquiriesService {
   }
 
   async answerInquiry(id: number, dto: AnswerInquiryDto): Promise<Inquiry> {
-    const inquiry = await this.inquiryRepo.findOne({ where: { id } });
-    if (!inquiry) {
-      throw new NotFoundException('문의를 찾을 수 없습니다.');
-    }
+    const inquiry = await findOrThrow(this.inquiryRepo, { id } as any, '문의를 찾을 수 없습니다.');
     inquiry.answer = dto.answer;
     inquiry.status = 'answered';
     inquiry.answeredAt = new Date();

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -27,7 +27,7 @@ export class InquiriesService {
   }
 
   async findOne(id: number, userId: number): Promise<Inquiry> {
-    const inquiry = await findOrThrow(this.inquiryRepo, { id } as any, '문의를 찾을 수 없습니다.');
+    const inquiry = await findOrThrow(this.inquiryRepo, { id }, '문의를 찾을 수 없습니다.');
     if (Number(inquiry.userId) !== Number(userId)) {
       throw new ForbiddenException('권한이 없습니다.');
     }
@@ -53,7 +53,7 @@ export class InquiriesService {
   }
 
   async answerInquiry(id: number, dto: AnswerInquiryDto): Promise<Inquiry> {
-    const inquiry = await findOrThrow(this.inquiryRepo, { id } as any, '문의를 찾을 수 없습니다.');
+    const inquiry = await findOrThrow(this.inquiryRepo, { id }, '문의를 찾을 수 없습니다.');
     inquiry.answer = dto.answer;
     inquiry.status = 'answered';
     inquiry.answeredAt = new Date();

--- a/backend/src/modules/navigation/navigation.service.ts
+++ b/backend/src/modules/navigation/navigation.service.ts
@@ -1,6 +1,5 @@
 import {
   Injectable,
-  NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -9,6 +8,7 @@ import { NavigationItem } from './entities/navigation-item.entity';
 import { CreateNavigationItemDto } from './dto/create-navigation-item.dto';
 import { UpdateNavigationItemDto } from './dto/update-navigation-item.dto';
 import { ReorderNavigationDto } from './dto/reorder-navigation.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 const MAX_DEPTH = 3;
 
@@ -44,10 +44,7 @@ export class NavigationService {
   }
 
   async update(id: number, dto: UpdateNavigationItemDto): Promise<NavigationItem> {
-    const item = await this.navigationRepository.findOne({ where: { id } });
-    if (!item) {
-      throw new NotFoundException('존재하지 않는 네비게이션 항목입니다.');
-    }
+    const item = await findOrThrow(this.navigationRepository, { id } as any, '존재하지 않는 네비게이션 항목입니다.');
 
     if (dto.parent_id !== undefined) {
       if (dto.parent_id !== null) {
@@ -64,10 +61,7 @@ export class NavigationService {
   }
 
   async remove(id: number): Promise<void> {
-    const item = await this.navigationRepository.findOne({ where: { id } });
-    if (!item) {
-      throw new NotFoundException('존재하지 않는 네비게이션 항목입니다.');
-    }
+    const item = await findOrThrow(this.navigationRepository, { id } as any, '존재하지 않는 네비게이션 항목입니다.');
     await this.navigationRepository.remove(item);
   }
 

--- a/backend/src/modules/navigation/navigation.service.ts
+++ b/backend/src/modules/navigation/navigation.service.ts
@@ -44,7 +44,7 @@ export class NavigationService {
   }
 
   async update(id: number, dto: UpdateNavigationItemDto): Promise<NavigationItem> {
-    const item = await findOrThrow(this.navigationRepository, { id } as any, '존재하지 않는 네비게이션 항목입니다.');
+    const item = await findOrThrow(this.navigationRepository, { id }, '존재하지 않는 네비게이션 항목입니다.');
 
     if (dto.parent_id !== undefined) {
       if (dto.parent_id !== null) {
@@ -61,7 +61,7 @@ export class NavigationService {
   }
 
   async remove(id: number): Promise<void> {
-    const item = await findOrThrow(this.navigationRepository, { id } as any, '존재하지 않는 네비게이션 항목입니다.');
+    const item = await findOrThrow(this.navigationRepository, { id }, '존재하지 않는 네비게이션 항목입니다.');
     await this.navigationRepository.remove(item);
   }
 

--- a/backend/src/modules/notices/notices.service.ts
+++ b/backend/src/modules/notices/notices.service.ts
@@ -44,7 +44,7 @@ export class NoticesService {
   }
 
   async findOne(id: number, locale?: string): Promise<Notice> {
-    const notice = await findOrThrow(this.noticeRepo, { id } as any, '공지사항을 찾을 수 없습니다.');
+    const notice = await findOrThrow(this.noticeRepo, { id }, '공지사항을 찾을 수 없습니다.');
     await this.noticeRepo.update(id, { viewCount: () => 'view_count + 1' });
     notice.viewCount += 1;
     return this.applyLocale(notice, locale);
@@ -63,13 +63,13 @@ export class NoticesService {
   }
 
   async update(id: number, dto: UpdateNoticeDto): Promise<Notice> {
-    const notice = await findOrThrow(this.noticeRepo, { id } as any, '공지사항을 찾을 수 없습니다.');
+    const notice = await findOrThrow(this.noticeRepo, { id }, '공지사항을 찾을 수 없습니다.');
     Object.assign(notice, dto);
     return this.noticeRepo.save(notice);
   }
 
   async remove(id: number): Promise<void> {
-    const notice = await findOrThrow(this.noticeRepo, { id } as any, '공지사항을 찾을 수 없습니다.');
+    const notice = await findOrThrow(this.noticeRepo, { id }, '공지사항을 찾을 수 없습니다.');
     await this.noticeRepo.remove(notice);
     this.logger.log(`Notice deleted: id=${id}`);
   }

--- a/backend/src/modules/notices/notices.service.ts
+++ b/backend/src/modules/notices/notices.service.ts
@@ -1,6 +1,5 @@
 import {
   Injectable,
-  NotFoundException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -9,6 +8,7 @@ import { Notice } from './entities/notice.entity';
 import { CreateNoticeDto } from './dto/create-notice.dto';
 import { UpdateNoticeDto } from './dto/update-notice.dto';
 import { NoticeQueryDto } from './dto/notice-query.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 @Injectable()
 export class NoticesService {
@@ -44,10 +44,7 @@ export class NoticesService {
   }
 
   async findOne(id: number, locale?: string): Promise<Notice> {
-    const notice = await this.noticeRepo.findOne({ where: { id } });
-    if (!notice) {
-      throw new NotFoundException('공지사항을 찾을 수 없습니다.');
-    }
+    const notice = await findOrThrow(this.noticeRepo, { id } as any, '공지사항을 찾을 수 없습니다.');
     await this.noticeRepo.update(id, { viewCount: () => 'view_count + 1' });
     notice.viewCount += 1;
     return this.applyLocale(notice, locale);
@@ -66,19 +63,13 @@ export class NoticesService {
   }
 
   async update(id: number, dto: UpdateNoticeDto): Promise<Notice> {
-    const notice = await this.noticeRepo.findOne({ where: { id } });
-    if (!notice) {
-      throw new NotFoundException('공지사항을 찾을 수 없습니다.');
-    }
+    const notice = await findOrThrow(this.noticeRepo, { id } as any, '공지사항을 찾을 수 없습니다.');
     Object.assign(notice, dto);
     return this.noticeRepo.save(notice);
   }
 
   async remove(id: number): Promise<void> {
-    const notice = await this.noticeRepo.findOne({ where: { id } });
-    if (!notice) {
-      throw new NotFoundException('공지사항을 찾을 수 없습니다.');
-    }
+    const notice = await findOrThrow(this.noticeRepo, { id } as any, '공지사항을 찾을 수 없습니다.');
     await this.noticeRepo.remove(notice);
     this.logger.log(`Notice deleted: id=${id}`);
   }

--- a/backend/src/modules/pages/pages.service.ts
+++ b/backend/src/modules/pages/pages.service.ts
@@ -13,6 +13,7 @@ import { UpdatePageDto } from './dto/update-page.dto';
 import { CreatePageBlockDto } from './dto/create-page-block.dto';
 import { UpdatePageBlockDto } from './dto/update-page-block.dto';
 import { ReorderBlocksDto } from './dto/reorder-blocks.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 const SUPPORTED_BLOCK_TYPES = [
   'hero_banner',
@@ -72,10 +73,7 @@ export class PagesService {
   }
 
   async update(id: number, dto: UpdatePageDto): Promise<Page> {
-    const page = await this.pageRepository.findOne({ where: { id } });
-    if (!page) {
-      throw new NotFoundException('존재하지 않는 페이지입니다.');
-    }
+    const page = await findOrThrow(this.pageRepository, { id } as any, '존재하지 않는 페이지입니다.');
     if (dto.slug && dto.slug !== page.slug) {
       const existing = await this.pageRepository.findOne({
         where: { slug: dto.slug },
@@ -89,10 +87,7 @@ export class PagesService {
   }
 
   async remove(id: number): Promise<void> {
-    const page = await this.pageRepository.findOne({ where: { id } });
-    if (!page) {
-      throw new NotFoundException('존재하지 않는 페이지입니다.');
-    }
+    const page = await findOrThrow(this.pageRepository, { id } as any, '존재하지 않는 페이지입니다.');
     if (page.is_published) {
       throw new BadRequestException(
         '공개 중인 페이지는 삭제할 수 없습니다. 먼저 비공개 처리하세요.',
@@ -105,10 +100,7 @@ export class PagesService {
     pageId: number,
     dto: CreatePageBlockDto,
   ): Promise<PageBlock> {
-    const page = await this.pageRepository.findOne({ where: { id: pageId } });
-    if (!page) {
-      throw new NotFoundException('존재하지 않는 페이지입니다.');
-    }
+    const page = await findOrThrow(this.pageRepository, { id: pageId } as any, '존재하지 않는 페이지입니다.');
     if (!SUPPORTED_BLOCK_TYPES.includes(dto.type)) {
       throw new BadRequestException('지원하지 않는 블록 타입입니다.');
     }
@@ -151,10 +143,7 @@ export class PagesService {
     pageId: number,
     dto: ReorderBlocksDto,
   ): Promise<void> {
-    const page = await this.pageRepository.findOne({ where: { id: pageId } });
-    if (!page) {
-      throw new NotFoundException('존재하지 않는 페이지입니다.');
-    }
+    const page = await findOrThrow(this.pageRepository, { id: pageId } as any, '존재하지 않는 페이지입니다.');
     for (const item of dto.orders) {
       await this.blockRepository.update(
         { id: item.id, page_id: pageId },

--- a/backend/src/modules/pages/pages.service.ts
+++ b/backend/src/modules/pages/pages.service.ts
@@ -73,7 +73,7 @@ export class PagesService {
   }
 
   async update(id: number, dto: UpdatePageDto): Promise<Page> {
-    const page = await findOrThrow(this.pageRepository, { id } as any, '존재하지 않는 페이지입니다.');
+    const page = await findOrThrow(this.pageRepository, { id }, '존재하지 않는 페이지입니다.');
     if (dto.slug && dto.slug !== page.slug) {
       const existing = await this.pageRepository.findOne({
         where: { slug: dto.slug },
@@ -87,7 +87,7 @@ export class PagesService {
   }
 
   async remove(id: number): Promise<void> {
-    const page = await findOrThrow(this.pageRepository, { id } as any, '존재하지 않는 페이지입니다.');
+    const page = await findOrThrow(this.pageRepository, { id }, '존재하지 않는 페이지입니다.');
     if (page.is_published) {
       throw new BadRequestException(
         '공개 중인 페이지는 삭제할 수 없습니다. 먼저 비공개 처리하세요.',
@@ -100,7 +100,7 @@ export class PagesService {
     pageId: number,
     dto: CreatePageBlockDto,
   ): Promise<PageBlock> {
-    const page = await findOrThrow(this.pageRepository, { id: pageId } as any, '존재하지 않는 페이지입니다.');
+    const page = await findOrThrow(this.pageRepository, { id: pageId }, '존재하지 않는 페이지입니다.');
     if (!SUPPORTED_BLOCK_TYPES.includes(dto.type)) {
       throw new BadRequestException('지원하지 않는 블록 타입입니다.');
     }
@@ -143,7 +143,7 @@ export class PagesService {
     pageId: number,
     dto: ReorderBlocksDto,
   ): Promise<void> {
-    const page = await findOrThrow(this.pageRepository, { id: pageId } as any, '존재하지 않는 페이지입니다.');
+    const page = await findOrThrow(this.pageRepository, { id: pageId }, '존재하지 않는 페이지입니다.');
     for (const item of dto.orders) {
       await this.blockRepository.update(
         { id: item.id, page_id: pageId },

--- a/backend/src/modules/products/categories.service.ts
+++ b/backend/src/modules/products/categories.service.ts
@@ -90,7 +90,7 @@ export class CategoriesService {
     }
 
     if (dto.parentId) {
-      await findOrThrow(this.categoryRepository, { id: dto.parentId } as any, `부모 카테고리(id: ${dto.parentId})를 찾을 수 없습니다.`);
+      await findOrThrow(this.categoryRepository, { id: dto.parentId }, `부모 카테고리(id: ${dto.parentId})를 찾을 수 없습니다.`);
     }
 
     const existing = await this.categoryRepository.findOne({ where: { slug: dto.slug } });
@@ -111,7 +111,7 @@ export class CategoriesService {
   }
 
   async update(id: number, dto: UpdateCategoryDto): Promise<Category> {
-    const category = await findOrThrow(this.categoryRepository, { id } as any, `카테고리(id: ${id})를 찾을 수 없습니다.`);
+    const category = await findOrThrow(this.categoryRepository, { id }, `카테고리(id: ${id})를 찾을 수 없습니다.`);
 
     if (dto.parentId !== undefined) {
       if (dto.parentId === id) {
@@ -119,7 +119,7 @@ export class CategoriesService {
       }
 
       if (dto.parentId) {
-        await findOrThrow(this.categoryRepository, { id: dto.parentId } as any, `부모 카테고리(id: ${dto.parentId})를 찾을 수 없습니다.`);
+        await findOrThrow(this.categoryRepository, { id: dto.parentId }, `부모 카테고리(id: ${dto.parentId})를 찾을 수 없습니다.`);
 
         const depth = await this.getDepth(dto.parentId);
         if (depth >= 3) {
@@ -148,7 +148,7 @@ export class CategoriesService {
   }
 
   async remove(id: number): Promise<void> {
-    const category = await findOrThrow(this.categoryRepository, { id } as any, `카테고리(id: ${id})를 찾을 수 없습니다.`);
+    const category = await findOrThrow(this.categoryRepository, { id }, `카테고리(id: ${id})를 찾을 수 없습니다.`);
 
     const childCount = await this.categoryRepository.count({ where: { parentId: id } });
     if (childCount > 0) {

--- a/backend/src/modules/products/categories.service.ts
+++ b/backend/src/modules/products/categories.service.ts
@@ -1,7 +1,6 @@
 import {
   Injectable,
   BadRequestException,
-  NotFoundException,
   ConflictException,
   Logger,
 } from '@nestjs/common';
@@ -11,6 +10,7 @@ import { Category } from './entities/category.entity';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
 import { ReorderCategoriesDto } from './dto/reorder-categories.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 export interface CategoryTree extends Omit<Category, 'children' | 'products'> {
   children: CategoryTree[];
@@ -90,10 +90,7 @@ export class CategoriesService {
     }
 
     if (dto.parentId) {
-      const parent = await this.categoryRepository.findOne({ where: { id: dto.parentId } });
-      if (!parent) {
-        throw new NotFoundException(`부모 카테고리(id: ${dto.parentId})를 찾을 수 없습니다.`);
-      }
+      await findOrThrow(this.categoryRepository, { id: dto.parentId } as any, `부모 카테고리(id: ${dto.parentId})를 찾을 수 없습니다.`);
     }
 
     const existing = await this.categoryRepository.findOne({ where: { slug: dto.slug } });
@@ -114,10 +111,7 @@ export class CategoriesService {
   }
 
   async update(id: number, dto: UpdateCategoryDto): Promise<Category> {
-    const category = await this.categoryRepository.findOne({ where: { id } });
-    if (!category) {
-      throw new NotFoundException(`카테고리(id: ${id})를 찾을 수 없습니다.`);
-    }
+    const category = await findOrThrow(this.categoryRepository, { id } as any, `카테고리(id: ${id})를 찾을 수 없습니다.`);
 
     if (dto.parentId !== undefined) {
       if (dto.parentId === id) {
@@ -125,10 +119,7 @@ export class CategoriesService {
       }
 
       if (dto.parentId) {
-        const parent = await this.categoryRepository.findOne({ where: { id: dto.parentId } });
-        if (!parent) {
-          throw new NotFoundException(`부모 카테고리(id: ${dto.parentId})를 찾을 수 없습니다.`);
-        }
+        await findOrThrow(this.categoryRepository, { id: dto.parentId } as any, `부모 카테고리(id: ${dto.parentId})를 찾을 수 없습니다.`);
 
         const depth = await this.getDepth(dto.parentId);
         if (depth >= 3) {
@@ -157,10 +148,7 @@ export class CategoriesService {
   }
 
   async remove(id: number): Promise<void> {
-    const category = await this.categoryRepository.findOne({ where: { id } });
-    if (!category) {
-      throw new NotFoundException(`카테고리(id: ${id})를 찾을 수 없습니다.`);
-    }
+    const category = await findOrThrow(this.categoryRepository, { id } as any, `카테고리(id: ${id})를 찾을 수 없습니다.`);
 
     const childCount = await this.categoryRepository.count({ where: { parentId: id } });
     if (childCount > 0) {

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -244,7 +244,7 @@ export class ProductsService {
   }
 
   private async findById(id: number): Promise<Product> {
-    return findOrThrow(this.productRepository, { id } as any, '상품을 찾을 수 없습니다.');
+    return findOrThrow(this.productRepository, { id }, '상품을 찾을 수 없습니다.');
   }
 
   async create(dto: CreateProductDto): Promise<Product> {

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -13,6 +13,7 @@ import { QueryProductsDto, ProductSort } from './dto/query-products.dto';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { CacheService } from '../cache/cache.service';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 const CACHE_TTL_LIST = 300;
 const CACHE_TTL_DETAIL = 600;
@@ -243,11 +244,7 @@ export class ProductsService {
   }
 
   private async findById(id: number): Promise<Product> {
-    const product = await this.productRepository.findOne({ where: { id } });
-    if (!product) {
-      throw new NotFoundException('상품을 찾을 수 없습니다.');
-    }
-    return product;
+    return findOrThrow(this.productRepository, { id } as any, '상품을 찾을 수 없습니다.');
   }
 
   async create(dto: CreateProductDto): Promise<Product> {

--- a/backend/src/modules/promotions/promotions.service.ts
+++ b/backend/src/modules/promotions/promotions.service.ts
@@ -31,7 +31,7 @@ export class PromotionsService {
   }
 
   async findOne(id: number): Promise<Promotion> {
-    return findOrThrow(this.promotionRepo, { id } as any, '프로모션을 찾을 수 없습니다.');
+    return findOrThrow(this.promotionRepo, { id }, '프로모션을 찾을 수 없습니다.');
   }
 
   async create(dto: CreatePromotionDto): Promise<Promotion> {
@@ -51,7 +51,7 @@ export class PromotionsService {
   }
 
   async update(id: number, dto: UpdatePromotionDto): Promise<Promotion> {
-    const promotion = await findOrThrow(this.promotionRepo, { id } as any, '프로모션을 찾을 수 없습니다.');
+    const promotion = await findOrThrow(this.promotionRepo, { id }, '프로모션을 찾을 수 없습니다.');
     if (dto.title !== undefined) promotion.title = dto.title;
     if (dto.description !== undefined) promotion.description = dto.description;
     if (dto.type !== undefined) promotion.type = dto.type;
@@ -64,7 +64,7 @@ export class PromotionsService {
   }
 
   async remove(id: number): Promise<void> {
-    const promotion = await findOrThrow(this.promotionRepo, { id } as any, '프로모션을 찾을 수 없습니다.');
+    const promotion = await findOrThrow(this.promotionRepo, { id }, '프로모션을 찾을 수 없습니다.');
     await this.promotionRepo.remove(promotion);
     this.logger.log(`Promotion deleted: id=${id}`);
   }
@@ -98,7 +98,7 @@ export class PromotionsService {
   }
 
   async updateBanner(id: number, dto: UpdateBannerDto): Promise<Banner> {
-    const banner = await findOrThrow(this.bannerRepo, { id } as any, '배너를 찾을 수 없습니다.');
+    const banner = await findOrThrow(this.bannerRepo, { id }, '배너를 찾을 수 없습니다.');
     if (dto.title !== undefined) banner.title = dto.title;
     if (dto.imageUrl !== undefined) banner.imageUrl = dto.imageUrl;
     if (dto.linkUrl !== undefined) banner.linkUrl = dto.linkUrl;
@@ -110,7 +110,7 @@ export class PromotionsService {
   }
 
   async removeBanner(id: number): Promise<void> {
-    const banner = await findOrThrow(this.bannerRepo, { id } as any, '배너를 찾을 수 없습니다.');
+    const banner = await findOrThrow(this.bannerRepo, { id }, '배너를 찾을 수 없습니다.');
     await this.bannerRepo.remove(banner);
     this.logger.log(`Banner deleted: id=${id}`);
   }

--- a/backend/src/modules/promotions/promotions.service.ts
+++ b/backend/src/modules/promotions/promotions.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
 import { Promotion } from './entities/promotion.entity';
 import { Banner } from './entities/banner.entity';
 import { CreatePromotionDto, UpdatePromotionDto } from './dto/create-promotion.dto';
 import { CreateBannerDto, UpdateBannerDto } from './dto/create-banner.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 @Injectable()
 export class PromotionsService {
@@ -30,11 +31,7 @@ export class PromotionsService {
   }
 
   async findOne(id: number): Promise<Promotion> {
-    const promotion = await this.promotionRepo.findOne({ where: { id } });
-    if (!promotion) {
-      throw new NotFoundException('프로모션을 찾을 수 없습니다.');
-    }
-    return promotion;
+    return findOrThrow(this.promotionRepo, { id } as any, '프로모션을 찾을 수 없습니다.');
   }
 
   async create(dto: CreatePromotionDto): Promise<Promotion> {
@@ -54,10 +51,7 @@ export class PromotionsService {
   }
 
   async update(id: number, dto: UpdatePromotionDto): Promise<Promotion> {
-    const promotion = await this.promotionRepo.findOne({ where: { id } });
-    if (!promotion) {
-      throw new NotFoundException('프로모션을 찾을 수 없습니다.');
-    }
+    const promotion = await findOrThrow(this.promotionRepo, { id } as any, '프로모션을 찾을 수 없습니다.');
     if (dto.title !== undefined) promotion.title = dto.title;
     if (dto.description !== undefined) promotion.description = dto.description;
     if (dto.type !== undefined) promotion.type = dto.type;
@@ -70,10 +64,7 @@ export class PromotionsService {
   }
 
   async remove(id: number): Promise<void> {
-    const promotion = await this.promotionRepo.findOne({ where: { id } });
-    if (!promotion) {
-      throw new NotFoundException('프로모션을 찾을 수 없습니다.');
-    }
+    const promotion = await findOrThrow(this.promotionRepo, { id } as any, '프로모션을 찾을 수 없습니다.');
     await this.promotionRepo.remove(promotion);
     this.logger.log(`Promotion deleted: id=${id}`);
   }
@@ -107,10 +98,7 @@ export class PromotionsService {
   }
 
   async updateBanner(id: number, dto: UpdateBannerDto): Promise<Banner> {
-    const banner = await this.bannerRepo.findOne({ where: { id } });
-    if (!banner) {
-      throw new NotFoundException('배너를 찾을 수 없습니다.');
-    }
+    const banner = await findOrThrow(this.bannerRepo, { id } as any, '배너를 찾을 수 없습니다.');
     if (dto.title !== undefined) banner.title = dto.title;
     if (dto.imageUrl !== undefined) banner.imageUrl = dto.imageUrl;
     if (dto.linkUrl !== undefined) banner.linkUrl = dto.linkUrl;
@@ -122,10 +110,7 @@ export class PromotionsService {
   }
 
   async removeBanner(id: number): Promise<void> {
-    const banner = await this.bannerRepo.findOne({ where: { id } });
-    if (!banner) {
-      throw new NotFoundException('배너를 찾을 수 없습니다.');
-    }
+    const banner = await findOrThrow(this.bannerRepo, { id } as any, '배너를 찾을 수 없습니다.');
     await this.bannerRepo.remove(banner);
     this.logger.log(`Banner deleted: id=${id}`);
   }

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -187,7 +187,7 @@ export class ReviewsService {
   }
 
   async update(id: number, userId: number, dto: UpdateReviewDto): Promise<ReviewResponse> {
-    const review = await findOrThrow(this.reviewRepo, { id } as any, '리뷰를 찾을 수 없습니다.', ['user']);
+    const review = await findOrThrow(this.reviewRepo, { id }, '리뷰를 찾을 수 없습니다.', ['user']);
 
     if (Number(review.userId) !== Number(userId)) {
       throw new ForbiddenException('권한이 없습니다.');
@@ -202,7 +202,7 @@ export class ReviewsService {
   }
 
   async remove(id: number, userId: number, userRole: string): Promise<void> {
-    const review = await findOrThrow(this.reviewRepo, { id } as any, '리뷰를 찾을 수 없습니다.');
+    const review = await findOrThrow(this.reviewRepo, { id }, '리뷰를 찾을 수 없습니다.');
 
     if (Number(review.userId) !== Number(userId) && userRole !== 'admin' && userRole !== 'super_admin') {
       throw new ForbiddenException('권한이 없습니다.');

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -3,7 +3,6 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
-  NotFoundException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -12,6 +11,7 @@ import { Review } from './entities/review.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { ReviewQueryDto } from './dto/review-query.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 export interface ReviewResponse {
   id: number;
@@ -187,14 +187,7 @@ export class ReviewsService {
   }
 
   async update(id: number, userId: number, dto: UpdateReviewDto): Promise<ReviewResponse> {
-    const review = await this.reviewRepo.findOne({
-      where: { id },
-      relations: ['user'],
-    });
-
-    if (!review) {
-      throw new NotFoundException('리뷰를 찾을 수 없습니다.');
-    }
+    const review = await findOrThrow(this.reviewRepo, { id } as any, '리뷰를 찾을 수 없습니다.', ['user']);
 
     if (Number(review.userId) !== Number(userId)) {
       throw new ForbiddenException('권한이 없습니다.');
@@ -209,11 +202,7 @@ export class ReviewsService {
   }
 
   async remove(id: number, userId: number, userRole: string): Promise<void> {
-    const review = await this.reviewRepo.findOne({ where: { id } });
-
-    if (!review) {
-      throw new NotFoundException('리뷰를 찾을 수 없습니다.');
-    }
+    const review = await findOrThrow(this.reviewRepo, { id } as any, '리뷰를 찾을 수 없습니다.');
 
     if (Number(review.userId) !== Number(userId) && userRole !== 'admin' && userRole !== 'super_admin') {
       throw new ForbiddenException('권한이 없습니다.');

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -1,5 +1,5 @@
 import {
-  Injectable, NotFoundException, BadRequestException,
+  Injectable, BadRequestException,
   ForbiddenException, Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -10,6 +10,7 @@ import { MockShippingAdapter } from './adapters/mock-shipping.adapter';
 import { CarrierCode, TrackingResult } from './interfaces/shipping-provider.interface';
 import { RegisterTrackingDto } from './dto/register-tracking.dto';
 import { TrackShipmentDto } from './dto/track-shipment.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 const ALLOWED_TRANSITIONS: Record<ShippingStatus, ShippingStatus[]> = {
   [ShippingStatus.PAYMENT_CONFIRMED]: [ShippingStatus.PREPARING],
@@ -35,12 +36,10 @@ export class ShippingService {
   }
 
   async getByOrderId(orderId: number, userId: number) {
-    const order = await this.orderRepository.findOne({ where: { id: orderId } });
-    if (!order) throw new NotFoundException('배송 정보를 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId } as any, '배송 정보를 찾을 수 없습니다.');
     if (Number(order.userId) !== Number(userId)) throw new ForbiddenException('접근 권한이 없습니다.');
 
-    const shipping = await this.shippingRepository.findOne({ where: { orderId } });
-    if (!shipping) throw new NotFoundException('배송 정보를 찾을 수 없습니다.');
+    const shipping = await findOrThrow(this.shippingRepository, { orderId } as any, '배송 정보를 찾을 수 없습니다.');
 
     let tracking: TrackingResult | null = null;
     if (shipping.trackingNumber) {
@@ -81,11 +80,9 @@ export class ShippingService {
   }
 
   async registerTracking(orderId: number, dto: RegisterTrackingDto) {
-    const order = await this.orderRepository.findOne({ where: { id: orderId } });
-    if (!order) throw new NotFoundException('주문 정보를 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId } as any, '주문 정보를 찾을 수 없습니다.');
 
-    const shipping = await this.shippingRepository.findOne({ where: { orderId } });
-    if (!shipping) throw new NotFoundException('배송 정보를 찾을 수 없습니다.');
+    const shipping = await findOrThrow(this.shippingRepository, { orderId } as any, '배송 정보를 찾을 수 없습니다.');
 
     this.validateTransition(shipping.status, ShippingStatus.PREPARING);
 

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -36,10 +36,10 @@ export class ShippingService {
   }
 
   async getByOrderId(orderId: number, userId: number) {
-    const order = await findOrThrow(this.orderRepository, { id: orderId } as any, '배송 정보를 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '배송 정보를 찾을 수 없습니다.');
     if (Number(order.userId) !== Number(userId)) throw new ForbiddenException('접근 권한이 없습니다.');
 
-    const shipping = await findOrThrow(this.shippingRepository, { orderId } as any, '배송 정보를 찾을 수 없습니다.');
+    const shipping = await findOrThrow(this.shippingRepository, { orderId }, '배송 정보를 찾을 수 없습니다.');
 
     let tracking: TrackingResult | null = null;
     if (shipping.trackingNumber) {
@@ -80,9 +80,9 @@ export class ShippingService {
   }
 
   async registerTracking(orderId: number, dto: RegisterTrackingDto) {
-    const order = await findOrThrow(this.orderRepository, { id: orderId } as any, '주문 정보를 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문 정보를 찾을 수 없습니다.');
 
-    const shipping = await findOrThrow(this.shippingRepository, { orderId } as any, '배송 정보를 찾을 수 없습니다.');
+    const shipping = await findOrThrow(this.shippingRepository, { orderId }, '배송 정보를 찾을 수 없습니다.');
 
     this.validateTransition(shipping.status, ShippingStatus.PREPARING);
 

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -24,7 +24,7 @@ export class UsersService {
   ) {}
 
   async updateProfile(userId: number, dto: UpdateProfileDto): Promise<Omit<User, 'password' | 'refreshToken'>> {
-    const user = await findOrThrow(this.userRepository, { id: userId } as any, '사용자를 찾을 수 없습니다.');
+    const user = await findOrThrow(this.userRepository, { id: userId }, '사용자를 찾을 수 없습니다.');
 
     if (dto.name !== undefined) user.name = dto.name;
     if (dto.phone !== undefined) user.phone = dto.phone ?? null;
@@ -71,7 +71,7 @@ export class UsersService {
   }
 
   async updateAddress(userId: number, addressId: number, dto: UpdateAddressDto): Promise<UserAddress> {
-    const address = await findOrThrow(this.addressRepository, { id: addressId } as any, '배송지를 찾을 수 없습니다.');
+    const address = await findOrThrow(this.addressRepository, { id: addressId }, '배송지를 찾을 수 없습니다.');
     if (Number(address.userId) !== Number(userId)) {
       throw new ForbiddenException('접근 권한이 없습니다.');
     }
@@ -96,7 +96,7 @@ export class UsersService {
   }
 
   async deleteAddress(userId: number, addressId: number): Promise<{ message: string }> {
-    const address = await findOrThrow(this.addressRepository, { id: addressId } as any, '배송지를 찾을 수 없습니다.');
+    const address = await findOrThrow(this.addressRepository, { id: addressId }, '배송지를 찾을 수 없습니다.');
     if (Number(address.userId) !== Number(userId)) {
       throw new ForbiddenException('접근 권한이 없습니다.');
     }

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -1,5 +1,5 @@
 import {
-  Injectable, NotFoundException, BadRequestException, ForbiddenException, Logger,
+  Injectable, BadRequestException, ForbiddenException, Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -8,6 +8,7 @@ import { UserAddress } from './entities/user-address.entity';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { CreateAddressDto } from './dto/create-address.dto';
 import { UpdateAddressDto } from './dto/update-address.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 const MAX_ADDRESSES = 10;
 
@@ -23,10 +24,7 @@ export class UsersService {
   ) {}
 
   async updateProfile(userId: number, dto: UpdateProfileDto): Promise<Omit<User, 'password' | 'refreshToken'>> {
-    const user = await this.userRepository.findOne({ where: { id: userId } });
-    if (!user) {
-      throw new NotFoundException('사용자를 찾을 수 없습니다.');
-    }
+    const user = await findOrThrow(this.userRepository, { id: userId } as any, '사용자를 찾을 수 없습니다.');
 
     if (dto.name !== undefined) user.name = dto.name;
     if (dto.phone !== undefined) user.phone = dto.phone ?? null;
@@ -73,10 +71,7 @@ export class UsersService {
   }
 
   async updateAddress(userId: number, addressId: number, dto: UpdateAddressDto): Promise<UserAddress> {
-    const address = await this.addressRepository.findOne({ where: { id: addressId } });
-    if (!address) {
-      throw new NotFoundException('배송지를 찾을 수 없습니다.');
-    }
+    const address = await findOrThrow(this.addressRepository, { id: addressId } as any, '배송지를 찾을 수 없습니다.');
     if (Number(address.userId) !== Number(userId)) {
       throw new ForbiddenException('접근 권한이 없습니다.');
     }
@@ -101,10 +96,7 @@ export class UsersService {
   }
 
   async deleteAddress(userId: number, addressId: number): Promise<{ message: string }> {
-    const address = await this.addressRepository.findOne({ where: { id: addressId } });
-    if (!address) {
-      throw new NotFoundException('배송지를 찾을 수 없습니다.');
-    }
+    const address = await findOrThrow(this.addressRepository, { id: addressId } as any, '배송지를 찾을 수 없습니다.');
     if (Number(address.userId) !== Number(userId)) {
       throw new ForbiddenException('접근 권한이 없습니다.');
     }

--- a/backend/src/modules/wishlist/wishlist.service.ts
+++ b/backend/src/modules/wishlist/wishlist.service.ts
@@ -1,7 +1,6 @@
 import {
   Injectable,
   ConflictException,
-  NotFoundException,
   ForbiddenException,
   Logger,
 } from '@nestjs/common';
@@ -9,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Wishlist } from './entities/wishlist.entity';
 import { CreateWishlistDto } from './dto/create-wishlist.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 export interface WishlistItemResponse {
   id: number;
@@ -119,11 +119,7 @@ export class WishlistService {
   }
 
   async remove(id: number, userId: number): Promise<void> {
-    const item = await this.wishlistRepo.findOne({ where: { id } });
-
-    if (!item) {
-      throw new NotFoundException('위시리스트 항목을 찾을 수 없습니다.');
-    }
+    const item = await findOrThrow(this.wishlistRepo, { id } as any, '위시리스트 항목을 찾을 수 없습니다.');
 
     if (Number(item.userId) !== Number(userId)) {
       throw new ForbiddenException('권한이 없습니다.');

--- a/backend/src/modules/wishlist/wishlist.service.ts
+++ b/backend/src/modules/wishlist/wishlist.service.ts
@@ -119,7 +119,7 @@ export class WishlistService {
   }
 
   async remove(id: number, userId: number): Promise<void> {
-    const item = await findOrThrow(this.wishlistRepo, { id } as any, '위시리스트 항목을 찾을 수 없습니다.');
+    const item = await findOrThrow(this.wishlistRepo, { id }, '위시리스트 항목을 찾을 수 없습니다.');
 
     if (Number(item.userId) !== Number(userId)) {
       throw new ForbiddenException('권한이 없습니다.');


### PR DESCRIPTION
## Summary
- Closes #156
- `findOrThrow` 제네릭 유틸리티를 `common/utils/repository.util.ts`에 생성
- 19개 서비스 파일에서 인라인 `findOne → null check → throw NotFoundException` 패턴을 유틸리티 호출로 교체 (30+ 중복 제거)
- 불필요한 `NotFoundException` import 정리
- `backend/CLAUDE.md`에 `findOrThrow` 사용 필수 규칙 추가

## Test plan
- [x] `npm run build` 통과
- [x] `npm run test` 통과 (39 suites, 349 tests)
- [ ] DB 스키마 변경 없음 — E2E 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)