### PR TITLE
fix: #303 스크롤 핸들러 리렌더 최적화 및 MobileNavContext 메모이제이션

### DIFF
--- a/src/contexts/MobileNavContext.tsx
+++ b/src/contexts/MobileNavContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useMemo, useState } from 'react'
 
 interface MobileNavContextValue {
   isVisible: boolean
@@ -17,8 +17,10 @@ export function MobileNavProvider({
 }) {
   const [isVisible] = useState(initialVisible)
 
+  const value = useMemo(() => ({ isVisible }), [isVisible])
+
   return (
-    <MobileNavContext.Provider value={{ isVisible }}>
+    <MobileNavContext.Provider value={value}>
       {children}
     </MobileNavContext.Provider>
   )

--- a/src/hooks/useScrollLogoTransition.ts
+++ b/src/hooks/useScrollLogoTransition.ts
@@ -37,10 +37,12 @@ export function useScrollLogoTransition({
       const heroEl = heroRef.current;
       if (!heroEl) return;
       const rect = heroEl.getBoundingClientRect();
-      setCachedRect({
-        top: rect.top + window.scrollY,
-        left: rect.left,
-        height: rect.height,
+      setCachedRect((prev) => {
+        const newRect = { top: rect.top + window.scrollY, left: rect.left, height: rect.height };
+        if (prev && prev.top === newRect.top && prev.left === newRect.left && prev.height === newRect.height) {
+          return prev;
+        }
+        return newRect;
       });
     };
 
@@ -133,7 +135,7 @@ export function useScrollLogoTransition({
           newProgress = Math.min(1, Math.max(0, scrolled / scrollableDistance));
         }
 
-        setProgress(newProgress);
+        setProgress((prev) => Math.abs(newProgress - prev) > 0.01 ? newProgress : prev);
       });
     };
 


### PR DESCRIPTION
## Summary
- `useScrollLogoTransition`: `setProgress`에 threshold 체크 추가 — 변화량이 0.01 미만이면 state 업데이트 스킵
- `useScrollLogoTransition`: `setCachedRect`에 동일값 체크 추가 — ResizeObserver 콜백에서 불필요한 리렌더 방지
- `MobileNavContext`: context value를 `useMemo`로 감싸 매 렌더마다 새 객체 생성 방지

## Test plan
- [ ] 빌드 통과 확인
- [ ] 기존 테스트 통과 확인 (사전 실패 26건 제외)
- [ ] 스크롤 시 로고 전환 애니메이션 정상 동작 확인

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)