### PR TITLE
perf: #224 Footer filter() 중복 제거, Recharts 콜백 메모이제이션

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -38,6 +38,7 @@ function renderNavLinks(items: NavigationItem[]) {
 export default function Footer() {
   const { items: footerItems } = useNavigation('footer');
   const hasCmsData = footerItems.length > 0;
+  const rootItems = hasCmsData ? footerItems.filter((item) => item.parent_id === null) : [];
 
   return (
     <footer className="bg-background border-t mt-auto">
@@ -47,7 +48,7 @@ export default function Footer() {
             <p className="text-sm font-medium text-foreground mb-4">고객센터</p>
             <nav className="flex flex-col gap-2">
               {hasCmsData
-                ? renderNavLinks(footerItems.filter((item) => item.parent_id === null).slice(0, 4))
+                ? renderNavLinks(rootItems.slice(0, 4))
                 : FALLBACK_LINKS.customerService.map((link) => (
                   <Link
                     key={link.id}
@@ -64,7 +65,7 @@ export default function Footer() {
             <p className="text-sm font-medium text-foreground mb-4">회사</p>
             <nav className="flex flex-col gap-2">
               {hasCmsData
-                ? renderNavLinks(footerItems.filter((item) => item.parent_id === null).slice(4, 6))
+                ? renderNavLinks(rootItems.slice(4, 6))
                 : FALLBACK_LINKS.company.map((link) => (
                   <Link
                     key={link.id}
@@ -81,7 +82,7 @@ export default function Footer() {
             <p className="text-sm font-medium text-foreground mb-4">쇼핑</p>
             <nav className="flex flex-col gap-2">
               {hasCmsData
-                ? renderNavLinks(footerItems.filter((item) => item.parent_id === null).slice(6, 10))
+                ? renderNavLinks(rootItems.slice(6, 10))
                 : FALLBACK_LINKS.shop.map((link) => (
                   <Link
                     key={link.id}

--- a/src/components/admin/DashboardCharts.tsx
+++ b/src/components/admin/DashboardCharts.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback } from 'react';
 import {
   LineChart,
   Line,
@@ -23,7 +24,20 @@ function formatDate(dateStr: string): string {
   return `${parts[1]}/${parts[2]}`;
 }
 
+function formatYAxisRevenue(value: number): string {
+  return formatCurrency(value, 'ko', { abbreviated: true });
+}
+
+function formatLabel(label: unknown): string {
+  return `날짜: ${String(label)}`;
+}
+
 export function RevenueLineChart({ data }: DashboardChartsProps) {
+  const formatTooltipRevenue = useCallback(
+    (value: unknown) => [formatCurrency(Number(value)), '매출'] as [string, string],
+    [],
+  );
+
   return (
     <div className="rounded-lg border p-4">
       <h3 className="mb-4 text-lg font-semibold">매출 추이</h3>
@@ -31,13 +45,10 @@ export function RevenueLineChart({ data }: DashboardChartsProps) {
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" tickFormatter={formatDate} fontSize={12} />
-          <YAxis tickFormatter={(value: number) => formatCurrency(value, 'ko', { abbreviated: true })} fontSize={12} />
+          <YAxis tickFormatter={formatYAxisRevenue} fontSize={12} />
           <Tooltip
-            formatter={(value) => [
-              formatCurrency(Number(value)),
-              '매출',
-            ]}
-            labelFormatter={(label) => `날짜: ${String(label)}`}
+            formatter={formatTooltipRevenue}
+            labelFormatter={formatLabel}
           />
           <Line
             type="monotone"
@@ -53,6 +64,11 @@ export function RevenueLineChart({ data }: DashboardChartsProps) {
 }
 
 export function OrderBarChart({ data }: DashboardChartsProps) {
+  const formatTooltipOrders = useCallback(
+    (value: unknown) => [`${Number(value)}건`, '주문 수'] as [string, string],
+    [],
+  );
+
   return (
     <div className="rounded-lg border p-4">
       <h3 className="mb-4 text-lg font-semibold">주문 수 추이</h3>
@@ -62,8 +78,8 @@ export function OrderBarChart({ data }: DashboardChartsProps) {
           <XAxis dataKey="date" tickFormatter={formatDate} fontSize={12} />
           <YAxis fontSize={12} />
           <Tooltip
-            formatter={(value) => [`${Number(value)}건`, '주문 수']}
-            labelFormatter={(label) => `날짜: ${String(label)}`}
+            formatter={formatTooltipOrders}
+            labelFormatter={formatLabel}
           />
           <Bar dataKey="order_count" fill="#3b82f6" radius={[4, 4, 0, 0]} />
         </BarChart>


### PR DESCRIPTION
## Summary
- `Footer.tsx`: `filter((item) => item.parent_id === null)` was called 3 times on the same array. Computed once into `rootItems` and sliced per section.
- `DashboardCharts.tsx`: Inline arrow functions in `Tooltip` `formatter` and `labelFormatter` props created new function references on every render. Extracted `YAxis` formatter to a module-level function and `Tooltip` formatters to `useCallback` hooks.

## Test plan
- [x] `npm run build` — passes with no errors
- [x] `npm run test:run` — 321 passed (7 pre-existing failures unrelated to this change)
- [x] Footer renders same nav links as before (logic unchanged, only filter deduplication)
- [x] Dashboard charts render correctly (callbacks stabilized, no behavior change)

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)