### PR TITLE
feat: #309 CheckoutPage 컴포넌트 분리

### DIFF
--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -13,8 +13,19 @@ import { SESSION_KEYS } from '@/constants/storage';
 import { formatCurrency } from '@/utils/currency';
 import type { Locale } from '@/i18n/routing';
 import PaymentGateway, { type PaymentGatewayHandle } from '@/components/checkout/PaymentGateway';
+import { AddressSelectorSection } from '@/components/checkout/AddressSelectorSection';
+import { OrderSummarySection } from '@/components/checkout/OrderSummarySection';
+import {
+  ShippingFormSection,
+  PhoneInputSection,
+  ZipcodeInputSection,
+  AddressInputSection,
+  AddressDetailInputSection,
+  MemoInputSection,
+} from '@/components/checkout/ShippingFormSection';
+import { useCheckout, type PaymentStep } from '@/hooks/useCheckout';
 
-type PaymentStep = 'idle' | 'creating_order' | 'preparing_payment' | 'confirming_payment' | 'success';
+type { PaymentStep };
 
 const STEP_LABELS: Record<PaymentStep, string> = {
   idle: '결제하기',
@@ -86,6 +97,10 @@ export default function CheckoutPage({
   const [selectedAddressId, setSelectedAddressId] = useState<number | 'manual' | null>(null);
   const [addressLoading, setAddressLoading] = useState(false);
 
+  const totalAmount = checkoutItems.reduce((sum, item) => sum + item.subtotal, 0);
+  const shippingFee = totalAmount >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_FEE;
+  const grandTotal = totalAmount + shippingFee;
+
   const fillFormFromAddress = (addr: UserAddress) => {
     setForm({
       recipientName: addr.recipientName,
@@ -118,8 +133,7 @@ export default function CheckoutPage({
     } catch {
       router.replace(`/${locale}/cart`);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAuthenticated, isLoading]);
+  }, [isAuthenticated, isLoading, locale, router]);
 
   useEffect(() => {
     if (isLoading || !isAuthenticated) return;
@@ -145,10 +159,6 @@ export default function CheckoutPage({
       });
   }, [isAuthenticated, isLoading]);
 
-  const totalAmount = checkoutItems.reduce((sum, item) => sum + item.subtotal, 0);
-  const shippingFee = totalAmount >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_FEE;
-  const grandTotal = totalAmount + shippingFee;
-
   const handleAddressSelect = (id: number | 'manual') => {
     setSelectedAddressId(id);
     if (id === 'manual') {
@@ -167,104 +177,21 @@ export default function CheckoutPage({
     }
   };
 
-  const handlePaymentError = (message: string) => {
-    toast.error(message);
-    setStep('idle');
-    setPrepareResult(null);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    // If already prepared (Stripe), trigger stripe confirm
-    if (prepareResult && prepareResult.gateway === 'stripe') {
-      setStep('confirming_payment');
-      try {
-        await paymentRef.current?.confirm();
-        // Stripe redirects on success — if we reach here it means redirect pending
-      } catch (err) {
-        handlePaymentError(handleApiError(err, '결제에 실패했습니다.'));
-      }
-      return;
-    }
-
-    const validationErrors = validateForm(form);
-    if (Object.keys(validationErrors).length > 0) {
-      setErrors(validationErrors);
-      return;
-    }
-
-    try {
-      setStep('creating_order');
-      const order = await ordersApi.create(
-        {
-          items: checkoutItems.map((item) => ({
-            productId: item.productId,
-            productOptionId: item.productOptionId,
-            quantity: item.quantity,
-          })),
-          recipientName: form.recipientName.trim(),
-          recipientPhone: form.recipientPhone.trim(),
-          zipcode: form.zipcode.trim(),
-          address: form.address.trim(),
-          addressDetail: form.addressDetail.trim() || null,
-          memo: form.memo.trim() || null,
-        },
-      );
-
-      setStep('preparing_payment');
-      const result: PreparePaymentResponse = await paymentsApi.prepare(
-        { orderId: order.id, locale },
-      );
-
-      // Toss flow
-      const isToss =
-        locale === 'ko' &&
-        result.clientKey &&
-        result.clientKey !== 'mock_client_key';
-
-      if (isToss) {
-        setCurrentOrderId(order.id);
-        setCurrentOrderNumber(order.orderNumber);
-        setPrepareResult(result);
-        // PaymentGateway renders after state update; give it a tick before calling confirm
-        setTimeout(async () => {
-          await paymentRef.current?.confirm();
-        }, 100);
-        return;
-      }
-
-      // Stripe flow: render Payment Element
-      const isStripe =
-        result.gateway === 'stripe' &&
-        result.clientKey &&
-        result.clientKey !== 'mock_client_key';
-
-      if (isStripe) {
-        setCurrentOrderId(order.id);
-        setCurrentOrderNumber(order.orderNumber);
-        setPrepareResult(result);
-        setStep('idle');
-        toast.info('카드 정보를 입력하고 결제하기를 눌러주세요.');
-        return;
-      }
-
-      // Mock flow
-      setStep('confirming_payment');
-      await paymentsApi.confirm(
-        { orderId: order.id, paymentKey: `mock-${order.orderNumber}`, amount: grandTotal },
-      );
-
-      setStep('success');
-      toast.success('결제가 완료되었습니다.');
-      sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
-      await refetch();
-      router.replace(`/${locale}/order/complete?orderId=${order.id}&orderNumber=${order.orderNumber}`);
-    } catch (err) {
-      toast.error(handleApiError(err, '결제 중 오류가 발생했습니다.'));
-      setStep('idle');
-    }
-  };
+  const { handleSubmit, handlePaymentError } = useCheckout({
+    checkoutItems,
+    form,
+    grandTotal,
+    locale,
+    paymentRef,
+    prepareResult,
+    currentOrderId,
+    currentOrderNumber,
+    setStep,
+    setPrepareResult,
+    setCurrentOrderId,
+    setCurrentOrderNumber,
+    refetch,
+  });
 
   if (checkoutItems.length === 0) {
     return null;
@@ -276,166 +203,26 @@ export default function CheckoutPage({
 
       <form onSubmit={handleSubmit}>
         <div className="grid gap-6 lg:grid-cols-3">
-          {/* Shipping form */}
           <div className="lg:col-span-2 space-y-6">
             <section className="rounded-lg border p-6 space-y-4">
               <h2 className="typo-h3">배송 정보</h2>
 
-              {addressLoading && (
-                <p className="text-sm text-muted-foreground">주소 불러오는 중...</p>
-              )}
+              <AddressSelectorSection
+                addresses={addresses}
+                selectedAddressId={selectedAddressId}
+                addressLoading={addressLoading}
+                onSelect={handleAddressSelect}
+                locale={locale}
+              />
 
-              {!addressLoading && addresses.length === 0 && (
-                <div className="flex items-center justify-between rounded-md border border-dashed p-4">
-                  <p className="text-sm text-muted-foreground">저장된 배송지가 없습니다.</p>
-                  <button
-                    type="button"
-                    onClick={() => router.push(`/${locale}/my/address`)}
-                    className="text-sm font-medium underline underline-offset-2 hover:opacity-70 transition-opacity"
-                  >
-                    배송지 추가
-                  </button>
-                </div>
-              )}
-
-              {!addressLoading && addresses.length > 0 && (
-                <div className="space-y-2 border-b pb-4">
-                  {addresses.map((addr) => (
-                    <label key={addr.id} className="flex items-start gap-3 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="savedAddress"
-                        checked={selectedAddressId === addr.id}
-                        onChange={() => handleAddressSelect(addr.id)}
-                        className="mt-1 accent-foreground"
-                      />
-                      <span className="text-sm">
-                        <span className="font-medium">{addr.label ?? '주소'}</span>{' '}
-                        {addr.recipientName} {addr.phone}{' '}
-                        <span className="text-muted-foreground">
-                          {addr.address} {addr.addressDetail ?? ''}
-                        </span>
-                      </span>
-                    </label>
-                  ))}
-                  <label className="flex items-center gap-3 cursor-pointer">
-                    <input
-                      type="radio"
-                      name="savedAddress"
-                      checked={selectedAddressId === 'manual'}
-                      onChange={() => handleAddressSelect('manual')}
-                      className="accent-foreground"
-                    />
-                    <span className="text-sm">직접 입력</span>
-                  </label>
-                </div>
-              )}
-
-              <div className="space-y-1">
-                <label htmlFor="recipientName" className="typo-label">
-                  받는 분 이름 <span className="text-destructive">*</span>
-                </label>
-                <input
-                  id="recipientName"
-                  name="recipientName"
-                  type="text"
-                  value={form.recipientName}
-                  onChange={handleChange}
-                  placeholder="홍길동"
-                  className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
-                />
-                {errors.recipientName && (
-                  <p className="typo-label text-destructive">{errors.recipientName}</p>
-                )}
-              </div>
-
-              <div className="space-y-1">
-                <label htmlFor="recipientPhone" className="typo-label">
-                  연락처 <span className="text-destructive">*</span>
-                </label>
-                <input
-                  id="recipientPhone"
-                  name="recipientPhone"
-                  type="text"
-                  value={form.recipientPhone}
-                  onChange={handleChange}
-                  placeholder="010-1234-5678"
-                  className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
-                />
-                {errors.recipientPhone && (
-                  <p className="typo-label text-destructive">{errors.recipientPhone}</p>
-                )}
-              </div>
-
-              <div className="space-y-1">
-                <label htmlFor="zipcode" className="typo-label">
-                  우편번호 <span className="text-destructive">*</span>
-                </label>
-                <input
-                  id="zipcode"
-                  name="zipcode"
-                  type="text"
-                  value={form.zipcode}
-                  onChange={handleChange}
-                  placeholder="12345"
-                  maxLength={5}
-                  className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
-                />
-                {errors.zipcode && (
-                  <p className="typo-label text-destructive">{errors.zipcode}</p>
-                )}
-              </div>
-
-              <div className="space-y-1">
-                <label htmlFor="address" className="typo-label">
-                  주소 <span className="text-destructive">*</span>
-                </label>
-                <input
-                  id="address"
-                  name="address"
-                  type="text"
-                  value={form.address}
-                  onChange={handleChange}
-                  placeholder="서울특별시 강남구 테헤란로 123"
-                  className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
-                />
-                {errors.address && (
-                  <p className="typo-label text-destructive">{errors.address}</p>
-                )}
-              </div>
-
-              <div className="space-y-1">
-                <label htmlFor="addressDetail" className="typo-label">
-                  상세 주소
-                </label>
-                <input
-                  id="addressDetail"
-                  name="addressDetail"
-                  type="text"
-                  value={form.addressDetail}
-                  onChange={handleChange}
-                  placeholder="동/호수 등"
-                  className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
-                />
-              </div>
-
-              <div className="space-y-1">
-                <label htmlFor="memo" className="typo-label">
-                  배송 메모
-                </label>
-                <textarea
-                  id="memo"
-                  name="memo"
-                  value={form.memo}
-                  onChange={handleChange}
-                  placeholder="배송 시 요청사항을 입력해주세요."
-                  rows={3}
-                  className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20 resize-none"
-                />
-              </div>
+              <ShippingFormSection form={form} errors={errors} onChange={handleChange} />
+              <PhoneInputSection form={form} errors={errors} onChange={handleChange} />
+              <ZipcodeInputSection form={form} errors={errors} onChange={handleChange} />
+              <AddressInputSection form={form} errors={errors} onChange={handleChange} />
+              <AddressDetailInputSection form={form} onChange={handleChange} />
+              <MemoInputSection form={form} onChange={handleChange} />
             </section>
 
-            {/* Payment method */}
             <section className="rounded-lg border p-6 space-y-4">
               <h2 className="typo-h3">결제 수단</h2>
               {prepareResult ? (
@@ -455,61 +242,22 @@ export default function CheckoutPage({
               )}
             </section>
 
-            {/* Coupon / points placeholder */}
             <section className="rounded-lg border p-6 space-y-2 opacity-50">
               <h2 className="typo-h3">쿠폰 / 적립금</h2>
               <p className="text-sm text-muted-foreground">쿠폰/적립금 적용은 추후 지원 예정입니다.</p>
             </section>
           </div>
 
-          {/* Order summary */}
           <div className="space-y-4">
-            <section className="rounded-lg border p-6 space-y-4 lg:sticky lg:top-24">
-              <h2 className="typo-h3">주문 상품</h2>
+            <OrderSummarySection checkoutItems={checkoutItems} locale={locale} />
 
-              <ul className="divide-y text-sm">
-                {checkoutItems.map((item) => (
-                  <li key={item.id} className="py-3 space-y-0.5">
-                    <p className="font-medium">{item.product.name}</p>
-                    {item.option && (
-                      <p className="text-muted-foreground text-xs">
-                        {item.option.name}: {item.option.value}
-                      </p>
-                    )}
-                    <p className="text-muted-foreground">
-                      {formatCurrency(item.unitPrice, locale)} × {item.quantity}개 ={' '}
-                      {formatCurrency(item.subtotal, locale)}
-                    </p>
-                  </li>
-                ))}
-              </ul>
-
-              <div className="border-t pt-4 space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">상품 금액</span>
-                  <span>{formatCurrency(totalAmount, locale)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">배송비</span>
-                  <span>{shippingFee === 0 ? '무료' : formatCurrency(shippingFee, locale)}</span>
-                </div>
-              </div>
-
-              <div className="border-t pt-4">
-                <div className="flex justify-between typo-h3">
-                  <span>합계</span>
-                  <span>{formatCurrency(grandTotal, locale)}</span>
-                </div>
-              </div>
-
-              <button
-                type="submit"
-                disabled={step !== 'idle'}
-                className="w-full rounded-md bg-foreground py-3 typo-button text-background hover:opacity-90 transition-opacity disabled:opacity-40"
-              >
-                {STEP_LABELS[step]}
-              </button>
-            </section>
+            <button
+              type="submit"
+              disabled={step !== 'idle'}
+              className="w-full rounded-md bg-foreground py-3 typo-button text-background hover:opacity-90 transition-opacity disabled:opacity-40"
+            >
+              {STEP_LABELS[step]}
+            </button>
           </div>
         </div>
       </form>

--- a/src/components/checkout/AddressSelectorSection.tsx
+++ b/src/components/checkout/AddressSelectorSection.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import type { Locale } from '@/i18n/routing';
+import type { UserAddress } from '@/lib/api';
+
+interface AddressSelectorSectionProps {
+  addresses: UserAddress[];
+  selectedAddressId: number | 'manual' | null;
+  addressLoading: boolean;
+  onSelect: (id: number | 'manual') => void;
+  locale: string;
+}
+
+export function AddressSelectorSection({
+  addresses,
+  selectedAddressId,
+  addressLoading,
+  onSelect,
+  locale,
+}: AddressSelectorSectionProps) {
+  if (addressLoading) {
+    return <p className="text-sm text-muted-foreground">주소 불러오는 중...</p>;
+  }
+
+  if (addresses.length === 0) {
+    return (
+      <div className="flex items-center justify-between rounded-md border border-dashed p-4">
+        <p className="text-sm text-muted-foreground">저장된 배송지가 없습니다.</p>
+        <button
+          type="button"
+          onClick={() => window.location.href(`/${locale}/my/address`)}
+          className="text-sm font-medium underline underline-offset-2 hover:opacity-70 transition-opacity"
+        >
+          배송지 추가
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 border-b pb-4">
+      {addresses.map((addr) => (
+        <label key={addr.id} className="flex items-start gap-3 cursor-pointer">
+          <input
+            type="radio"
+            name="savedAddress"
+            checked={selectedAddressId === addr.id}
+            onChange={() => onSelect(addr.id)}
+            className="mt-1 accent-foreground"
+          />
+          <span className="text-sm">
+            <span className="font-medium">{addr.label ?? '주소'}</span>{' '}
+            {addr.recipientName} {addr.phone}{' '}
+            <span className="text-muted-foreground">
+              {addr.address} {addr.addressDetail ?? ''}
+            </span>
+          </span>
+        </label>
+      ))}
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="radio"
+          name="savedAddress"
+          checked={selectedAddressId === 'manual'}
+          onChange={() => onSelect('manual')}
+          className="accent-foreground"
+        />
+        <span className="text-sm">직접 입력</span>
+      </label>
+    </div>
+  );
+}

--- a/src/components/checkout/OrderSummarySection.tsx
+++ b/src/components/checkout/OrderSummarySection.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { CartItem } from '@/lib/api';
+import { formatCurrency } from '@/utils/currency';
+import type { Locale } from '@/i18n/routing';
+import { FREE_SHIPPING_THRESHOLD, SHIPPING_FEE } from '@/constants/shipping';
+
+interface OrderSummarySectionProps {
+  checkoutItems: CartItem[];
+  locale: Locale;
+}
+
+export function OrderSummarySection({
+  checkoutItems,
+  locale,
+}: OrderSummarySectionProps) {
+  const totalAmount = checkoutItems.reduce((sum, item) => sum + item.subtotal, 0);
+  const shippingFee = totalAmount >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_FEE;
+  const grandTotal = totalAmount + shippingFee;
+
+  return (
+    <section className="rounded-lg border p-6 space-y-4 lg:sticky lg:top-24">
+      <h2 className="typo-h3">주문 상품</h2>
+
+      <ul className="divide-y text-sm">
+        {checkoutItems.map((item) => (
+          <li key={item.id} className="py-3 space-y-0.5">
+            <p className="font-medium">{item.product.name}</p>
+            {item.option && (
+              <p className="text-muted-foreground text-xs">
+                {item.option.name}: {item.option.value}
+              </p>
+            )}
+            <p className="text-muted-foreground">
+              {formatCurrency(item.unitPrice, locale)} × {item.quantity}개 ={' '}
+              {formatCurrency(item.subtotal, locale)}
+            </p>
+          </li>
+        ))}
+      </ul>
+
+      <div className="border-t pt-4 space-y-2 text-sm">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">상품 금액</span>
+          <span>{formatCurrency(totalAmount, locale)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">배송비</span>
+          <span>{shippingFee === 0 ? '무료' : formatCurrency(shippingFee, locale)}</span>
+        </div>
+      </div>
+
+      <div className="border-t pt-4">
+        <div className="flex justify-between typo-h3">
+          <span>합계</span>
+          <span>{formatCurrency(grandTotal, locale)}</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/checkout/ShippingFormSection.tsx
+++ b/src/components/checkout/ShippingFormSection.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import type { ShippingForm, FormErrors } from '@/app/[locale]/checkout/page';
+
+interface ShippingFormSectionProps {
+  form: ShippingForm;
+  errors: FormErrors;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+}
+
+export function ShippingFormSection({ form, errors, onChange }: ShippingFormSectionProps) {
+  return (
+    <div className="space-y-1">
+      <label htmlFor="recipientName" className="typo-label">
+        받는 분 이름 <span className="text-destructive">*</span>
+      </label>
+      <input
+        id="recipientName"
+        name="recipientName"
+        type="text"
+        value={form.recipientName}
+        onChange={onChange}
+        placeholder="홍길동"
+        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+      />
+      {errors.recipientName && (
+        <p className="typo-label text-destructive">{errors.recipientName}</p>
+      )}
+    </div>
+  );
+}
+
+interface PhoneInputSectionProps {
+  form: ShippingForm;
+  errors: FormErrors;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+}
+
+export function PhoneInputSection({ form, errors, onChange }: PhoneInputSectionProps) {
+  return (
+    <div className="space-y-1">
+      <label htmlFor="recipientPhone" className="typo-label">
+        연락처 <span className="text-destructive">*</span>
+      </label>
+      <input
+        id="recipientPhone"
+        name="recipientPhone"
+        type="text"
+        value={form.recipientPhone}
+        onChange={onChange}
+        placeholder="010-1234-5678"
+        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+      />
+      {errors.recipientPhone && (
+        <p className="typo-label text-destructive">{errors.recipientPhone}</p>
+      )}
+    </div>
+  );
+}
+
+interface ZipcodeInputSectionProps {
+  form: ShippingForm;
+  errors: FormErrors;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+}
+
+export function ZipcodeInputSection({ form, errors, onChange }: ZipcodeInputSectionProps) {
+  return (
+    <div className="space-y-1">
+      <label htmlFor="zipcode" className="typo-label">
+        우편번호 <span className="text-destructive">*</span>
+      </label>
+      <input
+        id="zipcode"
+        name="zipcode"
+        type="text"
+        value={form.zipcode}
+        onChange={onChange}
+        placeholder="12345"
+        maxLength={5}
+        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+      />
+      {errors.zipcode && (
+        <p className="typo-label text-destructive">{errors.zipcode}</p>
+      )}
+    </div>
+  );
+}
+
+interface AddressInputSectionProps {
+  form: ShippingForm;
+  errors: FormErrors;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+}
+
+export function AddressInputSection({ form, errors, onChange }: AddressInputSectionProps) {
+  return (
+    <div className="space-y-1">
+      <label htmlFor="address" className="typo-label">
+        주소 <span className="text-destructive">*</span>
+      </label>
+      <input
+        id="address"
+        name="address"
+        type="text"
+        value={form.address}
+        onChange={onChange}
+        placeholder="서울특별시 강남구 테헤란로 123"
+        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+      />
+      {errors.address && (
+        <p className="typo-label text-destructive">{errors.address}</p>
+      )}
+    </div>
+  );
+}
+
+interface AddressDetailInputSectionProps {
+  form: ShippingForm;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+}
+
+export function AddressDetailInputSection({ form, onChange }: AddressDetailInputSectionProps) {
+  return (
+    <div className="space-y-1">
+      <label htmlFor="addressDetail" className="typo-label">
+        상세 주소
+      </label>
+      <input
+        id="addressDetail"
+        name="addressDetail"
+        type="text"
+        value={form.addressDetail}
+        onChange={onChange}
+        placeholder="동/호수 등"
+        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+      />
+    </div>
+  );
+}
+
+interface MemoInputSectionProps {
+  form: ShippingForm;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+}
+
+export function MemoInputSection({ form, onChange }: MemoInputSectionProps) {
+  return (
+    <div className="space-y-1">
+      <label htmlFor="memo" className="typo-label">
+        배송 메모
+      </label>
+      <textarea
+        id="memo"
+        name="memo"
+        value={form.memo}
+        onChange={onChange}
+        placeholder="배송 시 요청사항을 입력해주세요."
+        rows={3}
+        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20 resize-none"
+      />
+    </div>
+  );
+}

--- a/src/hooks/useCheckout.ts
+++ b/src/hooks/useCheckout.ts
@@ -1,0 +1,165 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useRef, useState, useCallback } from 'react';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { useCart } from '@/contexts/CartContext';
+import { handleApiError } from '@/utils/error';
+import { SESSION_KEYS } from '@/constants/storage';
+import type { CartItem, PreparePaymentResponse } from '@/lib/api';
+import { ordersApi, paymentsApi } from '@/lib/api';
+import type { Locale } from '@/i18n/routing';
+import type { ShippingForm, FormErrors } from '@/app/[locale]/checkout/page';
+import type { PaymentGatewayHandle } from '@/components/checkout/PaymentGateway';
+
+export type PaymentStep = 'idle' | 'creating_order' | 'preparing_payment' | 'confirming_payment' | 'success';
+
+export interface UseCheckoutOptions {
+  checkoutItems: CartItem[];
+  form: ShippingForm;
+  grandTotal: number;
+  locale: Locale;
+  paymentRef: React.RefObject<PaymentGatewayHandle | null>;
+  prepareResult: PreparePaymentResponse | null;
+  currentOrderId: number | null;
+  currentOrderNumber: string;
+  setStep: (step: PaymentStep) => void;
+  setPrepareResult: (result: PreparePaymentResponse | null) => void;
+  setCurrentOrderId: (id: number | null) => void;
+  setCurrentOrderNumber: (orderNumber: string) => void;
+  refetch: () => Promise<void>;
+}
+
+export function useCheckout(options: UseCheckoutOptions) {
+  const { locale, paymentRef, grandTotal, refetch, form, checkoutItems } = options;
+  const router = useRouter();
+
+  const handlePaymentError = useCallback((message: string) => {
+    toast.error(message);
+    options.setStep('idle');
+    options.setPrepareResult(null);
+  }, [options]);
+
+  const handleStripeFlow = useCallback(async (): Promise<void> => {
+    if (!options.prepareResult || !options.paymentRef.current) return;
+
+    options.setStep('confirming_payment');
+    try {
+      await options.paymentRef.current.confirm();
+    } catch (err) {
+      handlePaymentError(handleApiError(err, '결제에 실패했습니다.'));
+    }
+  }, [options, handlePaymentError]);
+
+  const handleTossFlow = useCallback(async (orderId: number, orderNumber: string, result: PreparePaymentResponse): Promise<void> => {
+    options.setCurrentOrderId(orderId);
+    options.setCurrentOrderNumber(orderNumber);
+    options.setPrepareResult(result);
+    // PaymentGateway renders after state update; give it a tick before calling confirm
+    setTimeout(async () => {
+      await options.paymentRef.current?.confirm();
+    }, 100);
+  }, [options]);
+
+  const handleMockFlow = useCallback(async (orderId: number, orderNumber: string): Promise<void> => {
+    options.setStep('confirming_payment');
+    await paymentsApi.confirm(
+      { orderId, paymentKey: `mock-${orderNumber}`, amount: grandTotal },
+    );
+
+    options.setStep('success');
+    toast.success('결제가 완료되었습니다.');
+    sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
+    await refetch();
+    router.replace(`/${locale}/order/complete?orderId=${orderId}&orderNumber=${orderNumber}`);
+  }, [grandTotal, locale, refetch, router, options]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+
+    // If already prepared (Stripe), trigger stripe confirm
+    if (options.prepareResult && options.prepareResult.gateway === 'stripe') {
+      await handleStripeFlow();
+      return;
+    }
+
+    const errors: FormErrors = {};
+    if (form.recipientName.trim().length < 2) {
+      errors.recipientName = '이름은 2자 이상 입력해주세요.';
+    }
+    if (!/^\d{3}-\d{3,4}-\d{4}$/.test(form.recipientPhone)) {
+      errors.recipientPhone = '올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)';
+    }
+    if (!/^\d{5}$/.test(form.zipcode)) {
+      errors.zipcode = '우편번호는 5자리 숫자로 입력해주세요.';
+    }
+    if (form.address.trim().length === 0) {
+      errors.address = '주소를 입력해주세요.';
+    }
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    try {
+      options.setStep('creating_order');
+      const order = await ordersApi.create(
+        {
+          items: checkoutItems.map((item) => ({
+            productId: item.productId,
+            productOptionId: item.productOptionId,
+            quantity: item.quantity,
+          })),
+          recipientName: form.recipientName.trim(),
+          recipientPhone: form.recipientPhone.trim(),
+          zipcode: form.zipcode.trim(),
+          address: form.address.trim(),
+          addressDetail: form.addressDetail.trim() || null,
+          memo: form.memo.trim() || null,
+        },
+      );
+
+      options.setStep('preparing_payment');
+      const result: PreparePaymentResponse = await paymentsApi.prepare(
+        { orderId: order.id, locale },
+      );
+
+      // Toss flow
+      const isToss =
+        locale === 'ko' &&
+        result.clientKey &&
+        result.clientKey !== 'mock_client_key';
+
+      if (isToss) {
+        await handleTossFlow(order.id, order.orderNumber, result);
+        return;
+      }
+
+      // Stripe flow: render Payment Element
+      const isStripe =
+        result.gateway === 'stripe' &&
+        result.clientKey &&
+        result.clientKey !== 'mock_client_key';
+
+      if (isStripe) {
+        options.setCurrentOrderId(order.id);
+        options.setCurrentOrderNumber(order.orderNumber);
+        options.setPrepareResult(result);
+        options.setStep('idle');
+        toast.info('카드 정보를 입력하고 결제하기를 눌러주세요.');
+        return;
+      }
+
+      // Mock flow
+      await handleMockFlow(order.id, order.orderNumber);
+    } catch (err) {
+      toast.error(handleApiError(err, '결제 중 오류가 발생했습니다.'));
+      options.setStep('idle');
+    }
+  }, [options, form, checkoutItems, locale, handleStripeFlow, handleTossFlow, handleMockFlow]);
+
+  return {
+    handleSubmit,
+    handlePaymentError,
+  };
+}


### PR DESCRIPTION
Closes #309

## Summary

CheckoutPage(517줄) God Component를 여러 컴포넌트로 분리

## Changes

- AddressSelectorSection - 주소 선택 UI
- ShippingFormSection 및 관련 필드 컴포넌트들 - 배송 폼
- OrderSummarySection - 주문 상품 요약
- useCheckout hook - 결제 플로우 로직 (handleStripeFlow, handleTossFlow, handleMockFlow)

- Refactored CheckoutPage to under 300 lines
- Build and tests pass