### PR TITLE
fix: #302 OAuth accessToken에 tokenType: access 추가

### DIFF
--- a/backend/src/modules/auth/__tests__/oauth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/oauth.service.spec.ts
@@ -209,4 +209,42 @@ describe('OAuthService', () => {
       expect(mockUserRepository.create).not.toHaveBeenCalled();
     });
   });
+
+  describe('generateTokens', () => {
+    it('accessToken payload에 tokenType: access 포함', async () => {
+      const user = makeUser({ id: 1, email: 'test@example.com', role: UserRole.USER });
+      const signCalls: { payload: Record<string, unknown> }[] = [];
+      mockJwtService.sign.mockImplementation((payload: Record<string, unknown>) => {
+        signCalls.push({ payload });
+        return 'mock-token';
+      });
+
+      // Access private method via prototype
+      const generateTokens = (service as unknown as { generateTokens: (user: User) => Promise<{ accessToken: string; refreshToken: string }> }).generateTokens.bind(service);
+      await generateTokens(user);
+
+      // First sign call should be access token with tokenType: 'access'
+      const accessTokenCall = signCalls[0];
+      expect(accessTokenCall.payload).toHaveProperty('tokenType', 'access');
+      expect(accessTokenCall.payload).toHaveProperty('sub', user.id);
+      expect(accessTokenCall.payload).toHaveProperty('email', user.email);
+      expect(accessTokenCall.payload).toHaveProperty('role', user.role);
+    });
+
+    it('refreshToken payload에 tokenType: refresh 포함', async () => {
+      const user = makeUser({ id: 1, email: 'test@example.com', role: UserRole.USER });
+      const signCalls: { payload: Record<string, unknown> }[] = [];
+      mockJwtService.sign.mockImplementation((payload: Record<string, unknown>) => {
+        signCalls.push({ payload });
+        return 'mock-token';
+      });
+
+      const generateTokens = (service as unknown as { generateTokens: (user: User) => Promise<{ accessToken: string; refreshToken: string }> }).generateTokens.bind(service);
+      await generateTokens(user);
+
+      // Second sign call should be refresh token with tokenType: 'refresh'
+      const refreshTokenCall = signCalls[1];
+      expect(refreshTokenCall.payload).toHaveProperty('tokenType', 'refresh');
+    });
+  });
 });

--- a/backend/src/modules/auth/oauth.service.ts
+++ b/backend/src/modules/auth/oauth.service.ts
@@ -227,7 +227,7 @@ export class OAuthService {
 
   private async generateTokens(user: User): Promise<{ accessToken: string; refreshToken: string }> {
     const payload = { sub: user.id, email: user.email, role: user.role };
-    const accessToken = this.jwtService.sign(payload);
+    const accessToken = this.jwtService.sign({ ...payload, tokenType: 'access' });
     const refreshExpiresIn = (process.env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue;
     const refreshToken = this.jwtService.sign(
       { ...payload, tokenType: 'refresh' },


### PR DESCRIPTION
## Summary
- OAuth accessToken JWT payload에 누락된 `tokenType: 'access'` 추가
- `AuthService.generateTokens()`와 구조적으로 동일한 JWT 발급 보장

## Changes
- `backend/src/modules/auth/oauth.service.ts`: `generateTokens` 메서드에서 access token 생성 시 `{ ...payload, tokenType: 'access' }` 형태로 변경

## Test plan
- [x] `npm run test` — OAuth service tests 모두 통과
- [x] `npm run build` — 빌드 성공

## Related
- Closes #302