### PR TITLE
refactor: #314 인라인 StatusBadge 4곳 공통 컴포넌트로 통합

### DIFF
--- a/src/app/[locale]/admin/inquiries/page.tsx
+++ b/src/app/[locale]/admin/inquiries/page.tsx
@@ -9,6 +9,7 @@ import type { Inquiry } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { AdminTable } from '@/components/admin/AdminTable';
+import { InquiryStatusBadge } from '@/components/admin/StatusBadge';
 import { cn } from '@/components/ui/utils';
 
 type StatusFilter = 'all' | 'pending' | 'answered';
@@ -122,16 +123,7 @@ export default function AdminInquiriesPage() {
                 }}
               >
                 <td className="px-4 py-3">
-                  <span
-                    className={cn(
-                      'text-xs font-semibold px-2 py-0.5 rounded',
-                      inquiry.status === 'answered'
-                        ? 'bg-green-100 text-green-700'
-                        : 'bg-yellow-100 text-yellow-700',
-                    )}
-                  >
-                    {inquiry.status === 'answered' ? '답변완료' : '미답변'}
-                  </span>
+                  <InquiryStatusBadge status={inquiry.status as 'answered' | 'pending'} context="admin" />
                 </td>
                 <td className="px-4 py-3 text-sm">
                   <p className="font-medium truncate">{inquiry.user?.name ?? '-'}</p>

--- a/src/app/[locale]/admin/journal/page.tsx
+++ b/src/app/[locale]/admin/journal/page.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import FormInput from '@/components/ui/FormInput';
 import Modal from '@/components/ui/Modal';
 import { AdminTable } from '@/components/admin/AdminTable';
