### PR TITLE
feat: #172 스크롤 로고 전환 애니메이션 (히어로 → 헤더)

### DIFF
--- a/src/hooks/useScrollLogoTransition.ts
+++ b/src/hooks/useScrollLogoTransition.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 interface ScrollLogoState {
   progress: number;
@@ -13,61 +13,95 @@ interface UseScrollLogoTransitionOptions {
   heroRef: React.RefObject<HTMLElement | null>;
 }
 
+interface CachedHeroRect {
+  top: number;
+  left: number;
+  height: number;
+}
+
+const lerp = (start: number, end: number, t: number) => start + (end - start) * t;
+
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+
 export function useScrollLogoTransition({
   heroRef,
 }: UseScrollLogoTransitionOptions): ScrollLogoState {
   const [progress, setProgress] = useState(0);
+  // State-based cache triggers re-render when initial rect is measured
+  const [cachedRect, setCachedRect] = useState<CachedHeroRect | null>(null);
   const rafRef = useRef<number | null>(null);
 
-  const lerp = (start: number, end: number, t: number) => start + (end - start) * t;
+  // Measure hero rect on mount and on resize — never inside scroll or render
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
 
-  const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+    const measureRect = () => {
+      const heroEl = heroRef.current;
+      if (!heroEl) return;
+      const rect = heroEl.getBoundingClientRect();
+      setCachedRect({
+        top: rect.top + window.scrollY,
+        left: rect.left,
+        height: rect.height,
+      });
+    };
 
-  const calculateTransforms = useCallback(
-    (scrollProgress: number) => {
-      const heroRect = heroRef.current?.getBoundingClientRect();
-      if (!heroRect) {
-        return {
-          progress: scrollProgress,
-          isHeroVisible: scrollProgress < 1,
-          heroLogoStyle: { opacity: Math.max(0, 1 - scrollProgress) },
-          headerLogoStyle: { opacity: Math.min(1, scrollProgress) },
-        };
-      }
+    measureRect();
 
-      const headerHeight = 56;
-      const heroStartTop = heroRect.top;
-      const heroStartLeft = heroRect.left;
-      const heroStartScale = 1.2;
-      const heroStartFontSize = 24;
-      const headerFontSize = 20;
+    const resizeObserver = new ResizeObserver(measureRect);
+    if (heroRef.current) {
+      resizeObserver.observe(heroRef.current);
+    }
 
-      const p = easeOutCubic(scrollProgress);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [heroRef]);
 
-      const currentTop = lerp(heroStartTop, headerHeight / 2 - 10, p);
-      const currentLeft = lerp(heroStartLeft, 16, p);
-      const currentScale = lerp(heroStartScale, 1, p);
-      const currentFontSize = lerp(heroStartFontSize, headerFontSize, p);
-
-      const heroOpacity = scrollProgress < 0.1 ? 1 : Math.max(0, 1 - (scrollProgress - 0.1) / 0.4);
-      const headerOpacity = scrollProgress > 0.3 ? Math.min(1, (scrollProgress - 0.3) / 0.4) : 0;
-
+  const transforms = useMemo(() => {
+    if (!cachedRect) {
       return {
-        progress: scrollProgress,
-        isHeroVisible: heroOpacity > 0,
+        progress,
+        isHeroVisible: progress < 1,
         heroLogoStyle: {
-          opacity: heroOpacity,
-          transform: `translate(${currentLeft - heroStartLeft}px, ${currentTop - heroStartTop}px) scale(${currentScale})`,
-          fontSize: `${currentFontSize}px`,
-        },
-        headerLogoStyle: {
-          opacity: headerOpacity,
-          transform: `translateY(${(1 - p) * -20}px)`,
-        },
+          opacity: Math.max(0, 1 - progress),
+          transform: 'none',
+        } as React.CSSProperties,
+        headerLogoStyle: { opacity: Math.min(1, progress) } as React.CSSProperties,
       };
-    },
-    [heroRef]
-  );
+    }
+
+    const headerHeight = 56;
+    const heroStartTop = cachedRect.top;
+    const heroStartLeft = cachedRect.left;
+    const heroStartScale = 1.2;
+    const heroStartFontSize = 24;
+    const headerFontSize = 20;
+
+    const p = easeOutCubic(progress);
+
+    const currentTop = lerp(heroStartTop, headerHeight / 2 - 10, p);
+    const currentLeft = lerp(heroStartLeft, 16, p);
+    const currentScale = lerp(heroStartScale, 1, p);
+    const currentFontSize = lerp(heroStartFontSize, headerFontSize, p);
+
+    const heroOpacity = progress < 0.1 ? 1 : Math.max(0, 1 - (progress - 0.1) / 0.4);
+    const headerOpacity = progress > 0.3 ? Math.min(1, (progress - 0.3) / 0.4) : 0;
+
+    return {
+      progress,
+      isHeroVisible: heroOpacity > 0,
+      heroLogoStyle: {
+        opacity: heroOpacity,
+        transform: `translate(${currentLeft - heroStartLeft}px, ${currentTop - heroStartTop}px) scale(${currentScale})`,
+        fontSize: `${currentFontSize}px`,
+      } as React.CSSProperties,
+      headerLogoStyle: {
+        opacity: headerOpacity,
+        transform: `translateY(${(1 - p) * -20}px)`,
+      } as React.CSSProperties,
+    };
+  }, [progress, cachedRect]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -87,8 +121,8 @@ export function useScrollLogoTransition({
         const heroEl = heroRef.current;
         if (!heroEl) return;
 
+        // getBoundingClientRect inside RAF is acceptable — not in the render path
         const heroRect = heroEl.getBoundingClientRect();
-
         const viewportHeight = window.innerHeight;
         const heroHeight = heroRect.height;
 
@@ -115,8 +149,6 @@ export function useScrollLogoTransition({
       }
     };
   }, [heroRef]);
-
-  const transforms = calculateTransforms(progress);
 
   return {
     progress,


### PR DESCRIPTION
## Summary

- 히어로 섹션 로고가 스크롤 진행도에 따라 헤더 로고 위치로 부드럽게 이동하는 Scroll-driven Logo Animation 구현
- `useScrollLogoTransition` 훅: native rAF + ResizeObserver 기반 스크롤 진행도 계산, easeOutCubic 보간, useMemo 최적화
- `ScrollLogoContext`: 히어로 섹션에서 헤더로 로고 상태(style, progress) 전달
- 스크롤 0%: 헤더 로고 투명, 히어로 로고만 표시 / 스크롤 100%: 히어로 로고 숨김, 헤더 로고 표시
- 위치·크기·색상(흰색→기본색) 중간값 보간, prefers-reduced-motion 지원
- SSR 안전: 모든 window/document 접근 guard 처리
- 히어로 없는 페이지에서 헤더 로고 정상 표시

## Test plan

- [ ] 홈페이지 히어로 배너에서 스크롤 시 로고가 헤더 위치로 이동하는지 확인
- [ ] 스크롤 0%: 헤더 로고 투명, 히어로 로고 흰색 표시 확인
- [ ] 스크롤 100%: 히어로 로고 숨김, 헤더 로고 정상 표시 확인
- [ ] 중간값: 위치/크기/투명도 부드럽게 보간되는지 확인
- [ ] 히어로 없는 페이지(상품 상세 등)에서 헤더 로고 정상 표시 확인
- [ ] 모바일/데스크탑 양쪽에서 애니메이션 동작 확인
- [ ] `prefers-reduced-motion` 설정 시 애니메이션 비활성화 확인
- [ ] `npx vitest run src/hooks/__tests__/useScrollLogoTransition.test.ts` — 5개 테스트 통과

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)