### PR TITLE
fix: #306 useNavigation 모듈 레벨 캐시 추가 (TTL 5분)

### DIFF
--- a/src/hooks/__tests__/useNavigation.test.ts
+++ b/src/hooks/__tests__/useNavigation.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useNavigation } from '../useNavigation';
+import { useNavigation, clearNavCache } from '../useNavigation';
 
 const mockGetByGroup = vi.fn();
 
@@ -12,6 +12,7 @@ vi.mock('@/lib/api', () => ({
 describe('useNavigation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearNavCache();
   });
 
   it('API에서 네비게이션 항목을 가져온다', async () => {

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -51,6 +51,24 @@ function getStaticFallback(group: 'gnb' | 'sidebar' | 'footer'): NavigationItem[
   }
 }
 
+// Module-level cache with TTL
+const NAV_CACHE = new Map<string, { data: NavigationItem[]; timestamp: number }>();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+function getCached(group: string): NavigationItem[] | null {
+  const entry = NAV_CACHE.get(group);
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > CACHE_TTL) {
+    NAV_CACHE.delete(group);
+    return null;
+  }
+  return entry.data;
+}
+
+export function clearNavCache(): void {
+  NAV_CACHE.clear();
+}
+
 export function useNavigation(group: 'gnb' | 'sidebar' | 'footer') {
   const [items, setItems] = useState<NavigationItem[]>(getStaticFallback(group));
   const [loading, setLoading] = useState(true);
@@ -59,10 +77,19 @@ export function useNavigation(group: 'gnb' | 'sidebar' | 'footer') {
     let cancelled = false;
 
     async function load() {
+      const cached = getCached(group);
+      if (cached) {
+        setItems(cached);
+        setLoading(false);
+        return;
+      }
+
       try {
         const data = await navigationApi.getByGroup(group);
         if (!cancelled) {
-          setItems(data.length > 0 ? data : getStaticFallback(group));
+          const result = data.length > 0 ? data : getStaticFallback(group);
+          setItems(result);
+          NAV_CACHE.set(group, { data: result, timestamp: Date.now() });
         }
       } catch {
         if (!cancelled) {


### PR DESCRIPTION
## Summary

- `useNavigation` 훅에 모듈 레벨 캐시(`NAV_CACHE`) 추가 — TTL 5분
- 페이지 이동 시마다 발생하던 gnb/sidebar 중복 API 호출 제거
- `clearNavCache()` 함수 export하여 테스트 격리 지원

## Test plan

- [ ] `useNavigation` 단위 테스트 4개 통과 확인
- [ ] 빌드 성공 확인
- [ ] 브라우저에서 페이지 이동 시 네트워크 탭에서 navigation API 중복 호출 없음 확인

Closes #306