### PR TITLE
fix: #227 OAuth state null-null bypass 방어

### DIFF
--- a/src/components/auth/OAuthCallbackHandler.tsx
+++ b/src/components/auth/OAuthCallbackHandler.tsx
@@ -26,7 +26,7 @@ export default function OAuthCallbackHandler({ provider, apiMethod }: OAuthCallb
       return;
     }
 
-    if (state !== storedState) {
+    if (!state || !storedState || state !== storedState) {
       toast.error('보안 검증에 실패했습니다. 다시 시도해 주세요.');
       router.replace('/login');
       return;


### PR DESCRIPTION
## Summary
- `state !== storedState` 비교 시 양쪽이 모두 `null`이면 검증을 통과하는 보안 취약점 수정
- `!state || !storedState` null 체크를 추가하여 둘 중 하나라도 null이면 즉시 실패 처리

## Changes
- `src/components/auth/OAuthCallbackHandler.tsx`: state/storedState null 체크 추가

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)