### PR TITLE
feat: #219 replace raw text-* heading classes with typo-*

### DIFF
--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -99,7 +99,7 @@ export default function CartPage() {
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8">
-      <h1 className="mb-6 text-2xl font-bold">장바구니</h1>
+      <h1 className="mb-6 typo-h1">장바구니</h1>
 
       <div className="grid gap-6 lg:grid-cols-3">
         {/* Item list */}

--- a/src/app/[locale]/my/address/page.tsx
+++ b/src/app/[locale]/my/address/page.tsx
@@ -198,7 +198,7 @@ export default function AddressPage() {
           마이페이지
         </Link>
         <span className="text-muted-foreground">/</span>
-        <h1 className="text-xl font-bold">배송지 관리</h1>
+        <h1 className="typo-h2">배송지 관리</h1>
       </div>
 
       {loading ? (

--- a/src/app/[locale]/my/coupons/page.tsx
+++ b/src/app/[locale]/my/coupons/page.tsx
@@ -85,7 +85,7 @@ export default function MyCouponsPage() {
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-8">
-      <h1 className="mb-4 text-2xl font-bold">쿠폰함</h1>
+      <h1 className="mb-4 typo-h1">쿠폰함</h1>
 
       {/* 적립금 잔액 */}
       <div className="mb-6 rounded-lg border p-4 flex items-center justify-between">

--- a/src/app/[locale]/my/inquiries/new/page.tsx
+++ b/src/app/[locale]/my/inquiries/new/page.tsx
@@ -38,7 +38,7 @@ export default function NewInquiryPage() {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6">문의하기</h1>
+      <h1 className="typo-h1 mb-6">문의하기</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">문의 유형</label>

--- a/src/app/[locale]/my/inquiries/page.tsx
+++ b/src/app/[locale]/my/inquiries/page.tsx
@@ -42,7 +42,7 @@ export default function InquiriesPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">1:1 문의</h1>
+        <h1 className="typo-h1">1:1 문의</h1>
         <Link
           href="/my/inquiries/new"
           className="px-4 py-2 bg-black text-white text-sm rounded-lg hover:bg-gray-800 transition-colors"

--- a/src/app/[locale]/my/profile/page.tsx
+++ b/src/app/[locale]/my/profile/page.tsx
@@ -89,7 +89,7 @@ export default function ProfilePage() {
           마이페이지
         </Link>
         <span className="text-muted-foreground">/</span>
-        <h1 className="text-xl font-bold">회원정보 수정</h1>
+        <h1 className="typo-h2">회원정보 수정</h1>
       </div>
 
       <form onSubmit={handleSubmit} className="rounded-lg border p-6 space-y-5">

--- a/src/app/[locale]/my/wishlist/page.tsx
+++ b/src/app/[locale]/my/wishlist/page.tsx
@@ -58,7 +58,7 @@ export default function WishlistPage() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
-      <h1 className="mb-6 text-2xl font-bold">위시리스트</h1>
+      <h1 className="mb-6 typo-h1">위시리스트</h1>
 
       {dataLoading ? (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">

--- a/src/components/admin/ProductFormPage.tsx
+++ b/src/components/admin/ProductFormPage.tsx
@@ -151,7 +151,7 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-8">
-      <h1 className="mb-6 text-2xl font-bold">
+      <h1 className="mb-6 typo-h1">
         {mode === 'create' ? '상품 등록' : '상품 수정'}
       </h1>
 

--- a/src/components/blocks/NewsletterSignupBlock.tsx
+++ b/src/components/blocks/NewsletterSignupBlock.tsx
@@ -70,7 +70,7 @@ export default function NewsletterSignupBlock({ content }: Props) {
       )}>
         <h2 className={cn(
           'font-medium text-foreground',
-          template === 'minimal' ? 'text-xl' : 'text-2xl md:text-3xl'
+          template === 'minimal' ? 'typo-h2' : 'typo-h1 md:typo-display'
         )}>
           {title}
         </h2>


### PR DESCRIPTION
## Summary
- 10개 파일의 heading에 typo-* 클래스 적용 (text-2xl font-bold → typo-h1 등)

## Test plan
- [x] npm run build
- [x] npm run test:run