### PR TITLE
feat: #320 admin-dashboard SQL 집계 쿼리로 성능 개선

### DIFF
--- a/backend/src/modules/admin/__tests__/admin-dashboard.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-dashboard.service.spec.ts
@@ -6,19 +6,27 @@ import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { User } from '../../users/entities/user.entity';
 import { Product } from '../../products/entities/product.entity';
 
+function createMockQueryBuilder(overrides: Record<string, unknown> = {}) {
+  const qb: Record<string, jest.Mock> = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getRawOne: jest.fn().mockResolvedValue({ revenue: '0', count: '0', total: '0' }),
+    getRawMany: jest.fn().mockResolvedValue([]),
+  };
+  Object.assign(qb, overrides);
+  return qb;
+}
+
 function createMockRepository() {
   return {
     find: jest.fn().mockResolvedValue([]),
     count: jest.fn().mockResolvedValue(0),
     findOne: jest.fn(),
-    createQueryBuilder: jest.fn(() => ({
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      getRawOne: jest.fn().mockResolvedValue({ total: '0' }),
-      getRawMany: jest.fn().mockResolvedValue([]),
-    })),
+    createQueryBuilder: jest.fn(() => createMockQueryBuilder()),
   };
 }
 
@@ -70,19 +78,12 @@ describe('AdminDashboardService', () => {
     });
 
     it('should calculate revenue from orders excluding cancelled/refunded', async () => {
-      const todayOrders = [
-        { totalAmount: '50000', status: OrderStatus.PAID, createdAt: new Date() },
-        { totalAmount: '30000', status: OrderStatus.DELIVERED, createdAt: new Date() },
-      ];
-
-      // First call: today orders (KPI), second: yesterday orders
-      // Third call: revenue chart orders
-      // Fourth call: recent orders
-      orderRepo.find
-        .mockResolvedValueOnce(todayOrders)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
+      // createQueryBuilder is called multiple times: todayAgg, yesterdayAgg, revenueChart rows, orderStatusSummary
+      orderRepo.createQueryBuilder
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawOne: jest.fn().mockResolvedValue({ revenue: '80000', count: '2' }) }))
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawOne: jest.fn().mockResolvedValue({ revenue: '0', count: '0' }) }))
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawMany: jest.fn().mockResolvedValue([]) }))
+        .mockReturnValue(createMockQueryBuilder({ getRawMany: jest.fn().mockResolvedValue([]) }));
 
       const result = await service.getDashboard({ period: 'today' });
 
@@ -91,18 +92,11 @@ describe('AdminDashboardService', () => {
     });
 
     it('should calculate diff percentage correctly', async () => {
-      const todayOrders = [
-        { totalAmount: '100000', status: OrderStatus.PAID, createdAt: new Date() },
-      ];
-      const yesterdayOrders = [
-        { totalAmount: '80000', status: OrderStatus.PAID, createdAt: new Date() },
-      ];
-
-      orderRepo.find
-        .mockResolvedValueOnce(todayOrders)
-        .mockResolvedValueOnce(yesterdayOrders)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
+      orderRepo.createQueryBuilder
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawOne: jest.fn().mockResolvedValue({ revenue: '100000', count: '1' }) }))
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawOne: jest.fn().mockResolvedValue({ revenue: '80000', count: '1' }) }))
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawMany: jest.fn().mockResolvedValue([]) }))
+        .mockReturnValue(createMockQueryBuilder({ getRawMany: jest.fn().mockResolvedValue([]) }));
 
       const result = await service.getDashboard({ period: 'today' });
 
@@ -111,11 +105,11 @@ describe('AdminDashboardService', () => {
     });
 
     it('should return 100% diff when previous is 0 and current > 0', async () => {
-      orderRepo.find
-        .mockResolvedValueOnce([{ totalAmount: '50000', status: OrderStatus.PAID, createdAt: new Date() }])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
+      orderRepo.createQueryBuilder
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawOne: jest.fn().mockResolvedValue({ revenue: '50000', count: '1' }) }))
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawOne: jest.fn().mockResolvedValue({ revenue: '0', count: '0' }) }))
+        .mockReturnValueOnce(createMockQueryBuilder({ getRawMany: jest.fn().mockResolvedValue([]) }))
+        .mockReturnValue(createMockQueryBuilder({ getRawMany: jest.fn().mockResolvedValue([]) }));
 
       const result = await service.getDashboard({ period: 'today' });
 
