### PR TITLE
fix: #218 CMS cta_url URL 검증 추가

### DIFF
--- a/src/components/blocks/HeroBannerBlock.tsx
+++ b/src/components/blocks/HeroBannerBlock.tsx
@@ -11,6 +11,7 @@ import Logo from '@/components/Logo';
 import type { HeroBannerContent, HeroBannerSlide } from '@/lib/api';
 import { useScrollLogoTransition } from '@/hooks/useScrollLogoTransition';
 import { ScrollLogoProvider } from '@/contexts/ScrollLogoContext';
+import { isSafeUrl } from '@/utils/url';
 
 interface Props {
   content: HeroBannerContent;
@@ -123,7 +124,7 @@ function SliderHero({ slides, sectionRef, heroLogoStyle }: SliderHeroProps) {
                 {slide.cta_text && slide.cta_url && (
                   <div className="mt-8">
                     <Link
-                      href={slide.cta_url}
+                      href={isSafeUrl(slide.cta_url) ? slide.cta_url : '#'}
                       className="inline-block rounded-full border border-white px-8 py-3 typo-button text-white tracking-widest uppercase hover:bg-white hover:text-foreground transition-colors duration-300"
                     >
                       {slide.cta_text}
@@ -205,7 +206,7 @@ export default function HeroBannerBlock({ content }: Props) {
           {subtitle && <p className="mt-2 typo-body text-muted-foreground">{subtitle}</p>}
           {cta_text && cta_url && (
             <Link
-              href={cta_url}
+              href={isSafeUrl(cta_url) ? cta_url : '#'}
               className="mt-6 inline-block border border-foreground px-6 py-3 typo-button text-foreground hover:bg-foreground hover:text-background transition-colors"
             >
               {cta_text}
@@ -249,7 +250,7 @@ export default function HeroBannerBlock({ content }: Props) {
           {cta_text && cta_url && (
             <div className="mt-8">
               <Link
-                href={cta_url}
+                href={isSafeUrl(cta_url) ? cta_url : '#'}
                 className="inline-block rounded-full border border-current px-8 py-3 typo-button tracking-widest uppercase hover:bg-white hover:text-foreground transition-colors duration-300"
               >
                 {cta_text}

--- a/src/components/blocks/PromotionBannerBlock.tsx
+++ b/src/components/blocks/PromotionBannerBlock.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useScrollAnimation } from '@/hooks/useScrollAnimation';
 import type { PromotionBannerContent } from '@/lib/api';
+import { isSafeUrl } from '@/utils/url';
 
 interface Props {
   content: PromotionBannerContent;
@@ -25,7 +26,7 @@ export default function PromotionBannerBlock({ content }: Props) {
         {end_date && <CountdownTimer endDate={end_date} />}
         {cta_text && cta_url && (
           <Link
-            href={cta_url}
+            href={isSafeUrl(cta_url) ? cta_url : '#'}
             className="mt-6 inline-block border border-foreground px-8 py-3 text-sm font-medium text-foreground hover:bg-foreground hover:text-background transition-colors"
           >
             {cta_text}
@@ -48,7 +49,7 @@ export default function PromotionBannerBlock({ content }: Props) {
           {subtitle && <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>}
           {cta_text && cta_url && (
             <Link
-              href={cta_url}
+              href={isSafeUrl(cta_url) ? cta_url : '#'}
               className="mt-4 inline-block border border-foreground px-6 py-2 text-sm font-medium text-foreground hover:bg-foreground hover:text-background transition-colors"
             >
               {cta_text}
@@ -92,7 +93,7 @@ export default function PromotionBannerBlock({ content }: Props) {
         )}
         {cta_text && cta_url && (
           <Link
-            href={cta_url}
+            href={isSafeUrl(cta_url) ? cta_url : '#'}
             className={`inline-block border border-foreground px-8 py-3 text-sm font-medium text-foreground hover:bg-foreground hover:text-background transition-colors duration-600 ease-out ${
               visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
             }`}

--- a/src/components/blocks/SplitContentBlock.tsx
+++ b/src/components/blocks/SplitContentBlock.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import type { SplitContentContent } from '@/lib/api';
 import { cn } from '@/components/ui/utils';
+import { isSafeUrl } from '@/utils/url';
 
 interface Props {
   content: SplitContentContent;
@@ -111,7 +112,7 @@ export default function SplitContentBlock({ content }: Props) {
         )}
         {cta_text && cta_url && (
           <Link
-            href={cta_url}
+            href={isSafeUrl(cta_url) ? cta_url : '#'}
             className={cn(
               'mt-6 inline-block border border-foreground font-medium text-foreground transition-colors hover:bg-foreground hover:text-background',
               isLarge ? 'px-8 py-3 text-sm' : 'px-6 py-2.5 text-sm'

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns true only for safe relative paths (starting with /).
+ * Blocks javascript: protocol, protocol-relative URLs (//), and empty strings.
+ */
+export function isSafeUrl(url: string): boolean {
+  if (!url) return false;
+  return url.startsWith('/') && !url.startsWith('//');
+}


### PR DESCRIPTION
## Summary
- Closes #218
- src/utils/url.ts에 isSafeUrl() 유틸리티 추가
- HeroBannerBlock, SplitContentBlock, PromotionBannerBlock의 cta_url을 검증 후 사용
- javascript: 프로토콜 및 protocol-relative URL(//) 차단

## Test plan
- [ ] npm run build
- [ ] npm run test:run
- [ ] CMS에서 //evil.com 입력 시 # fallback 확인
- [ ] 정상 상대경로 /products 입력 시 정상 작동 확인