### PR TITLE
feat: #324 프로덕션 JWT_REFRESH_SECRET 미설정 시 기동 차단

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -46,6 +46,9 @@ export class AuthService implements OnModuleInit {
 
   onModuleInit() {
     if (!process.env.JWT_REFRESH_SECRET) {
+      if (process.env.NODE_ENV === 'production') {
+        throw new Error('JWT_REFRESH_SECRET must be set in production');
+      }
       this.logger.warn(
         'JWT_REFRESH_SECRET is not set. Using JWT_SECRET as fallback. Set a separate secret in production.',
       );


### PR DESCRIPTION
## Summary
- Closes #324
- `auth.service.ts`의 `onModuleInit()`에서 프로덕션 환경일 때 `JWT_REFRESH_SECRET` 미설정 시 하드 실패 처리
- 개발 환경에서는 기존 warn 로그 유지

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm run test (auth.service.spec.ts PASS)