### PR TITLE
feat: #190 ProductGridBlock bulk API로 최적화

### DIFF
--- a/backend/src/modules/products/dto/bulk-products.dto.ts
+++ b/backend/src/modules/products/dto/bulk-products.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNumber, ArrayMinSize, ArrayMaxSize } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class BulkProductsDto {
+  @ApiProperty({ example: [1, 2, 3], description: '상품 ID 목록', type: [Number] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(100)
+  @IsNumber({}, { each: true })
+  @Type(() => Number)
+  ids!: number[];
+}

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -22,6 +22,7 @@ import { ProductsService } from './products.service';
 import { QueryProductsDto } from './dto/query-products.dto';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
+import { BulkProductsDto } from './dto/bulk-products.dto';
 import { Public } from '../../common/decorators/public.decorator';
 import { Roles } from '../../common/decorators/roles.decorator';
 
@@ -54,6 +55,16 @@ export class ProductsController {
   @ApiQuery({ name: 'q', required: true, type: String, description: '검색어' })
   autocomplete(@Query('q') q: string) {
     return this.productsService.autocomplete(q);
+  }
+
+  @Post('bulk')
+  @Public()
+  @ApiOperation({ summary: '상품 벌크 조회', description: '여러 상품 ID로 상품 목록을 한 번에 조회합니다.' })
+  @ApiResponse({ status: 200, description: '상품 목록 조회 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  bulkLookup(@Body() dto: BulkProductsDto, @Request() req: RequestWithUser) {
+    const isAdmin = req.user?.role === 'admin';
+    return this.productsService.findBulk(dto.ids, isAdmin);
   }
 
   @Get(':id')

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -286,6 +286,34 @@ export class ProductsService {
     return { message: '삭제되었습니다.' };
   }
 
+  async findBulk(ids: number[], isAdmin = false, locale?: string): Promise<Product[]> {
+    if (!ids || ids.length === 0) return [];
+
+    const cacheKey = `products:bulk:${ids.sort().join(',')}`;
+    const cached = await this.cacheService.get<Product[]>(cacheKey);
+    if (cached) return cached.map((p) => this.applyLocale(p, locale));
+
+    const products = await this.productRepository
+      .createQueryBuilder('product')
+      .leftJoinAndSelect('product.category', 'category')
+      .leftJoinAndSelect('product.images', 'image', 'image.is_thumbnail = :isThumbnail', {
+        isThumbnail: true,
+      })
+      .where('product.id IN (:...ids)', { ids })
+      .getMany();
+
+    if (!isAdmin) {
+      const filtered = products.filter(
+        (p) => p.status === ProductStatus.ACTIVE,
+      );
+      await this.cacheService.set(cacheKey, filtered, CACHE_TTL_DETAIL);
+      return filtered.map((p) => this.applyLocale(p, locale));
+    }
+
+    await this.cacheService.set(cacheKey, products, CACHE_TTL_DETAIL);
+    return products.map((p) => this.applyLocale(p, locale));
+  }
+
   async autocomplete(q: string): Promise<{ id: number; name: string; slug: string }[]> {
     if (!q || q.length < 2) return [];
 

--- a/src/components/blocks/ProductGridBlock.tsx
+++ b/src/components/blocks/ProductGridBlock.tsx
@@ -33,13 +33,9 @@ export default function ProductGridBlock({ content }: Props) {
     async function fetchProducts() {
       try {
         if (product_ids && product_ids.length > 0) {
-          const results = await Promise.all(
-            product_ids.slice(0, limit).map((id) =>
-              productsApi.getById(id).then((p): Product => p).catch(() => null),
-            ),
-          );
+          const results = await productsApi.getBulk(product_ids.slice(0, limit));
           if (!cancelled) {
-            setProducts(results.filter((p): p is Product => p !== null));
+            setProducts(results);
           }
         } else if (category_id) {
           const res = await productsApi.getList({ categoryId: category_id, limit });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -231,6 +231,8 @@ export const productsApi = {
     apiClient.get<ProductListResponse>('/products', { params: params as Record<string, string | number | undefined> }),
   getById: (id: number, locale?: string) =>
     apiClient.get<ProductDetail>(`/products/${id}`, { params: locale ? { locale } : undefined }),
+  getBulk: (ids: number[]) =>
+    apiClient.post<Product[]>('/products/bulk', { ids }),
   autocomplete: (q: string) =>
     apiClient.get<AutocompleteItem[]>('/products/autocomplete', { params: { q } }),
 };


### PR DESCRIPTION
## Summary
- Closes #190
- `POST /api/products/bulk` 벌크 조회 API 추가
- `ProductGridBlock`에서 N개 개별 API 호출 → 1개 벌크 호출로 변경하여 429 Rate Limit 해결

## Changes
- **Backend**: `BulkProductsDto`, `ProductsService.findBulk()`, `POST /products/bulk` endpoint
- **Frontend**: `productsApi.getBulk()`, `ProductGridBlock`에서 벌크 API 사용

## Test plan
- [x] `npm run build` (frontend)
- [x] `npm run build` (backend)
- [x] `npm run test` (backend - 348 passed)