### PR TITLE
fix: #432 EN 로케일에 proposal-a-dasil 라이트 테마 복원

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,6 +14,11 @@
 
 @import "tailwindcss";
 
+/* ── Locale-scoped color tokens ────────────────────────────────── */
+/* KO (html[lang="ko"]) = 공방 다크 테마 / EN (html[lang="en"]) = 다실 라이트 테마 */
+@import './tokens-ko.css';
+@import './tokens-en.css';
+
 /* ── Brand CSS variables ───────────────────────────────────────── */
 :root {
   /* Color: 공방(工房) Craft Palette — dark base */


### PR DESCRIPTION
## Summary
- Closes #432
- `src/styles/globals.css` 상단에 `@import './tokens-ko.css'` / `@import './tokens-en.css'` 두 줄 복구
- `tokens-ko.css`(공방 다크), `tokens-en.css`(Wedgwood 라이트) 파일은 이미 존재했으나 PR #431에서 import가 제거되어 `html[lang="en"]` 스코프의 라이트 팔레트가 적용되지 않던 문제 해결

## 원인
PR #431 `daa27b2a feat: #426 apply design/proposal-b-gongbang design to main` 에서 globals.css 상단의 locale token import 두 줄이 함께 제거됨. 토큰 파일은 남았지만 import되지 않아 `html[lang="en"]` 선택자가 생성된 CSS 어디에도 존재하지 않게 됐고, 모든 로케일이 `:root` 공방 다크 팔레트를 공유하게 됨. 결과적으로 EN 페이지의 Header·Footer·CategoryNav 등에서 다크 텍스트 토큰 + 의도치 않은 배경이 충돌하여 가독성이 붕괴.

## 변경 내용
```diff
@import "tailwindcss";

+/* ── Locale-scoped color tokens ────────────────────────────────── */
+/* KO (html[lang="ko"]) = 공방 다크 테마 / EN (html[lang="en"]) = 다실 라이트 테마 */
+@import './tokens-ko.css';
+@import './tokens-en.css';
+
 /* ── Brand CSS variables ───────────────────────────────────────── */
 :root {
```

`:root` / `@theme inline` 의 KO 다크 기본값은 그대로 두어, token 파일 import 실패/누락 시에도 최소 KO 테마로 폴백 가능.

## Test plan
- [x] `npm run build` (성공)
- [x] `npm run test:run` — 367 passed / 4 failed (CheckoutPage.test.tsx 기존 flaky worker timeout, 본 PR 변경과 무관 — main 브랜치 기준으로도 동일 실패 재현 확인)
- [ ] `/en/` 경로 — HeroBanner/CategoryNav/Footer 다실 라이트 팔레트 렌더링 육안 확인
- [ ] `/ko/` 경로 — 공방 다크 팔레트 회귀 없음 확인