### PR TITLE
refactor: #157 assertOwnership 유틸리티 추출 — 소유권 검증 12곳 통합

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -99,6 +99,11 @@ Security pipeline: CORS → Rate Limiting → JWT Guard → ValidationPipe → C
   import { findOrThrow } from '../common/utils/repository.util';
   const product = await findOrThrow(this.productRepo, { id }, '상품을 찾을 수 없습니다.');
   ```
+- **`assertOwnership(entityUserId, currentUserId, message?)`** — 소유권 검증 + ForbiddenException. 인라인 `Number(x.userId) !== Number(userId)` 비교 금지, 반드시 이 유틸리티 사용. BigInt string 비교 버그를 중앙에서 처리.
+  ```typescript
+  import { assertOwnership } from '../common/utils/ownership.util';
+  assertOwnership(order.userId, userId);
+  ```
 
 ## Key Directories
 

--- a/backend/src/common/utils/ownership.util.ts
+++ b/backend/src/common/utils/ownership.util.ts
@@ -1,0 +1,15 @@
+import { ForbiddenException } from '@nestjs/common';
+
+/**
+ * 엔티티 소유권을 검증한다. userId가 일치하지 않으면 ForbiddenException을 던진다.
+ * TypeORM BigInt → string 반환 이슈를 Number() 변환으로 중앙 처리.
+ */
+export function assertOwnership(
+  entityUserId: number | string,
+  currentUserId: number | string,
+  message = '접근 권한이 없습니다.',
+): void {
+  if (Number(entityUserId) !== Number(currentUserId)) {
+    throw new ForbiddenException(message);
+  }
+}

--- a/backend/src/modules/cart/cart.service.ts
+++ b/backend/src/modules/cart/cart.service.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
-  ForbiddenException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -13,6 +12,7 @@ import { ProductOption } from '../products/entities/product-option.entity';
 import { AddToCartDto } from './dto/add-to-cart.dto';
 import { UpdateCartQuantityDto } from './dto/update-cart-quantity.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 export interface CartItemWithPrice {
   id: number;
@@ -152,9 +152,7 @@ export class CartService {
     dto: UpdateCartQuantityDto,
   ): Promise<CartItem> {
     const item = await findOrThrow(this.cartItemRepository, { id }, '장바구니 항목을 찾을 수 없습니다.');
-    if (Number(item.userId) !== Number(userId)) {
-      throw new ForbiddenException('접근 권한이 없습니다.');
-    }
+    assertOwnership(item.userId, userId);
 
     item.quantity = dto.quantity;
     return this.cartItemRepository.save(item);
@@ -162,9 +160,7 @@ export class CartService {
 
   async remove(id: number, userId: number): Promise<{ message: string }> {
     const item = await findOrThrow(this.cartItemRepository, { id }, '장바구니 항목을 찾을 수 없습니다.');
-    if (Number(item.userId) !== Number(userId)) {
-      throw new ForbiddenException('접근 권한이 없습니다.');
-    }
+    assertOwnership(item.userId, userId);
 
     await this.cartItemRepository.remove(item);
     return { message: '삭제되었습니다.' };

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -1,6 +1,5 @@
 import {
   Injectable,
-  ForbiddenException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -9,6 +8,7 @@ import { Inquiry } from './entities/inquiry.entity';
 import { CreateInquiryDto } from './dto/create-inquiry.dto';
 import { AnswerInquiryDto } from './dto/answer-inquiry.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 @Injectable()
 export class InquiriesService {
@@ -28,9 +28,7 @@ export class InquiriesService {
 
   async findOne(id: number, userId: number): Promise<Inquiry> {
     const inquiry = await findOrThrow(this.inquiryRepo, { id }, '문의를 찾을 수 없습니다.');
-    if (Number(inquiry.userId) !== Number(userId)) {
-      throw new ForbiddenException('권한이 없습니다.');
-    }
+    assertOwnership(inquiry.userId, userId, '권한이 없습니다.');
     return inquiry;
   }
 

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -1,5 +1,5 @@
 import {
-  Injectable, NotFoundException, BadRequestException, ForbiddenException, Logger,
+  Injectable, NotFoundException, BadRequestException, Logger,
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
@@ -11,6 +11,7 @@ import { ProductOption } from '../products/entities/product-option.entity';
 import { CartItem } from '../cart/entities/cart-item.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { CreateOrderDto } from './dto/create-order.dto';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 @Injectable()
 export class OrdersService {
@@ -205,9 +206,7 @@ export class OrdersService {
       throw new NotFoundException('주문을 찾을 수 없습니다.');
     }
 
-    if (Number(order.userId) !== Number(userId)) {
-      throw new ForbiddenException('접근 권한이 없습니다.');
-    }
+    assertOwnership(order.userId, userId);
 
     return order;
   }

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -1,6 +1,6 @@
 import {
   Injectable, NotFoundException, BadRequestException, ConflictException,
-  ForbiddenException, Logger, Inject, InternalServerErrorException,
+  Logger, Inject, InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -15,6 +15,7 @@ import { CancelPaymentDto } from './dto/cancel-payment.dto';
 import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
 import { resolveGatewayByLocale } from './payments.module';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 @Injectable()
 export class PaymentsService {
@@ -44,7 +45,7 @@ export class PaymentsService {
   async prepare(dto: PreparePaymentDto, userId: number) {
     const order = await this.orderRepository.findOne({ where: { id: dto.orderId } });
     if (!order) throw new NotFoundException('주문을 찾을 수 없습니다.');
-    if (Number(order.userId) !== Number(userId)) throw new ForbiddenException('접근 권한이 없습니다.');
+    assertOwnership(order.userId, userId);
     if (order.status !== OrderStatus.PENDING) {
       throw new ConflictException('이미 처리된 주문입니다.');
     }
@@ -82,7 +83,7 @@ export class PaymentsService {
       relations: ['order'],
     });
     if (!payment) throw new NotFoundException('결제 정보를 찾을 수 없습니다.');
-    if (Number(payment.order.userId) !== Number(userId)) throw new ForbiddenException('접근 권한이 없습니다.');
+    assertOwnership(payment.order.userId, userId);
 
     if (payment.status === PaymentStatus.CONFIRMED) {
       throw new ConflictException('이미 승인된 결제입니다.');
@@ -143,7 +144,7 @@ export class PaymentsService {
       relations: ['order'],
     });
     if (!payment) throw new NotFoundException('결제 정보를 찾을 수 없습니다.');
-    if (Number(payment.order.userId) !== Number(userId)) throw new ForbiddenException('접근 권한이 없습니다.');
+    assertOwnership(payment.order.userId, userId);
 
     if (payment.status !== PaymentStatus.CONFIRMED) {
       throw new BadRequestException('취소 가능한 상태가 아닙니다.');

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -12,6 +12,7 @@ import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { ReviewQueryDto } from './dto/review-query.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 export interface ReviewResponse {
   id: number;
@@ -189,9 +190,7 @@ export class ReviewsService {
   async update(id: number, userId: number, dto: UpdateReviewDto): Promise<ReviewResponse> {
     const review = await findOrThrow(this.reviewRepo, { id }, '리뷰를 찾을 수 없습니다.', ['user']);
 
-    if (Number(review.userId) !== Number(userId)) {
-      throw new ForbiddenException('권한이 없습니다.');
-    }
+    assertOwnership(review.userId, userId, '권한이 없습니다.');
 
     if (dto.rating !== undefined) review.rating = dto.rating;
     if (dto.content !== undefined) review.content = dto.content ?? null;

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -1,6 +1,6 @@
 import {
   Injectable, BadRequestException,
-  ForbiddenException, Logger,
+  Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -11,6 +11,7 @@ import { CarrierCode, TrackingResult } from './interfaces/shipping-provider.inte
 import { RegisterTrackingDto } from './dto/register-tracking.dto';
 import { TrackShipmentDto } from './dto/track-shipment.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 const ALLOWED_TRANSITIONS: Record<ShippingStatus, ShippingStatus[]> = {
   [ShippingStatus.PAYMENT_CONFIRMED]: [ShippingStatus.PREPARING],
@@ -37,7 +38,7 @@ export class ShippingService {
 
   async getByOrderId(orderId: number, userId: number) {
     const order = await findOrThrow(this.orderRepository, { id: orderId }, '배송 정보를 찾을 수 없습니다.');
-    if (Number(order.userId) !== Number(userId)) throw new ForbiddenException('접근 권한이 없습니다.');
+    assertOwnership(order.userId, userId);
 
     const shipping = await findOrThrow(this.shippingRepository, { orderId }, '배송 정보를 찾을 수 없습니다.');
 

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -1,5 +1,5 @@
 import {
-  Injectable, BadRequestException, ForbiddenException, Logger,
+  Injectable, BadRequestException, Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -9,6 +9,7 @@ import { UpdateProfileDto } from './dto/update-profile.dto';
 import { CreateAddressDto } from './dto/create-address.dto';
 import { UpdateAddressDto } from './dto/update-address.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 const MAX_ADDRESSES = 10;
 
@@ -72,9 +73,7 @@ export class UsersService {
 
   async updateAddress(userId: number, addressId: number, dto: UpdateAddressDto): Promise<UserAddress> {
     const address = await findOrThrow(this.addressRepository, { id: addressId }, '배송지를 찾을 수 없습니다.');
-    if (Number(address.userId) !== Number(userId)) {
-      throw new ForbiddenException('접근 권한이 없습니다.');
-    }
+    assertOwnership(address.userId, userId);
 
     if (dto.isDefault) {
       await this.addressRepository.update({ userId }, { isDefault: false });
@@ -97,9 +96,7 @@ export class UsersService {
 
   async deleteAddress(userId: number, addressId: number): Promise<{ message: string }> {
     const address = await findOrThrow(this.addressRepository, { id: addressId }, '배송지를 찾을 수 없습니다.');
-    if (Number(address.userId) !== Number(userId)) {
-      throw new ForbiddenException('접근 권한이 없습니다.');
-    }
+    assertOwnership(address.userId, userId);
 
     await this.addressRepository.remove(address);
     this.logger.log(`Address deleted: userId=${userId} addressId=${addressId}`);

--- a/backend/src/modules/wishlist/wishlist.service.ts
+++ b/backend/src/modules/wishlist/wishlist.service.ts
@@ -1,7 +1,6 @@
 import {
   Injectable,
   ConflictException,
-  ForbiddenException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -9,6 +8,7 @@ import { Repository } from 'typeorm';
 import { Wishlist } from './entities/wishlist.entity';
 import { CreateWishlistDto } from './dto/create-wishlist.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 export interface WishlistItemResponse {
   id: number;
@@ -121,9 +121,7 @@ export class WishlistService {
   async remove(id: number, userId: number): Promise<void> {
     const item = await findOrThrow(this.wishlistRepo, { id }, '위시리스트 항목을 찾을 수 없습니다.');
 
-    if (Number(item.userId) !== Number(userId)) {
-      throw new ForbiddenException('권한이 없습니다.');
-    }
+    assertOwnership(item.userId, userId, '권한이 없습니다.');
 
     await this.wishlistRepo.remove(item);
     this.logger.log(`Wishlist deleted: id=${id}, by userId=${userId}`);


### PR DESCRIPTION
## Summary
- Closes #157
- `assertOwnership` 유틸리티를 `common/utils/ownership.util.ts`에 생성
- 8개 서비스 파일 12곳에서 인라인 `Number(x.userId) !== Number(userId)` 패턴을 유틸리티 호출로 교체
- TypeORM BigInt → string 비교 버그를 중앙에서 처리
- 불필요한 `ForbiddenException` import 정리
- `backend/CLAUDE.md`에 `assertOwnership` 사용 필수 규칙 추가

## Test plan
- [x] `npm run build` 통과
- [x] `npm run test` 통과 (39 suites, 349 tests)
- [ ] DB 스키마 변경 없음 — E2E 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)