### PR TITLE
feat: #310 webhook 엔드포인트 DTO 검증 추가

### DIFF
--- a/backend/src/modules/payments/__tests__/payments.webhook.dto.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.dto.spec.ts
@@ -1,0 +1,85 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { WebhookPayloadDto } from '../dto/webhook-payload.dto';
+
+describe('WebhookPayloadDto — class-validator 검증', () => {
+  describe('forbidNonWhitelisted 시나리오', () => {
+    it('알 수 없는 필드 포함 시 유효성 오류 발생', async () => {
+      const dto = plainToInstance(WebhookPayloadDto, {
+        eventType: 'PAYMENT_STATUS_CHANGED',
+        unknownField: 'intrusion',
+      });
+      const errors = await validate(dto, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      });
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('unknownField');
+    });
+
+    it('eventType이 배열로 올 때 유효성 오류 발생', async () => {
+      const dto = plainToInstance(WebhookPayloadDto, {
+        eventType: ['PAYMENT_STATUS_CHANGED', 'etc'],
+      } as unknown as Record<string, unknown>);
+      const errors = await validate(dto, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('orderId가 숫자일 때 유효성 오류 발생 (string 기대)', async () => {
+      const dto = plainToInstance(WebhookPayloadDto, {
+        eventType: 'PAYMENT_STATUS_CHANGED',
+        orderId: 12345,
+      } as unknown as Record<string, unknown>);
+      const errors = await validate(dto, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('amount가 문자열일 때 유효성 오류 발생 (number 기대)', async () => {
+      const dto = plainToInstance(WebhookPayloadDto, {
+        eventType: 'PAYMENT_STATUS_CHANGED',
+        amount: '15000',
+      } as unknown as Record<string, unknown>);
+      const errors = await validate(dto, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('유효한 payload', () => {
+    it('모든 필드 생략 가능 (모두 optional)', async () => {
+      const dto = plainToInstance(WebhookPayloadDto, {});
+      const errors = await validate(dto);
+      expect(errors.length).toBe(0);
+    });
+
+    it('유효한 payload는 오류 없음', async () => {
+      const dto = plainToInstance(WebhookPayloadDto, {
+        eventType: 'PAYMENT_STATUS_CHANGED',
+        orderId: 'order_123',
+        status: 'DONE',
+        amount: 15000,
+        paymentKey: '5tqV9bRs34mXwdkz2oGv6r',
+        method: 'CARD',
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBe(0);
+    });
+
+    it('method가 CARD/ACCOUNT/VIRTUAL_ACCOUNT 등 유효한 문자열 허용', async () => {
+      const methods = ['CARD', 'ACCOUNT', 'VIRTUAL_ACCOUNT', 'PHONE', 'PRODUCT'];
+      for (const method of methods) {
+        const dto = plainToInstance(WebhookPayloadDto, { method });
+        const errors = await validate(dto);
+        expect(errors.length).toBe(0);
+      }
+    });
+  });
+});

--- a/backend/src/modules/payments/dto/webhook-payload.dto.ts
+++ b/backend/src/modules/payments/dto/webhook-payload.dto.ts
@@ -1,0 +1,52 @@
+import { IsString, IsOptional, IsNumber } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class WebhookPayloadDto {
+  @ApiPropertyOptional({
+    description: '이벤트 유형 (PAYMENT_STATUS_CHANGED 등)',
+    example: 'PAYMENT_STATUS_CHANGED',
+  })
+  @IsOptional()
+  @IsString({ message: '이벤트 유형은 문자열이어야 합니다.' })
+  eventType?: string;
+
+  @ApiPropertyOptional({
+    description: '주문 ID (ordered)',
+    example: '20241006000000000',
+  })
+  @IsOptional()
+  @IsString({ message: '주문 ID는 문자열이어야 합니다.' })
+  orderId?: string;
+
+  @ApiPropertyOptional({
+    description: '결제 상태',
+    example: 'DONE',
+  })
+  @IsOptional()
+  @IsString({ message: '결제 상태는 문자열이어야 합니다.' })
+  status?: string;
+
+  @ApiPropertyOptional({
+    description: '토스 결제 키',
+    example: '5tqV9bRs34mXwdkz2oGv6r',
+  })
+  @IsOptional()
+  @IsString({ message: '결제 키는 문자열이어야 합니다.' })
+  paymentKey?: string;
+
+  @ApiPropertyOptional({
+    description: '결제 금액',
+    example: 15000,
+  })
+  @IsOptional()
+  @IsNumber({}, { message: '결제 금액은 숫자여야 합니다.' })
+  amount?: number;
+
+  @ApiPropertyOptional({
+    description: '결제 수단',
+    example: 'CARD',
+  })
+  @IsOptional()
+  @IsString({ message: '결제 수단은 문자열이어야 합니다.' })
+  method?: string;
+}

--- a/backend/src/modules/payments/payments.controller.ts
+++ b/backend/src/modules/payments/payments.controller.ts
@@ -10,6 +10,7 @@ import { PaymentsService } from './payments.service';
 import { PreparePaymentDto } from './dto/prepare-payment.dto';
 import { ConfirmPaymentDto } from './dto/confirm-payment.dto';
 import { CancelPaymentDto } from './dto/cancel-payment.dto';
+import { WebhookPayloadDto } from './dto/webhook-payload.dto';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { Public } from '../../common/decorators/public.decorator';
 
@@ -52,10 +53,10 @@ export class PaymentsController {
   @ApiResponse({ status: 200, description: '웹훅 수신 성공' })
   @ApiHeader({ name: 'toss-signature', description: 'Toss 서명', required: true })
   async webhook(
-    @Body() payload: unknown,
+    @Body() dto: WebhookPayloadDto,
     @Headers('toss-signature') signature: string,
   ): Promise<{ received: boolean }> {
-    await this.paymentsService.handleWebhook(payload, signature);
+    await this.paymentsService.handleWebhook(dto, signature);
     return { received: true };
   }
 }


### PR DESCRIPTION
## Summary
- webhook 엔드포인트에 `WebhookPayloadDto` 추가 (class-validator)
- `whitelist: true, forbidNonWhitelisted: true` 옵션으로 알 수 없는 필드 차단
- TossPayments webhook 스펙 기반 `eventType`, `orderId`, `status`, `paymentKey`, `amount`, `method` 필드 정의

## 변경 내용
- `WebhookPayloadDto` 생성 (payments/dto/)
- `payments.controller.ts` webhook 메서드에서 `unknown` → `WebhookPayloadDto` 변경

## Test plan
- [x] `npm run test -- --testPathPattern="payments.webhook"` 통과
- [x] `npx eslint` 해당 파일 통과
- Closes #310