### PR TITLE
refactor: #160 트랜잭션 보일러플레이트 정리 + CLAUDE.md 규칙 추가

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -57,6 +57,7 @@ const req = context.switchToHttp().getRequest<{ user?: { id: number; role: strin
   ```
 - MySQL does NOT support `DROP FOREIGN KEY IF EXISTS` — use INFORMATION_SCHEMA check helper
 - Partially-ran migrations: use `CREATE TABLE IF NOT EXISTS` + existence-check helpers for idempotent `up()`
+- **트랜잭션**: `dataSource.transaction(async (manager) => { ... })` 사용 필수 — `queryRunner` 수동 관리(`connect/startTransaction/commit/rollback/release`) 금지. 단, pessimistic lock이 필요한 경우는 `queryRunner` 허용.
 
 ### Data Types
 - `DECIMAL(12,2)` for prices

--- a/backend/src/modules/settings/settings.service.spec.ts
+++ b/backend/src/modules/settings/settings.service.spec.ts
@@ -4,13 +4,13 @@ import { DataSource } from 'typeorm';
 import { SettingsService } from './settings.service';
 import { SiteSetting } from './entities/site-setting.entity';
 import { CacheService } from '../cache/cache.service';
+import { BadRequestException } from '@nestjs/common';
 
 describe('SettingsService', () => {
   let service: SettingsService;
   let mockRepo: Record<string, jest.Mock>;
   let mockCache: Record<string, jest.Mock>;
   let mockDataSource: Record<string, jest.Mock>;
-  let mockQueryRunner: Record<string, unknown>;
 
   const mockSettings: Partial<SiteSetting>[] = [
     { id: 1, key: 'color_primary', value: '#2563eb', group: 'color', defaultValue: '#2563eb', sortOrder: 1 },
@@ -19,23 +19,6 @@ describe('SettingsService', () => {
   ];
 
   beforeEach(async () => {
-    mockQueryRunner = {
-      connect: jest.fn(),
-      startTransaction: jest.fn(),
-      commitTransaction: jest.fn(),
-      rollbackTransaction: jest.fn(),
-      release: jest.fn(),
-      query: jest.fn(),
-      manager: {
-        createQueryBuilder: jest.fn().mockReturnValue({
-          update: jest.fn().mockReturnThis(),
-          set: jest.fn().mockReturnThis(),
-          where: jest.fn().mockReturnThis(),
-          execute: jest.fn().mockResolvedValue({ affected: 1 }),
-        }),
-      },
-    };
-
     mockRepo = {
       find: jest.fn().mockResolvedValue(mockSettings),
     };
@@ -48,7 +31,7 @@ describe('SettingsService', () => {
     };
 
     mockDataSource = {
-      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+      transaction: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -107,49 +90,63 @@ describe('SettingsService', () => {
 
   describe('bulkUpdate', () => {
     it('should update settings in a transaction and invalidate cache', async () => {
+      const mockManager = {
+        createQueryBuilder: jest.fn().mockReturnValue({
+          update: jest.fn().mockReturnThis(),
+          set: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          execute: jest.fn().mockResolvedValue({ affected: 1 }),
+        }),
+      };
+      mockDataSource.transaction.mockImplementation(async (cb: (m: unknown) => Promise<void>) => cb(mockManager));
+
       const items = [
         { key: 'color_primary', value: '#ff0000' },
         { key: 'color_background', value: '#000000' },
       ];
       await service.bulkUpdate(items);
-      expect(mockQueryRunner.connect).toHaveBeenCalled();
-      expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.release).toHaveBeenCalled();
+      expect(mockDataSource.transaction).toHaveBeenCalled();
       expect(mockCache.delPattern).toHaveBeenCalledWith('settings:*');
     });
 
-    it('should rollback on error', async () => {
-      (mockQueryRunner.manager as Record<string, jest.Mock>).createQueryBuilder.mockReturnValue({
-        update: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        execute: jest.fn().mockRejectedValue(new Error('DB error')),
-      });
+    it('should throw BadRequestException for invalid keys', async () => {
+      const mockManager = {
+        createQueryBuilder: jest.fn().mockReturnValue({
+          update: jest.fn().mockReturnThis(),
+          set: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          execute: jest.fn().mockResolvedValue({ affected: 0 }),
+        }),
+      };
+      mockDataSource.transaction.mockImplementation(async (cb: (m: unknown) => Promise<void>) => cb(mockManager));
+
+      await expect(service.bulkUpdate([{ key: 'invalid_key', value: 'y' }])).rejects.toThrow(BadRequestException);
+    });
+
+    it('should propagate DB errors', async () => {
+      mockDataSource.transaction.mockRejectedValue(new Error('DB error'));
       await expect(service.bulkUpdate([{ key: 'x', value: 'y' }])).rejects.toThrow('DB error');
-      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.release).toHaveBeenCalled();
     });
   });
 
   describe('resetToDefaults', () => {
     it('should reset all values and invalidate cache', async () => {
+      const mockManager = {
+        query: jest.fn(),
+      };
+      mockDataSource.transaction.mockImplementation(async (cb: (m: unknown) => Promise<void>) => cb(mockManager));
+
       await service.resetToDefaults();
-      expect(mockQueryRunner.connect).toHaveBeenCalled();
-      expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.query).toHaveBeenCalledWith(
+      expect(mockDataSource.transaction).toHaveBeenCalled();
+      expect(mockManager.query).toHaveBeenCalledWith(
         'UPDATE site_settings SET value = default_value',
       );
-      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.release).toHaveBeenCalled();
       expect(mockCache.delPattern).toHaveBeenCalledWith('settings:*');
     });
 
-    it('should rollback on error', async () => {
-      (mockQueryRunner.query as jest.Mock).mockRejectedValue(new Error('DB error'));
+    it('should propagate DB errors', async () => {
+      mockDataSource.transaction.mockRejectedValue(new Error('DB error'));
       await expect(service.resetToDefaults()).rejects.toThrow('DB error');
-      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.release).toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -43,13 +43,10 @@ export class SettingsService {
   }
 
   async bulkUpdate(items: SettingItemDto[]): Promise<void> {
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
-    try {
+    await this.dataSource.transaction(async (manager) => {
       const invalidKeys: string[] = [];
       for (const item of items) {
-        const result = await queryRunner.manager
+        const result = await manager
           .createQueryBuilder()
           .update(SiteSetting)
           .set({ value: item.value })
@@ -62,33 +59,18 @@ export class SettingsService {
       if (invalidKeys.length > 0) {
         throw new BadRequestException(`존재하지 않는 설정 키: ${invalidKeys.join(', ')}`);
       }
-      await queryRunner.commitTransaction();
       this.logger.log(`Settings bulk updated: ${items.length} items`);
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      throw err;
-    } finally {
-      await queryRunner.release();
-    }
+    });
     await this.cacheService.delPattern('settings:*');
   }
 
   async resetToDefaults(): Promise<void> {
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
-    try {
-      await queryRunner.query(
+    await this.dataSource.transaction(async (manager) => {
+      await manager.query(
         `UPDATE site_settings SET value = default_value`,
       );
-      await queryRunner.commitTransaction();
       this.logger.log('Settings reset to defaults');
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      throw err;
-    } finally {
-      await queryRunner.release();
-    }
+    });
     await this.cacheService.delPattern('settings:*');
   }
 }


### PR DESCRIPTION
## Summary
- Closes #160
- `settings.service.ts`: queryRunner 수동 관리 → `dataSource.transaction()` 패턴으로 리팩터 (2곳)
- 테스트 업데이트: transaction mock 패턴으로 전환
- `backend/CLAUDE.md`에 트랜잭션 규칙 추가
- BaseEntity 추출은 전체 Entity 수정 + 마이그레이션 영향이 크므로 별도 이슈로 분리 필요

## Test plan
- [x] `npm run build` 통과
- [x] `npm run test` 통과 (39 suites, 350 tests)
- [ ] DB 스키마 변경 없음 — E2E 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)