@@ -123,18 +117,16 @@ describe('AdminDashboardService', () => {
     });
 
     it('should aggregate order status summary', async () => {
-      orderRepo.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ total: '0' }),
-        getRawMany: jest.fn().mockResolvedValue([
-          { status: 'pending', count: '5' },
-          { status: 'paid', count: '12' },
-          { status: 'delivered', count: '150' },
-        ]),
-      });
+      orderRepo.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({
+          getRawOne: jest.fn().mockResolvedValue({ revenue: '0', count: '0' }),
+          getRawMany: jest.fn().mockResolvedValue([
+            { status: 'pending', count: '5' },
+            { status: 'paid', count: '12' },
+            { status: 'delivered', count: '150' },
+          ]),
+        }),
+      );
 
       const result = await service.getDashboard({});
 
@@ -155,11 +147,8 @@ describe('AdminDashboardService', () => {
         },
       ];
 
-      orderRepo.find
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce(mockOrders);
+      // getRecentOrders still uses find(); KPI/chart now use createQueryBuilder
+      orderRepo.find.mockResolvedValue(mockOrders);
 
       const result = await service.getDashboard({});
 
@@ -210,14 +199,9 @@ describe('AdminDashboardService', () => {
     });
 
     it('should sum product view counts for total_product_views', async () => {
-      productRepo.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ total: '4520' }),
-        getRawMany: jest.fn().mockResolvedValue([]),
-      });
+      productRepo.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({ getRawOne: jest.fn().mockResolvedValue({ total: '4520' }) }),
+      );
 
       const result = await service.getDashboard({});
 
@@ -225,14 +209,9 @@ describe('AdminDashboardService', () => {
     });
 
     it('should handle null view count total', async () => {
-      productRepo.createQueryBuilder.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawOne: jest.fn().mockResolvedValue({ total: null }),
-        getRawMany: jest.fn().mockResolvedValue([]),
-      });
+      productRepo.createQueryBuilder.mockReturnValue(
+        createMockQueryBuilder({ getRawOne: jest.fn().mockResolvedValue({ total: null }) }),
+      );
 
       const result = await service.getDashboard({});
 
