### PR TITLE
fix: #226 TextContentBlock SafeHtml 컴포넌트 사용

### DIFF
--- a/src/components/blocks/TextContentBlock.tsx
+++ b/src/components/blocks/TextContentBlock.tsx
@@ -1,7 +1,5 @@
-'use client';
-
-import { useEffect, useRef } from 'react';
 import type { TextContentContent } from '@/lib/api';
+import SafeHtml from '@/components/common/SafeHtml';
 
 interface Props {
   content: TextContentContent;
@@ -9,21 +7,11 @@ interface Props {
 
 export default function TextContentBlock({ content }: Props) {
   const { html, textAlign = 'center' } = content;
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!ref.current) return;
-    import('dompurify').then(({ default: DOMPurify }) => {
-      if (ref.current) {
-        ref.current.innerHTML = DOMPurify.sanitize(html);
-      }
-    });
-  }, [html]);
 
   return (
     <section className="my-8">
       <hr className="border-border" />
-      <div ref={ref} className="prose max-w-none py-6" style={{ textAlign }} />
+      <SafeHtml html={html} className="prose max-w-none py-6" style={{ textAlign }} />
       <hr className="border-border" />
     </section>
   );

--- a/src/components/common/SafeHtml.tsx
+++ b/src/components/common/SafeHtml.tsx
@@ -1,13 +1,15 @@
 import DOMPurify from 'isomorphic-dompurify';
+import type { CSSProperties } from 'react';
 
 interface SafeHtmlProps {
   html: string;
   className?: string;
+  style?: CSSProperties;
 }
 
 // Content is sanitized by DOMPurify before rendering — XSS safe
-export default function SafeHtml({ html, className }: SafeHtmlProps) {
+export default function SafeHtml({ html, className, style }: SafeHtmlProps) {
   const clean = DOMPurify.sanitize(html);
   // eslint-disable-next-line react/no-danger
-  return <div className={className} dangerouslySetInnerHTML={{ __html: clean }} />;
+  return <div className={className} style={style} dangerouslySetInnerHTML={{ __html: clean }} />;
 }


### PR DESCRIPTION
## Summary
- Closes #226
- TextContentBlock에서 async DOMPurify 직접 로딩 대신 SafeHtml 컴포넌트 사용
- SafeHtml 컴포넌트에 `style` prop 추가로 textAlign 지원
- `'use client'` 지시문, useEffect, useRef 의존성 제거로 Server Component로 전환

## Test plan
- [x] tsc --noEmit: TextContentBlock, SafeHtml 관련 타입 오류 없음
- [x] 기존 테스트 실패(7개)는 main 브랜치 동일 — 이 PR과 무관한 pre-existing 이슈
- [ ] npm run build
- [ ] npm run test:run