### PR TITLE
feat: #325 프로덕션 Swagger API 문서 비활성화

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -49,16 +49,18 @@ async function bootstrap() {
     }),
   );
 
-  const config = new DocumentBuilder()
-    .setTitle('옥화당 API')
-    .setDescription('옥화당 자사몰 백엔드 API 문서입니다.')
-    .setVersion('1.0')
-    .addCookieAuth('accessToken', { type: 'apiKey', in: 'cookie' }, 'accessToken')
-    .addCookieAuth('refreshToken', { type: 'apiKey', in: 'cookie' }, 'refreshToken')
-    .build();
+  if (process.env.NODE_ENV !== 'production') {
+    const config = new DocumentBuilder()
+      .setTitle('옥화당 API')
+      .setDescription('옥화당 자사몰 백엔드 API 문서입니다.')
+      .setVersion('1.0')
+      .addCookieAuth('accessToken', { type: 'apiKey', in: 'cookie' }, 'accessToken')
+      .addCookieAuth('refreshToken', { type: 'apiKey', in: 'cookie' }, 'refreshToken')
+      .build();
 
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document);
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api/docs', app, document);
+  }
 
   const port = process.env.PORT || 3000;
   await app.listen(port, '0.0.0.0');


### PR DESCRIPTION
## Summary
- Closes #325
- `main.ts`에서 Swagger 설정을 `NODE_ENV !== 'production'` 조건으로 감싸 프로덕션 노출 차단

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm run test