### PR TITLE
fix: #214 window 전역 결제 핸들러 제거

### DIFF
--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, use } from 'react';
+import { useState, useEffect, use, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
@@ -10,7 +10,7 @@ import type { CartItem, PreparePaymentResponse, UserAddress } from '@/lib/api';
 import { ordersApi, paymentsApi, usersApi } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import type { Locale } from '@/i18n/routing';
-import PaymentGateway from '@/components/checkout/PaymentGateway';
+import PaymentGateway, { type PaymentGatewayHandle } from '@/components/checkout/PaymentGateway';
 
 type PaymentStep = 'idle' | 'creating_order' | 'preparing_payment' | 'confirming_payment' | 'success';
 
@@ -79,6 +79,7 @@ export default function CheckoutPage({
     memo: '',
   });
   const [errors, setErrors] = useState<FormErrors>({});
+  const paymentRef = useRef<PaymentGatewayHandle>(null);
   const [addresses, setAddresses] = useState<UserAddress[]>([]);
   const [selectedAddressId, setSelectedAddressId] = useState<number | 'manual' | null>(null);
   const [addressLoading, setAddressLoading] = useState(false);
@@ -175,17 +176,14 @@ export default function CheckoutPage({
 
     // If already prepared (Stripe), trigger stripe confirm
     if (prepareResult && prepareResult.gateway === 'stripe') {
-      const stripeConfirm = (window as Window & { __stripeConfirm?: () => Promise<void> }).__stripeConfirm;
-      if (stripeConfirm) {
-        setStep('confirming_payment');
-        try {
-          await stripeConfirm();
-          // Stripe redirects on success — if we reach here it means redirect pending
-        } catch (err) {
-          handlePaymentError(handleApiError(err, '결제에 실패했습니다.'));
-        }
-        return;
+      setStep('confirming_payment');
+      try {
+        await paymentRef.current?.confirm();
+        // Stripe redirects on success — if we reach here it means redirect pending
+      } catch (err) {
+        handlePaymentError(handleApiError(err, '결제에 실패했습니다.'));
       }
+      return;
     }
 
     const validationErrors = validateForm(form);
@@ -217,7 +215,7 @@ export default function CheckoutPage({
         { orderId: order.id, locale },
       );
 
-      // Toss flow: invoke __tossPayHandler
+      // Toss flow
       const isToss =
         locale === 'ko' &&
         result.clientKey &&
@@ -227,13 +225,9 @@ export default function CheckoutPage({
         setCurrentOrderId(order.id);
         setCurrentOrderNumber(order.orderNumber);
         setPrepareResult(result);
-        // PaymentGateway component registers __tossPayHandler in useEffect
-        // Give it a tick to register, then call it
+        // PaymentGateway renders after state update; give it a tick before calling confirm
         setTimeout(async () => {
-          const tossHandler = (window as Window & { __tossPayHandler?: () => Promise<void> }).__tossPayHandler;
-          if (tossHandler) {
-            await tossHandler();
-          }
+          await paymentRef.current?.confirm();
         }, 100);
         return;
       }
@@ -444,6 +438,7 @@ export default function CheckoutPage({
               <h2 className="typo-h3">결제 수단</h2>
               {prepareResult ? (
                 <PaymentGateway
+                  ref={paymentRef}
                   prepareResult={prepareResult}
                   orderId={currentOrderId!}
                   orderNumber={currentOrderNumber}

--- a/src/components/checkout/PaymentGateway.tsx
+++ b/src/components/checkout/PaymentGateway.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import type { Locale } from '@/i18n/routing';
 import type { PreparePaymentResponse } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
+
+export interface PaymentGatewayHandle {
+  confirm: () => Promise<void>;
+}
 
 interface PaymentGatewayProps {
   prepareResult: PreparePaymentResponse;
@@ -16,79 +20,86 @@ interface PaymentGatewayProps {
 
 // ─── Toss Payments (ko) ───────────────────────────────────────────────────────
 
-function TossPaymentGateway({
-  prepareResult,
-  orderId,
-  orderNumber,
-  amount,
-  locale,
-  onError,
-}: PaymentGatewayProps) {
-  useEffect(() => {
-    const origin = window.location.origin;
+const TossPaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>(
+  function TossPaymentGateway(
+    { prepareResult, orderId, orderNumber, amount, locale, onError },
+    ref,
+  ) {
+    const handlerRef = useRef<(() => Promise<void>) | null>(null);
 
-    const handler = async () => {
-      try {
-        const { loadTossPayments } = await import('@tosspayments/tosspayments-sdk');
-        const tossPayments = await loadTossPayments(prepareResult.clientKey);
-        const payment = tossPayments.payment({ customerKey: `user_${orderId}` });
+    useEffect(() => {
+      const origin = window.location.origin;
 
-        sessionStorage.setItem(
-          'tossPaymentContext',
-          JSON.stringify({ orderId, orderNumber, amount }),
-        );
+      const handler = async () => {
+        try {
+          const { loadTossPayments } = await import('@tosspayments/tosspayments-sdk');
+          const tossPayments = await loadTossPayments(prepareResult.clientKey);
+          const payment = tossPayments.payment({ customerKey: `user_${orderId}` });
 
-        await payment.requestPayment({
-          method: 'CARD',
-          amount: { currency: 'KRW', value: amount },
-          orderId: orderNumber,
-          orderName: `주문 ${orderNumber}`,
-          successUrl: `${origin}/${locale}/checkout/success`,
-          failUrl: `${origin}/${locale}/checkout/fail`,
-        });
-      } catch (err) {
-        onError(handleApiError(err, '결제 초기화 오류'));
-      }
-    };
+          sessionStorage.setItem(
+            'tossPaymentContext',
+            JSON.stringify({ orderId, orderNumber, amount }),
+          );
 
-    (window as Window & { __tossPayHandler?: () => Promise<void> }).__tossPayHandler = handler;
+          await payment.requestPayment({
+            method: 'CARD',
+            amount: { currency: 'KRW', value: amount },
+            orderId: orderNumber,
+            orderName: `주문 ${orderNumber}`,
+            successUrl: `${origin}/${locale}/checkout/success`,
+            failUrl: `${origin}/${locale}/checkout/fail`,
+          });
+        } catch (err) {
+          onError(handleApiError(err, '결제 초기화 오류'));
+        }
+      };
 
-    return () => {
-      delete (window as Window & { __tossPayHandler?: () => Promise<void> }).__tossPayHandler;
-    };
-  }, [prepareResult.clientKey, orderId, orderNumber, amount, locale, onError]);
+      handlerRef.current = handler;
 
-  return (
-    <label className="flex items-center gap-3 cursor-pointer">
-      <input
-        type="radio"
-        name="paymentMethod"
-        value="toss"
-        defaultChecked
-        readOnly
-        className="accent-foreground"
-      />
-      <span className="text-sm">토스페이먼츠 (카드)</span>
-    </label>
-  );
-}
+      return () => {
+        handlerRef.current = null;
+      };
+    }, [prepareResult.clientKey, orderId, orderNumber, amount, locale, onError]);
+
+    useImperativeHandle(ref, () => ({
+      confirm: async () => {
+        if (handlerRef.current) {
+          await handlerRef.current();
+        }
+      },
+    }));
+
+    return (
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="radio"
+          name="paymentMethod"
+          value="toss"
+          defaultChecked
+          readOnly
+          className="accent-foreground"
+        />
+        <span className="text-sm">토스페이먼츠 (카드)</span>
+      </label>
+    );
+  },
+);
 
 // ─── Stripe Payment Element (en / ja / zh) ────────────────────────────────────
 
-function StripePaymentGateway({
-  clientSecret,
-  publishableKey,
-  locale,
-  onError,
-}: {
-  clientSecret: string;
-  publishableKey: string;
-  locale: string;
-  onError: (msg: string) => void;
-}) {
+const StripePaymentGateway = forwardRef<
+  PaymentGatewayHandle,
+  {
+    clientSecret: string;
+    publishableKey: string;
+    locale: string;
+    onError: (msg: string) => void;
+  }
+>(function StripePaymentGateway({ clientSecret, publishableKey, locale, onError }, ref) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState(true);
   const [mountError, setMountError] = useState<string | null>(null);
+  const confirmRef = useRef<(() => Promise<void>) | null>(null);
 
   useEffect(() => {
     if (!clientSecret || !publishableKey) {
@@ -129,7 +140,7 @@ function StripePaymentGateway({
         }
       });
 
-      (window as Window & { __stripeConfirm?: () => Promise<void> }).__stripeConfirm = async () => {
+      confirmRef.current = async () => {
         const { error } = await stripeInstance.confirmPayment({
           elements,
           confirmParams: {
@@ -144,10 +155,18 @@ function StripePaymentGateway({
 
     return () => {
       mounted = false;
-      delete (window as Window & { __stripeConfirm?: () => Promise<void> }).__stripeConfirm;
+      confirmRef.current = null;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clientSecret, publishableKey]);
+
+  useImperativeHandle(ref, () => ({
+    confirm: async () => {
+      if (confirmRef.current) {
+        await confirmRef.current();
+      }
+    },
+  }));
 
   return (
     <div className="space-y-3">
@@ -169,56 +188,69 @@ function StripePaymentGateway({
       <div ref={containerRef} className={loading ? 'sr-only' : undefined} />
     </div>
   );
-}
+});
 
 // ─── Mock / fallback ──────────────────────────────────────────────────────────
 
-function MockPaymentGateway() {
-  return (
-    <label className="flex items-center gap-3 cursor-pointer">
-      <input
-        type="radio"
-        name="paymentMethod"
-        value="mock"
-        defaultChecked
-        readOnly
-        className="accent-foreground"
-      />
-      <span className="text-sm">테스트 결제 (Mock)</span>
-    </label>
-  );
-}
+const MockPaymentGateway = forwardRef<PaymentGatewayHandle>(
+  function MockPaymentGateway(_props, ref) {
+    useImperativeHandle(ref, () => ({
+      confirm: async () => {
+        // Mock gateway: no-op — caller handles mock payment directly
+      },
+    }));
+
+    return (
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="radio"
+          name="paymentMethod"
+          value="mock"
+          defaultChecked
+          readOnly
+          className="accent-foreground"
+        />
+        <span className="text-sm">테스트 결제 (Mock)</span>
+      </label>
+    );
+  },
+);
 
 // ─── Public component ─────────────────────────────────────────────────────────
 
-export default function PaymentGateway(props: PaymentGatewayProps) {
-  const { prepareResult, locale } = props;
+const PaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>(
+  function PaymentGateway(props, ref) {
+    const { prepareResult, locale } = props;
 
-  const isToss =
-    locale === 'ko' &&
-    prepareResult.clientKey &&
-    prepareResult.clientKey !== 'mock_client_key';
+    const isToss =
+      locale === 'ko' &&
+      prepareResult.clientKey &&
+      prepareResult.clientKey !== 'mock_client_key';
 
-  if (isToss) {
-    return <TossPaymentGateway {...props} />;
-  }
+    if (isToss) {
+      return <TossPaymentGateway ref={ref} {...props} />;
+    }
 
-  const isStripe =
-    prepareResult.gateway === 'stripe' &&
-    prepareResult.clientKey &&
-    prepareResult.clientKey !== 'mock_client_key';
+    const isStripe =
+      prepareResult.gateway === 'stripe' &&
+      prepareResult.clientKey &&
+      prepareResult.clientKey !== 'mock_client_key';
 
-  if (isStripe) {
-    const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '';
-    return (
-      <StripePaymentGateway
-        clientSecret={prepareResult.clientKey}
-        publishableKey={publishableKey}
-        locale={locale}
-        onError={props.onError}
-      />
-    );
-  }
+    if (isStripe) {
+      const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '';
+      return (
+        <StripePaymentGateway
+          ref={ref}
+          clientSecret={prepareResult.clientKey}
+          publishableKey={publishableKey}
+          locale={locale}
+          onError={props.onError}
+        />
+      );
+    }
 
-  return <MockPaymentGateway />;
-}
+    return <MockPaymentGateway ref={ref} />;
+  },
+);
+
+export default PaymentGateway;


### PR DESCRIPTION
## Summary
- Closes #214
- window.__tossPayHandler, window.__stripeConfirm 전역 등록 제거
- React forwardRef + useImperativeHandle 패턴으로 교체하여 XSS 위험 차단
- PaymentGatewayHandle 인터페이스 export

## Test plan
- [ ] npm run build
- [ ] npm run test:run
- [ ] 체크아웃 페이지에서 결제 버튼 클릭 시 정상 동작 확인