### PR TITLE
fix: #235 CouponSelector formatCurrency() 뒤 '원' 이중 표기 제거

### DIFF
--- a/src/components/checkout/CouponSelector.tsx
+++ b/src/components/checkout/CouponSelector.tsx
@@ -80,8 +80,8 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
           <option key={c.id} value={c.id}>
             {c.name} (
             {c.type === 'percentage'
-              ? `${c.value}% 할인${c.maxDiscount ? ` / 최대 ${formatCurrency(c.maxDiscount)}원` : ''}`
-              : `${formatCurrency(c.value)}원 할인`}
+              ? `${c.value}% 할인${c.maxDiscount ? ` / 최대 ${formatCurrency(c.maxDiscount)}` : ''}`
+              : `${formatCurrency(c.value)} 할인`}
             )
           </option>
         ))}
@@ -89,7 +89,7 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
 
       {selected && (
         <p className="text-xs text-muted-foreground">
-          최소 주문금액: {formatCurrency(selected.minOrderAmount)}원 &middot; 만료:{' '}
+          최소 주문금액: {formatCurrency(selected.minOrderAmount)} &middot; 만료:{' '}
           {new Date(selected.expiresAt).toLocaleDateString('ko-KR')}
         </p>
       )}


### PR DESCRIPTION
## Summary

- `formatCurrency()`는 `Intl.NumberFormat`의 `style: 'currency'` 옵션을 사용해 이미 통화 단위(₩)를 포함한 문자열을 반환합니다.
- CouponSelector에서 `formatCurrency()` 결과 뒤에 `원`을 추가로 붙여 `₩10,000원`과 같이 이중 표기되던 문제를 수정했습니다.
- 영향 범위: 쿠폰 옵션 라벨(최대 할인금액, 정액 할인금액), 최소 주문금액 안내 문구 (총 3곳)

## Changes

- `src/components/checkout/CouponSelector.tsx`: `formatCurrency()` 호출 결과 뒤의 불필요한 `원` 제거 (3곳)

## Test plan

- [x] `npm run build` 통과
- [x] `npm run test:run` — 기존 pre-existing 실패(7건) 외 새로운 실패 없음
- [ ] 쿠폰 선택 화면에서 금액이 `₩10,000 할인` 형태로 단일 표기되는지 확인

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)