### PR TITLE
feat: #220 add error toast to silent .catch() handlers

### DIFF
--- a/src/app/[locale]/admin/navigation/page.tsx
+++ b/src/app/[locale]/admin/navigation/page.tsx
@@ -51,7 +51,10 @@ export default function AdminNavigationPage() {
           const setting = settings.find((s) => s.key === 'mobile_bottom_nav_visible');
           setBottomNavVisible(setting ? setting.value === 'true' : true);
         })
-        .catch(() => setBottomNavVisible(true))
+        .catch((err) => {
+          setBottomNavVisible(true);
+          toast.error(handleApiError(err, '네비게이션 설정을 불러오지 못했습니다.'));
+        })
         .finally(() => setBottomNavLoading(false));
     }
   }, [isAdmin]);

--- a/src/app/[locale]/my/coupons/page.tsx
+++ b/src/app/[locale]/my/coupons/page.tsx
@@ -7,6 +7,8 @@ import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { cn } from '@/components/ui/utils';
 import { formatCurrency } from '@/utils/currency';
+import { handleApiError } from '@/utils/error';
+import { toast } from 'sonner';
 
 type TabStatus = 'available' | 'used' | 'expired';
 
@@ -71,7 +73,10 @@ export default function MyCouponsPage() {
         setCoupons(res.coupons);
         setPointBalance(res.points.balance);
       })
-      .catch(() => setCoupons([]))
+      .catch((err) => {
+        setCoupons([]);
+        toast.error(handleApiError(err, '쿠폰 목록을 불러오지 못했습니다.'));
+      })
       .finally(() => setDataLoading(false));
   }, [isAuthenticated, tab]);
 

--- a/src/app/[locale]/my/wishlist/page.tsx
+++ b/src/app/[locale]/my/wishlist/page.tsx
@@ -25,7 +25,10 @@ export default function WishlistPage() {
     wishlistApi
       .getList()
       .then((res) => setItems(res.data))
-      .catch(() => setItems([]))
+      .catch((err) => {
+        setItems([]);
+        toast.error(handleApiError(err, '위시리스트를 불러오지 못했습니다.'));
+      })
       .finally(() => setDataLoading(false));
   }, [isAuthenticated]);
 

--- a/src/components/checkout/CouponSelector.tsx
+++ b/src/components/checkout/CouponSelector.tsx
@@ -5,6 +5,8 @@ import { couponsApi } from '@/lib/api';
 import type { CouponItem, CalculateDiscountResponse } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import { cn } from '@/components/ui/utils';
+import { toast } from 'sonner';
+import { handleApiError } from '@/utils/error';
 
 interface CouponSelectorProps {
   orderAmount: number;
@@ -21,7 +23,10 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
     couponsApi
       .getList('available')
       .then((res) => setCoupons(res.coupons))
-      .catch(() => setCoupons([]))
+      .catch((err) => {
+        setCoupons([]);
+        toast.error(handleApiError(err, '쿠폰 목록을 불러오지 못했습니다.'));
+      })
       .finally(() => setLoading(false));
   }, []);
 


### PR DESCRIPTION
## Summary
- 4개 파일의 silent .catch()에 toast.error 추가
- handleApiError 유틸리티 사용

## Test plan
- [x] npm run build
- [x] npm run test:run