### PR TITLE
feat: #315 findOrThrow 유틸 적용으로 인라인 findOne+throw 패턴 제거

### DIFF
--- a/backend/src/modules/admin/admin-members.service.ts
+++ b/backend/src/modules/admin/admin-members.service.ts
@@ -117,7 +117,7 @@ export class AdminMembersService {
       `Member #${targetId} role changed: ${target.role} → ${newRole} by #${requesterId}`,
     );
 
-    const updated = await this.userRepository.findOne({ where: { id: targetId } });
-    return toSafeUser(updated!);
+    const updated = await findOrThrow(this.userRepository, { id: targetId }, '회원을 찾을 수 없습니다.');
+    return toSafeUser(updated);
   }
 }

--- a/backend/src/modules/cart/cart.service.ts
+++ b/backend/src/modules/cart/cart.service.ts
@@ -1,6 +1,5 @@
 import {
   Injectable,
-  NotFoundException,
   BadRequestException,
   Logger,
 } from '@nestjs/common';
@@ -96,12 +95,7 @@ export class CartService {
   }
 
   async add(userId: number, dto: AddToCartDto): Promise<CartResponse> {
-    const product = await this.productRepository.findOne({
-      where: { id: dto.productId },
-    });
-    if (!product) {
-      throw new NotFoundException('상품을 찾을 수 없습니다.');
-    }
+    const product = await findOrThrow(this.productRepository, { id: dto.productId }, '상품을 찾을 수 없습니다.');
 
     if (dto.productOptionId != null) {
       const option = await this.productOptionRepository.findOne({

--- a/backend/src/modules/coupons/coupons.service.ts
+++ b/backend/src/modules/coupons/coupons.service.ts
@@ -139,14 +139,7 @@ export class CouponsService {
     let couponDiscount = 0;
 
     if (userCouponId) {
-      const uc = await this.userCouponRepo.findOne({
-        where: { id: userCouponId, userId },
-        relations: ['coupon'],
-      });
-
-      if (!uc) {
-        throw new NotFoundException('쿠폰을 찾을 수 없습니다.');
-      }
+      const uc = await findOrThrow(this.userCouponRepo, { id: userCouponId, userId }, '쿠폰을 찾을 수 없습니다.', ['coupon']);
 
       const now = new Date();
       if (uc.coupon.expiresAt < now) {

--- a/backend/src/modules/pages/pages.service.ts
+++ b/backend/src/modules/pages/pages.service.ts
@@ -1,7 +1,6 @@
 import {
   Injectable,
   ConflictException,
-  NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -43,13 +42,7 @@ export class PagesService {
   }
 
   async findBySlug(slug: string): Promise<Page> {
-    const page = await this.pageRepository.findOne({
-      where: { slug, is_published: true },
-      relations: ['blocks'],
-    });
-    if (!page) {
-      throw new NotFoundException('존재하지 않는 페이지입니다.');
-    }
+    const page = await findOrThrow(this.pageRepository, { slug, is_published: true }, '존재하지 않는 페이지입니다.', ['blocks']);
     page.blocks = page.blocks
       .filter((b) => b.is_visible)
       .sort((a, b) => a.sort_order - b.sort_order);
@@ -118,12 +111,7 @@ export class PagesService {
     blockId: number,
     dto: UpdatePageBlockDto,
   ): Promise<PageBlock> {
-    const block = await this.blockRepository.findOne({
-      where: { id: blockId, page_id: pageId },
-    });
-    if (!block) {
-      throw new NotFoundException('존재하지 않는 블록입니다.');
-    }
+    const block = await findOrThrow(this.blockRepository, { id: blockId, page_id: pageId }, '존재하지 않는 블록입니다.');
     if (dto.type && !SUPPORTED_BLOCK_TYPES.includes(dto.type)) {
       throw new BadRequestException('지원하지 않는 블록 타입입니다.');
     }
@@ -132,12 +120,7 @@ export class PagesService {
   }
 
   async removeBlock(pageId: number, blockId: number): Promise<void> {
-    const block = await this.blockRepository.findOne({
-      where: { id: blockId, page_id: pageId },
-    });
-    if (!block) {
-      throw new NotFoundException('존재하지 않는 블록입니다.');
-    }
+    const block = await findOrThrow(this.blockRepository, { id: blockId, page_id: pageId }, '존재하지 않는 블록입니다.');
     await this.blockRepository.remove(block);
   }
 

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -1,5 +1,5 @@
 import {
-  Injectable, NotFoundException, BadRequestException, ConflictException,
+  Injectable, BadRequestException, ConflictException,
   Logger, Inject, InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -16,6 +16,7 @@ import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
 import { resolveGatewayByLocale } from './payments.module';
 import { assertOwnership } from '../../common/utils/ownership.util';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 @Injectable()
 export class PaymentsService {
@@ -43,8 +44,7 @@ export class PaymentsService {
   }
 
   async prepare(dto: PreparePaymentDto, userId: number) {
-    const order = await this.orderRepository.findOne({ where: { id: dto.orderId } });
-    if (!order) throw new NotFoundException('주문을 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: dto.orderId }, '주문을 찾을 수 없습니다.');
     assertOwnership(order.userId, userId);
     if (order.status !== OrderStatus.PENDING) {
       throw new ConflictException('이미 처리된 주문입니다.');
@@ -78,11 +78,7 @@ export class PaymentsService {
   }
 
   async confirm(dto: ConfirmPaymentDto, userId: number) {
-    const payment = await this.paymentRepository.findOne({
-      where: { orderId: dto.orderId },
-      relations: ['order'],
-    });
-    if (!payment) throw new NotFoundException('결제 정보를 찾을 수 없습니다.');
+    const payment = await findOrThrow(this.paymentRepository, { orderId: dto.orderId }, '결제 정보를 찾을 수 없습니다.', ['order']);
     assertOwnership(payment.order.userId, userId);
 
     if (payment.status === PaymentStatus.CONFIRMED) {
@@ -139,11 +135,7 @@ export class PaymentsService {
   }
 
   async cancel(dto: CancelPaymentDto, userId: number) {
-    const payment = await this.paymentRepository.findOne({
-      where: { orderId: dto.orderId },
-      relations: ['order'],
-    });
-    if (!payment) throw new NotFoundException('결제 정보를 찾을 수 없습니다.');
+    const payment = await findOrThrow(this.paymentRepository, { orderId: dto.orderId }, '결제 정보를 찾을 수 없습니다.', ['order']);
     assertOwnership(payment.order.userId, userId);
 
     if (payment.status !== PaymentStatus.CONFIRMED) {

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -175,12 +175,9 @@ export class ReviewsService {
     this.logger.log(`Review created: id=${saved.id}, userId=${userId}, productId=${dto.productId}`);
 
     // Reload with user
-    const loaded = await this.reviewRepo.findOne({
-      where: { id: saved.id },
-      relations: ['user'],
-    });
+    const loaded = await findOrThrow(this.reviewRepo, { id: saved.id }, '리뷰를 찾을 수 없습니다.', ['user']);
 
-    return this.toResponse(loaded!);
+    return this.toResponse(loaded);
   }
 
   async update(id: number, userId: number, dto: UpdateReviewDto): Promise<ReviewResponse> {


### PR DESCRIPTION
## Summary
- Closes #315
- 8개 서비스 파일에서 인라인 `findOne → null check → throw NotFoundException` 패턴을 `findOrThrow` 유틸로 교체
- 대상: payments, cart, pages, admin-orders, admin-members, coupons, reviews, shipping

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm run test