### PR TITLE
feat: #297 DashboardPage에 useAdminGuard 추가

### DIFF
--- a/src/app/[locale]/admin/dashboard/__tests__/DashboardPage.test.tsx
+++ b/src/app/[locale]/admin/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import DashboardPage from '../page';
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  usePathname: () => '/admin/dashboard',
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockGet = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  adminDashboardApi: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+const mockUseAdminGuard = vi.fn();
+
+vi.mock('@/hooks/useAdminGuard', () => ({
+  useAdminGuard: () => mockUseAdminGuard(),
+}));
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({
+      kpi: {
+        today_revenue: 100000,
+        today_revenue_diff_pct: 10,
+        today_orders: 50,
+        today_orders_diff_pct: 5,
+        new_members_today: 10,
+        new_members_diff_pct: 0,
+        total_product_views: 1000,
+      },
+      revenue_chart: [],
+      order_status_summary: {},
+      recent_orders: [],
+    });
+  });
+
+  describe('useAdminGuard 통합', () => {
+    it('관리자가 아닌 경우 dashboard 데이터를 가져오지 않아야 한다', async () => {
+      mockUseAdminGuard.mockReturnValue({
+        user: { id: 1, email: 'user@test.com', name: 'User', role: 'user' },
+        isLoading: false,
+        isAdmin: false,
+      });
+
+      render(<DashboardPage />);
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it('관리자인 경우 dashboard 데이터를 가져와야 한다', async () => {
+      mockUseAdminGuard.mockReturnValue({
+        user: { id: 1, email: 'admin@test.com', name: 'Admin', role: 'admin' },
+        isLoading: false,
+        isAdmin: true,
+      });
+
+      render(<DashboardPage />);
+
+      await waitFor(() => {
+        expect(mockGet).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/app/[locale]/admin/dashboard/page.tsx
+++ b/src/app/[locale]/admin/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { handleApiError } from '@/utils/error';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 import { formatCurrency } from '@/utils/currency';
 import {
   adminDashboardApi,
@@ -83,6 +84,7 @@ function KpiCard({ label, value, diffPct, unit }: KpiCardProps) {
 }
 
 export default function DashboardPage() {
+  const { isAdmin } = useAdminGuard();
   const [data, setData] = useState<DashboardResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [period, setPeriod] = useState('30d');
@@ -109,10 +111,11 @@ export default function DashboardPage() {
   );
 
   useEffect(() => {
+    if (!isAdmin) return;
     if (period === 'custom' && (!customStart || !customEnd)) return;
     void fetchDashboard();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [period, customStart, customEnd]);
+  }, [isAdmin, period, customStart, customEnd]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Closes #297
- DashboardPage에 useAdminGuard Hook을 추가하여 관리자 권한 검증
- isAdmin이 false인 경우 dashboard 데이터를 가져오지 않음
- 다른 admin 페이지와 동일한 보안 패턴 적용

## Changes
- `src/app/[locale]/admin/dashboard/page.tsx`: useAdminGuard import 및 isAdmin 체크 추가
- `src/app/[locale]/admin/dashboard/__tests__/DashboardPage.test.tsx`: TDD 테스트 작성

## Test plan
- [x] npm run build
- [x] npm run test:run (DashboardPage tests passed)