### PR TITLE
refactor: #159 페이지네이션 헬퍼 paginate() 추출

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -119,6 +119,11 @@ Security pipeline: CORS → Rate Limiting → JWT Guard → ValidationPipe → C
   import { buildTree } from '../common/utils/tree.util';
   return buildTree(categories, 'id', 'parentId');
   ```
+- **`paginate(qb, { page?, limit? })`** — QueryBuilder 페이지네이션. 인라인 `skip/take/getManyAndCount` 금지. 기본 limit=20.
+  ```typescript
+  import { paginate, PaginatedResult } from '../common/utils/pagination.util';
+  return paginate(qb, { page, limit });
+  ```
 
 ## Key Directories
 

--- a/backend/src/common/utils/pagination.util.ts
+++ b/backend/src/common/utils/pagination.util.ts
@@ -1,0 +1,27 @@
+import { SelectQueryBuilder, ObjectLiteral } from 'typeorm';
+
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+/**
+ * QueryBuilder에 skip/take를 적용하고 getManyAndCount를 실행하여 페이지네이션 결과를 반환한다.
+ * 기본값: page=1, limit=20
+ */
+export async function paginate<T extends ObjectLiteral>(
+  qb: SelectQueryBuilder<T>,
+  pagination: { page?: number; limit?: number },
+): Promise<PaginatedResult<T>> {
+  const page = pagination.page ?? 1;
+  const limit = pagination.limit ?? 20;
+
+  const [items, total] = await qb
+    .skip((page - 1) * limit)
+    .take(limit)
+    .getManyAndCount();
+
+  return { items, total, page, limit };
+}

--- a/backend/src/modules/admin/admin-members.service.ts
+++ b/backend/src/modules/admin/admin-members.service.ts
@@ -9,6 +9,7 @@ import { Repository } from 'typeorm';
 import { User, UserRole } from '../users/entities/user.entity';
 import { AdminMembersQueryDto } from './dto/admin-members-query.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { paginate } from '../../common/utils/pagination.util';
 
 export interface SafeUser {
   id: number;
@@ -66,15 +67,11 @@ export class AdminMembersService {
       qb.andWhere('user.isActive = :isActive', { isActive: query.is_active });
     }
 
-    qb.skip((page - 1) * limit).take(limit);
-
-    const [users, total] = await qb.getManyAndCount();
+    const result = await paginate(qb, { page, limit });
 
     return {
-      items: users.map(toSafeUser),
-      total,
-      page,
-      limit,
+      ...result,
+      items: result.items.map(toSafeUser),
     };
   }
 

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -10,6 +10,7 @@ import { Shipping, ShippingStatus } from '../payments/entities/shipping.entity';
 import { AdminOrderQueryDto } from './dto/admin-order-query.dto';
 import { RegisterShippingDto } from './dto/register-shipping.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { paginate } from '../../common/utils/pagination.util';
 
 const ALLOWED_ORDER_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   [OrderStatus.PENDING]: [OrderStatus.PAID],
@@ -63,11 +64,7 @@ export class AdminOrdersService {
       qb.andWhere('order.createdAt <= :endDate', { endDate: `${query.endDate} 23:59:59` });
     }
 
-    qb.skip((page - 1) * limit).take(limit);
-
-    const [items, total] = await qb.getManyAndCount();
-
-    return { items, total, page, limit };
+    return paginate(qb, { page, limit });
   }
 
   async updateStatus(orderId: number, nextStatus: OrderStatus) {

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -12,6 +12,7 @@ import { CartItem } from '../cart/entities/cart-item.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { assertOwnership } from '../../common/utils/ownership.util';
+import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
 
 @Injectable()
 export class OrdersService {
@@ -182,17 +183,14 @@ export class OrdersService {
     }
   }
 
-  async findAll(userId: number, page = 1, limit = 10): Promise<{ items: Order[]; total: number; page: number; limit: number }> {
-    const [items, total] = await this.orderRepository
+  async findAll(userId: number, page = 1, limit = 10): Promise<PaginatedResult<Order>> {
+    const qb = this.orderRepository
       .createQueryBuilder('order')
       .leftJoinAndSelect('order.items', 'item')
       .where('order.userId = :userId', { userId })
-      .orderBy('order.createdAt', 'DESC')
-      .skip((page - 1) * limit)
-      .take(limit)
-      .getManyAndCount();
+      .orderBy('order.createdAt', 'DESC');
 
-    return { items, total, page, limit };
+    return paginate(qb, { page, limit });
   }
 
   async findOne(id: number, userId: number): Promise<Order> {

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -15,6 +15,7 @@ import { UpdateProductDto } from './dto/update-product.dto';
 import { CacheService } from '../cache/cache.service';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { applyLocale } from '../../common/utils/locale.util';
+import { paginate } from '../../common/utils/pagination.util';
 
 const CACHE_TTL_LIST = 300;
 const CACHE_TTL_DETAIL = 600;
@@ -128,11 +129,9 @@ export class ProductsService {
         qb.orderBy('product.createdAt', 'DESC');
     }
 
-    qb.skip((page - 1) * limit).take(limit);
-
     try {
-      const [items, total] = await qb.getManyAndCount();
-      const result = { items: items.map((p) => this.applyLocale(p, locale)), total, page, limit };
+      const paged = await paginate(qb, { page, limit });
+      const result = { ...paged, items: paged.items.map((p) => this.applyLocale(p, locale)) };
       await this.cacheService.set(cacheKey, result, CACHE_TTL_LIST);
       return result;
     } catch (err) {
@@ -174,10 +173,8 @@ export class ProductsService {
           case ProductSort.POPULAR: likeQb.orderBy('product.viewCount', 'DESC'); break;
           default: likeQb.orderBy('product.createdAt', 'DESC');
         }
-        likeQb.skip((page - 1) * limit).take(limit);
-
-        const [items, total] = await likeQb.getManyAndCount();
-        const result = { items: items.map((p) => this.applyLocale(p, locale)), total, page, limit };
+        const paged = await paginate(likeQb, { page, limit });
+        const result = { ...paged, items: paged.items.map((p) => this.applyLocale(p, locale)) };
         await this.cacheService.set(cacheKey, result, CACHE_TTL_LIST);
         return result;
       }

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -12,6 +12,7 @@ import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { ReviewQueryDto } from './dto/review-query.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { paginate } from '../../common/utils/pagination.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
 
 export interface ReviewResponse {
@@ -70,8 +71,6 @@ export class ReviewsService {
   }
 
   async findAll(query: ReviewQueryDto): Promise<ReviewListResult> {
-    const page = query.page ?? 1;
-    const limit = query.limit ?? 20;
     const sort = query.sort ?? 'recent';
 
     const qb = this.reviewRepo
@@ -94,10 +93,7 @@ export class ReviewsService {
         qb.orderBy('review.createdAt', 'DESC');
     }
 
-    const [reviews, total] = await qb
-      .skip((page - 1) * limit)
-      .take(limit)
-      .getManyAndCount();
+    const { items: reviews, total, page, limit } = await paginate(qb, query);
 
     const stats = await this.getStats(query.productId);
 


### PR DESCRIPTION
## Summary
- Closes #159
- `paginate(qb, { page?, limit? })` 헬퍼 + `PaginatedResult<T>` 타입 생성
- 5개 서비스에서 인라인 `skip/take/getManyAndCount` 패턴 제거
- orders 기본 limit=10 유지 (함수 인자 기본값), 나머지는 paginate 기본값 20 사용
- `backend/CLAUDE.md`에 paginate 사용 필수 규칙 추가

## Test plan
- [x] `npm run build` 통과
- [x] `npm run test` 통과 (39 suites, 349 tests)
- [ ] DB 스키마 변경 없음 — E2E 불필��

🤖 Generated with [Claude Code](https://claude.com/claude-code)