### PR TITLE
fix: #212 #233 어드민 4개 페이지 useAdminGuard 적용

### DIFF
--- a/src/app/[locale]/admin/members/page.tsx
+++ b/src/app/[locale]/admin/members/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 import { adminMembersApi } from '@/lib/api';
 import type { AdminMember } from '@/lib/api';
 import { AdminMembersTable } from '@/components/admin/AdminMembersTable';
@@ -23,6 +24,7 @@ const STATUS_FILTERS = [
 const PAGE_SIZE = 20;
 
 export default function AdminMembersPage() {
+  const { isAdmin } = useAdminGuard();
   const [members, setMembers] = useState<AdminMember[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -49,9 +51,9 @@ export default function AdminMembersPage() {
   );
 
   useEffect(() => {
-    void fetchMembers();
+    if (isAdmin) void fetchMembers();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, roleFilter, statusFilter, keyword]);
+  }, [isAdmin, page, roleFilter, statusFilter, keyword]);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 import { adminOrdersApi } from '@/lib/api';
 import type { AdminOrder } from '@/lib/api';
 import { AdminOrdersTable } from '@/components/admin/AdminOrdersTable';
@@ -22,6 +23,7 @@ const STATUS_FILTERS = [
 const PAGE_SIZE = 20;
 
 export default function AdminOrdersPage() {
+  const { isAdmin } = useAdminGuard();
   const [orders, setOrders] = useState<AdminOrder[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -51,9 +53,9 @@ export default function AdminOrdersPage() {
   );
 
   useEffect(() => {
-    void fetchOrders();
+    if (isAdmin) void fetchOrders();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, statusFilter, keyword, startDate, endDate]);
+  }, [isAdmin, page, statusFilter, keyword, startDate, endDate]);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/app/[locale]/admin/pages/page.tsx
+++ b/src/app/[locale]/admin/pages/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useReducer } from 'react';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 import { adminPagesApi } from '@/lib/api';
 import type { Page } from '@/lib/api';
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges';
@@ -15,6 +16,7 @@ import BlockPropertyPanel from '@/components/admin/page-editor/BlockPropertyPane
 import PreviewModal from '@/components/admin/page-editor/PreviewModal';
 
 export default function AdminPagesPage() {
+  const { isLoading: authLoading, isAdmin } = useAdminGuard();
   const [pages, setPages] = useState<Page[]>([]);
   const [selectedPage, setSelectedPage] = useState<Page | null>(null);
   const [selectedBlockId, setSelectedBlockId] = useState<number | null>(null);
@@ -40,8 +42,8 @@ export default function AdminPagesPage() {
   );
 
   useEffect(() => {
-    void loadPages();
-  }, [loadPages]);
+    if (isAdmin) void loadPages();
+  }, [isAdmin, loadPages]);
 
   const { handleSelectPage, handleCreatePage, handleDeletePage, handleTogglePublish, handleSave } =
     usePageEditor({
@@ -56,7 +58,7 @@ export default function AdminPagesPage() {
 
   const selectedBlock = draft.blocks.find((b) => b.id === selectedBlockId) ?? null;
 
-  if (loading) {
+  if (authLoading || loading) {
     return (
       <div className="flex h-full items-center justify-center">
         <span className="text-sm text-muted-foreground">로딩 중...</span>

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { toast } from 'sonner';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 import { adminProductsApi } from '@/lib/api';
 import type { Product } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
@@ -19,6 +20,7 @@ const STATUS_LABELS: Record<string, string> = {
 const PAGE_SIZE = 20;
 
 export default function AdminProductsPage() {
+  const { isAdmin } = useAdminGuard();
   const [products, setProducts] = useState<Product[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -39,8 +41,8 @@ export default function AdminProductsPage() {
   );
 
   useEffect(() => {
-    void fetchProducts();
-  }, [page, statusFilter, fetchProducts]);
+    if (isAdmin) void fetchProducts();
+  }, [isAdmin, page, statusFilter, fetchProducts]);
 
   const { execute: toggleStatus } = useAsyncAction(
     async (product: Product) => {


### PR DESCRIPTION
## Summary
- Closes #212
- Closes #233
- products, orders, members, pages 어드민 페이지에 useAdminGuard 적용
- isAdmin 플래그로 데이터 로딩 게이트 추가

## Test plan
- [x] npm run build
- [x] npm run test:run