### PR TITLE
feat: #221 use OAuthCallbackHandler for google/kakao callbacks

### DIFF
--- a/src/app/[locale]/auth/google/callback/page.tsx
+++ b/src/app/[locale]/auth/google/callback/page.tsx
@@ -1,47 +1,10 @@
 'use client';
 
-import { Suspense, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { toast } from 'sonner';
+import { Suspense } from 'react';
 import { authApi } from '@/lib/api';
-import { handleApiError } from '@/utils/error';
+import OAuthCallbackHandler from '@/components/auth/OAuthCallbackHandler';
 
-function GoogleCallbackInner() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const code = searchParams.get('code');
-    const state = searchParams.get('state');
-    const storedState = sessionStorage.getItem('oauth_state');
-
-    if (!code) {
-      toast.error('인증 코드가 없습니다.');
-      router.replace('/login');
-      return;
-    }
-
-    if (state !== storedState) {
-      toast.error('보안 검증에 실패했습니다. 다시 시도해 주세요.');
-      router.replace('/login');
-      return;
-    }
-
-    sessionStorage.removeItem('oauth_state');
-
-    authApi
-      .googleCallback(code)
-      .then(() => {
-        toast.success('Google 로그인되었습니다.');
-        window.location.href = '/';
-      })
-      .catch((err: unknown) => {
-        toast.error(handleApiError(err, 'Google 로그인에 실패했습니다.'));
-        router.replace('/login');
-      });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
+function GoogleCallbackFallback() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <p className="text-muted-foreground">Google 로그인 처리 중...</p>
@@ -51,14 +14,8 @@ function GoogleCallbackInner() {
 
 export default function GoogleCallbackPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-screen items-center justify-center">
-          <p className="text-muted-foreground">Google 로그인 처리 중...</p>
-        </div>
-      }
-    >
-      <GoogleCallbackInner />
+    <Suspense fallback={<GoogleCallbackFallback />}>
+      <OAuthCallbackHandler provider="google" apiMethod={(code) => authApi.googleCallback(code)} />
     </Suspense>
   );
 }

--- a/src/app/[locale]/auth/kakao/callback/page.tsx
+++ b/src/app/[locale]/auth/kakao/callback/page.tsx
@@ -1,47 +1,10 @@
 'use client';
 
-import { Suspense, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { toast } from 'sonner';
+import { Suspense } from 'react';
 import { authApi } from '@/lib/api';
-import { handleApiError } from '@/utils/error';
+import OAuthCallbackHandler from '@/components/auth/OAuthCallbackHandler';
 
-function KakaoCallbackInner() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const code = searchParams.get('code');
-    const state = searchParams.get('state');
-    const storedState = sessionStorage.getItem('oauth_state');
-
-    if (!code) {
-      toast.error('인증 코드가 없습니다.');
-      router.replace('/login');
-      return;
-    }
-
-    if (state !== storedState) {
-      toast.error('보안 검증에 실패했습니다. 다시 시도해 주세요.');
-      router.replace('/login');
-      return;
-    }
-
-    sessionStorage.removeItem('oauth_state');
-
-    authApi
-      .kakaoCallback(code)
-      .then(() => {
-        toast.success('카카오 로그인되었습니다.');
-        window.location.href = '/';
-      })
-      .catch((err: unknown) => {
-        toast.error(handleApiError(err, '카카오 로그인에 실패했습니다.'));
-        router.replace('/login');
-      });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
+function KakaoCallbackFallback() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <p className="text-muted-foreground">카카오 로그인 처리 중...</p>
@@ -51,14 +14,8 @@ function KakaoCallbackInner() {
 
 export default function KakaoCallbackPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-screen items-center justify-center">
-          <p className="text-muted-foreground">카카오 로그인 처리 중...</p>
-        </div>
-      }
-    >
-      <KakaoCallbackInner />
+    <Suspense fallback={<KakaoCallbackFallback />}>
+      <OAuthCallbackHandler provider="kakao" apiMethod={(code) => authApi.kakaoCallback(code)} />
     </Suspense>
   );
 }

--- a/src/components/auth/OAuthCallbackHandler.tsx
+++ b/src/components/auth/OAuthCallbackHandler.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { AuthTokenResponse } from '@/lib/api';
+import { handleApiError } from '@/utils/error';
 
 interface OAuthCallbackHandlerProps {
   provider: 'kakao' | 'google';
@@ -39,7 +40,7 @@ export default function OAuthCallbackHandler({ provider, apiMethod }: OAuthCallb
         window.location.href = '/';
       })
       .catch((err: unknown) => {
-        toast.error(err instanceof Error ? err.message : `${provider} 로그인에 실패했습니다.`);
+        toast.error(handleApiError(err, `${provider} 로그인에 실패했습니다.`));
         router.replace('/login');
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- google/kakao 콜백 페이지에서 OAuthCallbackHandler 사용
- OAuthCallbackHandler에서 handleApiError 사용

## Test plan
- [x] npm run build
- [x] npm run test:run