### PR TITLE
refactor: #215 ImageGallery 4개 책임 분리 - SRP 적용

### DIFF
--- a/src/components/products/ImageGallery.tsx
+++ b/src/components/products/ImageGallery.tsx
@@ -3,8 +3,12 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import Image from 'next/image'
 import { cn } from '@/components/ui/utils'
-import { ZoomIn, ZoomOut, X, ChevronLeft, ChevronRight } from 'lucide-react'
+import { ZoomIn } from 'lucide-react'
 import { TEAPOT_IMAGES } from '@/lib/teapot-images'
+import { useImageGallerySwipe } from '@/hooks/useImageGallerySwipe'
+import { useLightboxInteraction } from '@/hooks/useLightboxInteraction'
+import LightboxOverlay from './LightboxOverlay'
+import ThumbnailStrip from './ThumbnailStrip'
 
 interface ProductImage {
   id: number
@@ -68,55 +72,64 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
   const [isZoomed, setIsZoomed] = useState(false)
   const [zoomPos, setZoomPos] = useState({ x: 50, y: 50 })
   const [lightboxOpen, setLightboxOpen] = useState(false)
-  const [lightboxZoomed, setLightboxZoomed] = useState(false)
-  const [lightboxPan, setLightboxPan] = useState({ x: 0, y: 0 })
   const mainImageRef = useRef<HTMLDivElement>(null)
   const thumbnailRef = useRef<HTMLDivElement>(null)
-  const touchStartX = useRef<number | null>(null)
-  const touchSwiped = useRef(false)
-  const touchOnThumbnail = useRef(false)
   const rafId = useRef<number>(0)
-  const lightboxPanRef = useRef({ x: 0, y: 0 })
   const isDragging = useRef(false)
-  const dragStart = useRef({ x: 0, y: 0 })
-  const lightboxImgRef = useRef<HTMLDivElement>(null)
 
-  const selectedImage = images[selectedIndex]
+  const {
+    lightboxZoomed,
+    setLightboxZoomed,
+    lightboxPan,
+    lightboxPanRef,
+    handleLightboxMouseDown,
+    handleLightboxMouseMove,
+    handleLightboxMouseUp,
+    handleLightboxTouchStart,
+    handleLightboxTouchMove,
+    handleLightboxTouchEnd,
+    resetLightboxState,
+  } = useLightboxInteraction()
 
   const goPrev = useCallback(() => {
-    setLightboxZoomed(false)
-    setLightboxPan({ x: 0, y: 0 })
-    lightboxPanRef.current = { x: 0, y: 0 }
+    resetLightboxState()
     setSelectedIndex((i) => (i === 0 ? images.length - 1 : i - 1))
-  }, [images.length])
+  }, [images.length, resetLightboxState])
 
   const goNext = useCallback(() => {
-    setLightboxZoomed(false)
-    setLightboxPan({ x: 0, y: 0 })
-    lightboxPanRef.current = { x: 0, y: 0 }
+    resetLightboxState()
     setSelectedIndex((i) => (i === images.length - 1 ? 0 : i + 1))
-  }, [images.length])
+  }, [images.length, resetLightboxState])
+
+  const { handleTouchStart, handleTouchEnd, touchSwiped } = useImageGallerySwipe({
+    onSwipeLeft: goNext,
+    onSwipeRight: goPrev,
+    thumbnailRef,
+  })
+
+  const closeLightbox = useCallback(() => {
+    setLightboxOpen(false)
+    resetLightboxState()
+  }, [resetLightboxState])
 
   useEffect(() => {
     if (!lightboxOpen) return
     function onKey(e: KeyboardEvent) {
       if (e.key === 'ArrowLeft') goPrev()
       if (e.key === 'ArrowRight') goNext()
-      if (e.key === 'Escape') { setLightboxOpen(false); setLightboxZoomed(false) }
+      if (e.key === 'Escape') { setLightboxOpen(false); resetLightboxState() }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [lightboxOpen, goPrev, goNext])
+  }, [lightboxOpen, goPrev, goNext, resetLightboxState])
 
   useEffect(() => () => cancelAnimationFrame(rafId.current), [])
 
   useEffect(() => {
     if (!lightboxOpen) {
-      setLightboxZoomed(false)
-      setLightboxPan({ x: 0, y: 0 })
-      lightboxPanRef.current = { x: 0, y: 0 }
+      resetLightboxState()
     }
-  }, [lightboxOpen])
+  }, [lightboxOpen, resetLightboxState])
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (!isZoomed || !mainImageRef.current) return
@@ -133,81 +146,6 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
     })
   }, [isZoomed])
 
