### PR TITLE
[Frontend] #234 upload.ts ApiClient.uploadFile() 사용으로 전환

### DIFF
--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -1,31 +1,7 @@
+import { uploadApi, reviewsApi } from '@/lib/api';
 
+export type { UploadedFile } from '@/lib/api';
 
-export interface UploadedFile {
-  id: number;
-  url: string;
-  filename: string;
-  mimeType: string;
-  size: number;
-}
+export const uploadImage = uploadApi.uploadImage;
 
-async function uploadToEndpoint(endpoint: string, file: File): Promise<UploadedFile> {
-  const url = `/api${endpoint}`;
-  const formData = new FormData();
-  formData.append('file', file);
-  const response = await fetch(url, {
-    method: 'POST',
-    credentials: 'include',
-    body: formData,
-  });
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: 'An error occurred' }));
-    throw new Error((error as { message?: string }).message || `HTTP ${response.status}`);
-  }
-  return response.json() as Promise<UploadedFile>;
-}
-
-export const uploadImage = (file: File): Promise<UploadedFile> =>
-  uploadToEndpoint('/upload/image', file);
-
-export const uploadReviewImage = (file: File): Promise<UploadedFile> =>
-  uploadToEndpoint('/reviews/upload-image', file);
+export const uploadReviewImage = reviewsApi.uploadImage;


### PR DESCRIPTION
## Summary
- `src/utils/upload.ts`에서 raw `fetch()` 직접 호출을 제거하고 `ApiClient.uploadFile()`을 사용하도록 전환
- `uploadImage`는 `uploadApi.uploadImage`, `uploadReviewImage`는 `reviewsApi.uploadImage`로 위임
- `UploadedFile` 인터페이스 중복 정의 제거 — `@/lib/api`에서 re-export

## Test plan
- [x] `npm run build` — 빌드 성공
- [x] `npm run test:run` — 기존 통과 테스트 321개 모두 통과 (3개 파일 7개 실패는 main 브랜치에서도 동일하게 존재하는 pre-existing 실패)

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)