### PR TITLE
feat: #373 prepare for ElastiCache Redis production introduction

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,12 @@ JWT_EXPIRES_IN=1h
 JWT_REFRESH_EXPIRES_IN=7d
 FRONTEND_URL=http://localhost:5173
 REDIS_URL=redis://:${REDIS_PASSWORD}@localhost:6380
+
+# ─────────────────────────────────────────────
+# ElastiCache Redis (AWS 프로덕션)
+# ─────────────────────────────────────────────
+# REDIS_URL=redis://:<REDIS_PASSWORD>@<your-elasticache-endpoint>:6379
+# 예: REDIS_URL=redis://:MyAuthToken@okhwadang-redis.xxxxxx.aps2.cache.amazonaws.com:6379
 PAYMENT_GATEWAY=mock  # Required in production. 'mock' is blocked in production. Options: mock, toss, stripe
 TOSS_SECRET_KEY=   # Toss Payments secret key (for ko locale)
 TOSS_CLIENT_KEY=   # Toss Payments client key (for ko locale)

--- a/infra/redis/CACHE_INTEGRATION.md
+++ b/infra/redis/CACHE_INTEGRATION.md
@@ -1,0 +1,118 @@
+# 백엔드 Cache 모듈 — REDIS_URL 연동 가이드
+
+> **범위**: `backend/src/modules/cache/` — 기존 `CacheService`가 `REDIS_URL`을如何使用하는지 설명
+
+---
+
+## 1. 현재 구현 개요
+
+`CacheService` (`backend/src/modules/cache/cache.service.ts`)는 `ioredis`를 사용하여 Redis에 연결합니다.
+
+```typescript
+// CacheService 생성자
+constructor() {
+  const redisUrl = process.env.REDIS_URL;
+  if (redisUrl) {
+    this.client = new Redis(redisUrl);
+    this.client.on('error', (err: Error) =>
+      this.logger.warn(`Redis error: ${err.message}`),
+    );
+  }
+}
+```
+
+### 연결 유무에 따른 동작
+
+| 상태 | `get/set/del` 동작 |
+|------|-------------------|
+| `REDIS_URL` 없음 (로컬 개발) | ✅ `null` 반환 / silent fail — **서비스 중단 없음** |
+| `REDIS_URL` 설정됨 | 정상 캐시 동작 |
+
+---
+
+## 2. 환경 변수 참조
+
+| 변수 | 위치 | 현재 기본값 | ElastiCache용 |
+|------|------|-----------|--------------|
+| `REDIS_URL` | `.env.example` line 42 | `redis://:${REDIS_PASSWORD}@localhost:6380` | `redis://:<PASSWORD>@<endpoint>:6379` |
+| `REDIS_PASSWORD` | `.env.example` line 4 | `changeme_redis_password` | ElastiCache Auth token 또는 DSM |
+
+> **참고**: 현재 `.env.example`의 `REDIS_URL`은 **로컬 Docker Redis** (`localhost:6380`) 기준입니다. ElastiCache 사용 시 **포트 6379**로 변경해야 합니다.
+
+---
+
+## 3. 캐시用途 (현재 사용처)
+
+### 3.1 ProductsService — 상품 캐싱
+
+**파일**: `backend/src/modules/products/products.service.ts`
+
+`CacheService`를 사용하여 다음 데이터를 캐싱:
+
+- 상품 목록 (카테고리/검색 결과)
+- 개별 상품 상세 정보
+- 상품 슬러그 기반 조회
+
+**TTL**: 일반적으로 5~15분 (상품 변동频率에 따라 조정)
+
+### 3.2 SettingsService — 설정 캐싱
+
+**파일**: `backend/src/modules/settings/settings.service.ts`
+
+앱 전체 설정값을 Redis에 캐시:
+
+- 캐시 키: `settings:*`
+- TTL: 1시간
+
+---
+
+## 4. 캐시 무효화 전략
+
+### 패턴: `CacheService.delPattern()`
+
+```typescript
+// 상품 업데이트 시 관련 캐시 일괄 삭제
+await this.cacheService.delPattern('products:*');
+await this.cacheService.delPattern('search:*');
+```
+
+### 사용 규칙
+
+| 상황 | 무효화 방식 |
+|------|-----------|
+| 상품 생성/수정/삭제 | `delPattern('products:*')` + `delPattern('search:*')` |
+| 카테고리 변경 | `delPattern('products:category:*')` |
+| 설정 변경 | `delPattern('settings:*')` |
+| 주문 완료 | 세션/토큰 관련 캐시만 삭제 (상품 캐시 유지) |
+
+---
+
+## 5. ElastiCache 연결 시 .env.production 설정
+
+```env
+# ElastiCache (프로덕션)
+REDIS_URL=redis://:<REDIS_PASSWORD>@okhwadang-redis.xxxxxx.aps2.cache.amazonaws.com:6379
+REDIS_PASSWORD=<your-elasticache-auth-token>
+```
+
+### 로컬 개발 vs 프로덕션 구분
+
+```typescript
+// NestJS config에서 동적 URL 선택
+const redisUrl = process.env.NODE_ENV === 'production'
+  ? process.env.REDIS_URL                    // ElastiCache
+  : `redis://:${process.env.REDIS_PASSWORD}@localhost:6380`; // Docker
+```
+
+---
+
+## 6. 주요 캐시 키 패턴
+
+| 패턴 | 용도 | 권장 TTL |
+|------|------|---------|
+| `products:list:{hash}` | 상품 목록 (필터/정렬 포함) | 5분 |
+| `products:detail:{id}` | 개별 상품 | 10분 |
+| `products:slug:{slug}` | 슬러그 기반 상품 | 10분 |
+| `search:{query}:{page}` | 검색 결과 | 5분 |
+| `settings:*` | 전체 설정 | 1시간 |
+| `session:{userId}` | 사용자 세션 | 24시간 |

--- a/infra/redis/ELASTICACHE_SETUP.md
+++ b/infra/redis/ELASTICACHE_SETUP.md
@@ -1,0 +1,129 @@
+# AWS ElastiCache Redis — Phase 1 프로덕션 도입 가이드
+
+> **목적**: ECS/EC2와 같은 VPC 내 ElastiCache Redis(Redis 7)를 프로덕션 캐시로 도입하여 로컬 Redis 의존성을 제거
+
+---
+
+## 1. 인스턴스 사양
+
+| 항목 | 값 |
+|------|-----|
+| **인스턴스 타입** | `cache.t3.micro` (테스트/소규모 프로덕션용) |
+| **Redis 버전** | 7.x |
+| **포트** | `6379` (기본) |
+| **노드 타입** | Single-node (필요 시 Replica Node 추가) |
+| **파라미터 그룹** | `default.redis7.x` (또는 커스텀 `okhwadang-redis-7`) |
+| **암호화** | TLS in-transit (추천), at-rest (AWS 관리 키) |
+| **자동 백업** | Enabled, 유지 기간 7일 |
+
+---
+
+## 2. VPC / 서브넷 구성
+
+- **VPC**: ECS/EC2와 **동일 VPC** 사용
+- **서브넷**: 최소 2개 가용 영역(AZ)에 서브넷 배포
+  - 예: `10.0.1.0/24` (AZ-a), `10.0.2.0/24` (AZ-c)
+- **퍼블릭 액세스**: ❌ 비활성화 (VPC 내에서만 접근)
+- **NAT Gateway**: EC2가 NAT를 통해 ElastiCache에 접근할 수 있도록 구성
+
+---
+
+## 3. 보안 그룹 (필수)
+
+ElastiCache용 보안 그룹을 생성하고 **인바운드 규칙**을 추가:
+
+| 방향 | 소스 | 프로토콜 | 포트 | 설명 |
+|------|------|----------|------|------|
+| **인바운드** | EC2 보안 그룹 (또는 CIDR) | TCP | **6379** | Redis 접근 허용 |
+| **인바운드** | `10.0.0.0/16` (VPC CIDR) | TCP | 6379 | VPC 내부 접근 |
+
+> ⚠️ **주의**: Redis 포트(6379)를 공개하지 마십시오.
+
+```bash
+# AWS CLI로 생성 예시
+aws elasticache create-security-group \
+  --group-name okhwadang-redis-sg \
+  --description "ElastiCache Redis security group for okhwadang"
+
+aws ec2 authorize-security-group-ingress \
+  --group-name okhwadang-redis-sg \
+  --protocol tcp \
+  --port 6379 \
+  --source-group <ec2-security-group-id>
+```
+
+---
+
+## 4. 연결 문자열 (Connection String)
+
+ElastiCache 클러스터 엔드포인트를 확인:
+
+```bash
+aws elasticache describe-replication-groups \
+  --replication-group-id okhwadang-redis
+```
+
+엔드포인트 예시: `okhwadang-redis.xxxxxx.aps2.cache.amazonaws.com`
+
+**`.env.production` 설정:**
+
+```env
+REDIS_URL=redis://:<REDIS_PASSWORD>@okhwadang-redis.xxxxxx.aps2.cache.amazonaws.com:6379
+```
+
+> **참고**: ElastiCache 기본 엔드포인트는 **writer 노드**입니다. 읽기 분산이 필요하면 Reader 엔드포인트를 사용하거나 Replica Node를 추가하세요.
+
+---
+
+## 5. 파라미터 그룹 커스터마이징 (선택)
+
+```bash
+aws elasticache create-cache-parameter-group \
+  --cache-parameter-group-name okhwadang-redis-7 \
+  --cache-family redis7 \
+  --description "Custom parameter group for okhwadang"
+
+aws elasticache modify-cache-parameter-group \
+  --cache-parameter-group-name okhwadang-redis-7 \
+  --parameter-name-values \
+    ParameterName=maxmemory-policy,ParameterValue=allkeys-lru
+```
+
+---
+
+## 6. 기존 로컬 Redis에서 마이그레이션
+
+1. **ElastiCache 프로비저닝 완료** 후 엔드포인트 확인
+2. **REDIS_URL 변경** — `.env.production`에 ElastiCache 엔드포인트 설정
+3. **TTL 기반 자연스러운 캐시 교체** — 기존 키는 TTL 만료 시 삭제
+4. **소급 삭제** (필요 시): `redis-cli`로 `FLUSHDB` 실행 (⚠️ 프로덕션环境影响)
+5. **모니터링**: CloudWatch `DatabaseMemoryDatabaseBytesUsageForCache` 지표 확인
+
+---
+
+## 7. CloudWatch 대시보드 지표
+
+| 지표 | 설명 | 임계값 (예시) |
+|------|------|--------------|
+| `CPUUtilization` | Redis CPU 사용률 | > 80% 알람 |
+| `DatabaseMemoryUsagePercentage` | 메모리 사용률 | > 75% 알람 |
+| `CacheHitRate` | 캐시 히트율 | < 80% 알람 |
+| `CurrConnections` | 현재 연결 수 | > 500 알람 |
+| `ReplicationLag` | 복제 지연 (Replica 사용 시) | > 30초 알람 |
+
+---
+
+## 8. 장애 대응 체크리스트
+
+- [ ] ElastiCache 이벤트 알림 설정 (SNS 토픽 구독)
+- [ ] Cache Engine Version 업그레이드 일정 관리
+- [ ] 스냅샷 백업에서 복원 테스트 (Quarterly)
+- [ ] Connection timeout 설정 (`connectTimeout=5s`, `retryDelayMax=30s`)
+
+---
+
+## 9. 비용 최적화 (Phase 2 예정)
+
+- **Reserved Node**: 1년 약정으로 ~60% 절감
+- **Auto Scaling**: 메모리 사용량 기반 노드 스케일링 (ElastiCache Serverless 또는 Auto Scaling 그룹)
+- **Global Datastore**: 멀티 리전 재해 복구 (Phase 3)

--- a/infra/redis/REDIS_CLIENT_SETUP.md
+++ b/infra/redis/REDIS_CLIENT_SETUP.md
@@ -1,0 +1,171 @@
+# NestJS Redis Client — ioredis 통합 가이드
+
+> **범위**: NestJS 프로젝트에 `ioredis` 기반 Redis 클라이언트를 통합하는 표준 패턴
+
+---
+
+## 1. 기존 CacheModule vs NestJS CacheModule
+
+| 방식 | 장점 | 단점 |
+|------|------|------|
+| **기존 `CacheService` (ioredis 직접 사용)** | 커스터마이징 자유도 높음, 직접 `get/set/del` 호출 | 직접 연결 관리 필요 |
+| **NestJS `@nestjs/cache-manager`** |生命周期 관리 자동, 추상화 | 커스터마이징 제한적 |
+
+> **현재 프로젝트**: `CacheService`가 직접 `ioredis`를 사용하므로 **추가 설치 불필요**. 아래는 `CacheService`를 보강하거나 대체할 때 참고.
+
+---
+
+## 2. 기존 CacheService 아키텍처
+
+```
+AppModule
+  └── CacheModule (Global)
+        └── CacheService (ioredis client)
+              ├── get<T>(key: string): Promise<T | null>
+              ├── set(key: string, value: unknown, ttlSeconds: number): Promise<void>
+              ├── del(key: string): Promise<void>
+              └── delPattern(pattern: string): Promise<void>
+```
+
+모든 모듈에서 `@Inject(CacheService)` 없이도 접근 가능 (Global 모듈).
+
+---
+
+## 3. ElastiCache로 전환 시 체크리스트
+
+### 3.1 환경 변수
+
+```env
+# .env.production
+REDIS_URL=redis://:<REDIS_PASSWORD>@<elasticache-endpoint>:6379
+```
+
+### 3.2 연결 옵션 (ElastiCache 권장)
+
+```typescript
+// CacheService constructor에 추가 옵션
+this.client = new Redis(redisUrl, {
+  connectTimeout: 5000,      // 5s connection timeout
+  retryStrategy: (times) => {
+    if (times > 3) return null; // 3회 재시도 후 실패
+    return Math.min(times * 200, 30000);
+  },
+  enableReadyCheck: true,
+  maxRetriesPerRequest: 3,
+});
+```
+
+### 3.3 TLS 연결 (ElastiCache in-transit encryption)
+
+```typescript
+import Redis from 'ioredis';
+import * as fs from 'fs';
+
+// ElastiCache TLS 연결
+const redisUrl = process.env.REDIS_URL!;
+this.client = new Redis(redisUrl, {
+  tls: {
+    ca: fs.readFileSync('/path/to/amazon-rds-ca-bundle.pem'),
+  },
+});
+```
+
+---
+
+## 4. Cluster 모드 (Phase 2, 필요 시)
+
+```typescript
+import { RedisCluster } from 'ioredis';
+
+const cluster = new RedisCluster([
+  { host: 'node1.elasticache.com', port: 6379 },
+  { host: 'node2.elasticache.com', port: 6379 },
+], {
+  redisOptions: {
+    password: process.env.REDIS_PASSWORD,
+    tls: {},
+  },
+});
+```
+
+---
+
+## 5. 연결 상태 모니터링
+
+```typescript
+// CacheService에 추가
+this.client.on('connect', () => {
+  this.logger.log('Redis connected');
+});
+
+this.client.on('error', (err: Error) => {
+  this.logger.error(`Redis error: ${err.message}`);
+});
+
+this.client.on('close', () => {
+  this.logger.warn('Redis connection closed');
+});
+```
+
+---
+
+## 6. 헬스 체크 통합
+
+`CacheService`에 헬스 체크 메서드 추가:
+
+```typescript
+async ping(): Promise<boolean> {
+  if (!this.client) return false;
+  try {
+    const result = await this.client.ping();
+    return result === 'PONG';
+  } catch {
+    return false;
+  }
+}
+```
+
+NestJS HealthModule에 연동:
+
+```typescript
+// health.module.ts
+{
+  provide: 'redis',
+  useValue: cacheService,
+  healthIndicator: async (service: CacheService) => ({
+    redis: { status: await service.ping() ? 'up' : 'down' },
+  }),
+}
+```
+
+---
+
+## 7. 설치 (새로 시작하는 경우)
+
+```bash
+cd backend
+npm install ioredis
+npm install -D @types/ioredis
+```
+
+```typescript
+// src/modules/cache/cache.module.ts
+import { Global, Module } from '@nestjs/common';
+import { CacheService } from './cache.service';
+
+@Global()
+@Module({
+  providers: [CacheService],
+  exports: [CacheService],
+})
+export class CacheModule {}
+```
+
+---
+
+## 8. Phase 2에서 고려할 점
+
+- ** eviction policy**: `maxmemory-policy allkeys-lru` (Memcached 백틱 기반)
+- **복제**: Reader 엔드포인트로 읽기 분산
+- **Pub/Sub**: 세션 브로드캐스트 / 실시간 알림 용도
+- **Sentinel/Cluster**: 고가可用성 (HA) 구성


### PR DESCRIPTION
## Summary
- Closes #373
- Added ElastiCache setup documentation (instance specs, VPC, security group)
- Added REDIS_URL ElastiCache example to .env.example
- Added Redis client integration guide for NestJS

## Test plan
- [x] Infra docs only (no build required)