### PR TITLE
fix: #298 raw fetch 3곳을 ApiClient/api-server로 교체

### DIFF
--- a/src/app/[locale]/admin/settings/theme/page.tsx
+++ b/src/app/[locale]/admin/settings/theme/page.tsx
@@ -1,17 +1,13 @@
 import type { SiteSetting } from '@/lib/api';
+import { fetchSettings } from '@/lib/api-server';
 import ThemeEditor from './ThemeEditor';
 
 export const metadata = { title: '테마 편집' };
 
-const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
-
 export default async function ThemeSettingsPage() {
   let initialSettings: SiteSetting[] = [];
   try {
-    const res = await fetch(`${BACKEND_URL}/api/settings`, { cache: 'no-store' });
-    if (res.ok) {
-      initialSettings = await res.json() as SiteSetting[];
-    }
+    initialSettings = await fetchSettings();
   } catch {
     // fallback to empty - ThemeEditor handles empty state
   }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import Providers from '@/components/Providers';
 import RecentlyViewedWidget from '@/components/RecentlyViewedWidget';
 import { routing } from '@/i18n/routing';
 import type { Locale } from '@/i18n/routing';
+import { fetchSettingsMap } from '@/lib/api-server';
 
 const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
 
@@ -43,8 +44,6 @@ export async function generateMetadata({
   };
 }
 
-const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
-
 async function getThemeStyle(map: Record<string, string> | null): Promise<string> {
   if (!map) return '';
   const COLOR_RE = /^#[0-9a-fA-F]{3,8}$|^rgb\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)$/;
@@ -73,11 +72,7 @@ async function getThemeStyle(map: Record<string, string> | null): Promise<string
 
 async function getSettingsMap(): Promise<Record<string, string> | null> {
   try {
-    const res = await fetch(`${BACKEND_URL}/api/settings/map`, {
-      cache: 'no-store',
-    });
-    if (!res.ok) return null;
-    return res.json();
+    return await fetchSettingsMap();
   } catch {
     return null;
   }

--- a/src/components/MobileBottomNavWrapper.tsx
+++ b/src/components/MobileBottomNavWrapper.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { settingsApi } from '@/lib/api';
 import MobileBottomNav from './MobileBottomNav';
 
 export default function MobileBottomNavWrapper() {
   const [visible, setVisible] = useState<boolean | null>(null);
 
   useEffect(() => {
-    fetch('/api/settings?group=general')
-      .then((res) => res.json())
-      .then((data: Array<{ key: string; value: string }>) => {
+    settingsApi
+      .getAll('general')
+      .then((data) => {
         const setting = data.find((s) => s.key === 'mobile_bottom_nav_visible');
         setVisible(setting ? setting.value === 'true' : true);
       })

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,5 +1,5 @@
 import { cache } from 'react';
-import type { ProductListResponse, ProductSort, Category, ProductDetail, Page, CollectionsResponse, ArchivesResponse } from '@/lib/api';
+import type { ProductListResponse, ProductSort, Category, ProductDetail, Page, CollectionsResponse, ArchivesResponse, SiteSetting } from '@/lib/api';
 
 const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
 
@@ -76,4 +76,12 @@ export function fetchCollections() {
 
 export function fetchArchives() {
   return fetchFromBackend<ArchivesResponse>('/archives');
+}
+
+export function fetchSettings(group?: string) {
+  return fetchFromBackend<SiteSetting[]>('/settings', group ? { group } : undefined);
+}
+
+export function fetchSettingsMap() {
+  return fetchFromBackend<Record<string, string>>('/settings/map');
 }


### PR DESCRIPTION
## Summary
- `MobileBottomNavWrapper.tsx`: raw `fetch('/api/settings?group=general')` → `settingsApi.getAll('general')` from `@/lib/api`
- `admin/settings/theme/page.tsx`: raw `fetch(BACKEND_URL + '/api/settings')` → `fetchSettings()` from `@/lib/api-server`
- `[locale]/layout.tsx`: raw `fetch(BACKEND_URL + '/api/settings/map')` → `fetchSettingsMap()` from `@/lib/api-server`
- `api-server.ts`: `fetchSettings(group?)` 및 `fetchSettingsMap()` 헬퍼 함수 추가

## Test plan
- [ ] `npm run build` 통과 확인
- [ ] 기존 테스트 실패는 pre-existing (11 failed before changes)

Closes #298