### PR TITLE
refactor: #213 어드민 Pagination 공통 컴포넌트 추출

### DIFF
--- a/src/app/[locale]/admin/members/page.tsx
+++ b/src/app/[locale]/admin/members/page.tsx
@@ -5,6 +5,7 @@ import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { adminMembersApi } from '@/lib/api';
 import type { AdminMember } from '@/lib/api';
 import { AdminMembersTable } from '@/components/admin/AdminMembersTable';
+import AdminPagination from '@/components/admin/AdminPagination';
 
 const ROLE_FILTERS = [
   { label: '전체', value: '' },
@@ -134,21 +135,7 @@ export default function AdminMembersPage() {
       )}
 
       {/* 페이지네이션 */}
-      {totalPages > 1 && (
-        <div className="mt-4 flex justify-center gap-2">
-          {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
-            <button
-              key={p}
-              onClick={() => setPage(p)}
-              className={`rounded px-3 py-1 text-sm ${
-                page === p ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
-              }`}
-            >
-              {p}
-            </button>
-          ))}
-        </div>
-      )}
+      <AdminPagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
     </div>
   );
 }

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -6,6 +6,7 @@ import { adminOrdersApi } from '@/lib/api';
 import type { AdminOrder } from '@/lib/api';
 import { AdminOrdersTable } from '@/components/admin/AdminOrdersTable';
 import { ShippingModal } from '@/components/admin/ShippingModal';
+import AdminPagination from '@/components/admin/AdminPagination';
 
 const STATUS_FILTERS = [
   { label: '전체', value: '' },
@@ -144,21 +145,7 @@ export default function AdminOrdersPage() {
       )}
 
       {/* 페이지네이션 */}
-      {totalPages > 1 && (
-        <div className="mt-4 flex justify-center gap-2">
-          {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
-            <button
-              key={p}
-              onClick={() => setPage(p)}
-              className={`rounded px-3 py-1 text-sm ${
-                page === p ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
-              }`}
-            >
-              {p}
-            </button>
-          ))}
-        </div>
-      )}
+      <AdminPagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
 
       {/* 운송장 등록 모달 */}
       {shippingOrder && (

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -7,6 +7,7 @@ import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { adminProductsApi } from '@/lib/api';
 import type { Product } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
+import AdminPagination from '@/components/admin/AdminPagination';
 
 const STATUS_LABELS: Record<string, string> = {
   draft: '임시저장',
@@ -174,21 +175,7 @@ export default function AdminProductsPage() {
       )}
 
       {/* 페이지네이션 */}
-      {totalPages > 1 && (
-        <div className="mt-4 flex justify-center gap-2">
-          {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
-            <button
-              key={p}
-              onClick={() => setPage(p)}
-              className={`rounded px-3 py-1 text-sm ${
-                page === p ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
-              }`}
-            >
-              {p}
-            </button>
-          ))}
-        </div>
-      )}
+      <AdminPagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
     </div>
   );
 }

--- a/src/components/admin/AdminPagination.tsx
+++ b/src/components/admin/AdminPagination.tsx
@@ -1,0 +1,29 @@
+interface AdminPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function AdminPagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: AdminPaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="mt-4 flex justify-center gap-2">
+      {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+        <button
+          key={p}
+          onClick={() => onPageChange(p)}
+          className={`rounded px-3 py-1 text-sm ${
+            currentPage === p ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
+          }`}
+        >
+          {p}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- 어드민 3개 페이지(products, members, orders)에 복사-붙여넣기된 페이지네이션 UI를 `AdminPagination` 공통 컴포넌트로 추출
- `src/components/admin/AdminPagination.tsx` 신규 생성 — `currentPage`, `totalPages`, `onPageChange` props 수용
- 3개 페이지의 인라인 pagination JSX(15줄 × 3) 제거 후 단일 컴포넌트 호출로 대체

## Test plan

- [ ] `npm run build` 성공 확인
- [ ] `npm run test:run` — 기존 실패 테스트(7개, pre-existing) 외 새로운 실패 없음 확인
- [ ] 어드민 상품/회원/주문 페이지에서 페이지네이션 동작 확인

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)