### PR TITLE
refactor: #432 KO 헤더도 2줄 레이아웃으로 통일

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useLocale } from 'next-intl';
 import { ShoppingCart, Menu, X, Search, User, LogOut, LogIn, UserPlus, MessageSquare, Package } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import Logo from '@/components/Logo';
@@ -36,37 +35,6 @@ function CartBadge({ itemCount, className, iconSize = 'h-5 w-5' }: CartBadgeProp
         </span>
       )}
     </Link>
-  );
-}
-
-interface DesktopActionsProps {
-  isAuthenticated: boolean;
-  userName?: string;
-  itemCount: number;
-  onLogout: () => void;
-}
-
-function DesktopActions({ isAuthenticated, itemCount, onLogout }: DesktopActionsProps) {
-  const textClass = "text-muted-foreground hover:text-foreground";
-  return (
-    <div className="hidden md:flex items-center gap-4">
-      <LanguageSelector />
-      <CartBadge itemCount={itemCount} />
-      {isAuthenticated ? (
-        <>
-          <Link href="/my" aria-label="마이페이지" className={cn("transition-colors", textClass)}>
-            <User className="h-5 w-5" />
-          </Link>
-          <button type="button" onClick={onLogout} aria-label="로그아웃" className={cn("transition-colors", textClass)}>
-            <LogOut className="h-5 w-5" />
-          </button>
-        </>
-      ) : (
-        <Link href="/login" aria-label="로그인" className={cn("transition-colors", textClass)}>
-          <User className="h-5 w-5" />
-        </Link>
-      )}
-    </div>
   );
 }
 
@@ -486,8 +454,6 @@ function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
 
 export default function Header() {
   const router = useRouter();
-  const locale = useLocale();
-  const isEn = locale === 'en';
   const { isAuthenticated, user, logout } = useAuth();
   const { itemCount } = useCart();
   const { items: navItems } = useNavigation('gnb');
@@ -551,181 +517,99 @@ export default function Header() {
           ? 'bg-background/85 backdrop-blur-lg border-b border-border shadow-sm'
           : 'bg-background border-b border-transparent',
       )}>
