### PR TITLE
refactor: #300 수동 로딩 상태 9곳을 useAsyncAction으로 마이그레이션

### DIFF
--- a/src/app/[locale]/my/coupons/page.tsx
+++ b/src/app/[locale]/my/coupons/page.tsx
@@ -7,8 +7,7 @@ import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { cn } from '@/components/ui/utils';
 import { formatCurrency } from '@/utils/currency';
-import { handleApiError } from '@/utils/error';
-import { toast } from 'sonner';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 type TabStatus = 'available' | 'used' | 'expired';
 
@@ -62,23 +61,20 @@ export default function MyCouponsPage() {
   const [tab, setTab] = useState<TabStatus>('available');
   const [coupons, setCoupons] = useState<CouponItem[]>([]);
   const [pointBalance, setPointBalance] = useState(0);
-  const [dataLoading, setDataLoading] = useState(true);
+
+  const { execute: loadCoupons, isLoading: dataLoading } = useAsyncAction(
+    async () => {
+      const res = await couponsApi.getList(tab);
+      setCoupons(res.coupons);
+      setPointBalance(res.points.balance);
+    },
+    { errorMessage: '쿠폰 목록을 불러오지 못했습니다.' },
+  );
 
   useEffect(() => {
     if (!isAuthenticated) return;
-    setDataLoading(true);
-    couponsApi
-      .getList(tab)
-      .then((res) => {
-        setCoupons(res.coupons);
-        setPointBalance(res.points.balance);
-      })
-      .catch((err) => {
-        setCoupons([]);
-        toast.error(handleApiError(err, '쿠폰 목록을 불러오지 못했습니다.'));
-      })
-      .finally(() => setDataLoading(false));
-  }, [isAuthenticated, tab]);
+    void loadCoupons();
+  }, [isAuthenticated, tab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isLoading) {
     return (

--- a/src/app/[locale]/my/inquiries/new/page.tsx
+++ b/src/app/[locale]/my/inquiries/new/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { inquiriesApi } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
-import { handleApiError } from '@/utils/error';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 const INQUIRY_TYPES = ['상품', '배송', '결제', '교환/반품', '기타'];
 
@@ -16,24 +16,21 @@ export default function NewInquiryPage() {
   const [type, setType] = useState(INQUIRY_TYPES[0]);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [submitting, setSubmitting] = useState(false);
+  const { execute: submitInquiry, isLoading: submitting } = useAsyncAction(
+    async () => {
+      await inquiriesApi.create({ type, title: title.trim(), content: content.trim() });
+      router.push('/my/inquiries');
+    },
+    { successMessage: '문의가 접수되었습니다.', errorMessage: '문의 접수에 실패했습니다.' },
+  );
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !content.trim()) {
       toast.error('제목과 내용을 입력해주세요.');
       return;
     }
-    setSubmitting(true);
-    try {
-      await inquiriesApi.create({ type, title: title.trim(), content: content.trim() });
-      toast.success('문의가 접수되었습니다.');
-      router.push('/my/inquiries');
-    } catch (err) {
-      toast.error(handleApiError(err, '문의 접수에 실패했습니다.'));
-    } finally {
-      setSubmitting(false);
-    }
+    void submitInquiry();
   };
 
   return (

--- a/src/app/[locale]/my/profile/page.tsx
+++ b/src/app/[locale]/my/profile/page.tsx
@@ -2,12 +2,11 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { toast } from 'sonner';
-import { handleApiError } from '@/utils/error';
 import { useAuth } from '@/contexts/AuthContext';
 import { usersApi } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 interface ProfileForm {
   name: string;
@@ -35,7 +34,17 @@ export default function ProfilePage() {
   const { user, updateUser } = useAuth();
   const [form, setForm] = useState<ProfileForm>({ name: '', phone: '' });
   const [errors, setErrors] = useState<FormErrors>({});
-  const [submitting, setSubmitting] = useState(false);
+
+  const { execute: submitProfile, isLoading: submitting } = useAsyncAction(
+    async () => {
+      const updated = await usersApi.updateProfile({
+        name: form.name.trim(),
+        phone: form.phone.trim() || null,
+      });
+      updateUser({ name: updated.name, phone: updated.phone });
+    },
+    { successMessage: '회원정보가 수정되었습니다.', errorMessage: '수정 중 오류가 발생했습니다.' },
+  );
 
   useEffect(() => {
     if (user) {
@@ -51,27 +60,14 @@ export default function ProfilePage() {
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const validationErrors = validateForm(form);
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
       return;
     }
-
-    setSubmitting(true);
-    try {
-      const updated = await usersApi.updateProfile({
-        name: form.name.trim(),
-        phone: form.phone.trim() || null,
-      });
-      updateUser({ name: updated.name, phone: updated.phone });
-      toast.success('회원정보가 수정되었습니다.');
-    } catch (err) {
-      toast.error(handleApiError(err, '수정 중 오류가 발생했습니다.'));
-    } finally {
-      setSubmitting(false);
-    }
+    void submitProfile();
   };
 
   if (isLoading || !user) {

--- a/src/app/[locale]/my/wishlist/page.tsx
+++ b/src/app/[locale]/my/wishlist/page.tsx
@@ -4,52 +4,50 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
 import { wishlistApi, cartApi } from '@/lib/api';
 import type { WishlistItem } from '@/lib/api';
-import { handleApiError } from '@/utils/error';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import EmptyState from '@/components/EmptyState';
 import { cn } from '@/components/ui/utils';
 import PriceDisplay from '@/components/common/PriceDisplay';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 export default function WishlistPage() {
   const router = useRouter();
   const { isAuthenticated, isLoading } = useRequireAuth();
   const [items, setItems] = useState<WishlistItem[]>([]);
-  const [dataLoading, setDataLoading] = useState(true);
+
+  const { execute: loadWishlist, isLoading: dataLoading } = useAsyncAction(
+    async () => {
+      const res = await wishlistApi.getList();
+      setItems(res.data);
+    },
+    { errorMessage: '위시리스트를 불러오지 못했습니다.' },
+  );
 
   useEffect(() => {
     if (!isAuthenticated) return;
-    wishlistApi
-      .getList()
-      .then((res) => setItems(res.data))
-      .catch((err) => {
-        setItems([]);
-        toast.error(handleApiError(err, '위시리스트를 불러오지 못했습니다.'));
-      })
-      .finally(() => setDataLoading(false));
-  }, [isAuthenticated]);
+    void loadWishlist();
+  }, [isAuthenticated]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleRemove = async (wishlistId: number) => {
-    try {
+  const { execute: removeItem } = useAsyncAction(
+    async (wishlistId: number) => {
       await wishlistApi.remove(wishlistId);
       setItems((prev) => prev.filter((item) => item.id !== wishlistId));
-      toast.success('위시리스트에서 삭제되었습니다.');
-    } catch (err) {
-      toast.error(handleApiError(err, '삭제에 실패했습니다.'));
-    }
-  };
+    },
+    { successMessage: '위시리스트에서 삭제되었습니다.', errorMessage: '삭제에 실패했습니다.' },
+  );
 
-  const handleAddToCart = async (productId: number) => {
-    try {
+  const { execute: addToCartAction } = useAsyncAction(
+    async (productId: number) => {
       await cartApi.add({ productId, productOptionId: null, quantity: 1 });
-      toast.success('장바구니에 추가되었습니다.');
-    } catch (err) {
-      toast.error(handleApiError(err, '장바구니 추가에 실패했습니다.'));
-    }
-  };
+    },
+    { successMessage: '장바구니에 추가되었습니다.', errorMessage: '장바구니 추가에 실패했습니다.' },
+  );
+
+  const handleRemove = (wishlistId: number) => { void removeItem(wishlistId); };
+  const handleAddToCart = (productId: number) => { void addToCartAction(productId); };
 
   if (isLoading) {
     return (

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -126,7 +126,7 @@ describe('ProductCard', () => {
   });
 
   it('shows error toast when cart add fails', async () => {
-    mockAddItem.mockRejectedValue(new Error('fail'));
+    mockAddItem.mockRejectedValue(new Error('장바구니 담기에 실패했습니다.'));
     render(<ProductCard {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: '장바구니 담기' }));
     await waitFor(() => {

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -9,6 +9,7 @@ import { isSafeUrl } from '@/utils/url';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/components/ui/utils';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 export default function LoginForm() {
   const router = useRouter();
@@ -21,7 +22,6 @@ export default function LoginForm() {
   const [password, setPassword] = useState('');
   const [emailError, setEmailError] = useState('');
   const [passwordError, setPasswordError] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
   const handleTogglePassword = useCallback(() => {
@@ -29,26 +29,30 @@ export default function LoginForm() {
     setTimeout(() => setShowPassword(false), 1000);
   }, []);
 
-  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+  const { execute: submitLogin, isLoading: isSubmitting } = useAsyncAction(
+    async () => {
+      await login(email, password);
+      router.push(redirectTo);
+    },
+    {
+      onError: (err) => {
+        const message = handleApiError(err, '로그인에 실패했습니다.');
+        if (message.includes('이메일') || message.includes('email')) {
+          setEmailError(message);
+        } else if (message.includes('비밀번호') || message.includes('password')) {
+          setPasswordError(message);
+        } else {
+          setEmailError(message);
+        }
+      },
+    },
+  );
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setEmailError('');
     setPasswordError('');
-    setIsSubmitting(true);
-    try {
-      await login(email, password);
-      router.push(redirectTo);
-    } catch (err) {
-      const message = handleApiError(err, '로그인에 실패했습니다.');
-      if (message.includes('이메일') || message.includes('email')) {
-        setEmailError(message);
-      } else if (message.includes('비밀번호') || message.includes('password')) {
-        setPasswordError(message);
-      } else {
-        setEmailError(message);
-      }
-    } finally {
-      setIsSubmitting(false);
-    }
+    void submitLogin();
   };
 
   return (

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -3,11 +3,10 @@
 import { useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { toast } from 'sonner';
-import { handleApiError } from '@/utils/error';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/components/ui/utils';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -39,7 +38,13 @@ export default function RegisterForm() {
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { execute: submitRegister, isLoading: isSubmitting } = useAsyncAction(
+    async () => {
+      await register(email, password, name);
+      router.push('/login');
+    },
+    { errorMessage: '회원가입에 실패했습니다.' },
+  );
 
   const validate = (): boolean => {
     const next: Record<string, string> = {};
@@ -54,19 +59,10 @@ export default function RegisterForm() {
     return Object.keys(next).length === 0;
   };
 
-  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!validate()) return;
-
-    setIsSubmitting(true);
-    try {
-      await register(email, password, name);
-      router.push('/login');
-    } catch (err) {
-      toast.error(handleApiError(err, '회원가입에 실패했습니다.'));
-    } finally {
-      setIsSubmitting(false);
-    }
+    void submitRegister();
   };
 
   return (

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { memo, useState, useCallback } from 'react';
+import { memo, useCallback } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Heart, ShoppingCart } from 'lucide-react';
-import { toast } from 'sonner';
 import { cn } from '@/components/ui/utils';
 import type { ProductImage } from '@/lib/api';
 import PriceDisplay from '@/components/common/PriceDisplay';
@@ -12,6 +11,7 @@ import { useCart } from '@/contexts/CartContext';
 import { useWishlistToggle } from '@/hooks/useWishlistToggle';
 import type { Locale } from '@/utils/currency';
 import StarRating from '@/components/reviews/StarRating';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 
 interface ProductCardProps {
   id: number;
@@ -49,23 +49,20 @@ function ProductCard({
   const { addItem } = useCart();
   const { isWishlisted, loading: isWishlistLoading, toggle: handleToggleWishlist } = useWishlistToggle(id);
 
-  const [isCartLoading, setIsCartLoading] = useState(false);
+  const { execute: addToCart, isLoading: isCartLoading } = useAsyncAction(
+    async () => {
+      await addItem({ productId: id, productOptionId: null, quantity: 1 });
+    },
+    { successMessage: '장바구니에 담았습니다.', errorMessage: '장바구니 담기에 실패했습니다.' },
+  );
 
   const handleAddToCart = useCallback(
-    async (e: React.MouseEvent) => {
+    (e: React.MouseEvent) => {
       e.preventDefault();
       if (isSoldout || isCartLoading) return;
-      setIsCartLoading(true);
-      try {
-        await addItem({ productId: id, productOptionId: null, quantity: 1 });
-        toast.success('장바구니에 담았습니다.');
-      } catch {
-        toast.error('장바구니 담기에 실패했습니다.');
-      } finally {
-        setIsCartLoading(false);
-      }
+      void addToCart();
     },
-    [id, isSoldout, isCartLoading, addItem],
+    [id, isSoldout, isCartLoading, addToCart],
   );
 
   return (

--- a/src/components/products/ProductDetailClient.tsx
+++ b/src/components/products/ProductDetailClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { toast } from 'sonner'
 import { Heart } from 'lucide-react'
+import { useAsyncAction } from '@/hooks/useAsyncAction'
 import { Button } from '@/components/ui/button'
 import PriceDisplay from '@/components/common/PriceDisplay'
 import type { ProductDetail, ProductOption, ProductDetailImage, Collection } from '@/lib/api'
@@ -39,10 +40,8 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
   const { isVisible: isNavVisible } = useMobileNav()
   const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null)
   const [quantity, setQuantity] = useState(1)
-  const [isAdding, setIsAdding] = useState(false)
   const [isWishlisted, setIsWishlisted] = useState(false)
   const [wishlistId, setWishlistId] = useState<number | null>(null)
-  const [isTogglingWishlist, setIsTogglingWishlist] = useState(false)
 
   useEffect(() => {
     addRecentlyViewed({
@@ -82,29 +81,19 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
     setQuantity((q) => Math.min(q + 1, maxQuantity))
   }
 
-  async function handleAddToCart() {
-    if (product.options.length > 0 && !selectedOptionId) {
-      toast.error('옵션을 선택해 주세요.')
-      return
-    }
-    setIsAdding(true)
-    try {
-      await addItem({ productId: Number(product.id), productOptionId: selectedOptionId, quantity })
-      toast.success('장바구니에 담았습니다.')
-    } catch {
-      toast.error('장바구니 담기에 실패했습니다.')
-    } finally {
-      setIsAdding(false)
-    }
-  }
-
   function handleDecrease() {
     setQuantity((q) => Math.max(q - 1, 1))
   }
 
-  async function handleToggleWishlist() {
-    setIsTogglingWishlist(true)
-    try {
+  const { execute: addToCart, isLoading: isAdding } = useAsyncAction(
+    async () => {
+      await addItem({ productId: Number(product.id), productOptionId: selectedOptionId, quantity })
+    },
+    { successMessage: '장바구니에 담았습니다.', errorMessage: '장바구니 담기에 실패했습니다.' },
+  )
+
+  const { execute: toggleWishlist, isLoading: isTogglingWishlist } = useAsyncAction(
+    async () => {
       if (isWishlisted && wishlistId) {
         await wishlistApi.remove(wishlistId)
         setIsWishlisted(false)
@@ -116,26 +105,36 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
         setWishlistId(res.id)
         toast.success('위시리스트에 추가했습니다。')
       }
-    } catch {
-      toast.error('위시리스트 처리 중 오류가 발생했습니다。')
-    } finally {
-      setIsTogglingWishlist(false)
-    }
-  }
+    },
+    { errorMessage: '위시리스트 처리 중 오류가 발생했습니다。' },
+  )
 
-  async function handleBuyNow() {
+  const { execute: buyNow } = useAsyncAction(
+    async () => {
+      await addItem({ productId: Number(product.id), productOptionId: selectedOptionId, quantity })
+      router.push('/checkout')
+    },
+    { errorMessage: '구매 처리 중 오류가 발생했습니다.' },
+  )
+
+  function handleAddToCart() {
     if (product.options.length > 0 && !selectedOptionId) {
       toast.error('옵션을 선택해 주세요.')
       return
     }
-    setIsAdding(true)
-    try {
-      await addItem({ productId: Number(product.id), productOptionId: selectedOptionId, quantity })
-      router.push('/checkout')
-    } catch {
-      toast.error('구매 처리 중 오류가 발생했습니다.')
-      setIsAdding(false)
+    void addToCart()
+  }
+
+  function handleToggleWishlist() {
+    void toggleWishlist()
+  }
+
+  function handleBuyNow() {
+    if (product.options.length > 0 && !selectedOptionId) {
+      toast.error('옵션을 선택해 주세요.')
+      return
     }
+    void buyNow()
   }
 
   return (

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { toast } from 'sonner'
+import { useState, useEffect } from 'react'
 import { reviewsApi } from '@/lib/api'
 import type { ReviewItem, ReviewStats as ReviewStatsType, ReviewSort } from '@/lib/api'
 import { cn } from '@/components/ui/utils'
-import { handleApiError } from '@/utils/error'
+import { useAsyncAction } from '@/hooks/useAsyncAction'
 import ReviewCard from './ReviewCard'
 import ReviewStatsComponent from './ReviewStats'
 
@@ -29,26 +28,21 @@ export default function ReviewList({ productId }: ReviewListProps) {
   const [sort, setSort] = useState<ReviewSort>('recent')
   const [page, setPage] = useState(1)
   const [total, setTotal] = useState(0)
-  const [isLoading, setIsLoading] = useState(true)
   const limit = 20
 
-  const fetchReviews = useCallback(async () => {
-    setIsLoading(true)
-    try {
+  const { execute: fetchReviews, isLoading } = useAsyncAction(
+    async () => {
       const res = await reviewsApi.getByProduct(productId, { sort, page, limit })
       setReviews(res.data)
       setStats(res.stats)
       setTotal(res.pagination.total)
-    } catch (err: unknown) {
-      toast.error(handleApiError(err, '리뷰를 불러올 수 없습니다.'))
-    } finally {
-      setIsLoading(false)
-    }
-  }, [productId, sort, page])
+    },
+    { errorMessage: '리뷰를 불러올 수 없습니다.' },
+  )
 
   useEffect(() => {
     void fetchReviews()
-  }, [fetchReviews])
+  }, [productId, sort, page]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const totalPages = Math.ceil(total / limit)
 


### PR DESCRIPTION
## Summary
- 9개 컴포넌트/페이지에서 수동 `useState(loading) + try/catch/finally` 패턴을 `useAsyncAction` 훅으로 교체
- 코드 스타일 규칙 준수: "Data fetching: use `useAsyncAction` hook — no manual `useState(loading) + try/catch/finally`"
- `ProductCard.test.tsx`: 에러 토스트 테스트를 `useAsyncAction`의 `handleApiError` 동작에 맞게 수정

## Files Changed
- `src/components/auth/LoginForm.tsx` — `isSubmitting` 마이그레이션
- `src/components/auth/RegisterForm.tsx` — `isSubmitting` 마이그레이션
- `src/components/products/ProductCard.tsx` — `isCartLoading` 마이그레이션
- `src/components/products/ProductDetailClient.tsx` — `isAdding`, `isTogglingWishlist` 마이그레이션
- `src/components/reviews/ReviewList.tsx` — `isLoading` 마이그레이션
- `src/app/[locale]/my/wishlist/page.tsx` — `dataLoading` 마이그레이션
- `src/app/[locale]/my/coupons/page.tsx` — `dataLoading` 마이그레이션
- `src/app/[locale]/my/inquiries/new/page.tsx` — `submitting` 마이그레이션
- `src/app/[locale]/my/profile/page.tsx` — `submitting` 마이그레이션

## Test plan
- [ ] `npm run build` — 빌드 통과 확인
- [ ] `npm run test:run` — 기존 실패 테스트 외 신규 실패 없음 확인
- [ ] 로그인/회원가입 폼 로딩 상태 동작 확인
- [ ] 장바구니 담기 로딩 상태 동작 확인
- [ ] 위시리스트, 쿠폰, 문의, 프로필 페이지 로딩 상태 동작 확인

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)