### PR TITLE
feat: #176 상품 상세 페이지 타이포그래피 계층 개선

### DIFF
--- a/src/components/products/OptionSelector.tsx
+++ b/src/components/products/OptionSelector.tsx
@@ -23,7 +23,7 @@ export default function OptionSelector({ options, selectedOptionId, onSelect }: 
     <div className="flex flex-col gap-4">
       {Object.entries(groups).map(([groupName, groupOptions]) => (
         <div key={groupName} className="flex flex-col gap-2">
-          <span className="text-sm font-medium text-foreground">{groupName}</span>
+          <span className="typo-label text-foreground">{groupName}</span>
           <div className="flex flex-wrap gap-2">
             {groupOptions.map((option) => {
               const isSoldout = option.stock === 0

--- a/src/components/products/ProductDetailClient.tsx
+++ b/src/components/products/ProductDetailClient.tsx
@@ -95,7 +95,7 @@ export default function ProductDetailClient({ product, locale = 'ko' }: ProductD
         <div className="flex flex-col gap-6">
           {/* Breadcrumb */}
           {product.category && (
-            <nav className="text-sm text-muted-foreground">
+            <nav className="typo-label text-muted-foreground">
               <span>{product.category.name}</span>
               <span className="mx-1">/</span>
               <span className="text-foreground">{product.name}</span>
@@ -103,15 +103,17 @@ export default function ProductDetailClient({ product, locale = 'ko' }: ProductD
           )}
 
           {/* Name */}
-          <h1 className="text-2xl font-bold text-foreground">{product.name}</h1>
+          <h1 className="typo-h1 text-foreground">{product.name}</h1>
 
           {/* Short description */}
           {product.shortDescription && (
-            <p className="text-sm text-muted-foreground">{product.shortDescription}</p>
+            <p className="typo-body text-muted-foreground">{product.shortDescription}</p>
           )}
 
           {/* Price */}
-          <PriceDisplay price={product.price} salePrice={product.salePrice} size="lg" locale={locale} />
+          <div className="typo-h2 font-semibold">
+            <PriceDisplay price={product.price} salePrice={product.salePrice} size="lg" locale={locale} />
+          </div>
 
           {/* Options */}
           {product.options.length > 0 && (
@@ -124,7 +126,7 @@ export default function ProductDetailClient({ product, locale = 'ko' }: ProductD
 
           {/* Quantity */}
           <div className="flex flex-col gap-2">
-            <span className="text-sm font-medium text-foreground">수량</span>
+            <span className="typo-label text-foreground">수량</span>
             <QuantitySelector
               quantity={quantity}
               maxQuantity={Math.max(maxQuantity, 1)}

--- a/src/components/products/ProductTabs.tsx
+++ b/src/components/products/ProductTabs.tsx
@@ -34,7 +34,7 @@ export default function ProductTabs({ description, descriptionImages, productId 
             type="button"
             onClick={() => setActiveTab(tab)}
             className={cn(
-              'px-6 py-3 text-sm transition-colors',
+              'px-6 py-3 typo-body-sm transition-colors',
               activeTab === tab
                 ? 'border-b-2 border-foreground font-medium text-foreground'
                 : 'text-muted-foreground hover:text-foreground',


### PR DESCRIPTION
## Summary
- 상품명(h1)에 `typo-h1` 토큰 적용 (24px mobile / 36px desktop)
- 가격에 `typo-h2 + font-semibold` 래퍼 적용
- 브레드크럼, 수량 레이블, 옵션 그룹 레이블에 `typo-label` 적용
- 짧은 설명에 `typo-body` 적용
- ProductTabs 탭 버튼에 `typo-body-sm` 적용

## Test plan
- [ ] 상품 상세 페이지에서 제목 크기 계층 확인 (모바일/데스크톱 반응형)
- [ ] 가격 표시 크기 확인
- [ ] 옵션 레이블, 수량 레이블 가독성 확인
- [ ] 탭 버튼 텍스트 크기 확인
- [ ] `npm run build` 통과 확인
- [ ] `npm run test:run` 전체 통과 확인

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)