### PR TITLE
chore: #197 eslint-disable 주석 최소화

### DIFF
--- a/src/components/admin/page-editor/usePageEditor.ts
+++ b/src/components/admin/page-editor/usePageEditor.ts
@@ -157,7 +157,6 @@ export function usePageEditor({
         // fallback: clear dirty flags to prevent duplicate save
         const cleanBlocks: PageBlock[] = draft.blocks
           .filter((b) => !b._isNew || b.id > 0)
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .map(({ _isNew, _isModified, ...b }) => b as PageBlock);
         setSelectedPage((prev) => prev ? { ...prev, title: draft.title, slug: draft.slug } : prev);
         dispatch({ type: 'INIT', blocks: cleanBlocks, title: draft.title, slug: draft.slug });

--- a/src/components/blocks/BlockErrorBoundary.tsx
+++ b/src/components/blocks/BlockErrorBoundary.tsx
@@ -22,7 +22,6 @@ export default class BlockErrorBoundary extends Component<Props, State> {
     return { hasError: true };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   componentDidCatch(_error: Error, _errorInfo: ErrorInfo): void {
     // Error logging can be added here
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -145,7 +145,6 @@ class ApiClient {
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { params: _extractedParams, ...fetchOptions } = options ?? {};
 
     const { headers: optionHeaders, ...restFetchOptions } = fetchOptions ?? {};


### PR DESCRIPTION
## Summary

- `_언더스코어` prefix 변수에 불필요하게 붙어 있던 `@typescript-eslint/no-unused-vars` eslint-disable 주석 3개 제거
- ESLint의 typescript-eslint 기본 설정은 `_` prefix 변수를 자동으로 unused 검사에서 제외하므로 disable 주석이 필요하지 않음
- 나머지 31개 disable은 필요성 검토 후 유지:
  - `react/no-danger`: JSON-LD 서버 생성 데이터에 의도적으로 필요
  - `react-hooks/exhaustive-deps`: `useAsyncAction` 훅 재생성 패턴상 의존성 배열에서 제외 필요
  - `@next/next/no-img-element`: 어드민 이미지 업로더의 동적 src에 필요
  - `@typescript-eslint/no-explicit-any`: 테스트 파일의 mock 타입에 필요

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src/components/blocks/BlockErrorBoundary.tsx` | `componentDidCatch(_error, _errorInfo)` disable 제거 |
| `src/lib/api.ts` | `{ params: _extractedParams }` destructuring disable 제거 |
| `src/components/admin/page-editor/usePageEditor.ts` | `{ _isNew, _isModified, ...b }` destructuring disable 제거 |

Closes #197

## Test plan

- [x] `npm run build` — 빌드 성공 확인
- [x] `npm run test:run` — 기존 실패 테스트 외 변화 없음 확인 (pre-existing failures)
- [x] 제거된 disable 없이 ESLint 통과 확인 (빌드 중 lint 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)