### PR TITLE
refactor: #207 수동 loading 상태를 useAsyncAction 훅으로 전환

### DIFF
--- a/src/app/[locale]/admin/products/[id]/edit/page.tsx
+++ b/src/app/[locale]/admin/products/[id]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { productsApi } from '@/lib/api';
 import type { ProductDetail } from '@/lib/api';
 import ProductFormPage from '@/components/admin/ProductFormPage';
@@ -9,22 +10,24 @@ import ProductFormPage from '@/components/admin/ProductFormPage';
 export default function AdminProductEditPage() {
   const params = useParams();
   const [product, setProduct] = useState<ProductDetail | null>(null);
-  const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
 
+  const { execute: loadProduct, isLoading: loading } = useAsyncAction(
+    async () => {
+      const id = Number(params.id);
+      if (isNaN(id)) {
+        setNotFound(true);
+        return;
+      }
+      const p = await productsApi.getById(id);
+      setProduct(p);
+    },
+    { onError: () => setNotFound(true), errorMessage: '상품을 불러오지 못했습니다.' },
+  );
+
   useEffect(() => {
-    const id = Number(params.id);
-    if (isNaN(id)) {
-      setNotFound(true);
-      setLoading(false);
-      return;
-    }
-    productsApi
-      .getById(id)
-      .then((p) => setProduct(p))
-      .catch(() => setNotFound(true))
-      .finally(() => setLoading(false));
-  }, [params.id]);
+    void loadProduct();
+  }, [loadProduct]);
 
   if (loading) {
     return (

--- a/src/components/checkout/CouponSelector.tsx
+++ b/src/components/checkout/CouponSelector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { couponsApi } from '@/lib/api';
 import type { CouponItem, CalculateDiscountResponse } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
@@ -16,19 +17,19 @@ interface CouponSelectorProps {
 export default function CouponSelector({ orderAmount, onDiscountChange }: CouponSelectorProps) {
   const [coupons, setCoupons] = useState<CouponItem[]>([]);
   const [selectedId, setSelectedId] = useState<number | ''>('');
-  const [loading, setLoading] = useState(true);
   const [calculating, setCalculating] = useState(false);
 
+  const { execute: loadCoupons, isLoading: loading } = useAsyncAction(
+    async () => {
+      const res = await couponsApi.getList('available');
+      setCoupons(res.coupons);
+    },
+    { onError: () => setCoupons([]), errorMessage: '쿠폰 목록을 불러오지 못했습니다.' },
+  );
+
   useEffect(() => {
-    couponsApi
-      .getList('available')
-      .then((res) => setCoupons(res.coupons))
-      .catch((err) => {
-        setCoupons([]);
-        toast.error(handleApiError(err, '쿠폰 목록을 불러오지 못했습니다.'));
-      })
-      .finally(() => setLoading(false));
-  }, []);
+    void loadCoupons();
+  }, [loadCoupons]);
 
   const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const val = e.target.value;

--- a/src/components/checkout/PointInput.tsx
+++ b/src/components/checkout/PointInput.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { couponsApi } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import { cn } from '@/components/ui/utils';
@@ -12,15 +13,18 @@ interface PointInputProps {
 export default function PointInput({ onPointsChange }: PointInputProps) {
   const [balance, setBalance] = useState(0);
   const [value, setValue] = useState('');
-  const [loading, setLoading] = useState(true);
+
+  const { execute: loadPoints, isLoading: loading } = useAsyncAction(
+    async () => {
+      const res = await couponsApi.getPoints();
+      setBalance(res.balance);
+    },
+    { onError: () => setBalance(0), errorMessage: '적립금을 불러오지 못했습니다.' },
+  );
 
   useEffect(() => {
-    couponsApi
-      .getPoints()
-      .then((res) => setBalance(res.balance))
-      .catch(() => setBalance(0))
-      .finally(() => setLoading(false));
-  }, []);
+    void loadPoints();
+  }, [loadPoints]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value.replace(/\D/g, '');


### PR DESCRIPTION
## Summary
- Closes #207
- PointInput, CouponSelector, AdminProductEditPage에서 수동 useState(loading) + try/catch/finally 패턴을 useAsyncAction 훅으로 전환

## Test plan
- [x] npm run build
- [x] npm run test:run