### PR TITLE
fix: Vercel production 빌드 캐시 오염 해결 (rm -rf .next)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,6 @@
       ]
     }
   ],
-  "buildCommand": "npm run build",
+  "buildCommand": "rm -rf .next && npm run build",
   "outputDirectory": ".next"
 }


### PR DESCRIPTION
## Summary
Vercel production 환경의 `.next` 빌드 캐시가 오염되어 매 배포마다 아래 에러로 실패:
```
uncaughtException [TypeError: Cannot read properties of undefined (reading 'length')]
Error: Command "npm run build" exited with 1
```

- Preview 환경은 별도 빌드 캐시라 정상 동작 → production 전용 캐시가 원인
- \"Restored build cache from previous deployment (8JX2...)\" 로그가 매번 동일 시그니처로 뜸
- package.json 변경(#437)으로도 캐시 무효화가 안 됨 (Installing deps: up to date in 1s)

## 조치
`vercel.json` 의 `buildCommand` 를 `rm -rf .next && npm run build` 로 변경. 매 빌드에서 `.next` 초기화하여 오염된 캐시 재사용 차단.

Closes Vercel production build failure