### PR TITLE
fix: #432 EN locale 라이트 테마 실제 적용 (@theme inline → @theme 분리)

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -47,8 +47,12 @@
   --line-height-compact: 1.1;
 }
 
-@theme inline {
-  /* ── shadcn/ui 호환 토큰 (DB override 지원) ── */
+/* 색상 토큰은 @theme (non-inline) — 유틸리티가 var(--color-*)로 생성되어야
+   html[lang="en"] / html[lang="ko"] 스코프에서 tokens-*.css 의 런타임 오버라이드가
+   실제로 적용된다. @theme inline 을 쓰면 hex 리터럴이 유틸리티에 박혀서
+   런타임에 CSS 변수를 바꿔도 색상이 변경되지 않음. */
+@theme {
+  /* ── shadcn/ui 호환 토큰 — locale token 파일에서 런타임 override (KO 다크 폴백) ── */
   --color-primary: #C4956A;
   --color-primary-foreground: #141210;
   --color-secondary: #1E1C18;
@@ -66,9 +70,6 @@
   --color-border: #2E2822;
   --color-input: #2E2822;
   --color-ring: #C4956A;
-  --radius-sm: var(--db-radius-sm, 0.125rem);
-  --radius-md: var(--db-radius-md, 0.25rem);
-  --radius-lg: var(--db-radius-lg, 0.5rem);
 
   /* ── 니료(泥料) 악센트 토큰 — 카테고리 필터·배지 등 UI 악센트용 ── */
   --color-zuni: #8B4513;
@@ -79,6 +80,12 @@
   --color-nokni: #4A6741;
   --color-tea: #4A6741;
   --color-surface: #1E1C18;
+}
+
+@theme inline {
+  --radius-sm: var(--db-radius-sm, 0.125rem);
+  --radius-md: var(--db-radius-md, 0.25rem);
+  --radius-lg: var(--db-radius-lg, 0.5rem);
 
   /* ── 타이포그래피 — 폰트 패밀리 (3종) ── */
   --font-display: 'Noto Serif KR', 'Georgia', serif;


### PR DESCRIPTION
## Summary
- Follow-up to #432 / PR #433
- PR #433 에서 tokens-en.css import 를 복구했지만 **여전히 EN 페이지에서 `text-foreground` 등이 KO 다크 팔레트 색상(#F0EDE8)으로 렌더링됨** 을 Playwright 검증으로 확인
- 근본 원인: `globals.css`의 `@theme inline` 이 색상 토큰을 **hex 리터럴로 유틸리티에 박아넣어**, `html[lang="en"]` 스코프의 `--color-foreground` 오버라이드가 무시됨
- 조치: 색상 토큰을 `@theme inline` → `@theme`(non-inline) 으로 분리. 나머지(radius/font/size)는 `@theme inline` 유지

## Tailwind v4 동작 차이
| | 생성되는 유틸리티 | 런타임 CSS 변수 오버라이드 |
| --- | --- | --- |
| `@theme { --color-foreground: #F0EDE8 }` | `.text-foreground { color: var(--color-foreground); }` | ✅ 반영됨 |
| `@theme inline { --color-foreground: #F0EDE8 }` | `.text-foreground { color: #F0EDE8; }` | ❌ 무시됨 |

## 변경 내용
```diff
-@theme inline {
-  /* ── shadcn/ui 호환 토큰 (DB override 지원) ── */
+@theme {
+  /* ── shadcn/ui 호환 토큰 — locale token 파일에서 런타임 override (KO 다크 폴백) ── */
   --color-primary: #C4956A;
   ... (색상 토큰 18개)
-  --radius-sm: var(--db-radius-sm, 0.125rem);
-  --radius-md: ...
-  --radius-lg: ...
   --color-zuni: #8B4513;
   ... (니료 악센트 토큰 8개)
+}
+
+@theme inline {
+  --radius-sm: var(--db-radius-sm, 0.125rem);
+  --radius-md: var(--db-radius-md, 0.25rem);
+  --radius-lg: var(--db-radius-lg, 0.5rem);
   --font-display: ...
```

## Playwright 검증
- **/en** `lang=\"en\"`: body bg `rgb(253, 252, 249)` (라이트 크림), color `rgb(26, 26, 26)` (`#1A1A1A` 다크 잉크) — 정상
- **/ko** `lang=\"ko\"`: body bg `rgb(20, 18, 16)` (공방 다크), color `rgb(240, 237, 232)` (`#F0EDE8`) — 회귀 없음
- 가독성 검출 스크립트: EN 페이지 흰 배경+흰 글자 요소 17개 → 3개(Footer `/80` alpha 텍스트 오탐)로 축소

## Test plan
- [x] `npm run build` — 성공
- [x] `npm run test:run` — 367/383 passed (CheckoutPage flaky worker timeout은 본 PR 변경과 무관)
- [x] Playwright 로 /en 육안 확인 — 라이트 크림 배경 + 다크 잉크 텍스트 정상 렌더
- [x] Playwright 로 /ko 육안 확인 — 공방 다크 테마 회귀 없음

Closes #432 (추가 수정)