### PR TITLE
style: #241 inquiries 페이지 시맨틱 토큰 적용

### DIFF
--- a/src/app/[locale]/my/inquiries/new/page.tsx
+++ b/src/app/[locale]/my/inquiries/new/page.tsx
@@ -41,11 +41,11 @@ export default function NewInquiryPage() {
       <h1 className="typo-h1 mb-6">문의하기</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">문의 유형</label>
+          <label className="block text-sm font-medium text-foreground mb-1">문의 유형</label>
           <select
             value={type}
             onChange={(e) => setType(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+            className="w-full border border-input rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           >
             {INQUIRY_TYPES.map((t) => (
               <option key={t} value={t}>{t}</option>
@@ -53,38 +53,38 @@ export default function NewInquiryPage() {
           </select>
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">제목</label>
+          <label className="block text-sm font-medium text-foreground mb-1">제목</label>
           <input
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             maxLength={255}
             placeholder="문의 제목을 입력해주세요"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+            className="w-full border border-input rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">내용</label>
+          <label className="block text-sm font-medium text-foreground mb-1">내용</label>
           <textarea
             value={content}
             onChange={(e) => setContent(e.target.value)}
             rows={6}
             placeholder="문의 내용을 자세히 입력해주세요"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black resize-none"
+            className="w-full border border-input rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring resize-none"
           />
         </div>
         <div className="flex gap-3 pt-2">
           <button
             type="button"
             onClick={() => router.back()}
-            className="flex-1 py-2.5 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50"
+            className="flex-1 py-2.5 border border-input rounded-lg text-sm font-medium text-foreground hover:bg-muted"
           >
             취소
           </button>
           <button
             type="submit"
             disabled={submitting}
-            className="flex-1 py-2.5 bg-black text-white rounded-lg text-sm font-medium hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 py-2.5 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {submitting ? '접수 중...' : '문의 접수'}
           </button>

--- a/src/app/[locale]/my/inquiries/page.tsx
+++ b/src/app/[locale]/my/inquiries/page.tsx
@@ -45,7 +45,7 @@ export default function InquiriesPage() {
         <h1 className="typo-h1">1:1 문의</h1>
         <Link
           href="/my/inquiries/new"
-          className="px-4 py-2 bg-black text-white text-sm rounded-lg hover:bg-gray-800 transition-colors"
+          className="px-4 py-2 bg-primary text-primary-foreground text-sm rounded-lg hover:bg-primary/80 transition-colors"
         >
           문의하기
         </Link>
@@ -59,7 +59,7 @@ export default function InquiriesPage() {
             <li key={inquiry.id} className="border rounded-lg overflow-hidden">
               <button
                 onClick={() => setOpenId(openId === inquiry.id ? null : inquiry.id)}
-                className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+                className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-muted transition-colors"
               >
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 mb-1">
@@ -73,26 +73,26 @@ export default function InquiriesPage() {
                     >
                       {inquiry.status === 'answered' ? '답변완료' : '접수'}
                     </span>
-                    <span className="text-xs text-gray-400">{inquiry.type}</span>
+                    <span className="text-xs text-muted-foreground">{inquiry.type}</span>
                   </div>
-                  <p className="text-sm font-medium text-gray-800 truncate">{inquiry.title}</p>
+                  <p className="text-sm font-medium text-foreground truncate">{inquiry.title}</p>
                 </div>
-                <span className="ml-4 shrink-0 text-xs text-gray-400">
+                <span className="ml-4 shrink-0 text-xs text-muted-foreground">
                   {new Date(inquiry.createdAt).toLocaleDateString('ko-KR')}
                 </span>
               </button>
               {openId === inquiry.id && (
-                <div className="border-t px-4 py-3 bg-gray-50 space-y-3">
+                <div className="border-t px-4 py-3 bg-muted space-y-3">
                   <div>
-                    <p className="text-xs font-semibold text-gray-500 mb-1">문의 내용</p>
-                    <p className="text-sm text-gray-700 whitespace-pre-wrap">{inquiry.content}</p>
+                    <p className="text-xs font-semibold text-muted-foreground mb-1">문의 내용</p>
+                    <p className="text-sm text-foreground whitespace-pre-wrap">{inquiry.content}</p>
                   </div>
                   {inquiry.answer && (
-                    <div className="bg-white border rounded p-3">
-                      <p className="text-xs font-semibold text-blue-600 mb-1">답변</p>
-                      <p className="text-sm text-gray-700 whitespace-pre-wrap">{inquiry.answer}</p>
+                    <div className="bg-card border rounded p-3">
+                      <p className="text-xs font-semibold text-primary mb-1">답변</p>
+                      <p className="text-sm text-foreground whitespace-pre-wrap">{inquiry.answer}</p>
                       {inquiry.answeredAt && (
-                        <p className="text-xs text-gray-400 mt-1">
+                        <p className="text-xs text-muted-foreground mt-1">
                           {new Date(inquiry.answeredAt).toLocaleDateString('ko-KR')}
                         </p>
                       )}


### PR DESCRIPTION
## Summary

- `inquiries/page.tsx`, `inquiries/new/page.tsx`에서 원시 Tailwind 색상 클래스를 프로젝트 시맨틱 토큰으로 교체
- `bg-black` / `hover:bg-gray-800` → `bg-primary` / `hover:bg-primary/80`
- `text-gray-*` → `text-foreground` / `text-muted-foreground`
- `bg-gray-50` → `bg-muted`
- `bg-white` → `bg-card`
- `border-gray-300` → `border-input`
- `focus:ring-black` → `focus:ring-ring`
- `text-blue-600` → `text-primary`

## Test plan

- [ ] 문의 목록 페이지(`/my/inquiries`) 색상 정상 렌더링 확인
- [ ] 문의 작성 페이지(`/my/inquiries/new`) 폼 색상 정상 렌더링 확인
- [ ] 답변완료 / 접수 상태 뱃지 정상 출력 확인
- [ ] 기존 테스트 통과 (pre-existing failures 제외)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)