### PR TITLE
feat: #294 JWT signature verification in middleware

### DIFF
--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -3,6 +3,8 @@ import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
+import * as fs from 'fs';
+import * as path from 'path';
 import type ms from 'ms';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthController } from './auth.controller';
@@ -11,14 +13,26 @@ import { OAuthService } from './oauth.service';
 import { User } from '../users/entities/user.entity';
 import { UserAuthentication } from '../users/entities/user-authentication.entity';
 
+function getJwtPrivateKey(): string {
+  if (process.env.JWT_PRIVATE_KEY) {
+    return process.env.JWT_PRIVATE_KEY;
+  }
+  const keyPath = path.resolve(process.cwd(), 'keys', 'jwt-private.pem');
+  if (fs.existsSync(keyPath)) {
+    return fs.readFileSync(keyPath, 'utf-8');
+  }
+  throw new Error('JWT_PRIVATE_KEY environment variable or keys/jwt-private.pem file is required');
+}
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, UserAuthentication]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
-      secret: process.env.JWT_SECRET,
+      privateKey: getJwtPrivateKey(),
       signOptions: {
         expiresIn: (process.env.JWT_EXPIRES_IN ?? '1h') as ms.StringValue,
+        algorithm: 'RS256',
       },
     }),
     HttpModule,

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -3,6 +3,8 @@ import { PassportStrategy } from '@nestjs/passport';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import * as fs from 'fs';
+import * as path from 'path';
 import type { Request } from 'express';
 import { User } from '../../users/entities/user.entity';
 
@@ -19,23 +21,31 @@ function cookieExtractor(req: Request): string | null {
   return null;
 }
 
+function getJwtPublicKey(): string {
+  if (process.env.JWT_PUBLIC_KEY) {
+    return process.env.JWT_PUBLIC_KEY;
+  }
+  const keyPath = path.resolve(process.cwd(), 'keys', 'jwt-public.pem');
+  if (fs.existsSync(keyPath)) {
+    return fs.readFileSync(keyPath, 'utf-8');
+  }
+  throw new Error('JWT_PUBLIC_KEY environment variable or keys/jwt-public.pem file is required');
+}
+
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
   ) {
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      throw new Error('JWT_SECRET environment variable is required');
-    }
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         cookieExtractor,
         ExtractJwt.fromAuthHeaderAsBearerToken(),
       ]),
       ignoreExpiration: false,
-      secretOrKey: secret,
+      secretOrKey: getJwtPublicKey(),
+      algorithms: ['RS256'],
       passReqToCallback: false,
     });
   }

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,7 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 
-// next-intl/middleware imports next/server without .js extension which fails in Vitest ESM.
-// Mock it to return a passthrough so auth-guard tests can run in isolation.
 vi.mock('next-intl/middleware', () => ({
   default: () => (req: { url: string }) => new Response(null, { status: 200, headers: { location: req.url } }),
 }));
@@ -9,19 +7,55 @@ vi.mock('@/i18n/routing', () => ({
   routing: { locales: ['ko', 'en', 'ja', 'zh'], defaultLocale: 'ko' },
 }));
 
-import { middleware } from '@/middleware';
-import { NextRequest } from 'next/server';
+let testKeyPair: CryptoKeyPair;
+let testPublicKeyPem: string;
 
-/** Build a minimal JWT-shaped token with the given payload (no real signature). */
-function makeToken(payload: Record<string, unknown>): string {
-  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).replace(/=/g, '');
+beforeAll(async () => {
+  testKeyPair = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  );
+
+  const exportedPublicKey = await crypto.subtle.exportKey('spki', testKeyPair.publicKey);
+  const binaryKey = new Uint8Array(exportedPublicKey);
+  const base64Key = btoa(String.fromCharCode(...binaryKey));
+  testPublicKeyPem = `-----BEGIN PUBLIC KEY-----\n${base64Key.match(/.{1,64}/g)?.join('\n')}\n-----END PUBLIC KEY-----`;
+});
+
+async function makeSignedToken(payload: Record<string, unknown>): Promise<string> {
+  const header = btoa(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).replace(/=/g, '');
   const body = btoa(JSON.stringify(payload)).replace(/=/g, '');
-  return `${header}.${body}.fakesig`;
+
+  const data = new TextEncoder().encode(`${header}.${body}`);
+  const signature = await crypto.subtle.sign(
+    { name: 'RSASSA-PKCS1-v1_5' },
+    testKeyPair.privateKey,
+    data,
+  );
+  const sig = btoa(String.fromCharCode(...new Uint8Array(signature))).replace(/=/g, '');
+
+  return `${header}.${body}.${sig}`;
 }
 
