### PR TITLE
fix: @reduxjs/toolkit 직접 의존성 추가 (Vercel 빌드 실패 핫픽스)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-slot": "^1.1.1",
+        "@reduxjs/toolkit": "^2.11.2",
         "@stripe/stripe-js": "^9.0.1",
         "@testing-library/dom": "^10.4.1",
         "@tosspayments/tosspayments-sdk": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-slot": "^1.1.1",
+    "@reduxjs/toolkit": "^2.11.2",
     "@stripe/stripe-js": "^9.0.1",
     "@testing-library/dom": "^10.4.1",
     "@tosspayments/tosspayments-sdk": "^2.6.0",


### PR DESCRIPTION
## Summary
Vercel 프로덕션 빌드가 다음 에러로 실패:
```
Module not found: Can't resolve '@reduxjs/toolkit'
from ./node_modules/recharts/es6/state/eventSettingsSlice.js
```

recharts 3.8.1 은 `@reduxjs/toolkit` 을 dependencies 로 선언하나, Vercel 빌드 캐시가 해당 transitive dep 를 누락한 상태로 복원되는 케이스가 발생. 명시적 dependencies 로 선언해 해결.

## 변경 내용
- `package.json`: `@reduxjs/toolkit: ^2.11.2` 추가 (recharts peer 범위 `^1.9.0 || 2.x.x` 와 호환)
- `package-lock.json` 업데이트

## Test plan
- [x] 로컬 `rm -rf .next && npm run build` 성공 확인

Closes Vercel build failure reported after PR #436 merge