### PR TITLE
fix: #305 ThrottlerGuard를 모든 환경에서 항상 활성화

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -85,14 +85,10 @@ import { RolesGuard } from './common/guards/roles.guard';
   providers: [
     // Guard execution order: ThrottlerGuard → JwtAuthGuard → RolesGuard
     // DO NOT reorder — RolesGuard requires request.user populated by JwtAuthGuard
-    ...(process.env.NODE_ENV !== 'development'
-      ? [
-          {
-            provide: APP_GUARD,
-            useClass: ThrottlerGuard,
-          },
-        ]
-      : []),
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,


### PR DESCRIPTION
## Summary
- `NODE_ENV !== 'development'` 조건부 제거 — ThrottlerGuard를 모든 환경에서 항상 등록
- 스테이징이 실수로 development 모드로 실행될 때 레이트 리밋이 비활성화되는 보안 취약점 해소
- 개발 환경도 200 req/min (global), 30 req/min (auth) 제한을 충분히 허용함

## Test plan
- [ ] `npm run build` 빌드 통과 확인
- [ ] `npm run test` 기존 테스트 패스 유지 확인
- [ ] 개발 환경에서 ThrottlerGuard가 활성화되어 있는지 확인

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)