### PR TITLE
refactor: #216 주문 상태 레이블/색상 상수 통합

### DIFF
--- a/src/app/[locale]/my/orders/[id]/page.tsx
+++ b/src/app/[locale]/my/orders/[id]/page.tsx
@@ -8,7 +8,7 @@ import type { OrderResponse } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
-import { ORDER_STATUS_LABELS } from '@/constants/orderStatus';
+import { ORDER_STATUS_LABELS } from '@/constants/status';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import ShippingTimeline from '@/components/ShippingTimeline';
 

--- a/src/app/[locale]/my/page.tsx
+++ b/src/app/[locale]/my/page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
-import { ORDER_STATUS_LABELS } from '@/constants/orderStatus';
+import { ORDER_STATUS_LABELS } from '@/constants/status';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { formatCurrency } from '@/utils/currency';
 

--- a/src/components/common/StatusBadge.tsx
+++ b/src/components/common/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import { ORDER_STATUS_LABELS, ORDER_STATUS_COLORS } from '@/constants/orderStatus';
+import { ORDER_STATUS_LABELS, ORDER_STATUS_COLORS } from '@/constants/status';
 
 interface StatusBadgeProps {
   status: string;

--- a/src/constants/orderStatus.ts
+++ b/src/constants/orderStatus.ts
@@ -1,1 +1,0 @@
-export { ORDER_STATUS_LABELS, ORDER_STATUS_COLORS } from './status';


### PR DESCRIPTION
## Summary

- `src/constants/orderStatus.ts` (재export 배럴) 제거
- `src/app/[locale]/my/orders/[id]/page.tsx`, `src/app/[locale]/my/page.tsx`, `src/components/common/StatusBadge.tsx`의 import를 `@/constants/orderStatus` → `@/constants/status`로 통합
- 이미 `@/constants/status`를 사용하던 `AdminOrdersTable`, `OrderStatusSelect`, `dashboard/page.tsx`와 일관성 확보

## Test plan

- [ ] `npm run build` — TypeScript 컴파일 통과 확인
- [ ] `npm run test:run` — 기존 통과 테스트 321개 유지 확인 (실패 7개는 pre-existing)
- [ ] 주문 목록 페이지(`/my`, `/my/orders/[id]`) 상태 레이블 정상 표시 확인
- [ ] 관리자 주문 테이블 상태 배지 정상 표시 확인

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)