### PR TITLE
fix: #321 dashboard revenue에 formatCurrency 적용

### DIFF
--- a/src/app/[locale]/admin/dashboard/page.tsx
+++ b/src/app/[locale]/admin/dashboard/page.tsx
@@ -172,9 +172,8 @@ export default function DashboardPage() {
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <KpiCard
               label="오늘 매출"
-              value={data.kpi.today_revenue.toLocaleString()}
+              value={formatCurrency(data.kpi.today_revenue)}
               diffPct={data.kpi.today_revenue_diff_pct}
-              unit="원"
             />
             <KpiCard
               label="오늘 주문수"


### PR DESCRIPTION
## Summary
- Closes #321
- admin dashboard `today_revenue` KPI가 `toLocaleString()` 사용하던 것을 `formatCurrency()`로 교체하여 '원' 접미사 포함 및 프로젝트 규칙 준수

## Test plan
- [x] npm run build
- [x] npm run test:run