### PR TITLE
refactor: #231 categories/AdminMembersTable StatusBadge 컴포넌트 사용

### DIFF
--- a/src/app/[locale]/admin/categories/page.tsx
+++ b/src/app/[locale]/admin/categories/page.tsx
@@ -9,6 +9,7 @@ import { useAsyncAction } from '@/hooks/useAsyncAction';
 import CategoryFormModal from '@/components/admin/CategoryFormModal';
 import { ChevronRight, ChevronDown, GripVertical } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
+import { StatusBadge } from '@/components/admin/StatusBadge';
 import {
   DndContext,
   DragOverlay,
@@ -140,15 +141,7 @@ function SortableCategoryRow({
       </td>
       <td className="px-4 py-3 text-muted-foreground">{category.slug}</td>
       <td className="px-4 py-3">
-        <span
-          className={`rounded-full px-2 py-0.5 text-xs ${
-            category.isActive
-              ? 'bg-green-100 text-green-700'
-              : 'bg-secondary text-muted-foreground'
-          }`}
-        >
-          {category.isActive ? '활성' : '비활성'}
-        </span>
+        <StatusBadge isActive={category.isActive} />
       </td>
       <td className="px-4 py-3">
         <div className="flex items-center justify-center gap-1">
@@ -458,15 +451,7 @@ export default function AdminCategoriesPage() {
                 <td className="px-4 py-3 font-medium">{activeCategory.name}</td>
                 <td className="px-4 py-3 text-muted-foreground">{activeCategory.slug}</td>
                 <td className="px-4 py-3">
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs ${
-                      activeCategory.isActive
-                        ? 'bg-green-100 text-green-700'
-                        : 'bg-secondary text-muted-foreground'
-                    }`}
-                  >
-                    {activeCategory.isActive ? '활성' : '비활성'}
-                  </span>
+                  <StatusBadge isActive={activeCategory.isActive} />
                 </td>
                 <td className="px-4 py-3"></td>
                 <td className="px-4 py-3 text-right"></td>

--- a/src/components/admin/AdminMembersTable.tsx
+++ b/src/components/admin/AdminMembersTable.tsx
@@ -2,6 +2,7 @@
 
 import type { AdminMember } from '@/lib/api';
 import { MemberRoleSelect } from './MemberRoleSelect';
+import { StatusBadge } from './StatusBadge';
 
 const ROLE_LABELS: Record<string, string> = {
   user: '일반회원',
@@ -47,15 +48,7 @@ export function AdminMembersTable({ members, onRoleChange }: AdminMembersTablePr
                 </span>
               </td>
               <td className="px-4 py-3">
-                <span
-                  className={`rounded-full px-2 py-0.5 text-xs ${
-                    member.isActive
-                      ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
-                      : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
-                  }`}
-                >
-                  {member.isActive ? '활성' : '비활성'}
-                </span>
+                <StatusBadge isActive={member.isActive} />
               </td>
               <td className="px-4 py-3 text-muted-foreground">
                 {new Date(member.createdAt).toLocaleDateString('ko-KR')}

--- a/src/components/admin/StatusBadge.tsx
+++ b/src/components/admin/StatusBadge.tsx
@@ -4,7 +4,13 @@ interface StatusBadgeProps {
 
 export function StatusBadge({ isActive }: StatusBadgeProps) {
   return (
-    <span className={isActive ? 'text-green-600' : 'text-muted-foreground'}>
+    <span
+      className={`rounded-full px-2 py-0.5 text-xs ${
+        isActive
+          ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+          : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
+      }`}
+    >
       {isActive ? '활성' : '비활성'}
     </span>
   );


### PR DESCRIPTION
## Summary
- `AdminMembersTable`: 인라인 활성/비활성 뱃지 span을 `StatusBadge` 컴포넌트로 교체
- `categories/page.tsx`: `SortableCategoryRow` 및 `DragOverlay` 두 곳의 인라인 뱃지를 `StatusBadge` 컴포넌트로 교체
- `StatusBadge` 컴포넌트 스타일을 실제 사용 패턴(pill 형태 + 배경색)에 맞게 통일 (dark mode 지원 포함)

## Test plan
- [ ] 빌드 통과 확인 (`npm run build` — TypeScript/lint 단계 오류 없음)
- [ ] 테스트 통과 확인 (`npm run test:run` — 실패 7건은 main 브랜치 동일 pre-existing 실패)
- [ ] 관리자 카테고리 페이지에서 활성/비활성 뱃지 렌더링 확인
- [ ] 관리자 회원 목록 테이블에서 활성/비활성 뱃지 렌더링 확인
- [ ] 카테고리 DnD drag overlay에서 뱃지 렌더링 확인

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)