### PR TITLE
feat: #243 replace manual loading state with useAsyncAction hook

### DIFF
--- a/src/app/[locale]/admin/navigation/page.tsx
+++ b/src/app/[locale]/admin/navigation/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { adminNavigationApi, adminSettingsApi } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
 import type { NavigationItem } from '@/lib/api';
 import { useAdminGuard } from '@/hooks/useAdminGuard';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 import NavigationEditor from '@/components/admin/NavigationEditor';
 
 type NavGroup = 'gnb' | 'sidebar' | 'footer';
@@ -20,44 +21,36 @@ export default function AdminNavigationPage() {
   const { isLoading: authLoading, isAdmin } = useAdminGuard();
   const [activeTab, setActiveTab] = useState<NavGroup>('gnb');
   const [items, setItems] = useState<NavigationItem[]>([]);
-  const [loading, setLoading] = useState(true);
   const [bottomNavVisible, setBottomNavVisible] = useState(true);
-  const [bottomNavLoading, setBottomNavLoading] = useState(true);
 
-
-  const loadItems = useCallback(async (group: NavGroup) => {
-    setLoading(true);
-    try {
+  const { execute: loadItems, isLoading: loading } = useAsyncAction(
+    async (group: NavGroup) => {
       const data = await adminNavigationApi.getByGroup(group);
       setItems(data);
-    } catch {
-      toast.error('네비게이션 목록을 불러오지 못했습니다.');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+    },
+    { errorMessage: '네비게이션 목록을 불러오지 못했습니다.' },
+  );
 
   useEffect(() => {
     if (isAdmin) {
-      loadItems(activeTab);
+      void loadItems(activeTab);
     }
   }, [isAdmin, activeTab, loadItems]);
 
+  const { execute: loadBottomNav, isLoading: bottomNavLoading } = useAsyncAction(
+    async () => {
+      const settings = await adminSettingsApi.getAll('general');
+      const setting = settings.find((s) => s.key === 'mobile_bottom_nav_visible');
+      setBottomNavVisible(setting ? setting.value === 'true' : true);
+    },
+    { errorMessage: '네비게이션 설정을 불러오지 못했습니다.' },
+  );
+
   useEffect(() => {
     if (isAdmin) {
-      setBottomNavLoading(true);
-      adminSettingsApi.getAll('general')
-        .then((settings) => {
-          const setting = settings.find((s) => s.key === 'mobile_bottom_nav_visible');
-          setBottomNavVisible(setting ? setting.value === 'true' : true);
-        })
-        .catch((err) => {
-          setBottomNavVisible(true);
-          toast.error(handleApiError(err, '네비게이션 설정을 불러오지 못했습니다.'));
-        })
-        .finally(() => setBottomNavLoading(false));
+      void loadBottomNav();
     }
-  }, [isAdmin]);
+  }, [isAdmin, loadBottomNav]);
 
   const handleReload = async () => {
     await loadItems(activeTab);

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { toast } from 'sonner';
 import { cn } from '@/components/ui/utils';
 import { Button } from '@/components/ui/button';
 import EmptyState from '@/components/EmptyState';
 import ProductCard from '@/components/products/ProductCard';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { productsApi, type Product, type ProductSort } from '@/lib/api';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 const SORT_OPTIONS: { value: ProductSort; label: string }[] = [
   { value: 'latest', label: '최신순' },
@@ -32,7 +32,6 @@ export default function SearchPage() {
 
   const [products, setProducts] = useState<Product[]>([]);
   const [total, setTotal] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
 
   const [priceMinInput, setPriceMinInput] = useState(priceMin?.toString() ?? '');
   const [priceMaxInput, setPriceMaxInput] = useState(priceMax?.toString() ?? '');
@@ -53,10 +52,9 @@ export default function SearchPage() {
     [searchParams, router],
   );
 
-  useEffect(() => {
-    setIsLoading(true);
-    productsApi
-      .getList({
+  const { execute: loadProducts, isLoading } = useAsyncAction(
+    async () => {
+      const data = await productsApi.getList({
         q: q || undefined,
         sort,
         categoryId,
@@ -64,18 +62,16 @@ export default function SearchPage() {
         price_max: priceMax,
         page,
         limit: LIMIT,
-      })
-      .then((data) => {
-        setProducts(data.items);
-        setTotal(data.total);
-      })
-      .catch(() => {
-        toast.error('검색 중 오류가 발생했습니다');
-        setProducts([]);
-        setTotal(0);
-      })
-      .finally(() => setIsLoading(false));
-  }, [q, sort, categoryId, priceMin, priceMax, page]);
+      });
+      setProducts(data.items);
+      setTotal(data.total);
+    },
+    { errorMessage: '검색 중 오류가 발생했습니다.' },
+  );
+
+  useEffect(() => {
+    void loadProducts();
+  }, [q, sort, categoryId, priceMin, priceMax, page, loadProducts]);
 
   const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     updateParams({ sort: e.target.value });


### PR DESCRIPTION
## Summary
- Closes #243
- SearchPage: replace manual `useState(isLoading) + useEffect + try/catch/finally` with `useAsyncAction` hook
- admin/navigation/page.tsx: replace manual loading state for both `loadItems` and `bottomNavLoading` with `useAsyncAction`

## Test plan
- [ ] npm run build
- [ ] Search page loads and fetches products correctly
- [ ] Admin navigation page loads and fetches items correctly