### PR TITLE
fix: #308 reorder 라우트를 :id 라우트 앞으로 이동

### DIFF
--- a/backend/src/modules/archives/admin-archives.controller.ts
+++ b/backend/src/modules/archives/admin-archives.controller.ts
@@ -66,6 +66,16 @@ export class AdminArchivesController {
     return this.archivesService.createNiloType(dto);
   }
 
+  @Patch('nilo-types/reorder')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '이ilo 유형 순서 변경', description: '이ilo 유형들의 순서를 변경합니다.' })
+  @ApiResponse({ status: 200, description: '이ilo 유형 순서 변경 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  async reorderNiloTypes(@Body() items: { id: number; sortOrder: number }[]) {
+    await this.archivesService.reorderNiloTypes(items);
+  }
+
   @Patch('nilo-types/:id')
   @ApiCookieAuth()
   @ApiOperation({ summary: '이ilo 유형 수정', description: '기존 이ilo 유형 정보를 수정합니다.' })
@@ -92,16 +102,6 @@ export class AdminArchivesController {
   @ApiParam({ name: 'id', type: Number, description: '이ilo 유형 ID' })
   async deleteNiloType(@Param('id', ParseIntPipe) id: number) {
     await this.archivesService.deleteNiloType(id);
-  }
-
-  @Patch('nilo-types/reorder')
-  @ApiCookieAuth()
-  @ApiOperation({ summary: '이ilo 유형 순서 변경', description: '이ilo 유형들의 순서를 변경합니다.' })
-  @ApiResponse({ status: 200, description: '이ilo 유형 순서 변경 성공' })
-  @ApiResponse({ status: 401, description: '인증 필요' })
-  @ApiResponse({ status: 403, description: '권한 없음' })
-  async reorderNiloTypes(@Body() items: { id: number; sortOrder: number }[]) {
-    await this.archivesService.reorderNiloTypes(items);
   }
 
   @Get('process-steps')
@@ -196,6 +196,16 @@ export class AdminArchivesController {
     return this.archivesService.createArtist(dto);
   }
 
+  @Patch('artists/reorder')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '작가 순서 변경', description: '작가들의 순서를 변경합니다.' })
+  @ApiResponse({ status: 200, description: '작가 순서 변경 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  async reorderArtists(@Body() items: { id: number; sortOrder: number }[]) {
+    await this.archivesService.reorderArtists(items);
+  }
+
   @Patch('artists/:id')
   @ApiCookieAuth()
   @ApiOperation({ summary: '작가 수정', description: '기존 작가 정보를 수정합니다.' })
@@ -222,15 +232,5 @@ export class AdminArchivesController {
   @ApiParam({ name: 'id', type: Number, description: '작가 ID' })
   async deleteArtist(@Param('id', ParseIntPipe) id: number) {
     await this.archivesService.deleteArtist(id);
-  }
-
-  @Patch('artists/reorder')
-  @ApiCookieAuth()
-  @ApiOperation({ summary: '작가 순서 변경', description: '작가들의 순서를 변경합니다.' })
-  @ApiResponse({ status: 200, description: '작가 순서 변경 성공' })
-  @ApiResponse({ status: 401, description: '인증 필요' })
-  @ApiResponse({ status: 403, description: '권한 없음' })
-  async reorderArtists(@Body() items: { id: number; sortOrder: number }[]) {
-    await this.archivesService.reorderArtists(items);
   }
 }

--- a/backend/src/modules/collections/admin-collections.controller.ts
+++ b/backend/src/modules/collections/admin-collections.controller.ts
@@ -59,6 +59,16 @@ export class AdminCollectionsController {
     return this.collectionsService.create(dto);
   }
 
+  @Patch('reorder')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '컬렉션 순서 변경', description: '컬렉션들의 순서를 변경합니다.' })
+  @ApiResponse({ status: 200, description: '컬렉션 순서 변경 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  async reorder(@Body() items: { id: number; sortOrder: number }[]) {
+    await this.collectionsService.reorder(items);
+  }
+
   @Patch(':id')
   @ApiCookieAuth()
   @ApiOperation({ summary: '컬렉션 수정', description: '기존 컬렉션 정보를 수정합니다.' })
@@ -85,15 +95,5 @@ export class AdminCollectionsController {
   @ApiParam({ name: 'id', type: Number, description: '컬렉션 ID' })
   async remove(@Param('id', ParseIntPipe) id: number) {
     await this.collectionsService.remove(id);
-  }
-
-  @Patch('reorder')
-  @ApiCookieAuth()
-  @ApiOperation({ summary: '컬렉션 순서 변경', description: '컬렉션들의 순서를 변경합니다.' })
-  @ApiResponse({ status: 200, description: '컬렉션 순서 변경 성공' })
-  @ApiResponse({ status: 401, description: '인증 필요' })
-  @ApiResponse({ status: 403, description: '권한 없음' })
-  async reorder(@Body() items: { id: number; sortOrder: number }[]) {
-    await this.collectionsService.reorder(items);
   }
 }


### PR DESCRIPTION
## Summary
- NestJS는 라우트를 선언 순서대로 매칭하므로 `@Patch(':id')` 앞에 `@Patch('reorder')`를 선언해야 함
- `admin-archives.controller.ts`: `nilo-types/reorder`, `artists/reorder` 메서드를 각각 `:id` 라우트 앞으로 이동
- `admin-collections.controller.ts`: `reorder` 메서드를 `:id` 라우트 앞으로 이동

## Test plan
- [ ] `PATCH /admin/archives/nilo-types/reorder` 정상 동작 확인 (기존: 400 ParseIntPipe 오류)
- [ ] `PATCH /admin/archives/artists/reorder` 정상 동작 확인
- [ ] `PATCH /admin/collections/reorder` 정상 동작 확인
- [ ] 기존 `:id` PATCH 엔드포인트 정상 동작 확인

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)