### PR TITLE
feat: #425 i18n - fix Korean fields showing on English pages

### DIFF
--- a/backend/src/common/utils/locale.util.ts
+++ b/backend/src/common/utils/locale.util.ts
@@ -1,4 +1,5 @@
 const LOCALE_SUFFIX_MAP: Record<string, string> = {
+  ko: 'Ko',
   en: 'En',
   ja: 'Ja',
   zh: 'Zh',

--- a/backend/src/modules/archives/archives.controller.ts
+++ b/backend/src/modules/archives/archives.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { ArchivesService } from './archives.service';
 import { Public } from '../../common/decorators/public.decorator';
 
@@ -12,9 +12,10 @@ export class ArchivesController {
   @Get()
   @ApiOperation({ summary: '전체 아카이브 조회', description: '이ilo 유형, 공정 단계, 작가 정보를 모두 조회합니다.' })
   @ApiResponse({ status: 200, description: '아카이브 목록 조회 성공' })
-  async getAll() {
+  @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en, ja, zh)' })
+  async getAll(@Query('locale') locale?: string) {
     const [niloTypes, processSteps, artists] = await Promise.all([
-      this.archivesService.findAllNiloTypes(),
+      this.archivesService.findAllNiloTypes(locale),
       this.archivesService.findAllProcessSteps(),
       this.archivesService.findAllArtists(),
     ]);

--- a/backend/src/modules/archives/archives.service.ts
+++ b/backend/src/modules/archives/archives.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { NiloType, ProcessStep, Artist } from './entities/archive.entity';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { reorderEntities } from '../../common/utils/reorder.util';
+import { applyLocale } from '../../common/utils/locale.util';
 import {
   CreateNiloTypeDto,
   UpdateNiloTypeDto,
@@ -24,11 +25,16 @@ export class ArchivesService {
     private readonly artistRepository: Repository<Artist>,
   ) {}
 
-  async findAllNiloTypes(): Promise<NiloType[]> {
-    return this.niloTypeRepository.find({
+  private applyLocaleToNiloType(entity: NiloType, locale?: string): NiloType {
+    return applyLocale(entity, locale, ['name']);
+  }
+
+  async findAllNiloTypes(locale?: string): Promise<NiloType[]> {
+    const types = await this.niloTypeRepository.find({
       where: { isActive: true },
       order: { sortOrder: 'ASC' },
     });
+    return types.map((t) => this.applyLocaleToNiloType(t, locale));
   }
 
   async findAllProcessSteps(): Promise<ProcessStep[]> {

--- a/backend/src/modules/collections/collections.controller.ts
+++ b/backend/src/modules/collections/collections.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { CollectionsService } from './collections.service';
 import { CollectionType } from './entities/collection.entity';
 import { Public } from '../../common/decorators/public.decorator';
@@ -13,10 +13,11 @@ export class CollectionsController {
   @Get()
   @ApiOperation({ summary: '전체 컬렉션 조회', description: '도자기 유형과 형태 유형의 모든 컬렉션을 조회합니다.' })
   @ApiResponse({ status: 200, description: '컬렉션 목록 조회 성공' })
-  async getAll() {
+  @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en, ja, zh)' })
+  async getAll(@Query('locale') locale?: string) {
     const [clay, shape] = await Promise.all([
-      this.collectionsService.findAllByType(CollectionType.CLAY),
-      this.collectionsService.findAllByType(CollectionType.SHAPE),
+      this.collectionsService.findAllByType(CollectionType.CLAY, locale),
+      this.collectionsService.findAllByType(CollectionType.SHAPE, locale),
     ]);
     return { clay, shape };
   }
@@ -24,14 +25,16 @@ export class CollectionsController {
   @Get('clay')
   @ApiOperation({ summary: '도자기 컬렉션 조회', description: '도자기 유형(clay)의 컬렉션만 조회합니다.' })
   @ApiResponse({ status: 200, description: '도자기 컬렉션 목록 조회 성공' })
-  async getClayCollections() {
-    return this.collectionsService.findAllByType(CollectionType.CLAY);
+  @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en, ja, zh)' })
+  async getClayCollections(@Query('locale') locale?: string) {
+    return this.collectionsService.findAllByType(CollectionType.CLAY, locale);
   }
 
   @Get('shape')
   @ApiOperation({ summary: '형태 컬렉션 조회', description: '형태 유형(shape)의 컬렉션만 조회합니다.' })
   @ApiResponse({ status: 200, description: '형태 컬렉션 목록 조회 성공' })
-  async getShapeCollections() {
-    return this.collectionsService.findAllByType(CollectionType.SHAPE);
+  @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en, ja, zh)' })
+  async getShapeCollections(@Query('locale') locale?: string) {
+    return this.collectionsService.findAllByType(CollectionType.SHAPE, locale);
   }
 }

--- a/backend/src/modules/collections/collections.service.ts
+++ b/backend/src/modules/collections/collections.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { Collection, CollectionType } from './entities/collection.entity';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { reorderEntities } from '../../common/utils/reorder.util';
+import { applyLocale } from '../../common/utils/locale.util';
 import { CreateCollectionDto, UpdateCollectionDto } from './dto/collection.dto';
 
 @Injectable()
@@ -13,21 +14,28 @@ export class CollectionsService {
     private readonly collectionRepository: Repository<Collection>,
   ) {}
 
-  async findAllByType(type: CollectionType): Promise<Collection[]> {
-    return this.collectionRepository.find({
+  private applyLocaleToCollection(entity: Collection, locale?: string): Collection {
+    return applyLocale(entity, locale, ['name']);
+  }
+
+  async findAllByType(type: CollectionType, locale?: string): Promise<Collection[]> {
+    const collections = await this.collectionRepository.find({
       where: { type, isActive: true },
       order: { sortOrder: 'ASC' },
     });
+    return collections.map((c) => this.applyLocaleToCollection(c, locale));
   }
 
-  async findAll(): Promise<Collection[]> {
-    return this.collectionRepository.find({
+  async findAll(locale?: string): Promise<Collection[]> {
+    const collections = await this.collectionRepository.find({
       order: { type: 'ASC', sortOrder: 'ASC' },
     });
+    return collections.map((c) => this.applyLocaleToCollection(c, locale));
   }
 
-  async findById(id: number): Promise<Collection> {
-    return findOrThrow(this.collectionRepository, { id }, '컬렉션을 찾을 수 없습니다.');
+  async findById(id: number, locale?: string): Promise<Collection> {
+    const collection = await findOrThrow(this.collectionRepository, { id }, '컬렉션을 찾을 수 없습니다.');
+    return this.applyLocaleToCollection(collection, locale);
   }
 
   async create(dto: CreateCollectionDto): Promise<Collection> {

--- a/backend/src/modules/pages/pages.controller.ts
+++ b/backend/src/modules/pages/pages.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Param,
   Body,
+  Query,
   ParseIntPipe,
   HttpCode,
   HttpStatus,
@@ -16,6 +17,7 @@ import {
   ApiResponse,
   ApiParam,
   ApiCookieAuth,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { PagesService } from './pages.service';
 import { CreatePageDto } from './dto/create-page.dto';
@@ -34,9 +36,10 @@ export class PagesController {
   @Get()
   @Public()
   @ApiOperation({ summary: '公開ページ 목록 조회', description: '公開中のページ 목록을 조회합니다.' })
-  @ApiResponse({ status: 200, description: 'ページ 목록 조회 성공' })
-  findAllPublished() {
-    return this.pagesService.findAllPublished();
+  @ApiResponse({ status: 200, description: 'ページ一覧 조회 성공' })
+  @ApiQuery({ name: 'locale', required: false, description: '言語コード (ko, en, ja, zh)' })
+  findAllPublished(@Query('locale') locale?: string) {
+    return this.pagesService.findAllPublished(locale);
   }
 
   @Get(':slug')
@@ -45,8 +48,9 @@ export class PagesController {
   @ApiResponse({ status: 200, description: '페이지 상세 조회 성공' })
   @ApiResponse({ status: 404, description: '페이지를 찾을 수 없음' })
   @ApiParam({ name: 'slug', type: String, description: '페이지 슬러그' })
-  findBySlug(@Param('slug') slug: string) {
-    return this.pagesService.findBySlug(slug);
+  @ApiQuery({ name: 'locale', required: false, description: '言語コード (ko, en, ja, zh)' })
+  findBySlug(@Param('slug') slug: string, @Query('locale') locale?: string) {
+    return this.pagesService.findBySlug(slug, locale);
   }
 
   @Post()

--- a/backend/src/modules/pages/pages.service.ts
+++ b/backend/src/modules/pages/pages.service.ts
@@ -13,6 +13,7 @@ import { CreatePageBlockDto } from './dto/create-page-block.dto';
 import { UpdatePageBlockDto } from './dto/update-page-block.dto';
 import { ReorderBlocksDto } from './dto/reorder-blocks.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { applyLocale } from '../../common/utils/locale.util';
 
 const SUPPORTED_BLOCK_TYPES = [
   'hero_banner',
@@ -34,19 +35,24 @@ export class PagesService {
     private readonly blockRepository: Repository<PageBlock>,
   ) {}
 
-  async findAllPublished(): Promise<Page[]> {
-    return this.pageRepository.find({
+  private applyLocaleToPage(entity: Page, locale?: string): Page {
+    return applyLocale(entity, locale, ['title']);
+  }
+
+  async findAllPublished(locale?: string): Promise<Page[]> {
+    const pages = await this.pageRepository.find({
       where: { is_published: true },
       order: { created_at: 'DESC' },
     });
+    return pages.map((p) => this.applyLocaleToPage(p, locale));
   }
 
-  async findBySlug(slug: string): Promise<Page> {
+  async findBySlug(slug: string, locale?: string): Promise<Page> {
     const page = await findOrThrow(this.pageRepository, { slug, is_published: true }, '존재하지 않는 페이지입니다.', ['blocks']);
     page.blocks = page.blocks
       .filter((b) => b.is_visible)
       .sort((a, b) => a.sort_order - b.sort_order);
-    return page;
+    return this.applyLocaleToPage(page, locale);
   }
 
   async findAllAdmin(): Promise<Page[]> {

--- a/backend/src/modules/products/attributes.controller.ts
+++ b/backend/src/modules/products/attributes.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Param,
   Body,
+  Query,
   ParseIntPipe,
   HttpCode,
   HttpStatus,
@@ -14,6 +15,7 @@ import {
   ApiTags,
   ApiOperation,
   ApiBearerAuth,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { AttributesService } from './attributes.service';
 import { CreateAttributeTypeDto, UpdateAttributeTypeDto } from './dto/attribute-type.dto';
@@ -30,26 +32,36 @@ export class AttributesController {
 
   @Get('types')
   @ApiOperation({ summary: '모든 속성 유형 조회' })
-  async findAllTypes(): Promise<AttributeType[]> {
-    return this.attributesService.findAllAttributeTypes();
+  @ApiQuery({ name: 'locale', required: false, description: '言語コード (ko, en, ja, zh)' })
+  async findAllTypes(@Query('locale') locale?: string): Promise<AttributeType[]> {
+    return this.attributesService.findAllAttributeTypes(locale);
   }
 
   @Get('types/filterable')
   @ApiOperation({ summary: '필터 가능한 속성 유형만 조회' })
-  async findFilterableTypes(): Promise<AttributeType[]> {
-    return this.attributesService.getFilterableAttributes();
+  @ApiQuery({ name: 'locale', required: false, description: '言語コード (ko, en, ja, zh)' })
+  async findFilterableTypes(@Query('locale') locale?: string): Promise<AttributeType[]> {
+    return this.attributesService.getFilterableAttributes(locale);
   }
 
   @Get('types/:id')
   @ApiOperation({ summary: '속성 유형 상세 조회' })
-  async findTypeById(@Param('id', ParseIntPipe) id: number): Promise<AttributeType> {
-    return this.attributesService.findAttributeTypeById(id);
+  @ApiQuery({ name: 'locale', required: false, description: '言語コード (ko, en, ja, zh)' })
+  async findTypeById(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('locale') locale?: string,
+  ): Promise<AttributeType> {
+    return this.attributesService.findAttributeTypeById(id, locale);
   }
 
   @Get('types/code/:code')
   @ApiOperation({ summary: '속성 유형 코드로 조회' })
-  async findTypeByCode(@Param('code') code: string): Promise<AttributeType | null> {
-    return this.attributesService.findAttributeTypeByCode(code);
+  @ApiQuery({ name: 'locale', required: false, description: '言語コード (ko, en, ja, zh)' })
+  async findTypeByCode(
+    @Param('code') code: string,
+    @Query('locale') locale?: string,
+  ): Promise<AttributeType | null> {
+    return this.attributesService.findAttributeTypeByCode(code, locale);
   }
 
   @Get('types/:code/values')

--- a/backend/src/modules/products/attributes.service.ts
+++ b/backend/src/modules/products/attributes.service.ts
@@ -5,6 +5,7 @@ import { AttributeType, AttributeInputType } from './entities/attribute-type.ent
 import { ProductAttribute } from './entities/product-attribute.entity';
 import { CreateAttributeTypeDto, UpdateAttributeTypeDto } from './dto/attribute-type.dto';
 import { CreateProductAttributeDto, UpdateProductAttributeDto } from './dto/product-attribute.dto';
+import { applyLocale } from '../../common/utils/locale.util';
 
 @Injectable()
 export class AttributesService {
@@ -17,25 +18,32 @@ export class AttributesService {
     private readonly productAttributeRepository: Repository<ProductAttribute>,
   ) {}
 
+  private applyLocaleToAttributeType(entity: AttributeType, locale?: string): AttributeType {
+    return applyLocale(entity, locale, ['name']);
+  }
+
   // ─── Attribute Types ────────────────────────────────────────────────
 
-  async findAllAttributeTypes(): Promise<AttributeType[]> {
-    return this.attributeTypeRepository.find({
+  async findAllAttributeTypes(locale?: string): Promise<AttributeType[]> {
+    const types = await this.attributeTypeRepository.find({
       where: { isActive: true },
       order: { sortOrder: 'ASC', id: 'ASC' },
     });
+    return types.map((t) => this.applyLocaleToAttributeType(t, locale));
   }
 
-  async findAttributeTypeById(id: number): Promise<AttributeType> {
+  async findAttributeTypeById(id: number, locale?: string): Promise<AttributeType> {
     const type = await this.attributeTypeRepository.findOne({ where: { id } });
     if (!type) {
       throw new NotFoundException(`AttributeType ID ${id} not found`);
     }
-    return type;
+    return this.applyLocaleToAttributeType(type, locale);
   }
 
-  async findAttributeTypeByCode(code: string): Promise<AttributeType | null> {
-    return this.attributeTypeRepository.findOne({ where: { code } });
+  async findAttributeTypeByCode(code: string, locale?: string): Promise<AttributeType | null> {
+    const type = await this.attributeTypeRepository.findOne({ where: { code } });
+    if (!type) return null;
+    return this.applyLocaleToAttributeType(type, locale);
   }
 
   async createAttributeType(dto: CreateAttributeTypeDto): Promise<AttributeType> {
@@ -207,11 +215,12 @@ export class AttributesService {
 
   // ─── Filtering ──────────────────────────────────────────────────────
 
-  async getFilterableAttributes(): Promise<AttributeType[]> {
-    return this.attributeTypeRepository.find({
+  async getFilterableAttributes(locale?: string): Promise<AttributeType[]> {
+    const types = await this.attributeTypeRepository.find({
       where: { isFilterable: true, isActive: true },
       order: { sortOrder: 'ASC' },
     });
+    return types.map((t) => this.applyLocaleToAttributeType(t, locale));
   }
 
   async getAttributeValuesByTypeCode(code: string): Promise<string[]> {

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import { MessageSquare, FileText } from 'lucide-react';
 import { pagesApi } from '@/lib/api';
 import type { PageBlock } from '@/lib/api';
@@ -10,11 +11,13 @@ import BlockRenderer from '@/components/shared/blocks/BlockRenderer';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 
 export default function ContactPage() {
+  const params = useParams();
+  const locale = params.locale as string;
   const [blocks, setBlocks] = useState<PageBlock[]>([]);
 
   const { execute: loadPage, isLoading } = useAsyncAction(
     async () => {
-      const page = await pagesApi.getBySlug('contact');
+      const page = await pagesApi.getBySlug('contact', locale);
       if (page?.blocks) setBlocks(page.blocks);
     },
     { errorMessage: '페이지를 불러오지 못했습니다.' },

--- a/src/components/shared/blocks/ProductCarouselBlock.tsx
+++ b/src/components/shared/blocks/ProductCarouselBlock.tsx
@@ -32,13 +32,13 @@ export default function ProductCarouselBlock({ content }: Props) {
     async function fetchProducts() {
       try {
         if (product_ids && product_ids.length > 0) {
-          const results = await productsApi.getBulk(product_ids.slice(0, limit));
+          const results = await productsApi.getBulk(product_ids.slice(0, limit), locale);
           if (!cancelled) setProducts(results);
         } else if (category_id) {
-          const res = await productsApi.getList({ categoryId: category_id, sort, limit });
+          const res = await productsApi.getList({ categoryId: category_id, sort, limit, locale });
           if (!cancelled) setProducts(res.items);
         } else {
-          const res = await productsApi.getList({ sort, limit });
+          const res = await productsApi.getList({ sort, limit, locale });
           if (!cancelled) setProducts(res.items);
         }
       } catch {

--- a/src/components/shared/blocks/ProductGridBlock.tsx
+++ b/src/components/shared/blocks/ProductGridBlock.tsx
@@ -36,15 +36,15 @@ export default function ProductGridBlock({ content }: Props) {
     async function fetchProducts() {
       try {
         if (product_ids && product_ids.length > 0) {
-          const results = await productsApi.getBulk(product_ids.slice(0, limit));
+          const results = await productsApi.getBulk(product_ids.slice(0, limit), locale);
           if (!cancelled) {
             setProducts(results);
           }
         } else if (category_id) {
-          const res = await productsApi.getList({ categoryId: category_id, limit });
+          const res = await productsApi.getList({ categoryId: category_id, limit, locale });
           if (!cancelled) setProducts(res.items);
         } else {
-          const res = await productsApi.getList({ limit });
+          const res = await productsApi.getList({ limit, locale });
           if (!cancelled) setProducts(res.items);
         }
       } catch {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -283,8 +283,8 @@ export const productsApi = {
     apiClient.get<ProductListResponse>('/products', { params: params as Record<string, string | number | undefined> }),
   getById: (id: number, locale?: string) =>
     apiClient.get<ProductDetail>(`/products/${id}`, { params: locale ? { locale } : undefined }),
-  getBulk: (ids: number[]) =>
-    apiClient.post<Product[]>('/products/bulk', { ids }),
+  getBulk: (ids: number[], locale?: string) =>
+    apiClient.post<Product[]>('/products/bulk', { ids }, { params: locale ? { locale } : undefined }),
   autocomplete: (q: string) =>
     apiClient.get<AutocompleteItem[]>('/products/autocomplete', { params: { q } }),
 };
@@ -907,7 +907,8 @@ export interface ImageGalleryContent {
 }
 
 export const pagesApi = {
-  getBySlug: (slug: string) => apiClient.get<Page>(`/pages/${slug}`),
+  getBySlug: (slug: string, locale?: string) =>
+    apiClient.get<Page>(`/pages/${slug}`, { params: locale ? { locale } : undefined }),
   getAll: () => apiClient.get<Page[]>('/pages'),
 };
 


### PR DESCRIPTION
## Summary
- Closes #425
- Fixed i18n locale handling for Collections, Pages, Archives, and Attributes services
- Added `ko: 'Ko'` to `LOCALE_SUFFIX_MAP` (missing mapping)
- Added `locale` query parameter to all relevant controller endpoints
- Updated frontend components to pass locale to API calls

## Changes

### Backend
- **locale.util.ts**: Added `ko: 'Ko'` to LOCALE_SUFFIX_MAP
- **CollectionsService/Controller**: Added `applyLocale()` for `name`/`nameKo` fields
- **PagesService/Controller**: Added `applyLocale()` for `title` field
- **ArchivesService/Controller**: Added `applyLocale()` for `name`/`nameKo` on NiloType
- **AttributesService/Controller**: Added `applyLocale()` for `name` field
- **ProductsController**: Added `locale` parameter to `bulkLookup`

### Frontend
- **api.ts**: `getBySlug` and `getBulk` now accept optional `locale` parameter
- **ProductGridBlock**: Passes `locale` to API calls
- **ProductCarouselBlock**: Passes `locale` to API calls
- **ContactPage**: Passes `locale` to `pagesApi.getBySlug()`

## Test plan
- [x] npm run build (frontend)
- [x] npm run test:run (57 test files passed)
- [ ] cd backend && npm run build && npm run test