### PR TITLE
feat: #323 pages.service 블록 재정렬 병렬화

### DIFF
--- a/backend/src/modules/pages/pages.service.ts
+++ b/backend/src/modules/pages/pages.service.ts
@@ -146,11 +146,13 @@ export class PagesService {
     dto: ReorderBlocksDto,
   ): Promise<void> {
     const page = await findOrThrow(this.pageRepository, { id: pageId }, '존재하지 않는 페이지입니다.');
-    for (const item of dto.orders) {
-      await this.blockRepository.update(
-        { id: item.id, page_id: pageId },
-        { sort_order: item.sort_order },
-      );
-    }
+    await Promise.all(
+      dto.orders.map((item) =>
+        this.blockRepository.update(
+          { id: item.id, page_id: pageId },
+          { sort_order: item.sort_order },
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Closes #323
- `pages.service.ts`에서 순차 `for-of await` 블록 재정렬을 병렬 처리로 변경

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm run test (pages module: 21/21 passed)