### PR TITLE
fix: #299 silent catch 4곳에 에러 피드백 추가

### DIFF
--- a/src/app/[locale]/my/page.tsx
+++ b/src/app/[locale]/my/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
@@ -9,6 +10,7 @@ import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { ORDER_STATUS_LABELS } from '@/constants/status';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { formatCurrency } from '@/utils/currency';
+import { handleApiError } from '@/utils/error';
 import {
   Package,
   Heart,
@@ -41,7 +43,10 @@ export default function MyPage() {
     ordersApi
       .getList({ page: 1, limit: 3 })
       .then((res) => setRecentOrders(res.items))
-      .catch(() => setRecentOrders([]))
+      .catch((err: unknown) => {
+        toast.error(handleApiError(err, '주문 내역을 불러올 수 없습니다.'));
+        setRecentOrders([]);
+      })
       .finally(() => setOrdersLoading(false));
   }, [isAuthenticated]);
 

--- a/src/app/[locale]/order/complete/page.tsx
+++ b/src/app/[locale]/order/complete/page.tsx
@@ -5,9 +5,11 @@ import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { CheckCircle } from 'lucide-react';
+import { toast } from 'sonner';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
+import { handleApiError } from '@/utils/error';
 
 function OrderCompleteContent() {
   const router = useRouter();
@@ -32,7 +34,8 @@ function OrderCompleteContent() {
     ordersApi
       .getById(id)
       .then((data) => setOrder(data))
-      .catch(() => {
+      .catch((err: unknown) => {
+        toast.error(handleApiError(err, '주문 정보를 불러올 수 없습니다.'));
         router.replace('/');
       })
       .finally(() => setIsLoading(false));

--- a/src/components/MobileBottomNavWrapper.tsx
+++ b/src/components/MobileBottomNavWrapper.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { settingsApi } from '@/lib/api';
 import MobileBottomNav from './MobileBottomNav';
+import { handleApiError } from '@/utils/error';
 
 export default function MobileBottomNavWrapper() {
   const [visible, setVisible] = useState<boolean | null>(null);
@@ -14,7 +16,10 @@ export default function MobileBottomNavWrapper() {
         const setting = data.find((s) => s.key === 'mobile_bottom_nav_visible');
         setVisible(setting ? setting.value === 'true' : true);
       })
-      .catch(() => setVisible(true));
+      .catch((err: unknown) => {
+        toast.error(handleApiError(err, '설정을 불러올 수 없습니다.'));
+        setVisible(true);
+      });
   }, []);
 
   if (visible === null) return null;

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { toast } from 'sonner'
 import { reviewsApi } from '@/lib/api'
 import type { ReviewItem, ReviewStats as ReviewStatsType, ReviewSort } from '@/lib/api'
 import { cn } from '@/components/ui/utils'
+import { handleApiError } from '@/utils/error'
 import ReviewCard from './ReviewCard'
 import ReviewStatsComponent from './ReviewStats'
 
@@ -37,8 +39,8 @@ export default function ReviewList({ productId }: ReviewListProps) {
       setReviews(res.data)
       setStats(res.stats)
       setTotal(res.pagination.total)
-    } catch {
-      // Silently fail - empty state is shown
+    } catch (err: unknown) {
+      toast.error(handleApiError(err, '리뷰를 불러올 수 없습니다.'))
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
## Summary

- `my/page.tsx`: 주문 내역 로드 실패 시 toast.error 피드백 추가
- `order/complete/page.tsx`: 주문 정보 로드 실패 시 toast.error 피드백 추가
- `ReviewList.tsx`: 리뷰 로드 실패 시 toast.error 피드백 추가 (silent catch 제거)
- `MobileBottomNavWrapper.tsx`: 설정 로드 실패 시 toast.error 피드백 추가

code-style 규칙 위반 (`silent .catch(() => {})`) 4곳을 모두 수정하여 모든 catch 블록이 에러를 처리하도록 함.

## Test plan

- [ ] 각 페이지에서 네트워크 오류 시 toast 에러 메시지가 표시되는지 확인
- [ ] `npm run build` 통과 확인
- [ ] 기존 테스트 통과 확인 (26개 실패는 pre-existing)

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)