### PR TITLE
fix: #332 POST 엔드포인트 HttpCode(200) 적용

### DIFF
--- a/backend/src/modules/coupons/coupons.controller.ts
+++ b/backend/src/modules/coupons/coupons.controller.ts
@@ -5,6 +5,8 @@ import {
   Body,
   Query,
   Request,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -43,6 +45,7 @@ export class CouponsController {
   }
 
   @Post('calculate')
+  @HttpCode(HttpStatus.OK)
   @ApiCookieAuth()
   @ApiOperation({ summary: '할인 금액 계산', description: '쿠폰 적용 시 할인 금액을 계산합니다.' })
   @ApiResponse({ status: 200, description: '할인 금액 계산 성공' })

--- a/backend/src/modules/payments/payments.controller.ts
+++ b/backend/src/modules/payments/payments.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Headers, HttpCode } from '@nestjs/common';
+import { Controller, Post, Body, Headers, HttpCode, HttpStatus } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -29,6 +29,7 @@ export class PaymentsController {
   }
 
   @Post('confirm')
+  @HttpCode(HttpStatus.OK)
   @ApiCookieAuth()
   @ApiOperation({ summary: '결제 승인', description: '결제를 확정합니다.' })
   @ApiResponse({ status: 200, description: '결제 확정 성공' })
@@ -38,6 +39,7 @@ export class PaymentsController {
   }
 
   @Post('cancel')
+  @HttpCode(HttpStatus.OK)
   @ApiCookieAuth()
   @ApiOperation({ summary: '결제 취소', description: '결제를 취소합니다.' })
   @ApiResponse({ status: 200, description: '결제 취소 성공' })

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -9,6 +9,8 @@ import {
   Body,
   ParseIntPipe,
   Request,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -58,6 +60,7 @@ export class ProductsController {
   }
 
   @Post('bulk')
+  @HttpCode(HttpStatus.OK)
   @Public()
   @ApiOperation({ summary: '상품 벌크 조회', description: '여러 상품 ID로 상품 목록을 한 번에 조회합니다.' })
   @ApiResponse({ status: 200, description: '상품 목록 조회 성공' })

--- a/backend/src/modules/shipping/shipping.controller.ts
+++ b/backend/src/modules/shipping/shipping.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, ParseIntPipe, HttpCode, HttpStatus } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -32,6 +32,7 @@ export class ShippingController {
   }
 
   @Post('track')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '배송 추적', description: '운송장 번호로 배송을 추적합니다.' })
   @ApiResponse({ status: 200, description: '배송 추적 성공' })
   track(@Body() dto: TrackShipmentDto) {


### PR DESCRIPTION
## Summary
- Closes #332
- 조회/상태변경 성격의 POST 엔드포인트 5곳에 `@HttpCode(HttpStatus.OK)` 적용
  - POST /products/bulk
  - POST /payments/confirm, /payments/cancel
  - POST /coupons/calculate
  - POST /shipping/track
- Swagger 문서와 실제 응답 status 일치

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm run test (pre-existing 실패 22건은 본 변경과 무관)