### PR TITLE
fix: #192 카테고리 내비/상품 그리드 블록 로딩 상태 버그 수정

### DIFF
--- a/src/components/blocks/CategoryNavBlock.test.tsx
+++ b/src/components/blocks/CategoryNavBlock.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import CategoryNavBlock from '@/components/blocks/CategoryNavBlock';
+import type { Category } from '@/lib/api';
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    return <img data-testid="next-image" {...rest} />;
+  },
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('@/lib/api', () => ({
+  categoriesApi: {
+    getTree: vi.fn(),
+  },
+}));
+
+const mockCategories: Category[] = [
+  { id: 1, name: '자사호', slug: 'teapot', description: null, parentId: null },
+  { id: 2, name: '보이차', slug: 'puerh-tea', description: null, parentId: null },
+  { id: 3, name: '다구', slug: 'tea-ware', description: null, parentId: null },
+];
+
+describe('CategoryNavBlock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders categories when prefetched_categories is provided', async () => {
+    const content = {
+      category_ids: [],
+      template: 'text' as const,
+      prefetched_categories: mockCategories,
+    };
+
+    render(<CategoryNavBlock content={content} />);
+
+    await waitFor(() => {
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(3);
+    });
+  });
+
+  it('returns null when prefetched_categories is empty array', () => {
+    const content = {
+      category_ids: [],
+      template: 'text' as const,
+      prefetched_categories: [],
+    };
+
+    const { container } = render(<CategoryNavBlock content={content} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/blocks/CategoryNavBlock.tsx
+++ b/src/components/blocks/CategoryNavBlock.tsx
@@ -30,7 +30,7 @@ export default function CategoryNavBlock({ content }: Props) {
   const { ref, visible } = useScrollAnimation<HTMLElement>();
 
   useEffect(() => {
-    if (prefetched_categories) return;
+    if (prefetched_categories && prefetched_categories.length > 0) return;
 
     let cancelled = false;
 

--- a/src/components/blocks/ProductGridBlock.test.tsx
+++ b/src/components/blocks/ProductGridBlock.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ProductGridBlock from '@/components/blocks/ProductGridBlock';
+import type { Product } from '@/lib/api';
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    return <img data-testid="next-image" {...rest} />;
+  },
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('@/lib/api', () => ({
+  productsApi: {
+    getList: vi.fn(),
+    getById: vi.fn(),
+    getBulk: vi.fn(),
+    autocomplete: vi.fn(),
+  },
+}));
+
+vi.mock('@/contexts/CartContext', () => ({
+  useCart: () => ({ addItem: vi.fn(), items: [], itemCount: 0, totalAmount: 0, isLoading: false }),
+}));
+
+vi.mock('@/hooks/useWishlistToggle', () => ({
+  useWishlistToggle: () => ({ isWishlisted: false, loading: false, toggle: vi.fn() }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockProducts: Product[] = [
+  {
+    id: 1,
+    name: '테스트 상품 1',
+    slug: 'test-product-1',
+    price: 29000,
+    salePrice: null,
+    status: 'active',
+    isFeatured: true,
+    viewCount: 100,
+    category: null,
+    images: [{ id: 1, url: '/img1.jpg', alt: null, sortOrder: 0, isThumbnail: true, isDescriptionImage: false }],
+  },
+  {
+    id: 2,
+    name: '테스트 상품 2',
+    slug: 'test-product-2',
+    price: 39000,
+    salePrice: 29000,
+    status: 'active',
+    isFeatured: true,
+    viewCount: 50,
+    category: null,
+    images: [{ id: 2, url: '/img2.jpg', alt: null, sortOrder: 0, isThumbnail: true, isDescriptionImage: false }],
+  },
+];
+
+describe('ProductGridBlock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders products when prefetched_products is provided', async () => {
+    const content = {
+      limit: 4,
+      template: '4col' as const,
+      title: '테스트 상품',
+      prefetched_products: mockProducts,
+    };
+
+    render(<ProductGridBlock content={content} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('테스트 상품 1')).toBeInTheDocument();
+      expect(screen.getByText('테스트 상품 2')).toBeInTheDocument();
+    });
+  });
+
+  it('returns null when prefetched_products is empty array', () => {
+    const content = {
+      limit: 4,
+      template: '4col' as const,
+      prefetched_products: [],
+    };
+
+    const { container } = render(<ProductGridBlock content={content} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/blocks/ProductGridBlock.tsx
+++ b/src/components/blocks/ProductGridBlock.tsx
@@ -26,7 +26,7 @@ export default function ProductGridBlock({ content }: Props) {
   const { ref, visible } = useScrollAnimation<HTMLElement>();
 
   useEffect(() => {
-    if (prefetched_products) return;
+    if (prefetched_products && prefetched_products.length > 0) return;
 
     let cancelled = false;
 


### PR DESCRIPTION
## Summary
- Issue #192: 홈화면 카테고리 내비/상품 그리드 블록이 렌더링되지 않는 버그 수정
- `prefetched_products`와 `prefetched_categories`가 빈 배열일 때 로딩 상태가 영구적으로 `true`로 남아있던 문제 해결

## Changes
- `ProductGridBlock`: `useEffect` 조건을 `if (prefetched_products)` → `if (prefetched_products && prefetched_products.length > 0)`로 변경
- `CategoryNavBlock`: 동일한 조건 변경 적용

## Root Cause
빈 배열 `[]`은 JavaScript에서 truthy이기 때문에, `if (prefetched_products)` 조건이 `true`로 평가되어 useEffect가 early return했지만, 로딩 상태는 이미 `true`로 설정되어 영구적으로停留在

## Test Plan
- [x] `npm run build` 통과
- [x] `ProductGridBlock.test.tsx` 통과
- [x] `CategoryNavBlock.test.tsx` 통과