### PR TITLE
feat: #178 저널·FAQ 콘텐츠 페이지 타이포그래피 통일

### DIFF
--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -34,7 +34,7 @@ export default function FaqPage() {
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6">자주 묻는 질문</h1>
+      <h1 className="typo-h1 font-bold mb-6">자주 묻는 질문</h1>
 
       <div className="flex gap-2 flex-wrap mb-6">
         {CATEGORIES.map((cat) => (
@@ -42,7 +42,7 @@ export default function FaqPage() {
             key={cat}
             onClick={() => setActiveCategory(cat)}
             className={cn(
-              'px-4 py-1.5 rounded-full text-sm font-medium border transition-colors',
+              'px-4 py-1.5 rounded-full typo-button border transition-colors',
               activeCategory === cat
                 ? 'bg-black text-white border-black'
                 : 'border-gray-300 text-gray-600 hover:border-gray-500',
@@ -66,13 +66,13 @@ export default function FaqPage() {
           {faqs.map((faq) => (
             <Accordion.Item key={faq.id} value={String(faq.id)}>
               <Accordion.Header>
-                <Accordion.Trigger className="flex items-center justify-between w-full px-2 py-4 text-left text-sm font-medium text-gray-800 hover:bg-gray-50 transition-colors [&[data-state=open]>span]:rotate-180">
+                <Accordion.Trigger className="flex items-center justify-between w-full px-2 py-4 text-left typo-h3 text-gray-800 hover:bg-gray-50 transition-colors [&[data-state=open]>span]:rotate-180">
                   <span>{faq.question}</span>
                   <span className="ml-4 shrink-0 text-gray-400 transition-transform duration-200">▼</span>
                 </Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Content className="overflow-hidden data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up">
-                <div className="px-2 pb-4 text-sm text-gray-600 bg-gray-50">
+                <div className="px-2 pb-4 typo-body text-gray-600 bg-gray-50">
                   {faq.answer}
                 </div>
               </Accordion.Content>

--- a/src/app/[locale]/journal/page.tsx
+++ b/src/app/[locale]/journal/page.tsx
@@ -5,13 +5,13 @@ export default function JournalPage() {
     <div className="min-h-screen">
       {/* Hero */}
       <section className="bg-foreground text-background py-20 px-4 text-center">
-        <p className="text-xs font-semibold tracking-widest uppercase text-background/60 mb-3">
+        <p className="typo-label font-semibold tracking-widest uppercase text-background/60 mb-3">
           Journal
         </p>
-        <h1 className="font-display-ko text-4xl font-bold tracking-tight mb-4">
+        <h1 className="font-display-ko typo-h1 font-bold tracking-tight mb-4">
           차와 흙, 그리고 사람의 이야기
         </h1>
-        <p className="max-w-xl mx-auto text-sm text-background/70 leading-relaxed">
+        <p className="max-w-xl mx-auto typo-body text-background/80">
           다문화의 깊이, 자사호 사용법, 아름다운 찻자리 세팅, 옥화당 소식까지.
           차를 사랑하는 이들을 위한 읽을거리를 모았습니다.
         </p>


### PR DESCRIPTION
## Summary
- Closes #178
- 저널: typo-label(서브타이틀) + typo-h1(제목) + typo-body(본문)
- FAQ: typo-h1(페이지 제목) + typo-h3(질문) + typo-body(답변) + typo-button(카테고리)
- 공지 페이지는 미구현 상태로 제외

## Test plan
- [x] npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)