### PR TITLE
fix: #194 archive/page.tsx 에러 상태 UI 추가

### DIFF
--- a/src/app/[locale]/archive/error.tsx
+++ b/src/app/[locale]/archive/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Archive page error:', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="text-center max-w-md">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-6 mb-6">
+          <p className="text-sm text-red-600 mb-2">데이터를 불러오지 못했습니다</p>
+          <p className="text-xs text-red-500/70">{error.message || '알 수 없는 오류가 발생했습니다.'}</p>
+        </div>
+        <button
+          onClick={reset}
+          className="inline-flex items-center gap-2 text-sm font-medium bg-foreground text-background rounded px-6 py-3 hover:opacity-80 transition-opacity"
+        >
+          다시 시도
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/archive/page.tsx
+++ b/src/app/[locale]/archive/page.tsx
@@ -190,15 +190,22 @@ export default async function ArchivePage({ params }: ArchivePageProps) {
   let processSteps: ProcessStep[] = [];
   let artists: Artist[] = [];
 
+  let fetchError: Error | null = null;
+
   try {
     const data = await fetchArchives();
     niloTypes = data.niloTypes;
     processSteps = data.processSteps;
     artists = data.artists;
-  } catch {
+  } catch (err) {
+    fetchError = err instanceof Error ? err : new Error('아카이브 데이터를 불러오지 못했습니다.');
     niloTypes = [];
     processSteps = [];
     artists = [];
+  }
+
+  if (fetchError) {
+    throw fetchError;
   }
 
   return (


### PR DESCRIPTION
## Summary
- Closes #194
- API fetch 실패 시 조용히 실패하는問題を修正
- 에러发生时 throw하여 Next.js error boundary가 catch
- error.tsx 파일 추가: 에러 메시지 + 다시 시도 버튼 제공

## Changes
- `archive/page.tsx`: catch 블록에서 throw error로 변경
- `archive/error.tsx`: 에러 UI 컴포넌트 추가 (에러 메시지 + retry 버튼)

## Test plan
- [x] npm run build
- [x] npm run test:run