### PR TITLE
perf: #236 fetchProduct cache 키 통일로 이중 호출 제거

### DIFF
--- a/src/app/[locale]/products/[id]/page.tsx
+++ b/src/app/[locale]/products/[id]/page.tsx
@@ -14,7 +14,7 @@ interface ProductDetailProps {
 export async function generateMetadata({ params }: ProductDetailProps): Promise<Metadata> {
   const { id, locale } = await params
   const safeLocale = routing.locales.includes(locale as Locale) ? (locale as Locale) : routing.defaultLocale;
-  const product = await fetchProduct(Number(id))
+  const product = await fetchProduct(Number(id), safeLocale)
   if (!product) return { title: '상품을 찾을 수 없습니다' }
 
   const imageUrl = product.images?.[0]?.url ?? '';


### PR DESCRIPTION
## Summary

- `generateMetadata`에서 `fetchProduct(Number(id))` 호출 시 `locale` 인수가 누락되어 React `cache()`의 캐시 키가 `ProductDetailPage`의 `fetchProduct(Number(id), safeLocale)` 호출과 불일치
- 동일 상품 페이지 렌더링 시 같은 데이터에 대해 API가 두 번 호출되던 성능 문제 수정
- `generateMetadata`에도 `safeLocale`을 전달하여 두 호출의 캐시 키를 통일, React `cache()`가 정상적으로 요청을 deduplication하도록 개선

## Test plan

- [ ] 상품 상세 페이지 접속 시 `/products/:id` API 호출이 1회만 발생하는지 확인
- [ ] `generateMetadata`가 올바른 locale 기반 메타데이터를 반환하는지 확인
- [ ] `npm run build && npm run test:run` 통과 확인

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)