### PR TITLE
fix: #196 미사용 변수/import 일괄 제거

### DIFF
--- a/src/app/[locale]/archive/page.tsx
+++ b/src/app/[locale]/archive/page.tsx
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { cn } from '@/components/ui/utils';
 import { fetchArchives } from '@/lib/api-server';
-import { TEAPOT_IMAGES } from '@/lib/teapot-images';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { SectionHeading } from '@/components/common/SectionHeading';
 import type { NiloType, ProcessStep, Artist } from '@/lib/api';
@@ -76,7 +75,6 @@ function ProcessCard({ step: s }: { step: ProcessStep }) {
 }
 
 function ArtistCard({ artist, index, reversed }: { artist: Artist; index: number; reversed: boolean }) {
-  const img = TEAPOT_IMAGES[index % TEAPOT_IMAGES.length];
   return (
     <article
       className={cn(

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { ShoppingCart, Menu, X, Search, User, LogOut } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import Logo from '@/components/Logo';
@@ -45,7 +45,7 @@ interface DesktopActionsProps {
   onLogout: () => void;
 }
 
-function DesktopActions({ isAuthenticated, userName, itemCount, onLogout }: DesktopActionsProps) {
+function DesktopActions({ isAuthenticated, itemCount, onLogout }: DesktopActionsProps) {
   const textClass = "text-muted-foreground hover:text-foreground";
   return (
     <div className="hidden md:flex items-center gap-4">
@@ -338,7 +338,6 @@ function MobileSearchOverlay({ isOpen, onClose }: MobileSearchOverlayProps) {
 
 export default function Header() {
   const router = useRouter();
-  const pathname = usePathname();
   const { isAuthenticated, user, logout } = useAuth();
   const { itemCount } = useCart();
   const { items: navItems } = useNavigation('gnb');

--- a/src/components/blocks/ImageGalleryBlock.tsx
+++ b/src/components/blocks/ImageGalleryBlock.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
 import type { ImageGalleryContent } from '@/lib/api';
 import { cn } from '@/components/ui/utils';
 


### PR DESCRIPTION
## Summary
- Closes #196
- 미사용 변수/import 일괄 제거

## Changes
- `Header.tsx`: 미사용 `userName` props 제거, 미사용 `pathname` 변수 및 `usePathname` import 제거
- `ImageGalleryBlock.tsx`: 미사용 `Link` import 제거
- `archive/page.tsx`: 미사용 `img` 변수 및 `TEAPOT_IMAGES` import 제거

## Note
- `isAnimating` state는 `setIsAnimating` 호출에서 사용되고 있어 유지
- `collection/page.tsx`의 `locale`은 Next.js i18n 처리 위해 필요한 것으로 판단하여 유지
- `PaymentGateway.tsx`의 `onError`는 실제로 사용되고 있어 유지

## Test plan
- [x] npm run build