### PR TITLE
fix: #432 EN 로케일에 dasil 2줄 헤더 레이아웃 복원

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useLocale } from 'next-intl';
 import { ShoppingCart, Menu, X, Search, User, LogOut, LogIn, UserPlus, MessageSquare, Package } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import Logo from '@/components/Logo';
@@ -390,9 +391,10 @@ function MobileSearchOverlay({ isOpen, onClose }: MobileSearchOverlayProps) {
 
 interface DesktopNavProps {
   items: NavigationItem[];
+  fullWidth?: boolean;
 }
 
-function DesktopNav({ items }: DesktopNavProps) {
+function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
   const [hoveredId, setHoveredId] = useState<number | null>(null);
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const hoveredItem = items.find((item) => item.id === hoveredId);
@@ -406,7 +408,10 @@ function DesktopNav({ items }: DesktopNavProps) {
   return (
     <nav
       aria-label="메인 메뉴"
-      className="hidden md:flex items-center gap-6"
+      className={cn(
+        'hidden md:flex items-center',
+        fullWidth ? 'w-full gap-0' : 'gap-6',
+      )}
       onMouseLeave={() => setHoveredId(null)}
     >
       {items.map((item) => (
@@ -414,11 +419,13 @@ function DesktopNav({ items }: DesktopNavProps) {
           key={item.id}
           ref={(el) => { if (el) itemRefs.current.set(item.id, el); }}
           onMouseEnter={() => setHoveredId(item.id)}
+          className={cn(fullWidth && 'flex-1 flex items-center justify-center')}
         >
           <Link
             href={item.url}
             className={cn(
               'group relative flex items-center gap-1 py-2 typo-body-sm transition-colors duration-200',
+              fullWidth && 'w-full justify-center',
               hoveredId === item.id ? 'text-foreground' : 'text-muted-foreground',
             )}
           >
@@ -479,6 +486,8 @@ function DesktopNav({ items }: DesktopNavProps) {
 
 export default function Header() {
   const router = useRouter();
+  const locale = useLocale();
+  const isEn = locale === 'en';
   const { isAuthenticated, user, logout } = useAuth();
   const { itemCount } = useCart();
   const { items: navItems } = useNavigation('gnb');
@@ -542,84 +551,181 @@ export default function Header() {
           ? 'bg-background/85 backdrop-blur-lg border-b border-border shadow-sm'
           : 'bg-background border-b border-transparent',
       )}>
-        {/* Top row */}
-        <div className="mx-auto flex h-12 max-w-7xl items-center justify-between gap-2 px-4">
+        {isEn ? (
+          /* EN 다실 시안 — 2줄 헤더 (top: 로고/검색/액션 · bottom: GNB 전폭 균등) */
+          <>
+            <div className="mx-auto flex h-16 items-center justify-between gap-4 px-4 md:px-20">
+              {/* 햄버거 (mobile) */}
+              <button
+                type="button"
+                onClick={() => { setIsMenuOpen((p) => !p); setIsSearchOpen(false); }}
+                aria-expanded={isMenuOpen}
+                aria-controls="mobile-menu"
+                aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+                className="p-2 transition-colors shrink-0 text-muted-foreground hover:text-foreground md:hidden"
+              >
+                {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+              </button>
 
-          {/* 햄버거 */}
-          <button
-            type="button"
-            onClick={() => { setIsMenuOpen((p) => !p); setIsSearchOpen(false); }}
-            aria-expanded={isMenuOpen}
-            aria-controls="mobile-menu"
-            aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
-            className="p-2 -ml-2 transition-colors shrink-0 text-muted-foreground hover:text-foreground lg:hidden"
-          >
-            {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-          </button>
+              {/* 로고 */}
+              <Link href="/" className="shrink-0">
+                <div style={scrollLogo?.headerLogoStyle}>
+                  <Logo variant="header" />
+                </div>
+              </Link>
 
-          {/* 로고 */}
-          <Link href="/" className="shrink-0">
-            <div style={scrollLogo?.headerLogoStyle}>
-              <Logo variant="header" />
+              {/* 데스크탑 검색 (중앙, 넓은 영역) */}
+              <form
+                onSubmit={handleDesktopSearch}
+                role="search"
+                aria-label="상품 검색"
+                className="hidden md:flex relative items-center flex-1 max-w-lg mx-8"
+              >
+                <input
+                  type="search"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="상품 검색..."
+                  aria-label="상품 검색"
+                  className="w-full border-b border-muted-foreground/30 bg-transparent pl-1 pr-10 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:border-foreground transition-colors"
+                />
+                <button type="submit" aria-label="검색" className="absolute right-3 transition-colors text-muted-foreground hover:text-foreground">
+                  <Search className="h-4 w-4" />
+                </button>
+              </form>
+
+              {/* 데스크탑 액션 */}
+              <div className="hidden md:flex items-center gap-1">
+                <LanguageSelector />
+                <CartBadge itemCount={itemCount} />
+                {isAuthenticated ? (
+                  <>
+                    <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                      <User className="h-5 w-5" />
+                    </Link>
+                    <button type="button" onClick={() => void logout()} aria-label="로그아웃" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                      <LogOut className="h-5 w-5" />
+                    </button>
+                  </>
+                ) : (
+                  <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                    <User className="h-5 w-5" />
+                  </Link>
+                )}
+              </div>
+
+              {/* 모바일 우측 */}
+              <div className="md:hidden flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => { setIsSearchOpen((p) => !p); setIsMenuOpen(false); }}
+                  aria-label={isSearchOpen ? '검색 닫기' : '검색 열기'}
+                  aria-expanded={isSearchOpen}
+                  className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {isSearchOpen ? <X className="h-5 w-5" /> : <Search className="h-5 w-5" />}
+                </button>
+                {isAuthenticated ? (
+                  <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                    <User className="h-5 w-5" />
+                  </Link>
+                ) : (
+                  <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                    <User className="h-5 w-5" />
+                  </Link>
+                )}
+                <div className="p-2">
+                  <CartBadge itemCount={itemCount} />
+                </div>
+              </div>
             </div>
-          </Link>
 
-          {/* 데스크탑 네비 */}
-          <DesktopNav items={navItems} />
-
-          {/* 데스크탑 검색 */}
-          <form
-            onSubmit={handleDesktopSearch}
-            role="search"
-            aria-label="상품 검색"
-            className="hidden md:flex relative items-center flex-1 max-w-sm"
-          >
-            <input
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="상품 검색..."
-              aria-label="상품 검색"
-              className="w-full rounded-md border border-input bg-background pl-3 pr-10 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-            <button type="submit" aria-label="검색" className="absolute right-2 transition-colors text-muted-foreground hover:text-foreground">
-              <Search className="h-4 w-4" />
-            </button>
-          </form>
-
-          {/* 데스크탑 액션 */}
-          <DesktopActions
-            isAuthenticated={isAuthenticated}
-            userName={user?.name}
-            itemCount={itemCount}
-            onLogout={() => void logout()}
-          />
-
-          {/* 모바일 우측: 검색 + 카트 + 로그인/마이페이지 */}
-          <div className="md:hidden flex items-center gap-1 ml-auto">
+            {/* Bottom row — GNB 전폭 균등 분할 */}
+            <div className="hidden md:block border-t border-border/50">
+              <div className="flex h-12 items-stretch justify-between px-4 md:px-20">
+                <DesktopNav items={navItems} fullWidth />
+              </div>
+            </div>
+          </>
+        ) : (
+          /* KO 공방 시안 — 1줄 헤더 */
+          <div className="mx-auto flex h-12 max-w-7xl items-center justify-between gap-2 px-4">
+            {/* 햄버거 */}
             <button
               type="button"
-              onClick={() => { setIsSearchOpen((p) => !p); setIsMenuOpen(false); }}
-              aria-label={isSearchOpen ? '검색 닫기' : '검색 열기'}
-              aria-expanded={isSearchOpen}
-              className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => { setIsMenuOpen((p) => !p); setIsSearchOpen(false); }}
+              aria-expanded={isMenuOpen}
+              aria-controls="mobile-menu"
+              aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+              className="p-2 -ml-2 transition-colors shrink-0 text-muted-foreground hover:text-foreground lg:hidden"
             >
-              {isSearchOpen ? <X className="h-5 w-5" /> : <Search className="h-5 w-5" />}
+              {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
             </button>
-            {isAuthenticated ? (
-              <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
-                <User className="h-5 w-5" />
-              </Link>
-            ) : (
-              <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
-                <User className="h-5 w-5" />
-              </Link>
-            )}
-            <div className="p-2">
-              <CartBadge itemCount={itemCount} />
+
+            {/* 로고 */}
+            <Link href="/" className="shrink-0">
+              <div style={scrollLogo?.headerLogoStyle}>
+                <Logo variant="header" />
+              </div>
+            </Link>
+
+            {/* 데스크탑 네비 */}
+            <DesktopNav items={navItems} />
+
+            {/* 데스크탑 검색 */}
+            <form
+              onSubmit={handleDesktopSearch}
+              role="search"
+              aria-label="상품 검색"
+              className="hidden md:flex relative items-center flex-1 max-w-sm"
+            >
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="상품 검색..."
+                aria-label="상품 검색"
+                className="w-full rounded-md border border-input bg-background pl-3 pr-10 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <button type="submit" aria-label="검색" className="absolute right-2 transition-colors text-muted-foreground hover:text-foreground">
+                <Search className="h-4 w-4" />
+              </button>
+            </form>
+
+            {/* 데스크탑 액션 */}
+            <DesktopActions
+              isAuthenticated={isAuthenticated}
+              userName={user?.name}
+              itemCount={itemCount}
+              onLogout={() => void logout()}
+            />
+
+            {/* 모바일 우측: 검색 + 카트 + 로그인/마이페이지 */}
+            <div className="md:hidden flex items-center gap-1 ml-auto">
+              <button
+                type="button"
+                onClick={() => { setIsSearchOpen((p) => !p); setIsMenuOpen(false); }}
+                aria-label={isSearchOpen ? '검색 닫기' : '검색 열기'}
+                aria-expanded={isSearchOpen}
+                className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {isSearchOpen ? <X className="h-5 w-5" /> : <Search className="h-5 w-5" />}
+              </button>
+              {isAuthenticated ? (
+                <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                  <User className="h-5 w-5" />
+                </Link>
+              ) : (
+                <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                  <User className="h-5 w-5" />
+                </Link>
+              )}
+              <div className="p-2">
+                <CartBadge itemCount={itemCount} />
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
       </header>
 


### PR DESCRIPTION
## Summary
- Follow-up to #432 — EN 헤더 레이아웃을 design/proposal-a-dasil 시안 대로 2줄로 복원
- PR #431(공방 디자인 적용) 에서 Header가 KO/EN 공통 1줄 구조로 통합되면서 EN dasil 시안의 2줄 헤더가 사라진 상태였음

## 변경 내용
- `Header.tsx` 에 `useLocale()` 추가, `isEn` 분기로 EN은 dasil 2줄 레이아웃 렌더
- KO는 기존 공방 1줄 레이아웃 유지 (회귀 없음)
- `DesktopNav` 에 `fullWidth` prop 추가 — EN 에서만 `flex-1` 균등 분할 적용

### EN 2줄 구조 (dasil)
- **Top row** (`h-16`, `px-20`): 햄버거(mobile) · 로고 · 중앙 검색창(border-b 스타일) · 액션(Language + Cart + User)
- **Bottom row** (`h-12`, `border-t border-border/50`): GNB 메뉴 전폭 균등 분할

### KO 1줄 구조 (공방 · 기존 유지)
- 단일 `h-12` row — 햄버거 · 로고 · GNB · 검색 · 액션

## Playwright 검증
- **/en**: header 114px = top 64px + bottom 49px + 1px border, 2줄 정상 렌더
- **/ko**: header 49px, 1줄 유지 — 회귀 없음
- **/en/products**: 2줄 헤더 + GNB "홈/자사호/보이차·다구/베스트/브랜드 소개/기획전" 전폭 균등 분할 확인

## Test plan
- [x] `npm run build`
- [x] `npm run test:run` (CheckoutPage flaky worker timeout은 본 PR 변경과 무관)
- [x] Playwright /en, /ko, /en/products 육안 확인

Closes #432 (추가 수정)