-  const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0].clientX
-    touchSwiped.current = false
-    touchOnThumbnail.current = false
-    const target = e.target as HTMLElement
-    if (thumbnailRef.current?.contains(target)) {
-      touchOnThumbnail.current = true
-    }
-  }, [])
-
-  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
-    if (touchStartX.current === null) return
-    const diff = touchStartX.current - e.changedTouches[0].clientX
-    if (Math.abs(diff) > 50 && !touchOnThumbnail.current) {
-      touchSwiped.current = true
-      diff > 0 ? goNext() : goPrev()
-    }
-    touchStartX.current = null
-  }, [goNext, goPrev])
-
-  const handleLightboxTouchStart = useCallback((e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0].clientX
-    touchSwiped.current = false
-    if (lightboxZoomed) {
-      isDragging.current = true
-      dragStart.current = {
-        x: e.touches[0].clientX - lightboxPanRef.current.x,
-        y: e.touches[0].clientY - lightboxPanRef.current.y,
-      }
-    }
-  }, [lightboxZoomed])
-
-  const handleLightboxTouchMove = useCallback((e: React.TouchEvent) => {
-    if (!isDragging.current || !lightboxZoomed) return
-    const maxPan = 100
-    const newX = Math.min(maxPan, Math.max(-maxPan, e.touches[0].clientX - dragStart.current.x))
-    const newY = Math.min(maxPan, Math.max(-maxPan, e.touches[0].clientY - dragStart.current.y))
-    lightboxPanRef.current = { x: newX, y: newY }
-    setLightboxPan({ x: newX, y: newY })
-  }, [lightboxZoomed])
-
-  const handleLightboxTouchEnd = useCallback((e: React.TouchEvent) => {
-    if (touchStartX.current !== null && !lightboxZoomed) {
-      const diff = touchStartX.current - e.changedTouches[0].clientX
-      if (Math.abs(diff) > 50) {
-        touchSwiped.current = true
-        diff > 0 ? goNext() : goPrev()
-      }
-    }
-    touchStartX.current = null
-    isDragging.current = false
-  }, [lightboxZoomed, goNext, goPrev])
-
-  const handleLightboxMouseDown = useCallback((e: React.MouseEvent) => {
-    if (!lightboxZoomed) return
-    isDragging.current = true
-    dragStart.current = {
-      x: e.clientX - lightboxPanRef.current.x,
-      y: e.clientY - lightboxPanRef.current.y,
-    }
-  }, [lightboxZoomed])
-
-  const handleLightboxMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!isDragging.current || !lightboxZoomed) return
-    const maxPan = 150
-    const newX = Math.min(maxPan, Math.max(-maxPan, e.clientX - dragStart.current.x))
-    const newY = Math.min(maxPan, Math.max(-maxPan, e.clientY - dragStart.current.y))
-    lightboxPanRef.current = { x: newX, y: newY }
-    setLightboxPan({ x: newX, y: newY })
-  }, [lightboxZoomed])
-
-  const handleLightboxMouseUp = useCallback(() => {
-    isDragging.current = false
-  }, [])
-
   const imageStyle = useMemo(
     () => isZoomed
       ? { transformOrigin: `${zoomPos.x}% ${zoomPos.y}%` }
@@ -222,13 +160,6 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
       transition: isDragging.current ? 'none' : 'transform 0.2s ease-out',
     }
   }, [lightboxZoomed, lightboxPan.x, lightboxPan.y])
-
-  const closeLightbox = useCallback(() => {
-    setLightboxOpen(false)
-    setLightboxZoomed(false)
-    setLightboxPan({ x: 0, y: 0 })
-    lightboxPanRef.current = { x: 0, y: 0 }
-  }, [])
 
   if (isLoading) {
     return <ImageGallerySkeleton />
@@ -249,10 +180,11 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
     )
   }
 
