### PR TITLE
fix: #333 orders.findAll 성능 개선 및 포인트 잔액 TOCTOU 방지

### DIFF
--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -1,13 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { getDataSourceToken } from '@nestjs/typeorm';
-import { Repository, DataSource, SelectQueryBuilder } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
 import { OrdersService } from '../orders.service';
 import { Order, OrderStatus } from '../entities/order.entity';
-import { OrderItem } from '../entities/order-item.entity';
 import { CreateOrderDto } from '../dto/create-order.dto';
-import { PointHistory } from '../../coupons/entities/point-history.entity';
 
 const mockQueryRunner = {
   connect: jest.fn(),
@@ -20,6 +17,7 @@ const mockQueryRunner = {
     create: jest.fn(),
     save: jest.fn(),
     update: jest.fn(),
+    getRepository: jest.fn(),
   },
 };
 
@@ -30,8 +28,6 @@ const mockDataSource = {
 const mockOrderRepository = {
   createQueryBuilder: jest.fn(),
 };
-
-const mockPointHistoryRepository = {};
 
 describe('OrdersService', () => {
   let service: OrdersService;
@@ -44,7 +40,6 @@ describe('OrdersService', () => {
       providers: [
         OrdersService,
         { provide: getRepositoryToken(Order), useValue: mockOrderRepository },
-        { provide: getRepositoryToken(PointHistory), useValue: mockPointHistoryRepository },
         { provide: DataSource, useValue: mockDataSource },
       ],
     }).compile();
@@ -163,6 +158,26 @@ describe('OrdersService', () => {
       expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
     });
 
+    it('insufficient points inside transaction → BadRequestException + rollback', async () => {
+      const dto: CreateOrderDto = {
+        items: [{ productId: 1, quantity: 1 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+        address: '서울시',
+        pointsUsed: 5000,
+      };
+
+      // point balance check uses queryRunner.manager.getRepository (inside transaction)
+      const mockPointRepo = {
+        findOne: jest.fn().mockResolvedValue({ balance: 1000 }),
+      };
+      mockQueryRunner.manager.getRepository.mockReturnValue(mockPointRepo);
+
+      await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+    });
+
     it('valid dto → creates order, deducts stock, clears cart', async () => {
       const dto: CreateOrderDto = {
         items: [{ productId: 1, quantity: 2 }],
@@ -225,14 +240,14 @@ describe('OrdersService', () => {
   });
 
   describe('findAll()', () => {
-    it('returns paginated user orders', async () => {
+    it('returns paginated user orders without loading full item relations', async () => {
       const mockOrders = [
-        { id: 1, userId: 1, orderNumber: 'ORD-1', items: [] },
-        { id: 2, userId: 1, orderNumber: 'ORD-2', items: [] },
+        { id: 1, userId: 1, orderNumber: 'ORD-1', itemCount: 2 },
+        { id: 2, userId: 1, orderNumber: 'ORD-2', itemCount: 1 },
       ] as unknown as Order[];
 
       const mockQb = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        loadRelationCountAndMap: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
@@ -246,6 +261,8 @@ describe('OrdersService', () => {
       expect(result.total).toBe(2);
       expect(result.page).toBe(1);
       expect(result.limit).toBe(10);
+      // must use loadRelationCountAndMap, not leftJoinAndSelect
+      expect(mockQb.loadRelationCountAndMap).toHaveBeenCalledWith('order.itemCount', 'order.items');
     });
   });
 

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -2,7 +2,7 @@ import {
   Injectable, NotFoundException, BadRequestException, Logger,
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { randomBytes } from 'crypto';
 import { Order, OrderStatus } from './entities/order.entity';
 import { OrderItem } from './entities/order-item.entity';
@@ -21,8 +21,6 @@ export class OrdersService {
   constructor(
     @InjectRepository(Order)
     private readonly orderRepository: Repository<Order>,
-    @InjectRepository(PointHistory)
-    private readonly pointHistoryRepo: Repository<PointHistory>,
     @InjectDataSource()
     private readonly dataSource: DataSource,
   ) {}
@@ -33,32 +31,29 @@ export class OrdersService {
     return `ORD-${date}-${random}`;
   }
 
-  private async getUserPointBalance(userId: number): Promise<number> {
-    const latest = await this.pointHistoryRepo.findOne({
-      where: { userId },
-      order: { createdAt: 'DESC', id: 'DESC' },
-    });
-    return latest ? latest.balance : 0;
-  }
-
   async create(userId: number, dto: CreateOrderDto): Promise<Order> {
     if (!dto.items || dto.items.length === 0) {
       throw new BadRequestException('주문 항목이 없습니다.');
     }
 
     const pointsToUse = dto.pointsUsed ?? 0;
-    if (pointsToUse > 0) {
-      const balance = await this.getUserPointBalance(userId);
-      if (pointsToUse > balance) {
-        throw new BadRequestException('적립금이 부족합니다.');
-      }
-    }
 
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
     try {
+      if (pointsToUse > 0) {
+        const latest = await queryRunner.manager.getRepository(PointHistory).findOne({
+          where: { userId },
+          order: { createdAt: 'DESC', id: 'DESC' },
+        });
+        const balance = latest ? latest.balance : 0;
+        if (pointsToUse > balance) {
+          throw new BadRequestException('적립금이 부족합니다.');
+        }
+      }
+
       const orderItems: Partial<OrderItem>[] = [];
       let totalAmount = 0;
 
@@ -143,7 +138,11 @@ export class OrdersService {
       const savedOrder = await queryRunner.manager.save(Order, order);
 
       if (pointsToUse > 0) {
-        const currentBalance = await this.getUserPointBalance(userId);
+        const latestPoint = await queryRunner.manager.getRepository(PointHistory).findOne({
+          where: { userId },
+          order: { createdAt: 'DESC', id: 'DESC' },
+        });
+        const currentBalance = latestPoint ? latestPoint.balance : 0;
         const newBalance = currentBalance - pointsToUse;
         const pointHistory = queryRunner.manager.create(PointHistory, {
           userId,
@@ -186,7 +185,7 @@ export class OrdersService {
   async findAll(userId: number, page = 1, limit = 10): Promise<PaginatedResult<Order>> {
     const qb = this.orderRepository
       .createQueryBuilder('order')
-      .leftJoinAndSelect('order.items', 'item')
+      .loadRelationCountAndMap('order.itemCount', 'order.items')
       .where('order.userId = :userId', { userId })
       .orderBy('order.createdAt', 'DESC');
 


### PR DESCRIPTION
## Summary

- `findAll()`: `leftJoinAndSelect('order.items', 'item')` 제거 → `loadRelationCountAndMap('order.itemCount', 'order.items')`로 교체. 목록 뷰에서 전체 아이템 데이터를 JOIN 로딩하지 않고 개수만 조회.
- `create()`: `getUserPointBalance()`가 트랜잭션 밖 `this.pointHistoryRepo`를 사용하던 TOCTOU 버그 수정. 포인트 잔액 조회를 `queryRunner.manager.getRepository(PointHistory).findOne(...)` 으로 이동하여 동일 트랜잭션 scope 안에서 실행.
- `pointHistoryRepo` 주입 제거 — 더 이상 불필요.

## Test plan

- [x] `create() / insufficient points inside transaction` — 트랜잭션 내 포인트 잔액 부족 시 `BadRequestException` + rollback 검증 (신규 테스트)
- [x] `findAll() / returns paginated user orders without loading full item relations` — `loadRelationCountAndMap` 호출 검증 (기존 테스트 보강)
- [x] 기존 orders.service 테스트 10개 전체 통과 확인
- [x] `npm run build` 통과

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)