### PR TITLE
refactor: #158 applyLocale, reorderEntities, buildTree 유틸리티 추출

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -104,6 +104,21 @@ Security pipeline: CORS → Rate Limiting → JWT Guard → ValidationPipe → C
   import { assertOwnership } from '../common/utils/ownership.util';
   assertOwnership(order.userId, userId);
   ```
+- **`applyLocale(entity, locale, fields[])`** — 다국어 필드 매핑. 서비스 내 private applyLocale에서 위임. 로케일 맵 하드코딩 금지.
+  ```typescript
+  import { applyLocale } from '../common/utils/locale.util';
+  return applyLocale(product, locale, ['name', 'description', 'shortDescription']);
+  ```
+- **`reorderEntities(repo, items, sortField?)`** — 정렬순서 일괄 업데이트 (Promise.all 병렬). 순차 for-of await 금지.
+  ```typescript
+  import { reorderEntities } from '../common/utils/reorder.util';
+  await reorderEntities(this.repo, items);
+  ```
+- **`buildTree(items, idKey?, parentKey?)`** — 플랫 목록을 parent-child 트리로 변환. 인라인 Map 기반 트리 빌드 금지.
+  ```typescript
+  import { buildTree } from '../common/utils/tree.util';
+  return buildTree(categories, 'id', 'parentId');
+  ```
 
 ## Key Directories
 

--- a/backend/src/common/utils/locale.util.ts
+++ b/backend/src/common/utils/locale.util.ts
@@ -1,0 +1,30 @@
+const LOCALE_SUFFIX_MAP: Record<string, string> = {
+  en: 'En',
+  ja: 'Ja',
+  zh: 'Zh',
+};
+
+/**
+ * 엔티티의 다국어 필드를 locale에 맞게 매핑한다.
+ * locale이 'ko'이거나 없으면 원본 그대로 반환.
+ */
+export function applyLocale<T>(
+  entity: T,
+  locale: string | undefined,
+  fields: string[],
+): T {
+  if (!locale || locale === 'ko') return entity;
+  const suffix = LOCALE_SUFFIX_MAP[locale];
+  if (!suffix) return entity;
+
+  const overrides: Record<string, unknown> = {};
+  for (const field of fields) {
+    const localizedKey = `${field}${suffix}`;
+    const localizedValue = (entity as Record<string, unknown>)[localizedKey];
+    if (localizedValue !== null && localizedValue !== undefined) {
+      overrides[field] = localizedValue;
+    }
+  }
+
+  return { ...entity, ...overrides } as T;
+}

--- a/backend/src/common/utils/reorder.util.ts
+++ b/backend/src/common/utils/reorder.util.ts
@@ -1,0 +1,19 @@
+import { Repository, ObjectLiteral } from 'typeorm';
+
+/**
+ * 엔티티 목록의 정렬순서를 일괄 업데이트한다. Promise.all로 병렬 실행.
+ * @param repo TypeORM Repository
+ * @param items { id, sortOrder } 배열
+ * @param sortField DB 컬럼명 (기본값: 'sortOrder')
+ */
+export async function reorderEntities<T extends ObjectLiteral>(
+  repo: Repository<T>,
+  items: { id: number; sortOrder: number }[],
+  sortField = 'sortOrder',
+): Promise<void> {
+  await Promise.all(
+    items.map(({ id, sortOrder }) =>
+      repo.update(id, { [sortField]: sortOrder } as any),
+    ),
+  );
+}

--- a/backend/src/common/utils/tree.util.ts
+++ b/backend/src/common/utils/tree.util.ts
@@ -1,0 +1,36 @@
+/**
+ * 플랫 목록을 parent-child 트리 구조로 변환한다.
+ * @param items 플랫 목록
+ * @param idKey ID 필드명 (기본값: 'id')
+ * @param parentKey 부모 ID 필드명 (기본값: 'parentId')
+ */
+export function buildTree<T extends Record<string, any>>(
+  items: T[],
+  idKey = 'id',
+  parentKey = 'parentId',
+): (T & { children: T[] })[] {
+  type TreeNode = T & { children: T[] };
+  const map = new Map<number, TreeNode>();
+  const roots: TreeNode[] = [];
+
+  for (const item of items) {
+    map.set(Number(item[idKey]), { ...item, children: [] } as TreeNode);
+  }
+
+  for (const item of items) {
+    const node = map.get(Number(item[idKey]))!;
+    const parentIdValue = item[parentKey];
+    if (parentIdValue === null || parentIdValue === undefined) {
+      roots.push(node);
+    } else {
+      const parent = map.get(Number(parentIdValue));
+      if (parent) {
+        parent.children.push(node);
+      } else {
+        roots.push(node);
+      }
+    }
+  }
+
+  return roots;
+}

--- a/backend/src/modules/archives/archives.service.ts
+++ b/backend/src/modules/archives/archives.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { NiloType, ProcessStep, Artist } from './entities/archive.entity';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { reorderEntities } from '../../common/utils/reorder.util';
 import {
   CreateNiloTypeDto,
   UpdateNiloTypeDto,
@@ -64,9 +65,7 @@ export class ArchivesService {
   }
 
   async reorderNiloTypes(items: { id: number; sortOrder: number }[]): Promise<void> {
-    for (const item of items) {
-      await this.niloTypeRepository.update({ id: item.id }, { sortOrder: item.sortOrder });
-    }
+    await reorderEntities(this.niloTypeRepository, items);
   }
 
   async findProcessStepById(id: number): Promise<ProcessStep> {
@@ -110,8 +109,6 @@ export class ArchivesService {
   }
 
   async reorderArtists(items: { id: number; sortOrder: number }[]): Promise<void> {
-    for (const item of items) {
-      await this.artistRepository.update({ id: item.id }, { sortOrder: item.sortOrder });
-    }
+    await reorderEntities(this.artistRepository, items);
   }
 }

--- a/backend/src/modules/collections/collections.service.ts
+++ b/backend/src/modules/collections/collections.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Collection, CollectionType } from './entities/collection.entity';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { reorderEntities } from '../../common/utils/reorder.util';
 import { CreateCollectionDto, UpdateCollectionDto } from './dto/collection.dto';
 
 @Injectable()
@@ -46,8 +47,6 @@ export class CollectionsService {
   }
 
   async reorder(items: { id: number; sortOrder: number }[]): Promise<void> {
-    for (const item of items) {
-      await this.collectionRepository.update({ id: item.id }, { sortOrder: item.sortOrder });
-    }
+    await reorderEntities(this.collectionRepository, items);
   }
 }

--- a/backend/src/modules/faqs/faqs.service.ts
+++ b/backend/src/modules/faqs/faqs.service.ts
@@ -6,6 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindOptionsWhere } from 'typeorm';
 import { Faq } from './entities/faq.entity';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { applyLocale } from '../../common/utils/locale.util';
 import { CreateFaqDto } from './dto/create-faq.dto';
 import { UpdateFaqDto } from './dto/update-faq.dto';
 import { FaqQueryDto } from './dto/faq-query.dto';
@@ -20,19 +21,7 @@ export class FaqsService {
   ) {}
 
   private applyLocale(faq: Faq, locale?: string): Faq {
-    if (!locale || locale === 'ko') return faq;
-    const localeMap: Record<string, 'En' | 'Ja' | 'Zh'> = { en: 'En', ja: 'Ja', zh: 'Zh' };
-    const suffix = localeMap[locale];
-    if (!suffix) return faq;
-
-    const questionKey = `question${suffix}` as keyof Faq;
-    const answerKey = `answer${suffix}` as keyof Faq;
-
-    return {
-      ...faq,
-      question: (faq[questionKey] as string | null) ?? faq.question,
-      answer: (faq[answerKey] as string | null) ?? faq.answer,
-    };
+    return applyLocale(faq, locale, ['question', 'answer']);
   }
 
   async findAll(query: FaqQueryDto): Promise<Faq[]> {

--- a/backend/src/modules/navigation/navigation.service.ts
+++ b/backend/src/modules/navigation/navigation.service.ts
@@ -9,6 +9,8 @@ import { CreateNavigationItemDto } from './dto/create-navigation-item.dto';
 import { UpdateNavigationItemDto } from './dto/update-navigation-item.dto';
 import { ReorderNavigationDto } from './dto/reorder-navigation.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { reorderEntities } from '../../common/utils/reorder.util';
+import { buildTree } from '../../common/utils/tree.util';
 
 const MAX_DEPTH = 3;
 
@@ -66,37 +68,12 @@ export class NavigationService {
   }
 
   async reorder(dto: ReorderNavigationDto): Promise<void> {
-    for (const orderItem of dto.orders) {
-      await this.navigationRepository.update(
-        { id: orderItem.id },
-        { sort_order: orderItem.sort_order },
-      );
-    }
+    const items = dto.orders.map((o) => ({ id: o.id, sortOrder: o.sort_order }));
+    await reorderEntities(this.navigationRepository, items, 'sort_order');
   }
 
   private buildTree(items: NavigationItem[]): NavigationItem[] {
-    const map = new Map<number, NavigationItem>();
-    const roots: NavigationItem[] = [];
-
-    for (const item of items) {
-      map.set(Number(item.id), { ...item, children: [] });
-    }
-
-    for (const item of items) {
-      const node = map.get(Number(item.id))!;
-      if (item.parent_id === null) {
-        roots.push(node);
-      } else {
-        const parent = map.get(Number(item.parent_id));
-        if (parent) {
-          parent.children.push(node);
-        } else {
-          roots.push(node);
-        }
-      }
-    }
-
-    return roots;
+    return buildTree(items, 'id', 'parent_id');
   }
 
   private async validateDepth(parentId: number, currentItemId?: number): Promise<void> {

--- a/backend/src/modules/notices/notices.service.ts
+++ b/backend/src/modules/notices/notices.service.ts
@@ -9,6 +9,7 @@ import { CreateNoticeDto } from './dto/create-notice.dto';
 import { UpdateNoticeDto } from './dto/update-notice.dto';
 import { NoticeQueryDto } from './dto/notice-query.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { applyLocale } from '../../common/utils/locale.util';
 
 @Injectable()
 export class NoticesService {
@@ -20,19 +21,7 @@ export class NoticesService {
   ) {}
 
   private applyLocale(notice: Notice, locale?: string): Notice {
-    if (!locale || locale === 'ko') return notice;
-    const localeMap: Record<string, 'En' | 'Ja' | 'Zh'> = { en: 'En', ja: 'Ja', zh: 'Zh' };
-    const suffix = localeMap[locale];
-    if (!suffix) return notice;
-
-    const titleKey = `title${suffix}` as keyof Notice;
-    const contentKey = `content${suffix}` as keyof Notice;
-
-    return {
-      ...notice,
-      title: (notice[titleKey] as string | null) ?? notice.title,
-      content: (notice[contentKey] as string | null) ?? notice.content,
-    };
+    return applyLocale(notice, locale, ['title', 'content']);
   }
 
   async findAll(query: NoticeQueryDto = {}): Promise<Notice[]> {

--- a/backend/src/modules/products/categories.service.ts
+++ b/backend/src/modules/products/categories.service.ts
@@ -11,6 +11,7 @@ import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
 import { ReorderCategoriesDto } from './dto/reorder-categories.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { buildTree } from '../../common/utils/tree.util';
 
 export interface CategoryTree extends Omit<Category, 'children' | 'products'> {
   children: CategoryTree[];
@@ -43,28 +44,7 @@ export class CategoriesService {
   }
 
   private buildTree(categories: Category[]): CategoryTree[] {
-    const map = new Map<number, CategoryTree>();
-    const roots: CategoryTree[] = [];
-
-    for (const cat of categories) {
-      map.set(cat.id, { ...cat, children: [] });
-    }
-
-    for (const cat of categories) {
-      const node = map.get(cat.id)!;
-      if (cat.parentId === null) {
-        roots.push(node);
-      } else {
-        const parent = map.get(cat.parentId);
-        if (parent) {
-          parent.children.push(node);
-        } else {
-          roots.push(node);
-        }
-      }
-    }
-
-    return roots;
+    return buildTree(categories, 'id', 'parentId') as CategoryTree[];
   }
 
   private async getDepth(parentId: number | null | undefined): Promise<number> {

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -14,6 +14,7 @@ import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { CacheService } from '../cache/cache.service';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { applyLocale } from '../../common/utils/locale.util';
 
 const CACHE_TTL_LIST = 300;
 const CACHE_TTL_DETAIL = 600;
@@ -42,21 +43,7 @@ export class ProductsService {
   }
 
   private applyLocale(product: Product, locale?: string): Product {
-    if (!locale || locale === 'ko') return product;
-    const localeMap: Record<string, 'En' | 'Ja' | 'Zh'> = { en: 'En', ja: 'Ja', zh: 'Zh' };
-    const suffix = localeMap[locale];
-    if (!suffix) return product;
-
-    const nameKey = `name${suffix}` as keyof Product;
-    const descKey = `description${suffix}` as keyof Product;
-    const shortDescKey = `shortDescription${suffix}` as keyof Product;
-
-    return {
-      ...product,
-      name: (product[nameKey] as string | null) ?? product.name,
-      description: (product[descKey] as string | null) ?? product.description,
-      shortDescription: (product[shortDescKey] as string | null) ?? product.shortDescription,
-    };
+    return applyLocale(product, locale, ['name', 'description', 'shortDescription']);
   }
 
   async findAll(


### PR DESCRIPTION
## Summary
- Closes #158
- `applyLocale` — 다국어 필드 매핑 (products, notices, faqs 3곳 로케일 맵 하드코딩 제거)
- `reorderEntities` — 정렬순서 일괄 업데이트 (Promise.all 병렬, 순차 for-of await 제거)
- `buildTree` — 플랫→트리 변환 (categories, navigation 동일 알고리즘 통합)
- `backend/CLAUDE.md`에 3개 유틸리티 사용 필수 규칙 추가

## Test plan
- [x] `npm run build` 통과
- [x] `npm run test` 통과 (39 suites, 349 tests)
- [ ] DB 스키마 변경 없음 — E2E 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)