### PR TITLE
refactor: #221 OAuth 콜백 페이지 OAuthCallbackHandler 사용으로 중복 제거

### DIFF
--- a/src/app/[locale]/auth/google/callback/page.tsx
+++ b/src/app/[locale]/auth/google/callback/page.tsx
@@ -15,7 +15,7 @@ function GoogleCallbackFallback() {
 export default function GoogleCallbackPage() {
   return (
     <Suspense fallback={<GoogleCallbackFallback />}>
-      <OAuthCallbackHandler provider="google" apiMethod={(code) => authApi.googleCallback(code)} />
+      <OAuthCallbackHandler provider="google" apiMethod={authApi.googleCallback} />
     </Suspense>
   );
 }

--- a/src/app/[locale]/auth/kakao/callback/page.tsx
+++ b/src/app/[locale]/auth/kakao/callback/page.tsx
@@ -15,7 +15,7 @@ function KakaoCallbackFallback() {
 export default function KakaoCallbackPage() {
   return (
     <Suspense fallback={<KakaoCallbackFallback />}>
-      <OAuthCallbackHandler provider="kakao" apiMethod={(code) => authApi.kakaoCallback(code)} />
+      <OAuthCallbackHandler provider="kakao" apiMethod={authApi.kakaoCallback} />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Google/Kakao OAuth 콜백 페이지의 `apiMethod` prop에서 불필요한 래퍼 람다 제거
- `(code) => authApi.googleCallback(code)` → `authApi.googleCallback` (point-free 단순화)
- 두 콜백 페이지 모두 이미 `OAuthCallbackHandler`를 사용 중이며, 이번 PR로 마지막 중복 코드 제거

## Test plan
- [ ] Build: `npm run build` — compiled successfully (no errors)
- [ ] Tests: 321 passed (7 pre-existing failures in ProductGridBlock/BlockRenderer, unrelated to OAuth)
- [ ] Google OAuth 콜백 동작 확인
- [ ] Kakao OAuth 콜백 동작 확인

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)