### PR TITLE
feat: #317 coupons에서 assertOwnership 유틸 적용

### DIFF
--- a/backend/src/modules/coupons/coupons.service.ts
+++ b/backend/src/modules/coupons/coupons.service.ts
@@ -13,6 +13,7 @@ import { CreateCouponDto } from './dto/create-coupon.dto';
 import { CalculateDiscountDto } from './dto/calculate-discount.dto';
 import { IssueCouponDto } from './dto/issue-coupon.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { assertOwnership } from '../../common/utils/ownership.util';
 
 export interface CouponResponse {
   id: number;
@@ -266,9 +267,7 @@ export class CouponsService {
       if (!uc) {
         throw new NotFoundException('쿠폰을 찾을 수 없습니다.');
       }
-      if (Number(uc.userId) !== Number(userId)) {
-        throw new BadRequestException('권한이 없는 쿠폰입니다.');
-      }
+      assertOwnership(uc.userId, userId, '권한이 없는 쿠폰입니다.');
       if (uc.status !== 'available') {
         throw new BadRequestException('이미 사용된 쿠폰입니다.');
       }


### PR DESCRIPTION
## Summary
- Closes #317
- `coupons.service.ts`에서 인라인 `Number(x) !== Number(y)` 소유권 비교를 `assertOwnership` 유틸로 교체
- BigInt 문자열 비교 버그 위험 제거

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm run test (coupons 전체 통과)