### PR TITLE
fix: #225 middleware admin role 검증 추가

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -12,11 +12,22 @@ vi.mock('@/i18n/routing', () => ({
 import { middleware } from '@/middleware';
 import { NextRequest } from 'next/server';
 
-function makeRequest(pathname: string, hasToken = false): NextRequest {
+/** Build a minimal JWT-shaped token with the given payload (no real signature). */
+function makeToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).replace(/=/g, '');
+  const body = btoa(JSON.stringify(payload)).replace(/=/g, '');
+  return `${header}.${body}.fakesig`;
+}
+
+const ADMIN_TOKEN = makeToken({ sub: '1', role: 'admin' });
+const SUPER_ADMIN_TOKEN = makeToken({ sub: '2', role: 'super_admin' });
+const USER_TOKEN = makeToken({ sub: '3', role: 'user' });
+
+function makeRequest(pathname: string, token?: string): NextRequest {
   const url = `http://localhost${pathname}`;
   const req = new NextRequest(url);
-  if (hasToken) {
-    req.cookies.set('accessToken', 'test-token');
+  if (token) {
+    req.cookies.set('accessToken', token);
   }
   return req;
 }
@@ -31,10 +42,25 @@ describe('middleware', () => {
     expect(location).toContain('redirect=%2Fadmin');
   });
 
-  it('passes through /admin when accessToken cookie is present', () => {
-    const req = makeRequest('/admin', true);
+  it('passes through /admin when accessToken cookie has admin role', () => {
+    const req = makeRequest('/admin', ADMIN_TOKEN);
     const res = middleware(req);
     expect(res.status).toBe(200);
+  });
+
+  it('passes through /admin when accessToken cookie has super_admin role', () => {
+    const req = makeRequest('/admin', SUPER_ADMIN_TOKEN);
+    const res = middleware(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('redirects /admin to / when accessToken cookie has non-admin role', () => {
+    const req = makeRequest('/admin', USER_TOKEN);
+    const res = middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/');
+    expect(location).not.toContain('/login');
   });
 
   it('redirects /my to /login when no accessToken cookie', () => {
@@ -107,9 +133,18 @@ describe('middleware', () => {
     expect(location).toContain('/ja/login');
   });
 
-  it('passes through locale-prefixed admin when token present', () => {
-    const req = makeRequest('/en/admin', true);
+  it('passes through locale-prefixed admin when token has admin role', () => {
+    const req = makeRequest('/en/admin', ADMIN_TOKEN);
     const res = middleware(req);
     expect(res.status).toBe(200);
+  });
+
+  it('redirects locale-prefixed /ko/admin to /ko/ when token has non-admin role', () => {
+    const req = makeRequest('/ko/admin', USER_TOKEN);
+    const res = middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/ko/');
+    expect(location).not.toContain('/login');
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,26 @@ const intlMiddleware = createMiddleware(routing);
 // Compile regex once at module scope; trailing path is optional to match bare /ko
 const localePattern = new RegExp(`^/(${routing.locales.join('|')})(/.*)?$`);
 
+const ADMIN_ROLES = new Set(['admin', 'super_admin']);
+
+/**
+ * Decode JWT payload without signature verification (edge runtime safe).
+ * Returns true if the token's role claim is an admin role.
+ */
+function hasAdminRole(token: string): boolean {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return false;
+    // base64url → base64 → JSON
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const json = atob(base64);
+    const payload = JSON.parse(json) as Record<string, unknown>;
+    return typeof payload.role === 'string' && ADMIN_ROLES.has(payload.role);
+  } catch {
+    return false;
+  }
+}
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get('accessToken')?.value;
@@ -17,12 +37,15 @@ export function middleware(request: NextRequest) {
   const localePrefix = localeMatch ? `/${localeMatch[1]}` : '';
   const pathnameWithoutLocale = localeMatch ? (localeMatch[2] || '/') : pathname;
 
-  // Protect admin routes — require authentication
+  // Protect admin routes — require authentication and admin role
   if (pathnameWithoutLocale.startsWith('/admin')) {
     if (!token) {
       const loginUrl = new URL(`${localePrefix}/login`, request.url);
       loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
       return NextResponse.redirect(loginUrl);
+    }
+    if (!hasAdminRole(token)) {
+      return NextResponse.redirect(new URL(`${localePrefix}/`, request.url));
     }
   }
 


### PR DESCRIPTION
## Summary
- Closes #225
- middleware.ts의 /admin 경로 보호에 JWT role claim 검증 추가
- non-admin 사용자는 / 로 리다이렉트하여 admin UI 노출 차단
- 서명 검증 없이 payload decode만 수행 (edge runtime 제약)

## Test plan
- [x] npm run build
- [x] npm run test:run (middleware 14/14 통과)
- [ ] 일반 유저 토큰으로 /admin 접근 시 / 리다이렉트 확인
- [ ] admin 토큰으로 /admin 접근 시 정상 접근 확인