### PR TITLE
feat: #216 use centralized order status constants

### DIFF
--- a/src/app/[locale]/admin/dashboard/page.tsx
+++ b/src/app/[locale]/admin/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
   type DashboardResponse,
   type DashboardQueryParams,
 } from '@/lib/api';
+import { ORDER_STATUS_LABELS } from '@/constants/status';
 
 const RevenueLineChart = dynamic(
   () =>
@@ -35,15 +36,7 @@ function ChartSkeleton() {
   );
 }
 
-const ORDER_STATUS_LABELS: Record<string, string> = {
-  pending: '대기',
-  paid: '결제완료',
-  preparing: '준비중',
-  shipped: '배송중',
-  delivered: '배송완료',
-  cancelled: '취소',
-  refunded: '환불',
-};
+
 
 const PERIOD_OPTIONS = [
   { value: 'today', label: '오늘' },

--- a/src/components/admin/AdminOrdersTable.tsx
+++ b/src/components/admin/AdminOrdersTable.tsx
@@ -3,26 +3,7 @@
 import type { AdminOrder } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import { OrderStatusSelect } from './OrderStatusSelect';
-
-const STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-yellow-100 text-yellow-700',
-  paid: 'bg-blue-100 text-blue-700',
-  preparing: 'bg-indigo-100 text-indigo-700',
-  shipped: 'bg-purple-100 text-purple-700',
-  delivered: 'bg-green-100 text-green-700',
-  cancelled: 'bg-red-100 text-red-700',
-  refunded: 'bg-orange-100 text-orange-700',
-};
-
-const STATUS_LABELS: Record<string, string> = {
-  pending: '결제대기',
-  paid: '결제완료',
-  preparing: '상품준비중',
-  shipped: '배송중',
-  delivered: '배송완료',
-  cancelled: '주문취소',
-  refunded: '환불완료',
-};
+import { ORDER_STATUS_LABELS, ORDER_STATUS_COLORS } from '@/constants/status';
 
 interface AdminOrdersTableProps {
   orders: AdminOrder[];
@@ -68,8 +49,8 @@ export function AdminOrdersTable({ orders, onStatusChange, onShippingRegister }:
               </td>
               <td className="px-4 py-3 text-right">{formatCurrency(order.totalAmount)}</td>
               <td className="px-4 py-3">
-                <span className={`rounded-full px-2 py-0.5 text-xs ${STATUS_COLORS[order.status] ?? 'bg-secondary'}`}>
-                  {STATUS_LABELS[order.status] ?? order.status}
+                <span className={`rounded-full px-2 py-0.5 text-xs ${ORDER_STATUS_COLORS[order.status] ?? 'bg-secondary'}`}>
+                  {ORDER_STATUS_LABELS[order.status] ?? order.status}
                 </span>
               </td>
               <td className="px-4 py-3 text-xs text-muted-foreground">

--- a/src/components/admin/OrderStatusSelect.tsx
+++ b/src/components/admin/OrderStatusSelect.tsx
@@ -4,16 +4,7 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 import { adminOrdersApi } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
-
-const STATUS_LABELS: Record<string, string> = {
-  pending: '결제대기',
-  paid: '결제완료',
-  preparing: '상품준비중',
-  shipped: '배송중',
-  delivered: '배송완료',
-  cancelled: '주문취소',
-  refunded: '환불완료',
-};
+import { ORDER_STATUS_LABELS } from '@/constants/status';
 
 const ALLOWED_TRANSITIONS: Record<string, string[]> = {
   pending: ['paid'],
@@ -41,7 +32,7 @@ export function OrderStatusSelect({ orderId, currentStatus, onStatusChange }: Or
     setUpdating(true);
     try {
       await adminOrdersApi.updateStatus(orderId, nextStatus);
-      toast.success(`주문 상태가 ${STATUS_LABELS[nextStatus]}(으)로 변경되었습니다.`);
+      toast.success(`주문 상태가 ${ORDER_STATUS_LABELS[nextStatus]}(으)로 변경되었습니다.`);
       onStatusChange();
     } catch (err) {
       toast.error(handleApiError(err, '상태 변경에 실패했습니다.'));
@@ -53,7 +44,7 @@ export function OrderStatusSelect({ orderId, currentStatus, onStatusChange }: Or
   if (allowedNext.length === 0) {
     return (
       <span className="text-xs text-muted-foreground">
-        {STATUS_LABELS[currentStatus] ?? currentStatus}
+        {ORDER_STATUS_LABELS[currentStatus] ?? currentStatus}
       </span>
     );
   }
@@ -65,10 +56,10 @@ export function OrderStatusSelect({ orderId, currentStatus, onStatusChange }: Or
       onChange={(e) => void handleChange(e.target.value)}
       className="rounded border bg-background px-2 py-1 text-xs disabled:opacity-50"
     >
-      <option value="">{STATUS_LABELS[currentStatus] ?? currentStatus}</option>
+      <option value="">{ORDER_STATUS_LABELS[currentStatus] ?? currentStatus}</option>
       {allowedNext.map((s) => (
         <option key={s} value={s}>
-          → {STATUS_LABELS[s]}
+          → {ORDER_STATUS_LABELS[s]}
         </option>
       ))}
     </select>

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -44,5 +44,5 @@ export const CARRIER_TRACKING_URLS: Partial<Record<CarrierCode, string>> = {
 export const MEMBER_ROLE_LABELS: Record<string, string> = {
   user: '일반 회원',
   admin: '관리자',
-  super_admin: '超级管理员',
+  super_admin: '최고관리자',
 };


### PR DESCRIPTION
## Summary
- 주문 상태 레이블/색상 중앙 constants 사용 (4개 파일)
- super_admin 레이블 한국어로 수정

## Test plan
- [x] npm run build
- [x] npm run test:run