+  const selectedImage = images[selectedIndex]
+
   return (
     <>
       <div className="flex flex-col gap-3">
-        {/* 메인 이미지 */}
         <div
           ref={mainImageRef}
           className="relative aspect-square w-full overflow-hidden rounded-lg bg-muted cursor-zoom-in group"
@@ -280,7 +212,6 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
             priority
           />
 
-          {/* 이미지 위치 점 인디케이터 */}
           <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5">
             {images.map((_, i) => (
               <span
@@ -293,7 +224,6 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
             ))}
           </div>
 
-          {/* 확대 힌트 */}
           {!isZoomed && (
             <div className="absolute inset-0 flex items-end justify-end p-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
               <span className="flex items-center gap-1 rounded-full bg-black/50 px-2 py-1 text-xs text-white backdrop-blur-sm">
@@ -305,7 +235,6 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
 
           {images.length > 1 && (
             <>
-              {/* 이전 화살표 - 항상 약간 표시 */}
               <button
                 type="button"
                 onClick={(e) => { e.stopPropagation(); touchSwiped.current = false; goPrev() }}
@@ -317,7 +246,6 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
                   ‹
                 </span>
               </button>
-              {/* 다음 화살표 - 항상 약간 표시 */}
               <button
                 type="button"
                 onClick={(e) => { e.stopPropagation(); touchSwiped.current = false; goNext() }}
@@ -333,146 +261,37 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
           )}
         </div>
 
-        {/* 썸네일 */}
         {images.length > 1 && (
-          <div ref={thumbnailRef} className="relative">
-            <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
-              {images.map((image, index) => (
-                <button
-                  key={image.id}
-                  type="button"
-                  onClick={() => setSelectedIndex(index)}
-                  className={cn(
-                    'relative aspect-square w-16 flex-shrink-0 overflow-hidden rounded-md border-2 bg-muted transition-all',
-                    index === selectedIndex
-                      ? 'ring-2 ring-primary border-transparent'
-                      : 'border-transparent hover:border-border',
-                  )}
-                  aria-label={`이미지 ${index + 1} 선택`}
-                >
-                  <Image
-                    src={image.url}
-                    alt={image.alt ?? `상품 이미지 ${index + 1}`}
-                    fill
-                    sizes="64px"
-                    className="object-cover"
-                  />
-                </button>
-              ))}
-            </div>
-            {/* 좌측 스크롤 인디케이터 */}
-            <div className="absolute left-0 top-0 bottom-0 w-6 bg-gradient-to-r from-muted/40 to-transparent pointer-events-none" />
-            {/* 우측 스크롤 인디케이터 */}
-            <div className="absolute right-0 top-0 bottom-0 w-6 bg-gradient-to-l from-muted/40 to-transparent pointer-events-none" />
-          </div>
+          <ThumbnailStrip
+            images={images}
+            selectedIndex={selectedIndex}
+            onSelectIndex={setSelectedIndex}
+            thumbnailRef={thumbnailRef}
+          />
         )}
       </div>
 
-      {/* 라이트박스 */}
-      {lightboxOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm animate-lightbox-in"
-          onClick={closeLightbox}
-          onTouchStart={handleLightboxTouchStart}
-          onTouchMove={handleLightboxTouchMove}
-          onTouchEnd={handleLightboxTouchEnd}
-        >
-          {/* 닫기 */}
-          <button
-            type="button"
-            onClick={closeLightbox}
-            className="absolute right-4 top-4 rounded-full bg-white/10 hover:bg-white/20 p-3 text-white transition-colors z-50"
-            aria-label="닫기"
-          >
-            <X className="size-6" />
-          </button>
-
-          {/* 줌 토글 - 상태에 따라 배경색 변화 */}
-          <button
-            type="button"
-            onClick={(e) => { e.stopPropagation(); touchSwiped.current = false; setLightboxZoomed((z) => !z); if (lightboxZoomed) { setLightboxPan({ x: 0, y: 0 }); lightboxPanRef.current = { x: 0, y: 0 } } }}
-            className={cn(
-              'absolute right-16 top-4 rounded-full p-3 text-white transition-colors z-50',
-              lightboxZoomed ? 'bg-white/30 hover:bg-white/40' : 'bg-white/10 hover:bg-white/20',
-            )}
-            aria-label={lightboxZoomed ? '축소' : '확대'}
-          >
-            {lightboxZoomed ? <ZoomOut className="size-6" /> : <ZoomIn className="size-6" />}
-          </button>
-
-          {/* 이미지 - 애니메이션 + aspect ratio */}
-          <div
-            className="relative z-10 max-h-[85vh] max-w-[90vw]"
-            onClick={(e) => { e.stopPropagation(); if (!touchSwiped.current && !isDragging.current) { setLightboxZoomed((z) => { if (z) { setLightboxPan({ x: 0, y: 0 }); lightboxPanRef.current = { x: 0, y: 0 } }; return !z }) } }}
-            onMouseDown={handleLightboxMouseDown}
-            onMouseMove={handleLightboxMouseMove}
-            onMouseUp={handleLightboxMouseUp}
-            onMouseLeave={handleLightboxMouseUp}
-            style={{ cursor: lightboxZoomed ? (isDragging.current ? 'grabbing' : 'grab') : 'zoom-in' }}
-          >
-            <div
-              ref={lightboxImgRef}
-              className="relative transition-transform duration-200"
-              style={{ width: '90vw', height: 'auto', maxHeight: '85vh', aspectRatio: 'auto' }}
-            >
-              <Image
-                src={selectedImage.url}
-                alt={selectedImage.alt ?? '상품 이미지'}
-                width={900}
-                height={900}
-                className="object-contain w-full h-full"
-                style={lightboxImageStyle}
-                priority
-              />
-            </div>
-          </div>
-
-          {/* 화살표 */}
-          {images.length > 1 && (
-            <>
-              <button
-                type="button"
-                onClick={(e) => { e.stopPropagation(); touchSwiped.current = false; goPrev() }}
-                className="absolute left-4 top-4 rounded-full bg-white/10 hover:bg-white/20 p-4 text-white transition-colors z-50 opacity-60 hover:opacity-100"
-                aria-label="이전 이미지"
-              >
-                <ChevronLeft className="size-8" />
-              </button>
-              <button
-                type="button"
-                onClick={(e) => { e.stopPropagation(); touchSwiped.current = false; goNext() }}
-                className="absolute right-4 top-4 rounded-full bg-white/10 hover:bg-white/20 p-4 text-white transition-colors z-50 opacity-60 hover:opacity-100"
-                aria-label="다음 이미지"
-              >
-                <ChevronRight className="size-8" />
-              </button>
-            </>
-          )}
-
-          {/* 이미지 카운터 */}
-          <div className="absolute bottom-20 left-1/2 -translate-x-1/2 rounded-full bg-white/10 px-4 py-1.5 text-sm text-white backdrop-blur-sm z-50">
-            {selectedIndex + 1} / {images.length}
-          </div>
-
-          {/* dot 인디케이터 */}
-          {images.length > 1 && (
-            <div className="absolute bottom-6 left-1/2 -translate-x-1/2 flex gap-2 z-50">
-              {images.map((_, i) => (
-                <button
-                  key={i}
-                  type="button"
-                  onClick={(e) => { e.stopPropagation(); touchSwiped.current = false; setSelectedIndex(i) }}
-                  className={cn(
-                    'size-2 rounded-full transition-all',
-                    i === selectedIndex ? 'bg-white scale-125' : 'bg-white/40',
-                  )}
-                  aria-label={`이미지 ${i + 1}`}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
+      <LightboxOverlay
+        images={images}
+        selectedIndex={selectedIndex}
+        onSelectIndex={setSelectedIndex}
+        lightboxOpen={lightboxOpen}
+        lightboxZoomed={lightboxZoomed}
+        setLightboxZoomed={setLightboxZoomed}
+        lightboxPanRef={lightboxPanRef}
+        lightboxImageStyle={lightboxImageStyle}
+        onClose={closeLightbox}
+        onPrev={goPrev}
+        onNext={goNext}
+        handleLightboxMouseDown={handleLightboxMouseDown}
+        handleLightboxMouseMove={handleLightboxMouseMove}
+        handleLightboxMouseUp={handleLightboxMouseUp}
+        handleLightboxTouchStart={handleLightboxTouchStart}
+        handleLightboxTouchMove={handleLightboxTouchMove}
+        handleLightboxTouchEnd={handleLightboxTouchEnd}
+        touchSwiped={touchSwiped}
+        isDragging={isDragging}
+      />
     </>
   )
 }

--- a/src/components/products/LightboxOverlay.tsx
+++ b/src/components/products/LightboxOverlay.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import Image from 'next/image'
+import { ZoomIn, ZoomOut, X, ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '@/components/ui/utils'
+
+interface LightboxOverlayProps {
+  images: Array<{
+    id: number
+    url: string
+    alt: string | null
+    sortOrder: number
+    isThumbnail: boolean
+  }>
+  selectedIndex: number
+  onSelectIndex: (index: number) => void
+  lightboxOpen: boolean
+  lightboxZoomed: boolean
+  setLightboxZoomed: (zoomed: boolean) => void
+  lightboxPanRef: React.MutableRefObject<{ x: number; y: number }>
+  lightboxImageStyle: React.CSSProperties
+  onClose: () => void
+  onPrev: () => void
+  onNext: () => void
+  handleLightboxMouseDown: (e: React.MouseEvent) => void
+  handleLightboxMouseMove: (e: React.MouseEvent) => void
+  handleLightboxMouseUp: () => void
+  handleLightboxTouchStart: (e: React.TouchEvent) => void
+  handleLightboxTouchMove: (e: React.TouchEvent) => void
+  handleLightboxTouchEnd: (e: React.TouchEvent) => void
+  touchSwiped: React.MutableRefObject<boolean>
+  isDragging: React.MutableRefObject<boolean>
+}
+
+export default function LightboxOverlay({
+  images,
+  selectedIndex,
+  onSelectIndex,
+  lightboxOpen,
+  lightboxZoomed,
+  setLightboxZoomed,
+  lightboxPanRef,
+  lightboxImageStyle,
+  onClose,
+  onPrev,
+  onNext,
+  handleLightboxMouseDown,
+  handleLightboxMouseMove,
+  handleLightboxMouseUp,
+  handleLightboxTouchStart,
+  handleLightboxTouchMove,
+  handleLightboxTouchEnd,
+  touchSwiped,
+  isDragging,
+}: LightboxOverlayProps) {
+  if (!lightboxOpen) return null
+
+  const selectedImage = images[selectedIndex]
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm animate-lightbox-in"
+      onClick={onClose}
+      onTouchStart={handleLightboxTouchStart}
+      onTouchMove={handleLightboxTouchMove}
+      onTouchEnd={handleLightboxTouchEnd}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute right-4 top-4 rounded-full bg-white/10 hover:bg-white/20 p-3 text-white transition-colors z-50"
+        aria-label="닫기"
+      >
+        <X className="size-6" />
+      </button>
+
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          touchSwiped.current = false
+          setLightboxZoomed(!lightboxZoomed)
+          if (lightboxZoomed) {
+            const resetPan = { x: 0, y: 0 }
+            lightboxPanRef.current = resetPan
+          }
+        }}
+        className={cn(
+          'absolute right-16 top-4 rounded-full p-3 text-white transition-colors z-50',
+          lightboxZoomed ? 'bg-white/30 hover:bg-white/40' : 'bg-white/10 hover:bg-white/20',
+        )}
+        aria-label={lightboxZoomed ? '축소' : '확대'}
+      >
+        {lightboxZoomed ? <ZoomOut className="size-6" /> : <ZoomIn className="size-6" />}
+      </button>
+
+      <div
+        className="relative z-10 max-h-[85vh] max-w-[90vw]"
+        onClick={(e) => {
+          e.stopPropagation()
+          if (!touchSwiped.current && !isDragging.current) {
+            setLightboxZoomed((z) => {
+              if (z) {
+                const resetPan = { x: 0, y: 0 }
+                lightboxPanRef.current = resetPan
+              }
+              return !z
+            })
+          }
+        }}
+        onMouseDown={handleLightboxMouseDown}
+        onMouseMove={handleLightboxMouseMove}
+        onMouseUp={handleLightboxMouseUp}
+        onMouseLeave={handleLightboxMouseUp}
+        style={{ cursor: lightboxZoomed ? (isDragging.current ? 'grabbing' : 'grab') : 'zoom-in' }}
+      >
+        <div
+          className="relative transition-transform duration-200"
+          style={{ width: '90vw', height: 'auto', maxHeight: '85vh', aspectRatio: 'auto' }}
+        >
+          <Image
+            src={selectedImage.url}
+            alt={selectedImage.alt ?? '상품 이미지'}
+            width={900}
+            height={900}
+            className="object-contain w-full h-full"
+            style={lightboxImageStyle}
+            priority
+          />
+        </div>
+      </div>
+
+      {images.length > 1 && (
+        <>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              touchSwiped.current = false
+              onPrev()
+            }}
+            className="absolute left-4 top-4 rounded-full bg-white/10 hover:bg-white/20 p-4 text-white transition-colors z-50 opacity-60 hover:opacity-100"
+            aria-label="이전 이미지"
+          >
+            <ChevronLeft className="size-8" />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              touchSwiped.current = false
+              onNext()
+            }}
+            className="absolute right-4 top-4 rounded-full bg-white/10 hover:bg-white/20 p-4 text-white transition-colors z-50 opacity-60 hover:opacity-100"
+            aria-label="다음 이미지"
+          >
+            <ChevronRight className="size-8" />
+          </button>
+        </>
+      )}
+
+      <div className="absolute bottom-20 left-1/2 -translate-x-1/2 rounded-full bg-white/10 px-4 py-1.5 text-sm text-white backdrop-blur-sm z-50">
+        {selectedIndex + 1} / {images.length}
+      </div>
+
+      {images.length > 1 && (
+        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 flex gap-2 z-50">
+          {images.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                touchSwiped.current = false
+                onSelectIndex(i)
+              }}
+              className={cn(
+                'size-2 rounded-full transition-all',
+                i === selectedIndex ? 'bg-white scale-125' : 'bg-white/40',
+              )}
+              aria-label={`이미지 ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/products/ThumbnailStrip.tsx
+++ b/src/components/products/ThumbnailStrip.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import Image from 'next/image'
+import { cn } from '@/components/ui/utils'
+
+interface ThumbnailStripProps {
+  images: Array<{
+    id: number
+    url: string
+    alt: string | null
+    sortOrder: number
+    isThumbnail: boolean
+  }>
+  selectedIndex: number
+  onSelectIndex: (index: number) => void
+  thumbnailRef: React.RefObject<HTMLDivElement | null>
+}
+
+export default function ThumbnailStrip({
+  images,
+  selectedIndex,
+  onSelectIndex,
+  thumbnailRef,
+}: ThumbnailStripProps) {
+  return (
+    <div ref={thumbnailRef} className="relative">
+      <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
+        {images.map((image, index) => (
+          <button
+            key={image.id}
+            type="button"
+            onClick={() => onSelectIndex(index)}
+            className={cn(
+              'relative aspect-square w-16 flex-shrink-0 overflow-hidden rounded-md border-2 bg-muted transition-all',
+              index === selectedIndex
+                ? 'ring-2 ring-primary border-transparent'
+                : 'border-transparent hover:border-border',
+            )}
+            aria-label={`이미지 ${index + 1} 선택`}
+          >
+            <Image
+              src={image.url}
+              alt={image.alt ?? `상품 이미지 ${index + 1}`}
+              fill
+              sizes="64px"
+              className="object-cover"
+            />
+          </button>
+        ))}
+      </div>
+      <div className="absolute left-0 top-0 bottom-0 w-6 bg-gradient-to-r from-muted/40 to-transparent pointer-events-none" />
+      <div className="absolute right-0 top-0 bottom-0 w-6 bg-gradient-to-l from-muted/40 to-transparent pointer-events-none" />
+    </div>
+  )
+}

--- a/src/hooks/useImageGallerySwipe.ts
+++ b/src/hooks/useImageGallerySwipe.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useRef, useCallback } from 'react'
+
+interface UseImageGallerySwipeOptions {
+  onSwipeLeft: () => void
+  onSwipeRight: () => void
+  thumbnailRef?: React.RefObject<HTMLDivElement | null>
+}
+
+export function useImageGallerySwipe({
+  onSwipeLeft,
+  onSwipeRight,
+  thumbnailRef,
+}: UseImageGallerySwipeOptions) {
+  const touchStartX = useRef<number | null>(null)
+  const touchSwiped = useRef(false)
+  const touchOnThumbnail = useRef(false)
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX
+    touchSwiped.current = false
+    touchOnThumbnail.current = false
+    const target = e.target as HTMLElement
+    if (thumbnailRef?.current?.contains(target)) {
+      touchOnThumbnail.current = true
+    }
+  }, [thumbnailRef])
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (touchStartX.current === null) return
+    const diff = touchStartX.current - e.changedTouches[0].clientX
+    if (Math.abs(diff) > 50 && !touchOnThumbnail.current) {
+      touchSwiped.current = true
+      void (diff > 0 ? onSwipeLeft() : onSwipeRight())
+    }
+    touchStartX.current = null
+  }, [onSwipeLeft, onSwipeRight])
+
+  return {
+    handleTouchStart,
+    handleTouchEnd,
+    touchSwiped,
+  }
+}

--- a/src/hooks/useLightboxInteraction.ts
+++ b/src/hooks/useLightboxInteraction.ts
@@ -1,0 +1,77 @@
+'use client'
+
+import { useState, useRef, useCallback } from 'react'
+
+export function useLightboxInteraction() {
+  const [lightboxZoomed, setLightboxZoomed] = useState(false)
+  const [lightboxPan, setLightboxPan] = useState({ x: 0, y: 0 })
+  const lightboxPanRef = useRef({ x: 0, y: 0 })
+  const isDragging = useRef(false)
+  const dragStart = useRef({ x: 0, y: 0 })
+
+  const resetLightboxState = useCallback(() => {
+    setLightboxZoomed(false)
+    setLightboxPan({ x: 0, y: 0 })
+    lightboxPanRef.current = { x: 0, y: 0 }
+  }, [])
+
+  const handleLightboxMouseDown = useCallback((e: React.MouseEvent) => {
+    if (!lightboxZoomed) return
+    isDragging.current = true
+    dragStart.current = {
+      x: e.clientX - lightboxPanRef.current.x,
+      y: e.clientY - lightboxPanRef.current.y,
+    }
+  }, [lightboxZoomed])
+
+  const handleLightboxMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isDragging.current || !lightboxZoomed) return
+    const maxPan = 150
+    const newX = Math.min(maxPan, Math.max(-maxPan, e.clientX - dragStart.current.x))
+    const newY = Math.min(maxPan, Math.max(-maxPan, e.clientY - dragStart.current.y))
+    lightboxPanRef.current = { x: newX, y: newY }
+    setLightboxPan({ x: newX, y: newY })
+  }, [lightboxZoomed])
+
+  const handleLightboxMouseUp = useCallback(() => {
+    isDragging.current = false
+  }, [])
+
+  const handleLightboxTouchStart = useCallback((e: React.TouchEvent) => {
+    if (lightboxZoomed) {
+      isDragging.current = true
+      dragStart.current = {
+        x: e.touches[0].clientX - lightboxPanRef.current.x,
+        y: e.touches[0].clientY - lightboxPanRef.current.y,
+      }
+    }
+  }, [lightboxZoomed])
+
+  const handleLightboxTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!isDragging.current || !lightboxZoomed) return
+    const maxPan = 100
+    const newX = Math.min(maxPan, Math.max(-maxPan, e.touches[0].clientX - dragStart.current.x))
+    const newY = Math.min(maxPan, Math.max(-maxPan, e.touches[0].clientY - dragStart.current.y))
+    lightboxPanRef.current = { x: newX, y: newY }
+    setLightboxPan({ x: newX, y: newY })
+  }, [lightboxZoomed])
+
+  const handleLightboxTouchEnd = useCallback(() => {
+    isDragging.current = false
+  }, [])
+
+  return {
+    lightboxZoomed,
+    setLightboxZoomed,
+    lightboxPan,
+    setLightboxPan,
+    lightboxPanRef,
+    handleLightboxMouseDown,
+    handleLightboxMouseMove,
+    handleLightboxMouseUp,
+    handleLightboxTouchStart,
+    handleLightboxTouchMove,
+    handleLightboxTouchEnd,
+    resetLightboxState,
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #215
- ImageGallery.tsx 단일 파일(478줄)을 4개 책임으로 분리하여 SRP 적용
- `useImageGallerySwipe` hook: 터치/스와이프 제스처 핸들링
- `useLightboxInteraction` hook: 라이트박스 줌/팬/드래그
- `LightboxOverlay` component: 라이트박스 오버레이 UI
- `ThumbnailStrip` component: 썸네일 스트립
- `resetLightboxState()` helper: 4곳 중복된 리셋 로직 통합

## Test plan
- [x] npm run build
- [x] npm run test:run (ImageGallery tests: 3/3 passed)