### PR TITLE
feat: #313 useAdminGuard 반환값 사용

### DIFF
--- a/src/app/[locale]/admin/faqs/page.tsx
+++ b/src/app/[locale]/admin/faqs/page.tsx
@@ -27,7 +27,7 @@ const FAQ_DEFAULTS: CreateFaqData = {
 };
 
 export default function AdminFaqsPage() {
-  useAdminGuard();
+  const { isAdmin } = useAdminGuard();
 
   const [faqs, setFaqs] = useState<Faq[]>([]);
   const [filterCategory, setFilterCategory] = useState('전체');
@@ -55,8 +55,9 @@ export default function AdminFaqsPage() {
   );
 
   useEffect(() => {
+    if (!isAdmin) return;
     void loadFaqs();
-  }, [loadFaqs]);
+  }, [isAdmin, loadFaqs]);
 
   const filtered = filterCategory === '전체'
     ? faqs

--- a/src/app/[locale]/admin/inquiries/page.tsx
+++ b/src/app/[locale]/admin/inquiries/page.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/components/ui/utils';
 type StatusFilter = 'all' | 'pending' | 'answered';
 
 export default function AdminInquiriesPage() {
-  useAdminGuard();
+  const { isAdmin } = useAdminGuard();
 
   const [inquiries, setInquiries] = useState<Inquiry[]>([]);
   const [filter, setFilter] = useState<StatusFilter>('all');
@@ -32,8 +32,9 @@ export default function AdminInquiriesPage() {
   );
 
   useEffect(() => {
+    if (!isAdmin) return;
     void loadInquiries();
-  }, [loadInquiries]);
+  }, [isAdmin, loadInquiries]);
 
   const filtered = filter === 'all'
     ? inquiries


### PR DESCRIPTION
## Summary
- AdminInquiriesPage와 AdminFaqsPage에서 `useAdminGuard()` 반환값을 사용하여 관리자 여부 체크 후 데이터 로딩
- 비관리자에게 불필요한 401 API 호출 방지

## Changes
- `src/app/[locale]/admin/inquiries/page.tsx`: `isAdmin` guard 추가
- `src/app/[locale]/admin/faqs/page.tsx`: `isAdmin` guard 추가

Closes #313