### PR TITLE
refactor: #228 배송비/무료배송 매직 리터럴 상수화

### DIFF
--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import EmptyState from '@/components/EmptyState';
 import CartItemRow from '@/components/cart/CartItemRow';
 import { formatCurrency } from '@/utils/currency';
+import { FREE_SHIPPING_THRESHOLD, SHIPPING_FEE } from '@/constants/shipping';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 
 export default function CartPage() {
@@ -146,7 +147,7 @@ export default function CartPage() {
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">배송비</span>
-              <span>{selectedTotal >= 30000 ? '무료' : '3,000원'}</span>
+              <span>{selectedTotal >= FREE_SHIPPING_THRESHOLD ? '무료' : formatCurrency(SHIPPING_FEE)}</span>
             </div>
           </div>
 
@@ -156,7 +157,7 @@ export default function CartPage() {
               <span>
                 {formatCurrency(
                   selectedTotal +
-                  (selectedTotal >= 30000 || selectedTotal === 0 ? 0 : 3000)
+                  (selectedTotal >= FREE_SHIPPING_THRESHOLD || selectedTotal === 0 ? 0 : SHIPPING_FEE)
                 )}
               </span>
             </div>

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useCart } from '@/contexts/CartContext';
 import type { CartItem, PreparePaymentResponse, UserAddress } from '@/lib/api';
 import { ordersApi, paymentsApi, usersApi } from '@/lib/api';
+import { FREE_SHIPPING_THRESHOLD, SHIPPING_FEE } from '@/constants/shipping';
 import { formatCurrency } from '@/utils/currency';
 import type { Locale } from '@/i18n/routing';
 import PaymentGateway, { type PaymentGatewayHandle } from '@/components/checkout/PaymentGateway';
@@ -144,7 +145,7 @@ export default function CheckoutPage({
   }, [isAuthenticated, isLoading]);
 
   const totalAmount = checkoutItems.reduce((sum, item) => sum + item.subtotal, 0);
-  const shippingFee = totalAmount >= 30000 ? 0 : 3000;
+  const shippingFee = totalAmount >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_FEE;
   const grandTotal = totalAmount + shippingFee;
 
   const handleAddressSelect = (id: number | 'manual') => {

--- a/src/constants/shipping.ts
+++ b/src/constants/shipping.ts
@@ -1,0 +1,2 @@
+export const FREE_SHIPPING_THRESHOLD = 30000;
+export const SHIPPING_FEE = 3000;


### PR DESCRIPTION
## Summary
- `src/constants/shipping.ts` 파일 생성: `FREE_SHIPPING_THRESHOLD = 30000`, `SHIPPING_FEE = 3000` 상수 정의
- `src/app/[locale]/cart/page.tsx`: 하드코딩된 30000/3000을 상수로 교체
- `src/app/[locale]/checkout/page.tsx`: 하드코딩된 30000/3000을 상수로 교체

## Test plan
- [ ] 장바구니 페이지에서 배송비 표시 확인 (30000원 미만: 3,000원, 이상: 무료)
- [ ] 결제 페이지에서 배송비 계산 확인
- [ ] `npm run test:run` 통과 확인 (기존 실패 테스트는 사전 존재)

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)