@@ -240,19 +219,15 @@ describe('AdminDashboardService', () => {
     });
 
     it('should show user name as 알 수 없음 when user is null', async () => {
-      orderRepo.find
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([
-          {
-            orderNumber: 'ORD-002',
-            user: null,
-            totalAmount: '10000',
-            status: OrderStatus.PENDING,
-            createdAt: new Date(),
-          },
-        ]);
+      orderRepo.find.mockResolvedValue([
+        {
+          orderNumber: 'ORD-002',
+          user: null,
+          totalAmount: '10000',
+          status: OrderStatus.PENDING,
+          createdAt: new Date(),
+        },
+      ]);
 
       const result = await service.getDashboard({});
 

--- a/backend/src/modules/admin/admin-dashboard.service.ts
+++ b/backend/src/modules/admin/admin-dashboard.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Between, Not, In } from 'typeorm';
+import { Repository, Between } from 'typeorm';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
 import { User } from '../users/entities/user.entity';
 import { Product } from '../products/entities/product.entity';
@@ -139,20 +139,22 @@ export class AdminDashboardService {
 
     const excludedStatuses = [OrderStatus.CANCELLED, OrderStatus.REFUNDED];
 
-    const [todayOrders, yesterdayOrders, todayMembers, yesterdayMembers, viewCountResult] =
+    const [todayAgg, yesterdayAgg, todayMembers, yesterdayMembers, viewCountResult] =
       await Promise.all([
-        this.orderRepository.find({
-          where: {
-            createdAt: Between(todayStart, todayEnd),
-            status: Not(In(excludedStatuses)),
-          },
-        }),
-        this.orderRepository.find({
-          where: {
-            createdAt: Between(yesterdayStart, yesterdayEnd),
-            status: Not(In(excludedStatuses)),
-          },
-        }),
+        this.orderRepository
+          .createQueryBuilder('o')
+          .select('COALESCE(SUM(o.totalAmount), 0)', 'revenue')
+          .addSelect('COUNT(*)', 'count')
+          .where('o.createdAt BETWEEN :start AND :end', { start: todayStart, end: todayEnd })
+          .andWhere('o.status NOT IN (:...statuses)', { statuses: excludedStatuses })
+          .getRawOne() as Promise<{ revenue: string; count: string }>,
+        this.orderRepository
+          .createQueryBuilder('o')
+          .select('COALESCE(SUM(o.totalAmount), 0)', 'revenue')
+          .addSelect('COUNT(*)', 'count')
+          .where('o.createdAt BETWEEN :start AND :end', { start: yesterdayStart, end: yesterdayEnd })
+          .andWhere('o.status NOT IN (:...statuses)', { statuses: excludedStatuses })
+          .getRawOne() as Promise<{ revenue: string; count: string }>,
         this.userRepository.count({
           where: { createdAt: Between(todayStart, todayEnd) },
         }),
@@ -165,17 +167,10 @@ export class AdminDashboardService {
           .getRawOne() as Promise<{ total: string | null }>,
       ]);
 
-    const todayRevenue = todayOrders.reduce(
-      (sum, o) => sum + Number(o.totalAmount),
-      0,
-    );
-    const yesterdayRevenue = yesterdayOrders.reduce(
-      (sum, o) => sum + Number(o.totalAmount),
-      0,
-    );
-
-    const todayOrderCount = todayOrders.length;
-    const yesterdayOrderCount = yesterdayOrders.length;
+    const todayRevenue = Number(todayAgg?.revenue ?? 0);
+    const yesterdayRevenue = Number(yesterdayAgg?.revenue ?? 0);
+    const todayOrderCount = Number(todayAgg?.count ?? 0);
+    const yesterdayOrderCount = Number(yesterdayAgg?.count ?? 0);
 
     return {
       today_revenue: todayRevenue,
@@ -204,12 +199,15 @@ export class AdminDashboardService {
   ): Promise<RevenueChartItem[]> {
     const excludedStatuses = [OrderStatus.CANCELLED, OrderStatus.REFUNDED];
 
-    const orders = await this.orderRepository.find({
-      where: {
-        createdAt: Between(startDate, endDate),
-        status: Not(In(excludedStatuses)),
-      },
-    });
+    const rows = await this.orderRepository
+      .createQueryBuilder('o')
+      .select('DATE(o.createdAt)', 'date')
+      .addSelect('COALESCE(SUM(o.totalAmount), 0)', 'revenue')
+      .addSelect('COUNT(*)', 'count')
+      .where('o.createdAt BETWEEN :start AND :end', { start: startDate, end: endDate })
+      .andWhere('o.status NOT IN (:...statuses)', { statuses: excludedStatuses })
+      .groupBy('DATE(o.createdAt)')
+      .getRawMany() as { date: string; revenue: string; count: string }[];
 
     const dailyMap = new Map<string, { revenue: number; count: number }>();
 
@@ -220,12 +218,11 @@ export class AdminDashboardService {
       current.setDate(current.getDate() + 1);
     }
 
-    for (const order of orders) {
-      const dateStr = new Date(order.createdAt).toISOString().split('T')[0];
-      const entry = dailyMap.get(dateStr);
-      if (entry) {
-        entry.revenue += Number(order.totalAmount);
-        entry.count += 1;
+    for (const row of rows) {
+      if (!row.date) continue;
+      const dateStr = typeof row.date === 'string' ? row.date.split('T')[0] : new Date(row.date).toISOString().split('T')[0];
+      if (dailyMap.has(dateStr)) {
+        dailyMap.set(dateStr, { revenue: Number(row.revenue), count: Number(row.count) });
       }
     }
 


### PR DESCRIPTION
## Summary
- Closes #320
- `admin-dashboard.service.ts`의 KPI/매출 차트에서 전체 Order 엔티티 로드 → SQL 집계 쿼리로 변경
- 불필요한 메모리 사용 및 데이터 전송 제거

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm run test