### PR TITLE
refactor: #312 sessionStorage 키 중앙 상수 파일로 통합

### DIFF
--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -9,6 +9,7 @@ import EmptyState from '@/components/EmptyState';
 import CartItemRow from '@/components/cart/CartItemRow';
 import { formatCurrency } from '@/utils/currency';
 import { FREE_SHIPPING_THRESHOLD, SHIPPING_FEE } from '@/constants/shipping';
+import { SESSION_KEYS } from '@/constants/storage';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 
 export default function CartPage() {
@@ -55,7 +56,7 @@ export default function CartPage() {
       return;
     }
     const selectedItems = items.filter((item) => selectedIds.has(item.id));
-    sessionStorage.setItem('checkoutItems', JSON.stringify(selectedItems));
+    sessionStorage.setItem(SESSION_KEYS.CHECKOUT_ITEMS, JSON.stringify(selectedItems));
     router.push('/checkout');
   };
 

--- a/src/app/[locale]/checkout/fail/page.tsx
+++ b/src/app/[locale]/checkout/fail/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
 import type { Locale } from '@/i18n/routing';
+import { SESSION_KEYS } from '@/constants/storage';
 
 function CheckoutFailContent({ locale }: { locale: Locale }) {
   const searchParams = useSearchParams();
@@ -15,7 +16,7 @@ function CheckoutFailContent({ locale }: { locale: Locale }) {
 
   useEffect(() => {
     toast.error(message);
-    sessionStorage.removeItem('tossPaymentContext');
+    sessionStorage.removeItem(SESSION_KEYS.TOSS_CONTEXT);
   }, [message]);
 
   return (

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -9,6 +9,7 @@ import { useCart } from '@/contexts/CartContext';
 import type { CartItem, PreparePaymentResponse, UserAddress } from '@/lib/api';
 import { ordersApi, paymentsApi, usersApi } from '@/lib/api';
 import { FREE_SHIPPING_THRESHOLD, SHIPPING_FEE } from '@/constants/shipping';
+import { SESSION_KEYS } from '@/constants/storage';
 import { formatCurrency } from '@/utils/currency';
 import type { Locale } from '@/i18n/routing';
 import PaymentGateway, { type PaymentGatewayHandle } from '@/components/checkout/PaymentGateway';
@@ -102,7 +103,7 @@ export default function CheckoutPage({
       router.replace(`/${locale}/login`);
       return;
     }
-    const raw = sessionStorage.getItem('checkoutItems');
+    const raw = sessionStorage.getItem(SESSION_KEYS.CHECKOUT_ITEMS);
     if (!raw) {
       router.replace(`/${locale}/cart`);
       return;
@@ -256,7 +257,7 @@ export default function CheckoutPage({
 
       setStep('success');
       toast.success('결제가 완료되었습니다.');
-      sessionStorage.removeItem('checkoutItems');
+      sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
       await refetch();
       router.replace(`/${locale}/order/complete?orderId=${order.id}&orderNumber=${order.orderNumber}`);
     } catch (err) {

--- a/src/app/[locale]/checkout/success/page.tsx
+++ b/src/app/[locale]/checkout/success/page.tsx
@@ -8,6 +8,7 @@ import { handleApiError } from '@/utils/error';
 import { useCart } from '@/contexts/CartContext';
 import { paymentsApi } from '@/lib/api';
 import type { Locale } from '@/i18n/routing';
+import { SESSION_KEYS } from '@/constants/storage';
 
 function CheckoutSuccessContent({ locale }: { locale: Locale }) {
   const router = useRouter();
@@ -26,7 +27,7 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
       return;
     }
 
-    const raw = sessionStorage.getItem('tossPaymentContext');
+    const raw = sessionStorage.getItem(SESSION_KEYS.TOSS_CONTEXT);
     if (!raw) {
       toast.error('결제 컨텍스트를 찾을 수 없습니다.');
       router.replace(`/${locale}/cart`);
@@ -50,8 +51,8 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
       .confirm({ orderId: ctx.orderId, paymentKey, amount: ctx.amount })
       .then(async () => {
         toast.success('결제가 완료되었습니다.');
-        sessionStorage.removeItem('checkoutItems');
-        sessionStorage.removeItem('tossPaymentContext');
+        sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
+        sessionStorage.removeItem(SESSION_KEYS.TOSS_CONTEXT);
         await refetch();
         router.replace(
           `/${locale}/order/complete?orderId=${ctx.orderId}&orderNumber=${ctx.orderNumber}`,

--- a/src/components/auth/OAuthCallbackHandler.tsx
+++ b/src/components/auth/OAuthCallbackHandler.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { AuthTokenResponse } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
+import { SESSION_KEYS } from '@/constants/storage';
 
 interface OAuthCallbackHandlerProps {
   provider: 'kakao' | 'google';
@@ -18,7 +19,7 @@ export default function OAuthCallbackHandler({ provider, apiMethod }: OAuthCallb
   useEffect(() => {
     const code = searchParams.get('code');
     const state = searchParams.get('state');
-    const storedState = sessionStorage.getItem('oauth_state');
+    const storedState = sessionStorage.getItem(SESSION_KEYS.OAUTH_STATE);
 
     if (!code) {
       toast.error('인증 코드가 없습니다.');
@@ -32,7 +33,7 @@ export default function OAuthCallbackHandler({ provider, apiMethod }: OAuthCallb
       return;
     }
 
-    sessionStorage.removeItem('oauth_state');
+    sessionStorage.removeItem(SESSION_KEYS.OAUTH_STATE);
 
     apiMethod(code, state)
       .then(() => {

--- a/src/components/checkout/PaymentGateway.tsx
+++ b/src/components/checkout/PaymentGateway.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 're
 import type { Locale } from '@/i18n/routing';
 import type { PreparePaymentResponse } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
+import { SESSION_KEYS } from '@/constants/storage';
 
 export interface PaymentGatewayHandle {
   confirm: () => Promise<void>;
@@ -37,7 +38,7 @@ const TossPaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>
           const payment = tossPayments.payment({ customerKey: `user_${orderId}` });
 
           sessionStorage.setItem(
-            'tossPaymentContext',
+            SESSION_KEYS.TOSS_CONTEXT,
             JSON.stringify({ orderId, orderNumber, amount }),
           );
 

--- a/src/components/products/ProductGrid.tsx
+++ b/src/components/products/ProductGrid.tsx
@@ -8,10 +8,9 @@ import SortDropdown from '@/components/products/SortDropdown';
 import { cn } from '@/components/ui/utils';
 import type { Product } from '@/lib/api';
 import type { Locale } from '@/utils/currency';
+import { LOCAL_KEYS } from '@/constants/storage';
 
 type ViewMode = 'grid' | 'list';
-
-const STORAGE_KEY = 'products-view-mode';
 
 interface ProductGridProps {
   products: Product[];
@@ -23,7 +22,7 @@ export default function ProductGrid({ products, total, locale = 'ko' }: ProductG
   const [view, setView] = useState<ViewMode>('grid');
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as ViewMode | null;
+    const stored = localStorage.getItem(LOCAL_KEYS.VIEW_MODE) as ViewMode | null;
     if (stored === 'grid' || stored === 'list') {
       setView(stored);
     }

--- a/src/components/products/ViewToggle.tsx
+++ b/src/components/products/ViewToggle.tsx
@@ -3,10 +3,9 @@
 import { useEffect, useState } from 'react';
 import { LayoutGrid, List } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
+import { LOCAL_KEYS } from '@/constants/storage';
 
 type ViewMode = 'grid' | 'list';
-
-const STORAGE_KEY = 'products-view-mode';
 
 interface ViewToggleProps {
   value?: ViewMode;
@@ -18,7 +17,7 @@ export default function ViewToggle({ value, onChange }: ViewToggleProps) {
 
   useEffect(() => {
     if (value === undefined) {
-      const stored = localStorage.getItem(STORAGE_KEY) as ViewMode | null;
+      const stored = localStorage.getItem(LOCAL_KEYS.VIEW_MODE) as ViewMode | null;
       if (stored === 'grid' || stored === 'list') {
         setMode(stored);
       }
@@ -27,7 +26,7 @@ export default function ViewToggle({ value, onChange }: ViewToggleProps) {
 
   const handleChange = (newMode: ViewMode) => {
     setMode(newMode);
-    localStorage.setItem(STORAGE_KEY, newMode);
+    localStorage.setItem(LOCAL_KEYS.VIEW_MODE, newMode);
     onChange?.(newMode);
   };
 

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,0 +1,9 @@
+export const SESSION_KEYS = {
+  CHECKOUT_ITEMS: 'checkoutItems',
+  TOSS_CONTEXT: 'tossPaymentContext',
+  OAUTH_STATE: 'oauth_state',
+} as const;
+
+export const LOCAL_KEYS = {
+  VIEW_MODE: 'products-view-mode',
+} as const;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, useCallback, useEffect, useMemo, ReactNode } from 'react';
 import { toast } from 'sonner';
 import { authApi } from '@/lib/api';
+import { SESSION_KEYS } from '@/constants/storage';
 
 interface User {
   id: number;
@@ -77,7 +78,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const loginWithKakao = useCallback(() => {
     const state = generateState();
-    sessionStorage.setItem('oauth_state', state);
+    sessionStorage.setItem(SESSION_KEYS.OAUTH_STATE, state);
     const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID ?? '';
     const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI ?? '';
     const url = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&state=${state}`;
@@ -90,7 +91,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const loginWithGoogle = useCallback(() => {
     const state = generateState();
-    sessionStorage.setItem('oauth_state', state);
+    sessionStorage.setItem(SESSION_KEYS.OAUTH_STATE, state);
     const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? '';
     const redirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI ?? '';
     const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&scope=openid%20email%20profile&state=${state}`;


### PR DESCRIPTION
## Summary
- Closes #312
- `src/constants/storage.ts` 추가: SESSION_KEYS, LOCAL_KEYS
- checkoutItems, tossPaymentContext, oauth_state, products-view-mode 문자열 리터럴 제거
- 키 값 자체는 유지 (사용자 기존 저장 데이터 호환)

## Test plan
- [x] npm run build
- [x] npm run test:run
- [ ] 체크아웃 플로우 수동 확인 (cart → checkout → success)
- [ ] OAuth 로그인 플로우 수동 확인
- [ ] 상품 목록 view mode 토글 확인