### PR TITLE
ci: backend 변경 시에만 배포 실행

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy Backend
 on:
   push:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- `deploy.yml`에 `on.push.paths` 필터 추가 — `backend/**` 또는 `deploy.yml` 변경 시에만 트리거
- `workflow_dispatch` 추가로 Actions 탭에서 수동 배포 가능

docs/CI만 수정하고 main에 머지해도 더 이상 EC2 재배포/pm2 재시작이 발생하지 않는다.

## Test plan
- [ ] 이 PR 머지 후, 다음 문서-only 머지에서 deploy 워크플로우가 실행되지 않는지 확인
- [ ] 백엔드 파일 변경 머지 시 deploy 정상 실행 확인
- [ ] Actions 탭에서 "Run workflow" 수동 트리거 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)