### PR TITLE
fix: #319 HTML sanitize 및 JSON-LD 이스케이프 강화

### DIFF
--- a/src/app/[locale]/products/[id]/page.tsx
+++ b/src/app/[locale]/products/[id]/page.tsx
@@ -77,7 +77,10 @@ export default async function ProductDetailPage({ params }: ProductDetailProps) 
     },
   };
 
-  const jsonLdString = JSON.stringify(jsonLd).replace(/</g, '\\u003c');
+  const jsonLdString = JSON.stringify(jsonLd)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 
   return (
     <>

--- a/src/components/products/ProductTabs.tsx
+++ b/src/components/products/ProductTabs.tsx
@@ -21,7 +21,10 @@ export default function ProductTabs({ description, descriptionImages, productId 
 
   useEffect(() => {
     import('dompurify').then((mod) => {
-      setSanitized(mod.default.sanitize(description ?? ''))
+      setSanitized(mod.default.sanitize(description ?? '', {
+        ALLOWED_TAGS: ['p','br','strong','em','ul','ol','li','h2','h3','h4','a','img'],
+        ALLOWED_ATTR: ['href','src','alt','target','rel'],
+      }))
     })
   }, [description])
 


### PR DESCRIPTION
## Summary
- DOMPurify.sanitize에 `ALLOWED_TAGS`, `ALLOWED_ATTR` 허용 목록을 명시하여 불필요한 태그/속성 제거
- JSON-LD 문자열화 시 `>`, `&` 이스케이프 추가 (`\u003e`, `\u0026`) 로 XSS 벡터 차단

Closes #319

## Test plan
- [ ] 상품 상세 페이지 접속 → 상세정보 탭에서 허용된 태그(`p`, `strong`, `a` 등)만 렌더링 확인
- [ ] `<script>`, `<iframe>` 등 금지 태그가 sanitize 후 제거됨을 확인
- [ ] 페이지 소스에서 JSON-LD `<script type="application/ld+json">` 내 `>`, `&` 문자가 `\u003e`, `\u0026`로 이스케이프 확인
- [ ] 빌드 성공: `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)