### PR TITLE
fix: #296 auth 엔드포인트 401 시 토큰 갱신 스킵 처리

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,15 @@
 const API_BASE = '/api';
 
+// Auth endpoints that must not trigger token refresh on 401 (would cause infinite loops)
+const AUTH_SKIP_REFRESH = new Set([
+  '/auth/login',
+  '/auth/register',
+  '/auth/refresh',
+  '/auth/logout',
+  '/auth/kakao',
+  '/auth/google',
+]);
+
 // 401 interceptor state — shared across all ApiClient instances
 let _isRefreshing = false;
 let _refreshQueue: Array<{ resolve: () => void; reject: (err: unknown) => void }> = [];
@@ -183,7 +193,7 @@ class ApiClient {
     });
 
     if (response.status === 401) {
-      if (endpoint === '/auth/login') {
+      if (AUTH_SKIP_REFRESH.has(endpoint)) {
         const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
         throw new Error(error.message || `HTTP ${response.status}`);
       }


### PR DESCRIPTION
## Summary

- `/auth/login`만 토큰 갱신 스킵하던 401 인터셉터를 모든 auth 엔드포인트로 확장
- `/auth/refresh` → 401 → refresh → 401 무한 루프 방지
- `AUTH_SKIP_REFRESH` Set을 모듈 스코프 상수로 정의 (SCREAMING_SNAKE_CASE 컨벤션)

## 변경 파일

- `src/lib/api.ts`: 401 핸들러에서 단일 `/auth/login` 체크 → `AUTH_SKIP_REFRESH` Set 체크로 교체

Closes #296