+import { JournalStatusBadge } from '@/components/admin/StatusBadge';
 import ProductImageUploader from '@/components/admin/ProductImageUploader';
 
 const CATEGORY_LABELS: Record<JournalCategory, string> = {
@@ -91,16 +92,7 @@ function JournalRow({
       </td>
       <td className="py-3 px-4 text-sm text-muted-foreground">{journal.date}</td>
       <td className="py-3 px-4">
-        <button
-          onClick={() => onTogglePublish(journal)}
-          className={`rounded-full px-3 py-1 text-xs font-medium ${
-            journal.isPublished
-              ? 'bg-green-100 text-green-700 hover:bg-green-200'
-              : 'bg-secondary text-muted-foreground hover:bg-secondary/80'
-          }`}
-        >
-          {journal.isPublished ? '공개' : '비공개'}
-        </button>
+        <JournalStatusBadge isPublished={journal.isPublished} onClick={() => onTogglePublish(journal)} />
       </td>
       <td className="py-3 px-4">
         <div className="flex gap-2">

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -9,6 +9,7 @@ import { adminProductsApi } from '@/lib/api';
 import type { Product } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import AdminPagination from '@/components/admin/AdminPagination';
+import { ProductStatusBadge } from '@/components/admin/StatusBadge';
 
 const STATUS_LABELS: Record<string, string> = {
   draft: '임시저장',
@@ -134,17 +135,7 @@ export default function AdminProductsPage() {
                   <td className="px-4 py-3 font-medium">{p.name}</td>
                   <td className="px-4 py-3">{formatCurrency(p.price)}</td>
                   <td className="px-4 py-3">
-                    <span
-                      className={`rounded-full px-2 py-0.5 text-xs ${
-                        p.status === 'active'
-                          ? 'bg-green-100 text-green-700'
-                          : p.status === 'soldout'
-                          ? 'bg-red-100 text-red-700'
-                          : 'bg-secondary text-muted-foreground'
-                      }`}
-                    >
-                      {STATUS_LABELS[p.status] ?? p.status}
-                    </span>
+                    <ProductStatusBadge status={p.status as 'active' | 'soldout' | 'draft' | 'hidden'} />
                   </td>
                   <td className="px-4 py-3">{p.isFeatured ? '✓' : '-'}</td>
                   <td className="px-4 py-3 text-right">

--- a/src/app/[locale]/my/inquiries/page.tsx
+++ b/src/app/[locale]/my/inquiries/page.tsx
@@ -8,7 +8,7 @@ import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import EmptyState from '@/components/EmptyState';
-import { cn } from '@/components/ui/utils';
+import { InquiryStatusBadge } from '@/components/admin/StatusBadge';
 
 export default function InquiriesPage() {
   const { isAuthenticated } = useRequireAuth();
@@ -63,16 +63,7 @@ export default function InquiriesPage() {
               >
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 mb-1">
-                    <span
-                      className={cn(
-                        'text-xs font-semibold px-2 py-0.5 rounded',
-                        inquiry.status === 'answered'
-                          ? 'bg-green-100 text-green-700'
-                          : 'bg-yellow-100 text-yellow-700',
-                      )}
-                    >
-                      {inquiry.status === 'answered' ? '답변완료' : '접수'}
-                    </span>
+                    <InquiryStatusBadge status={inquiry.status as 'answered' | 'pending'} context="my" />
                     <span className="text-xs text-muted-foreground">{inquiry.type}</span>
                   </div>
                   <p className="text-sm font-medium text-foreground truncate">{inquiry.title}</p>

--- a/src/components/admin/StatusBadge.tsx
+++ b/src/components/admin/StatusBadge.tsx
@@ -1,17 +1,113 @@
-interface StatusBadgeProps {
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/components/ui/utils';
+
+const statusBadgeVariants = cva(
+  'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold',
+  {
+    variants: {
+      color: {
+        green: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+        red: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+        yellow: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
+        secondary: 'bg-secondary text-muted-foreground',
+      },
+    },
+    defaultVariants: {
+      color: 'secondary',
+    },
+  },
+);
+
+// ── isActive (기존 API) ──────────────────────────────────────────────────────
+
+interface ActiveStatusBadgeProps extends VariantProps<typeof statusBadgeVariants> {
   isActive: boolean;
+  className?: string;
 }
 
-export function StatusBadge({ isActive }: StatusBadgeProps) {
+export function StatusBadge({ isActive, className }: ActiveStatusBadgeProps) {
   return (
-    <span
-      className={`rounded-full px-2 py-0.5 text-xs ${
-        isActive
-          ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
-          : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
-      }`}
-    >
+    <span className={cn(statusBadgeVariants({ color: isActive ? 'green' : 'red' }), className)}>
       {isActive ? '활성' : '비활성'}
     </span>
+  );
+}
+
+// ── Product status ───────────────────────────────────────────────────────────
+
+type ProductStatus = 'active' | 'soldout' | 'draft' | 'hidden';
+
+const PRODUCT_STATUS_LABELS: Record<ProductStatus, string> = {
+  active: '판매중',
+  soldout: '품절',
+  draft: '임시저장',
+  hidden: '숨김',
+};
+
+const PRODUCT_STATUS_COLORS: Record<ProductStatus, VariantProps<typeof statusBadgeVariants>['color']> = {
+  active: 'green',
+  soldout: 'red',
+  draft: 'secondary',
+  hidden: 'secondary',
+};
+
+interface ProductStatusBadgeProps {
+  status: ProductStatus;
+  className?: string;
+}
+
+export function ProductStatusBadge({ status, className }: ProductStatusBadgeProps) {
+  const color = PRODUCT_STATUS_COLORS[status] ?? 'secondary';
+  const label = PRODUCT_STATUS_LABELS[status] ?? status;
+  return (
+    <span className={cn(statusBadgeVariants({ color }), className)}>
+      {label}
+    </span>
+  );
+}
+
+// ── Inquiry status ───────────────────────────────────────────────────────────
+
+type InquiryStatus = 'answered' | 'pending';
+
+interface InquiryStatusBadgeProps {
+  status: InquiryStatus;
+  /** 'admin': 미답변 | 'my': 접수 (default: 'admin') */
+  context?: 'admin' | 'my';
+  className?: string;
+}
+
+export function InquiryStatusBadge({ status, context = 'admin', className }: InquiryStatusBadgeProps) {
+  const isAnswered = status === 'answered';
+  const pendingLabel = context === 'my' ? '접수' : '미답변';
+  return (
+    <span className={cn(statusBadgeVariants({ color: isAnswered ? 'green' : 'yellow' }), className)}>
+      {isAnswered ? '답변완료' : pendingLabel}
+    </span>
+  );
+}
+
+// ── Journal publish status (clickable toggle button) ─────────────────────────
+
+interface JournalStatusBadgeProps {
+  isPublished: boolean;
+  onClick?: () => void;
+  className?: string;
+}
+
+export function JournalStatusBadge({ isPublished, onClick, className }: JournalStatusBadgeProps) {
+  const Tag = onClick ? 'button' : 'span';
+  return (
+    <Tag
+      {...(onClick ? { type: 'button' as const, onClick } : {})}
+      className={cn(
+        statusBadgeVariants({ color: isPublished ? 'green' : 'secondary' }),
+        'rounded-full px-3 py-1',
+        onClick && 'cursor-pointer hover:opacity-80 transition-opacity',
+        className,
+      )}
+    >
+      {isPublished ? '공개' : '비공개'}
+    </Tag>
   );
 }


### PR DESCRIPTION
## Summary
- Closes #314
- StatusBadge 컴포넌트에 `ProductStatusBadge`, `InquiryStatusBadge`, `JournalStatusBadge` variant 추가 (CVA 기반)
- admin/products, admin/inquiries, admin/journal, my/inquiries 4곳의 인라인 badge 스타일 제거 후 공통 컴포넌트로 교체
- 색상·크기 일관성 확보 (green/red/yellow/secondary)

## Test plan
- [x] npm run build
- [x] npm run test:run
- [ ] 시각 확인: admin/products, admin/inquiries, admin/journal, my/inquiries