-        {isEn ? (
-          /* EN 다실 시안 — 2줄 헤더 (top: 로고/검색/액션 · bottom: GNB 전폭 균등) */
-          <>
-            <div className="mx-auto flex h-16 items-center justify-between gap-4 px-4 md:px-20">
-              {/* 햄버거 (mobile) */}
-              <button
-                type="button"
-                onClick={() => { setIsMenuOpen((p) => !p); setIsSearchOpen(false); }}
-                aria-expanded={isMenuOpen}
-                aria-controls="mobile-menu"
-                aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
-                className="p-2 transition-colors shrink-0 text-muted-foreground hover:text-foreground md:hidden"
-              >
-                {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-              </button>
+        {/* 2줄 헤더 — top: 로고/검색/액션 · bottom: GNB 전폭 균등 */}
+        <div className="mx-auto flex h-16 items-center justify-between gap-4 px-4 md:px-20">
+          {/* 햄버거 (mobile) */}
+          <button
+            type="button"
+            onClick={() => { setIsMenuOpen((p) => !p); setIsSearchOpen(false); }}
+            aria-expanded={isMenuOpen}
+            aria-controls="mobile-menu"
+            aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+            className="p-2 transition-colors shrink-0 text-muted-foreground hover:text-foreground md:hidden"
+          >
+            {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
 
-              {/* 로고 */}
-              <Link href="/" className="shrink-0">
-                <div style={scrollLogo?.headerLogoStyle}>
-                  <Logo variant="header" />
-                </div>
-              </Link>
-
-              {/* 데스크탑 검색 (중앙, 넓은 영역) */}
-              <form
-                onSubmit={handleDesktopSearch}
-                role="search"
-                aria-label="상품 검색"
-                className="hidden md:flex relative items-center flex-1 max-w-lg mx-8"
-              >
-                <input
-                  type="search"
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  placeholder="상품 검색..."
-                  aria-label="상품 검색"
-                  className="w-full border-b border-muted-foreground/30 bg-transparent pl-1 pr-10 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:border-foreground transition-colors"
-                />
-                <button type="submit" aria-label="검색" className="absolute right-3 transition-colors text-muted-foreground hover:text-foreground">
-                  <Search className="h-4 w-4" />
-                </button>
-              </form>
-
-              {/* 데스크탑 액션 */}
-              <div className="hidden md:flex items-center gap-1">
-                <LanguageSelector />
-                <CartBadge itemCount={itemCount} />
-                {isAuthenticated ? (
-                  <>
-                    <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
-                      <User className="h-5 w-5" />
-                    </Link>
-                    <button type="button" onClick={() => void logout()} aria-label="로그아웃" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
-                      <LogOut className="h-5 w-5" />
-                    </button>
-                  </>
-                ) : (
-                  <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
-                    <User className="h-5 w-5" />
-                  </Link>
-                )}
-              </div>
-
-              {/* 모바일 우측 */}
-              <div className="md:hidden flex items-center gap-1">
-                <button
-                  type="button"
-                  onClick={() => { setIsSearchOpen((p) => !p); setIsMenuOpen(false); }}
-                  aria-label={isSearchOpen ? '검색 닫기' : '검색 열기'}
-                  aria-expanded={isSearchOpen}
-                  className="p-2 text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  {isSearchOpen ? <X className="h-5 w-5" /> : <Search className="h-5 w-5" />}
-                </button>
-                {isAuthenticated ? (
-                  <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
-                    <User className="h-5 w-5" />
-                  </Link>
-                ) : (
-                  <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
-                    <User className="h-5 w-5" />
-                  </Link>
-                )}
-                <div className="p-2">
-                  <CartBadge itemCount={itemCount} />
-                </div>
-              </div>
+          {/* 로고 */}
+          <Link href="/" className="shrink-0">
+            <div style={scrollLogo?.headerLogoStyle}>
+              <Logo variant="header" />
             </div>
+          </Link>
 
-            {/* Bottom row — GNB 전폭 균등 분할 */}
-            <div className="hidden md:block border-t border-border/50">
-              <div className="flex h-12 items-stretch justify-between px-4 md:px-20">
-                <DesktopNav items={navItems} fullWidth />
-              </div>
-            </div>
-          </>
-        ) : (
-          /* KO 공방 시안 — 1줄 헤더 */
-          <div className="mx-auto flex h-12 max-w-7xl items-center justify-between gap-2 px-4">
-            {/* 햄버거 */}
-            <button
-              type="button"
-              onClick={() => { setIsMenuOpen((p) => !p); setIsSearchOpen(false); }}
-              aria-expanded={isMenuOpen}
-              aria-controls="mobile-menu"
-              aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
-              className="p-2 -ml-2 transition-colors shrink-0 text-muted-foreground hover:text-foreground lg:hidden"
-            >
-              {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-            </button>
-
-            {/* 로고 */}
-            <Link href="/" className="shrink-0">
-              <div style={scrollLogo?.headerLogoStyle}>
-                <Logo variant="header" />
-              </div>
-            </Link>
-
-            {/* 데스크탑 네비 */}
-            <DesktopNav items={navItems} />
-
-            {/* 데스크탑 검색 */}
-            <form
-              onSubmit={handleDesktopSearch}
-              role="search"
+          {/* 데스크탑 검색 (중앙, 넓은 영역) */}
+          <form
+            onSubmit={handleDesktopSearch}
+            role="search"
+            aria-label="상품 검색"
+            className="hidden md:flex relative items-center flex-1 max-w-lg mx-8"
+          >
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="상품 검색..."
               aria-label="상품 검색"
-              className="hidden md:flex relative items-center flex-1 max-w-sm"
-            >
-              <input
-                type="search"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="상품 검색..."
-                aria-label="상품 검색"
-                className="w-full rounded-md border border-input bg-background pl-3 pr-10 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-              <button type="submit" aria-label="검색" className="absolute right-2 transition-colors text-muted-foreground hover:text-foreground">
-                <Search className="h-4 w-4" />
-              </button>
-            </form>
-
-            {/* 데스크탑 액션 */}
-            <DesktopActions
-              isAuthenticated={isAuthenticated}
-              userName={user?.name}
-              itemCount={itemCount}
-              onLogout={() => void logout()}
+              className="w-full border-b border-muted-foreground/30 bg-transparent pl-1 pr-10 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:border-foreground transition-colors"
             />
+            <button type="submit" aria-label="검색" className="absolute right-3 transition-colors text-muted-foreground hover:text-foreground">
+              <Search className="h-4 w-4" />
+            </button>
+          </form>
 
-            {/* 모바일 우측: 검색 + 카트 + 로그인/마이페이지 */}
-            <div className="md:hidden flex items-center gap-1 ml-auto">
-              <button
-                type="button"
-                onClick={() => { setIsSearchOpen((p) => !p); setIsMenuOpen(false); }}
-                aria-label={isSearchOpen ? '검색 닫기' : '검색 열기'}
-                aria-expanded={isSearchOpen}
-                className="p-2 text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {isSearchOpen ? <X className="h-5 w-5" /> : <Search className="h-5 w-5" />}
-              </button>
-              {isAuthenticated ? (
+          {/* 데스크탑 액션 */}
+          <div className="hidden md:flex items-center gap-1">
+            <LanguageSelector />
+            <CartBadge itemCount={itemCount} />
+            {isAuthenticated ? (
+              <>
                 <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
                   <User className="h-5 w-5" />
                 </Link>
-              ) : (
-                <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
-                  <User className="h-5 w-5" />
-                </Link>
-              )}
-              <div className="p-2">
-                <CartBadge itemCount={itemCount} />
-              </div>
+                <button type="button" onClick={() => void logout()} aria-label="로그아웃" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                  <LogOut className="h-5 w-5" />
+                </button>
+              </>
+            ) : (
+              <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                <User className="h-5 w-5" />
+              </Link>
+            )}
+          </div>
+
+          {/* 모바일 우측 */}
+          <div className="md:hidden flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => { setIsSearchOpen((p) => !p); setIsMenuOpen(false); }}
+              aria-label={isSearchOpen ? '검색 닫기' : '검색 열기'}
+              aria-expanded={isSearchOpen}
+              className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {isSearchOpen ? <X className="h-5 w-5" /> : <Search className="h-5 w-5" />}
+            </button>
+            {isAuthenticated ? (
+              <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                <User className="h-5 w-5" />
+              </Link>
+            ) : (
+              <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                <User className="h-5 w-5" />
+              </Link>
+            )}
+            <div className="p-2">
+              <CartBadge itemCount={itemCount} />
             </div>
           </div>
-        )}
+        </div>
+
+        {/* Bottom row — GNB 전폭 균등 분할 */}
+        <div className="hidden md:block border-t border-border/50">
+          <div className="flex h-12 items-stretch justify-between px-4 md:px-20">
+            <DesktopNav items={navItems} fullWidth />
+          </div>
+        </div>
 
       </header>
 


### PR DESCRIPTION
## Summary
- PR #435 에서 EN만 2줄, KO는 1줄로 분기했으나, 요청에 따라 KO도 동일한 2줄 헤더로 통일
- `useLocale()` 기반 분기 제거 → Header 가 단일 2줄 레이아웃만 렌더

## 변경 내용
- `Header.tsx`: `useLocale`/`isEn` 제거, 2줄 JSX만 남김 (EN dasil 구조를 그대로 공용)
- 미사용이 된 `DesktopActions` 컴포넌트 제거 (LOC 116 감소)
- `DesktopNav` `fullWidth` prop 은 유지 (2줄 bottom row 전폭 균등 분할에 사용)

## Playwright 검증 (desktop 1280)
- **/ko**: header 114px = top 64 + bottom 49 + 1px border, 2줄 렌더 ✅
- **/en**: 동일 2줄 유지 ✅ 회귀 없음

## Test plan
- [x] `npm run build`
- [x] `npm run test:run`
- [x] Playwright /ko, /en 육안 확인

Closes #432 (최종 통일)