### PR TITLE
feat: #301 error.tsx boundary 추가

### DIFF
--- a/src/app/[locale]/(routes)/error.tsx
+++ b/src/app/[locale]/(routes)/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/archives/error.tsx
+++ b/src/app/[locale]/admin/archives/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/categories/error.tsx
+++ b/src/app/[locale]/admin/categories/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/collections/error.tsx
+++ b/src/app/[locale]/admin/collections/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/dashboard/error.tsx
+++ b/src/app/[locale]/admin/dashboard/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/error.tsx
+++ b/src/app/[locale]/admin/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/faqs/error.tsx
+++ b/src/app/[locale]/admin/faqs/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/inquiries/error.tsx
+++ b/src/app/[locale]/admin/inquiries/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/journal/error.tsx
+++ b/src/app/[locale]/admin/journal/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/members/error.tsx
+++ b/src/app/[locale]/admin/members/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/navigation/error.tsx
+++ b/src/app/[locale]/admin/navigation/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/orders/error.tsx
+++ b/src/app/[locale]/admin/orders/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/pages/error.tsx
+++ b/src/app/[locale]/admin/pages/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/products/[id]/edit/error.tsx
+++ b/src/app/[locale]/admin/products/[id]/edit/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/products/error.tsx
+++ b/src/app/[locale]/admin/products/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/products/new/error.tsx
+++ b/src/app/[locale]/admin/products/new/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/admin/settings/theme/error.tsx
+++ b/src/app/[locale]/admin/settings/theme/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/artist/[slug]/error.tsx
+++ b/src/app/[locale]/artist/[slug]/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/artist/error.tsx
+++ b/src/app/[locale]/artist/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/cart/error.tsx
+++ b/src/app/[locale]/cart/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/checkout/error.tsx
+++ b/src/app/[locale]/checkout/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/checkout/fail/error.tsx
+++ b/src/app/[locale]/checkout/fail/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/checkout/success/error.tsx
+++ b/src/app/[locale]/checkout/success/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/contact/error.tsx
+++ b/src/app/[locale]/contact/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/event/[id]/error.tsx
+++ b/src/app/[locale]/event/[id]/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/event/error.tsx
+++ b/src/app/[locale]/event/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/faq/error.tsx
+++ b/src/app/[locale]/faq/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/journal/[slug]/error.tsx
+++ b/src/app/[locale]/journal/[slug]/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/journal/error.tsx
+++ b/src/app/[locale]/journal/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/address/error.tsx
+++ b/src/app/[locale]/my/address/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/coupons/error.tsx
+++ b/src/app/[locale]/my/coupons/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/error.tsx
+++ b/src/app/[locale]/my/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/inquiries/error.tsx
+++ b/src/app/[locale]/my/inquiries/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/inquiries/new/error.tsx
+++ b/src/app/[locale]/my/inquiries/new/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/orders/[id]/error.tsx
+++ b/src/app/[locale]/my/orders/[id]/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/orders/error.tsx
+++ b/src/app/[locale]/my/orders/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/profile/error.tsx
+++ b/src/app/[locale]/my/profile/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/recently-viewed/error.tsx
+++ b/src/app/[locale]/my/recently-viewed/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/my/wishlist/error.tsx
+++ b/src/app/[locale]/my/wishlist/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/notice/[id]/error.tsx
+++ b/src/app/[locale]/notice/[id]/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/notice/error.tsx
+++ b/src/app/[locale]/notice/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/order/complete/error.tsx
+++ b/src/app/[locale]/order/complete/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/p/[slug]/error.tsx
+++ b/src/app/[locale]/p/[slug]/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/pages/[slug]/error.tsx
+++ b/src/app/[locale]/pages/[slug]/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/products/[id]/error.tsx
+++ b/src/app/[locale]/products/[id]/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/products/error.tsx
+++ b/src/app/[locale]/products/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/products/preview/error.tsx
+++ b/src/app/[locale]/products/preview/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/app/[locale]/search/error.tsx
+++ b/src/app/[locale]/search/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorFallback error={error} onRetry={reset} />;
+}

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+interface ErrorFallbackProps {
+  error: Error & { digest?: string };
+  onRetry: () => void;
+}
+
+export default function ErrorFallback({ error, onRetry }: ErrorFallbackProps) {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="text-center max-w-md">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-6 mb-6">
+          <p className="text-sm text-red-600 mb-2">데이터를 불러오지 못했습니다</p>
+          <p className="text-xs text-red-500/70">{error.message || '알 수 없는 오류가 발생했습니다.'}</p>
+        </div>
+        <button
+          onClick={onRetry}
+          className="inline-flex items-center gap-2 text-sm font-medium bg-foreground text-background rounded px-6 py-3 hover:opacity-80 transition-opacity"
+        >
+          다시 시도
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- issue #301 해결: 데이터 페칭 페이지에 error.tsx boundary 추가
- `ErrorFallback` 컴포넌트 생성 (`src/components/ErrorFallback.tsx`)
- 49개 page 디렉토리에 error.tsx 추가

## Changes
- `ErrorFallback` 컴포넌트: 에러 메시지 + 재시도 버튼 UI
- 48개 error.tsx 파일 추가 (이미 존재하던 archive, collection 제외)

## 테스트
- 빌드 성공 확인

Closes #301