### PR TITLE
feat: #202 어드민 카테고리 드래그 순서 조정

### DIFF
--- a/src/app/[locale]/admin/categories/page.tsx
+++ b/src/app/[locale]/admin/categories/page.tsx
@@ -7,8 +7,9 @@ import type { AdminCategory, CreateCategoryData } from '@/lib/api';
 import { useAdminGuard } from '@/hooks/useAdminGuard';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
 import CategoryFormModal from '@/components/admin/CategoryFormModal';
-import { ChevronRight, ChevronDown, GripVertical } from 'lucide-react';
-import { cn } from '@/components/ui/utils';
+import { GripVertical } from 'lucide-react';
+import { StatusBadge } from '@/components/admin/StatusBadge';
+import { SortableCategoryRow } from '@/components/admin/SortableCategoryRow';
 import {
   DndContext,
   DragOverlay,
@@ -24,9 +25,7 @@ import {
   SortableContext,
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
-  useSortable,
 } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
 
 interface FlattenedCategory extends AdminCategory {
   depth: number;
@@ -36,14 +35,15 @@ function flattenCategories(
   categories: AdminCategory[],
   parentId: number | null = null,
   depth = 0,
+  expandedIds: Set<number> = new Set(),
 ): FlattenedCategory[] {
   const result: FlattenedCategory[] = [];
   const roots = categories.filter((c) => c.parentId === parentId);
 
   for (const cat of roots) {
     result.push({ ...cat, depth });
-    if (cat.children && cat.children.length > 0) {
-      result.push(...flattenCategories(cat.children, cat.id, depth + 1));
+    if (cat.children && cat.children.length > 0 && expandedIds.has(cat.id)) {
+      result.push(...flattenCategories(cat.children, cat.id, depth + 1, expandedIds));
     }
   }
 
@@ -57,138 +57,6 @@ function getSiblings(category: AdminCategory, list: AdminCategory[]): AdminCateg
   return list.filter((c) => c.parentId === category.parentId);
 }
 
-interface SortableCategoryRowProps {
-  category: AdminCategory;
-  categories: AdminCategory[];
-  expandedIds: Set<number>;
-  onToggleExpand: (id: number) => void;
-  onEdit: (category: AdminCategory) => void;
-  onDelete: (category: AdminCategory) => void;
-  onMoveUp: (category: AdminCategory) => void;
-  onMoveDown: (category: AdminCategory) => void;
-  getSiblings: (category: AdminCategory, list: AdminCategory[]) => AdminCategory[];
-  isDraggable: boolean;
-}
-
-function SortableCategoryRow({
-  category,
-  categories,
-  expandedIds,
-  onToggleExpand,
-  onEdit,
-  onDelete,
-  onMoveUp,
-  onMoveDown,
-  getSiblings,
-  isDraggable,
-}: SortableCategoryRowProps) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: category.id, disabled: !isDraggable });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  };
-
-  const hasChildren = category.children && category.children.length > 0;
-  const isExpanded = expandedIds.has(category.id);
-  const siblings = getSiblings(category, categories);
-  const index = siblings.findIndex((s) => s.id === category.id);
-  const isFirst = index === 0;
-  const isLast = index === siblings.length - 1;
-
-  return (
-    <tr ref={setNodeRef} style={style} className="hover:bg-secondary/30">
-      <td className="px-4 py-3">
-        <div className="flex items-center gap-1">
-          {isDraggable && (
-            <button
-              {...attributes}
-              {...listeners}
-              className="cursor-grab touch-none rounded p-1 hover:bg-muted active:cursor-grabbing"
-            >
-              <GripVertical className="h-4 w-4 text-muted-foreground" />
-            </button>
-          )}
-          {hasChildren ? (
-            <button
-              onClick={() => onToggleExpand(category.id)}
-              className="rounded p-1 hover:bg-muted"
-            >
-              {isExpanded ? (
-                <ChevronDown className="h-4 w-4" />
-              ) : (
-                <ChevronRight className="h-4 w-4" />
-              )}
-            </button>
-          ) : (
-            <span className="w-6" />
-          )}
-        </div>
-      </td>
-      <td className="px-4 py-3 text-muted-foreground">{category.id}</td>
-      <td className={cn('px-4 py-3 font-medium')}>
-        {category.name}
-      </td>
-      <td className="px-4 py-3 text-muted-foreground">{category.slug}</td>
-      <td className="px-4 py-3">
-        <span
-          className={`rounded-full px-2 py-0.5 text-xs ${
-            category.isActive
-              ? 'bg-green-100 text-green-700'
-              : 'bg-secondary text-muted-foreground'
-          }`}
-        >
-          {category.isActive ? '활성' : '비활성'}
-        </span>
-      </td>
-      <td className="px-4 py-3">
-        <div className="flex items-center justify-center gap-1">
-          <button
-            onClick={() => void onMoveUp(category)}
-            disabled={isFirst}
-            aria-label="위로 이동"
-            className="rounded px-2 py-1 text-xs hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
-          >
-            ↑
-          </button>
-          <span className="text-xs text-muted-foreground">{index + 1}</span>
-          <button
-            onClick={() => void onMoveDown(category)}
-            disabled={isLast}
-            aria-label="아래로 이동"
-            className="rounded px-2 py-1 text-xs hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
-          >
-            ↓
-          </button>
-        </div>
-      </td>
-      <td className="px-4 py-3 text-right">
-        <div className="flex justify-end gap-2">
-          <button
-            onClick={() => onEdit(category)}
-            className="rounded border px-2 py-1 text-xs hover:bg-secondary"
-          >
-            수정
-          </button>
-          <button
-            onClick={() => onDelete(category)}
-            className="rounded border border-destructive/30 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
-          >
-            삭제
-          </button>
-        </div>
-      </td>
-    </tr>
-  );
-}
 
 export default function AdminCategoriesPage() {
   const { isLoading: authLoading, isAdmin } = useAdminGuard();
@@ -304,7 +172,7 @@ export default function AdminCategoriesPage() {
   );
 
   const rootCategories = categories.filter((c) => c.parentId === null);
-  const flattenedRootCategories = flattenCategories(rootCategories, null, 0);
+  const flattenedRootCategories = flattenCategories(rootCategories, null, 0, expandedIds);
   const rootCategoryIds = flattenedRootCategories.map((c) => c.id);
 
   const findCategoryById = (id: number): AdminCategory | undefined => {
@@ -437,6 +305,14 @@ export default function AdminCategoriesPage() {
         )}
       </div>
 
+      <CategoryFormModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        initial={editTarget}
+        onSubmit={handleSubmit}
+        categories={categories}
+      />
+
       <DragOverlay>
         {activeCategory ? (
           <table className="w-full text-sm">
@@ -449,15 +325,7 @@ export default function AdminCategoriesPage() {
                 <td className="px-4 py-3 font-medium">{activeCategory.name}</td>
                 <td className="px-4 py-3 text-muted-foreground">{activeCategory.slug}</td>
                 <td className="px-4 py-3">
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs ${
-                      activeCategory.isActive
-                        ? 'bg-green-100 text-green-700'
-                        : 'bg-secondary text-muted-foreground'
-                    }`}
-                  >
-                    {activeCategory.isActive ? '활성' : '비활성'}
-                  </span>
+                  <StatusBadge isActive={activeCategory.isActive} />
                 </td>
                 <td className="px-4 py-3"></td>
                 <td className="px-4 py-3 text-right"></td>

--- a/src/components/admin/SortableCategoryRow.tsx
+++ b/src/components/admin/SortableCategoryRow.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { ChevronRight, ChevronDown, GripVertical } from 'lucide-react';
+import { CSS } from '@dnd-kit/utilities';
+import { useSortable } from '@dnd-kit/sortable';
+import type { AdminCategory } from '@/lib/api';
+import { cn } from '@/components/ui/utils';
+import { StatusBadge } from '@/components/admin/StatusBadge';
+
+export interface SortableCategoryRowProps {
+  category: AdminCategory;
+  categories: AdminCategory[];
+  expandedIds: Set<number>;
+  onToggleExpand: (id: number) => void;
+  onEdit: (category: AdminCategory) => void;
+  onDelete: (category: AdminCategory) => void;
+  onMoveUp: (category: AdminCategory) => void;
+  onMoveDown: (category: AdminCategory) => void;
+  getSiblings: (category: AdminCategory, list: AdminCategory[]) => AdminCategory[];
+  isDraggable: boolean;
+}
+
+export function SortableCategoryRow({
+  category,
+  categories,
+  expandedIds,
+  onToggleExpand,
+  onEdit,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  getSiblings,
+  isDraggable,
+}: SortableCategoryRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: category.id, disabled: !isDraggable });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const hasChildren = category.children && category.children.length > 0;
+  const isExpanded = expandedIds.has(category.id);
+  const siblings = getSiblings(category, categories);
+  const index = siblings.findIndex((s) => s.id === category.id);
+  const isFirst = index === 0;
+  const isLast = index === siblings.length - 1;
+
+  return (
+    <tr ref={setNodeRef} style={style} className="hover:bg-secondary/30">
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-1">
+          {isDraggable && (
+            <button
+              {...attributes}
+              {...listeners}
+              className="cursor-grab touch-none rounded p-1 hover:bg-muted active:cursor-grabbing"
+            >
+              <GripVertical className="h-4 w-4 text-muted-foreground" />
+            </button>
+          )}
+          {hasChildren ? (
+            <button
+              onClick={() => onToggleExpand(category.id)}
+              className="rounded p-1 hover:bg-muted"
+            >
+              {isExpanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+            </button>
+          ) : (
+            <span className="w-6" />
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">{category.id}</td>
+      <td className={cn('px-4 py-3 font-medium')}>
+        {category.name}
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">{category.slug}</td>
+      <td className="px-4 py-3">
+        <StatusBadge isActive={category.isActive} />
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center justify-center gap-1">
+          <button
+            onClick={() => void onMoveUp(category)}
+            disabled={isFirst}
+            aria-label="위로 이동"
+            className="rounded px-2 py-1 text-xs hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            ↑
+          </button>
+          <span className="text-xs text-muted-foreground">{index + 1}</span>
+          <button
+            onClick={() => void onMoveDown(category)}
+            disabled={isLast}
+            aria-label="아래로 이동"
+            className="rounded px-2 py-1 text-xs hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            ↓
+          </button>
+        </div>
+      </td>
+      <td className="px-4 py-3 text-right">
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={() => onEdit(category)}
+            className="rounded border px-2 py-1 text-xs hover:bg-secondary"
+          >
+            수정
+          </button>
+          <button
+            onClick={() => onDelete(category)}
+            className="rounded border border-destructive/30 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+          >
+            삭제
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
## Summary

- `@dnd-kit/core` + `@dnd-kit/sortable`를 사용해 카테고리 테이블에 드래그 앤 드롭 순서 조정 기능 추가
- 루트 카테고리만 드래그 가능 (같은 레벨 형제 간 순서 변경만 허용)
- 드롭 시 `PATCH /api/categories/reorder` API 호출 (`ReorderCategoriesDto` 포맷 준수)
- `SortableCategoryRow` 컴포넌트를 분리해 재사용성과 가독성 향상
- 드래그 중 시각적 피드백 제공 (투명도 변경, DragOverlay 섀도우 효과)
- 기존 위/아래 버튼 방식은 유지하여 서브 카테고리도 순서 조정 가능

Closes #202

## Test plan

- [ ] 어드민 카테고리 페이지 접속 확인
- [ ] 루트 카테고리 드래그 핸들(⠿ 아이콘)로 드래그하여 순서 변경 확인
- [ ] 드래그 중 DragOverlay 섀도우 시각적 피드백 확인
- [ ] 드롭 후 순서가 저장되고 새로고침해도 유지되는지 확인
- [ ] 다른 레벨 카테고리 간 드래그 시 에러 토스트 표시 확인
- [ ] 서브 카테고리는 ↑/↓ 버튼으로 순서 변경 확인
- [ ] 카테고리 추가/수정/삭제 기존 기능 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)