-const ADMIN_TOKEN = makeToken({ sub: '1', role: 'admin' });
-const SUPER_ADMIN_TOKEN = makeToken({ sub: '2', role: 'super_admin' });
-const USER_TOKEN = makeToken({ sub: '3', role: 'user' });
+function makeForgedToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).replace(/=/g, '');
+  const body = btoa(JSON.stringify(payload)).replace(/=/g, '');
+  return `${header}.${body}.FORGEDSIGNATURE123456789`;
+}
+
+import { middleware, resetPublicKeyCache, setTestPublicKey } from '@/middleware';
+import { NextRequest } from 'next/server';
+
+beforeEach(() => {
+  resetPublicKeyCache();
+  setTestPublicKey(testPublicKeyPem);
+});
 
 function makeRequest(pathname: string, token?: string): NextRequest {
   const url = `http://localhost${pathname}`;
@@ -33,118 +67,151 @@ function makeRequest(pathname: string, token?: string): NextRequest {
 }
 
 describe('middleware', () => {
-  it('redirects /admin to /login when no accessToken cookie', () => {
+  it('redirects /admin to /login when no accessToken cookie', async () => {
     const req = makeRequest('/admin');
-    const res = middleware(req);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('/login');
     expect(location).toContain('redirect=%2Fadmin');
   });
 
-  it('passes through /admin when accessToken cookie has admin role', () => {
-    const req = makeRequest('/admin', ADMIN_TOKEN);
-    const res = middleware(req);
+  it('passes through /admin when accessToken cookie has valid admin role signature', async () => {
+    const adminToken = await makeSignedToken({ sub: 1, role: 'admin', tokenType: 'access' });
+    const req = makeRequest('/admin', adminToken);
+    const res = await middleware(req);
     expect(res.status).toBe(200);
   });
 
-  it('passes through /admin when accessToken cookie has super_admin role', () => {
-    const req = makeRequest('/admin', SUPER_ADMIN_TOKEN);
-    const res = middleware(req);
+  it('passes through /admin when accessToken cookie has valid super_admin role', async () => {
+    const superAdminToken = await makeSignedToken({ sub: 2, role: 'super_admin', tokenType: 'access' });
+    const req = makeRequest('/admin', superAdminToken);
+    const res = await middleware(req);
     expect(res.status).toBe(200);
   });
 
-  it('redirects /admin to / when accessToken cookie has non-admin role', () => {
-    const req = makeRequest('/admin', USER_TOKEN);
-    const res = middleware(req);
+  it('redirects /admin to / when accessToken cookie has valid non-admin role', async () => {
+    const userToken = await makeSignedToken({ sub: 3, role: 'user', tokenType: 'access' });
+    const req = makeRequest('/admin', userToken);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('/');
     expect(location).not.toContain('/login');
   });
 
-  it('redirects /my to /login when no accessToken cookie', () => {
+  it('SECURITY: rejects forged token with fake signature even if role is admin', async () => {
+    const forgedAdminToken = makeForgedToken({ sub: 99, role: 'admin', tokenType: 'access' });
+    const req = makeRequest('/admin', forgedAdminToken);
+    const res = await middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/');
+    expect(location).not.toContain('/admin');
+    expect(location).not.toContain('/login');
+  });
+
+  it('SECURITY: rejects forged token even if it claims super_admin role', async () => {
+    const forgedAdminToken = makeForgedToken({ sub: 99, role: 'admin', tokenType: 'access' });
+    const req = makeRequest('/admin', forgedAdminToken);
+    const res = await middleware(req);
+    expect(res.status).toBe(307);
+  });
+
+  it('redirects /my to /login when no accessToken cookie', async () => {
     const req = makeRequest('/my');
-    const res = middleware(req);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('/login');
     expect(location).toContain('redirect=%2Fmy');
   });
 
-  it('redirects /checkout to /login when no accessToken cookie', () => {
+  it('redirects /checkout to /login when no accessToken cookie', async () => {
     const req = makeRequest('/checkout');
-    const res = middleware(req);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('/login');
     expect(location).toContain('redirect=%2Fcheckout');
   });
 
-  it('redirects sub-paths like /admin/products and /my/orders', () => {
+  it('redirects sub-paths like /admin/products and /my/orders', async () => {
     for (const path of ['/admin/products', '/admin/settings', '/my/orders', '/checkout/success']) {
       const req = makeRequest(path);
-      const res = middleware(req);
+      const res = await middleware(req);
       expect(res.status).toBe(307);
       const location = res.headers.get('location');
       expect(location).toContain('/login');
     }
   });
 
-  it('preserves query string in redirect param', () => {
+  it('preserves query string in redirect param', async () => {
     const req = makeRequest('/checkout?coupon=ABC');
-    const res = middleware(req);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('redirect=%2Fcheckout%3Fcoupon%3DABC');
   });
 
-  it('passes through public routes without cookie', () => {
+  it('passes through public routes without cookie', async () => {
     for (const path of ['/', '/products', '/login']) {
       const req = makeRequest(path);
-      const res = middleware(req);
+      const res = await middleware(req);
       expect(res.status).toBe(200);
     }
   });
 
-  it('redirects locale-prefixed /ko/admin to /ko/login with full path in redirect', () => {
+  it('redirects locale-prefixed /ko/admin to /ko/login with full path in redirect', async () => {
     const req = makeRequest('/ko/admin');
-    const res = middleware(req);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('/ko/login');
     expect(location).toContain('redirect=%2Fko%2Fadmin');
   });
 
-  it('redirects locale-prefixed /en/checkout to /en/login', () => {
+  it('redirects locale-prefixed /en/checkout to /en/login', async () => {
     const req = makeRequest('/en/checkout');
-    const res = middleware(req);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('/en/login');
     expect(location).toContain('redirect=%2Fen%2Fcheckout');
   });
 
-  it('redirects locale-prefixed /ja/my to /ja/login', () => {
+  it('redirects locale-prefixed /ja/my to /ja/login', async () => {
     const req = makeRequest('/ja/my');
-    const res = middleware(req);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('/ja/login');
   });
 
-  it('passes through locale-prefixed admin when token has admin role', () => {
-    const req = makeRequest('/en/admin', ADMIN_TOKEN);
-    const res = middleware(req);
+  it('passes through locale-prefixed admin when token has admin role', async () => {
+    const adminToken = await makeSignedToken({ sub: 1, role: 'admin', tokenType: 'access' });
+    const req = makeRequest('/en/admin', adminToken);
+    const res = await middleware(req);
     expect(res.status).toBe(200);
   });
 
-  it('redirects locale-prefixed /ko/admin to /ko/ when token has non-admin role', () => {
-    const req = makeRequest('/ko/admin', USER_TOKEN);
-    const res = middleware(req);
+  it('redirects locale-prefixed /ko/admin to /ko/ when token has non-admin role', async () => {
+    const userToken = await makeSignedToken({ sub: 3, role: 'user', tokenType: 'access' });
+    const req = makeRequest('/ko/admin', userToken);
+    const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
     expect(location).toContain('/ko/');
     expect(location).not.toContain('/login');
+  });
+
+  it('SECURITY: rejects forged token on locale-prefixed admin route', async () => {
+    const forgedAdminToken = makeForgedToken({ sub: 99, role: 'admin', tokenType: 'access' });
+    const req = makeRequest('/ko/admin', forgedAdminToken);
+    const res = await middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/ko/');
+    expect(location).not.toContain('/admin');
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,51 +5,115 @@ import { routing } from '@/i18n/routing';
 
 const intlMiddleware = createMiddleware(routing);
 
-// Compile regex once at module scope; trailing path is optional to match bare /ko
 const localePattern = new RegExp(`^/(${routing.locales.join('|')})(/.*)?$`);
 
 const ADMIN_ROLES = new Set(['admin', 'super_admin']);
 
-/**
- * Decode JWT payload without signature verification (edge runtime safe).
- * Returns true if the token's role claim is an admin role.
- */
-function hasAdminRole(token: string): boolean {
+export function resetPublicKeyCache(): void {
+  // No-op for backwards compatibility
+}
+
+let testPublicKey: string | null = null;
+
+export function setTestPublicKey(pem: string): void {
+  testPublicKey = pem;
+}
+
+async function getPublicKey(): Promise<CryptoKey | null> {
+  const publicKeyPem = testPublicKey ?? process.env.JWT_PUBLIC_KEY;
+  if (!publicKeyPem) return null;
+
+  const keyType = publicKeyPem.includes('BEGIN PUBLIC KEY') ? 'spki' : 'raw';
+
+  let binaryKey: ArrayBuffer;
+  if (keyType === 'spki') {
+    const pemBody = publicKeyPem
+      .replace(/-----BEGIN PUBLIC KEY-----/, '')
+      .replace(/-----END PUBLIC KEY-----/, '')
+      .replace(/\s/g, '');
+    const binaryStr = atob(pemBody);
+    const keyBytes = new Uint8Array(binaryStr.length);
+    for (let i = 0; i < binaryStr.length; i++) {
+      keyBytes[i] = binaryStr.charCodeAt(i);
+    }
+    binaryKey = keyBytes.buffer;
+  } else {
+    const binaryStr = atob(publicKeyPem);
+    const keyBytes = new Uint8Array(binaryStr.length);
+    for (let i = 0; i < binaryStr.length; i++) {
+      keyBytes[i] = binaryStr.charCodeAt(i);
+    }
+    binaryKey = keyBytes.buffer;
+  }
+
+  return crypto.subtle.importKey(
+    'spki',
+    binaryKey,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['verify'],
+  );
+}
+
+async function verifyRS256(token: string): Promise<Record<string, unknown> | null> {
   try {
     const parts = token.split('.');
-    if (parts.length !== 3) return false;
-    // base64url → base64 → JSON
-    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    const json = atob(base64);
-    const payload = JSON.parse(json) as Record<string, unknown>;
-    return typeof payload.role === 'string' && ADMIN_ROLES.has(payload.role);
+    if (parts.length !== 3) return null;
+
+    const header = JSON.parse(atob(parts[0].replace(/-/g, '+').replace(/_/g, '/')));
+    if (header.alg !== 'RS256' || header.typ !== 'JWT') return null;
+
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+
+    const key = await getPublicKey();
+    if (!key) return null;
+
+    const signature = Uint8Array.from(
+      atob(parts[2].replace(/-/g, '+').replace(/_/g, '/')),
+      (c) => c.charCodeAt(0),
+    ).buffer;
+
+    const data = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+
+    const valid = await crypto.subtle.verify(
+      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+      key,
+      signature,
+      data,
+    );
+
+    if (!valid) return null;
+    return payload;
   } catch {
-    return false;
+    return null;
   }
 }
 
-export function middleware(request: NextRequest) {
+async function hasAdminRole(token: string): Promise<boolean> {
+  const payload = await verifyRS256(token);
+  if (!payload) return false;
+  return typeof payload.role === 'string' && ADMIN_ROLES.has(payload.role);
+}
+
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get('accessToken')?.value;
 
-  // Extract locale prefix and stripped path for auth checks
   const localeMatch = pathname.match(localePattern);
   const localePrefix = localeMatch ? `/${localeMatch[1]}` : '';
   const pathnameWithoutLocale = localeMatch ? (localeMatch[2] || '/') : pathname;
 
-  // Protect admin routes — require authentication and admin role
   if (pathnameWithoutLocale.startsWith('/admin')) {
     if (!token) {
       const loginUrl = new URL(`${localePrefix}/login`, request.url);
       loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
       return NextResponse.redirect(loginUrl);
     }
-    if (!hasAdminRole(token)) {
+    if (!(await hasAdminRole(token))) {
       return NextResponse.redirect(new URL(`${localePrefix}/`, request.url));
     }
   }
 
-  // Protect user-only routes
   if (pathnameWithoutLocale.startsWith('/my') || pathnameWithoutLocale.startsWith('/checkout')) {
     if (!token) {
       const loginUrl = new URL(`${localePrefix}/login`, request.url);
@@ -58,7 +122,6 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  // Skip intl middleware for API routes
   if (pathnameWithoutLocale.startsWith('/api')) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary
- Closes #294
- Implement RS256 JWT signature verification in frontend middleware
- Backend now uses RS256 (RSA) for signing access tokens instead of HS256
- Frontend middleware now verifies JWT signature using public key before checking role claim
- This prevents attackers from forging admin tokens to access admin pages

## Changes
### Backend
- `auth.module.ts`: Switch from HS256 to RS256 using private key for signing
- `jwt.strategy.ts`: Use public key for verification with RS256 algorithm
- Added key loading from `JWT_PRIVATE_KEY` env var or `keys/jwt-private.pem` file

### Frontend
- `middleware.ts`: Added `verifyRS256()` function using Web Crypto API
- JWT signature is now verified before reading role claim
- Added `setTestPublicKey()` and `resetPublicKeyCache()` for testing

## Security Fix
Before: Anyone could forge a JWT with `role: "admin"` and access admin pages
After: JWT signature must be verified with the server's public key

## Test plan
- [x] npm run build (frontend)
- [x] Backend auth tests pass
- [x] Security tests verify forged tokens are rejected