### PR TITLE
feat: #430 i18n — 영어 페이지에서 Header/Footer/导航 hardcoded 한국어 i18n 처리

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -17,21 +17,30 @@ vi.mock('@/i18n/navigation', () => ({
   usePathname: () => '/',
 }));
 
-vi.mock('next-intl', () => ({
-  useLocale: () => 'ko',
-  useTranslations: () => (key: string) => {
-    const translations: Record<string, string> = {
-      'promotion.limitedTime': 'Limited Time',
-      'promotion.specialOffer': 'Special Offer',
-      'promotion.eventEnded': '이벤트가 종료되었습니다',
-      'promotion.days': '일',
-      'promotion.hours': '시간',
-      'promotion.minutes': '분',
-      'promotion.seconds': '초',
-    };
-    return translations[key] || key;
-  },
-}));
+vi.mock('next-intl', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next-intl')>();
+  const messages = (await import('@/i18n/messages/ko.json')).default as Record<string, Record<string, string>>;
+  return {
+    ...actual,
+    useLocale: () => 'ko',
+    useTranslations: (namespace: string) => (key: string) => {
+      const ns = messages[namespace] ?? {};
+      return ns[key] ?? key;
+    },
+  };
+});
+
+vi.mock('next-intl/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next-intl/server')>();
+  const messages = (await import('@/i18n/messages/ko.json')).default as Record<string, Record<string, string>>;
+  return {
+    ...actual,
+    getTranslations: async (namespace: string) => {
+      const ns = messages[namespace] ?? {};
+      return (key: string) => ns[key] ?? key;
+    },
+  };
+});
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({

--- a/src/app/[locale]/(routes)/page.tsx
+++ b/src/app/[locale]/(routes)/page.tsx
@@ -1,19 +1,25 @@
 import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import BlockRenderer from '@/components/shared/blocks/BlockRenderer';
 import { fetchPage, fetchCategories, fetchProducts } from '@/lib/api-server';
 import type { Product, Category, PageBlock } from '@/lib/api';
 
 export const revalidate = 60;
 
-export const metadata: Metadata = {
-  title: '옥화당 — 공식 쇼핑몰',
-  description: '다양한 상품을 만나보세요.',
-  openGraph: {
-    title: '옥화당 — 공식 쇼핑몰',
-    description: '다양한 상품을 만나보세요.',
-    type: 'website',
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('home');
+  const title = t('metaTitle');
+  const description = t('metaDescription');
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+    },
+  };
+}
 
 async function fetchHomeData(): Promise<{
   featured: Product[];
@@ -43,12 +49,23 @@ async function fetchHomeData(): Promise<{
   };
 }
 
+interface DefaultBlockCopy {
+  featuredProducts: string;
+  popularProducts: string;
+  promoTitle: string;
+  promoSubtitle: string;
+  promoCta: string;
+}
+
 /** DB에 홈페이지가 없을 때 사용하는 기본 블록 배열 */
-function buildDefaultBlocks(data: {
-  featured: Product[];
-  popular: Product[];
-  categories: Category[];
-}): PageBlock[] {
+function buildDefaultBlocks(
+  data: {
+    featured: Product[];
+    popular: Product[];
+    categories: Category[];
+  },
+  copy: DefaultBlockCopy,
+): PageBlock[] {
   return [
     {
       id: -1,
@@ -72,7 +89,7 @@ function buildDefaultBlocks(data: {
       id: -3,
       type: 'product_grid',
       content: {
-        title: '추천 상품',
+        title: copy.featuredProducts,
         template: '4col',
         limit: 8,
         more_href: '/products?isFeatured=true',
@@ -85,7 +102,7 @@ function buildDefaultBlocks(data: {
       id: -4,
       type: 'product_grid',
       content: {
-        title: '인기 상품',
+        title: copy.popularProducts,
         template: '4col',
         limit: 8,
         more_href: '/products?sort=popular',
@@ -98,9 +115,9 @@ function buildDefaultBlocks(data: {
       id: -5,
       type: 'promotion_banner',
       content: {
-        title: '지금 바로 쇼핑하세요',
-        subtitle: '다양한 상품을 둘러보세요',
-        cta_text: '쇼핑하기',
+        title: copy.promoTitle,
+        subtitle: copy.promoSubtitle,
+        cta_text: copy.promoCta,
         cta_url: '/products',
         template: 'full-width',
       },
@@ -111,14 +128,21 @@ function buildDefaultBlocks(data: {
 }
 
 export default async function Home() {
-  const [homePage, homeData] = await Promise.all([
+  const [homePage, homeData, t] = await Promise.all([
     fetchPage('home'),
     fetchHomeData(),
+    getTranslations('home'),
   ]);
 
   const blocks = homePage?.blocks?.length
     ? homePage.blocks
-    : buildDefaultBlocks(homeData);
+    : buildDefaultBlocks(homeData, {
+        featuredProducts: t('featuredProducts'),
+        popularProducts: t('popularProducts'),
+        promoTitle: t('promoTitle'),
+        promoSubtitle: t('promoSubtitle'),
+        promoCta: t('promoCta'),
+      });
 
   const heroBlocks = blocks.filter((b) => b.type === 'hero_banner');
   const restBlocks = blocks.filter((b) => b.type !== 'hero_banner');

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
-import { getMessages, setRequestLocale } from 'next-intl/server';
+import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
 import { Toaster } from 'sonner';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
@@ -95,9 +95,10 @@ export default async function LocaleLayout({
 
   setRequestLocale(safeLocale);
 
-  const [messages, settingsMap] = await Promise.all([
+  const [messages, settingsMap, tNav] = await Promise.all([
     getMessages(),
     getSettingsMap(),
+    getTranslations('navigation'),
   ]);
 
   const themeStyle = await getThemeStyle(settingsMap);
@@ -117,7 +118,7 @@ export default async function LocaleLayout({
           href="#main-content"
           className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
         >
-          본문으로 바로가기
+          {tNav('skipToContent')}
         </a>
         <NextIntlClientProvider messages={messages}>
           <Providers>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { Link } from '@/i18n/navigation';
+import { useTranslations } from 'next-intl';
 import { useNavigation } from '@/hooks/useNavigation';
 import type { NavigationItem } from '@/lib/api';
 
@@ -21,39 +22,22 @@ const ShoppingBagIcon = ({ size = 18 }: { size?: number }) => (
   </svg>
 );
 
-const SOCIAL_LINKS = [
+const SOCIAL_LINKS: {
+  id: 'instagram' | 'naver';
+  href: string;
+  icon: ({ size }: { size?: number }) => React.ReactElement;
+}[] = [
   {
     id: 'instagram',
-    label: '인스타그램',
     href: 'https://www.instagram.com/ockhwadang',
     icon: InstagramIcon,
   },
   {
     id: 'naver',
-    label: '네이버 스마트스토어',
     href: 'https://smartstore.naver.com/ockhwadang',
     icon: ShoppingBagIcon,
   },
 ];
-
-const FALLBACK_LINKS = {
-  customerService: [
-    { id: -1, label: '고객센터', url: '/pages/support' },
-    { id: -2, label: '자주 묻는 질문', url: '/faq' },
-    { id: -3, label: '배송 안내', url: '/pages/shipping' },
-    { id: -4, label: '반품 및 교환', url: '/pages/returns' },
-  ],
-  company: [
-    { id: -5, label: '이용약관', url: '/pages/terms' },
-    { id: -6, label: '개인정보처리방침', url: '/pages/privacy' },
-  ],
-  shop: [
-    { id: -7, label: '전체 상품', url: '/products' },
-    { id: -8, label: '컬렉션', url: '/collection' },
-    { id: -9, label: 'Archive', url: '/archive' },
-    { id: -10, label: 'Journal', url: '/journal' },
-  ],
-};
 
 function renderNavLinks(items: NavigationItem[]) {
   return items.map((item) => (
@@ -68,20 +52,45 @@ function renderNavLinks(items: NavigationItem[]) {
 }
 
 export default function Footer() {
+  const t = useTranslations('footer');
   const { items: footerItems } = useNavigation('footer');
   const hasCmsData = footerItems.length > 0;
   const rootItems = hasCmsData ? footerItems.filter((item) => item.parent_id === null) : [];
+
+  const socialLabels: Record<'instagram' | 'naver', string> = {
+    instagram: 'Instagram',
+    naver: 'Naver Smart Store',
+  };
+
+  const fallbackLinks = {
+    customerService: [
+      { id: -1, label: t('support'), url: '/pages/support' },
+      { id: -2, label: t('faq'), url: '/faq' },
+      { id: -3, label: t('shipping'), url: '/pages/shipping' },
+      { id: -4, label: t('returns'), url: '/pages/returns' },
+    ],
+    company: [
+      { id: -5, label: t('terms'), url: '/pages/terms' },
+      { id: -6, label: t('privacy'), url: '/pages/privacy' },
+    ],
+    shop: [
+      { id: -7, label: t('allProducts'), url: '/products' },
+      { id: -8, label: t('collection'), url: '/collection' },
+      { id: -9, label: t('archive'), url: '/archive' },
+      { id: -10, label: t('journal'), url: '/journal' },
+    ],
+  };
 
   return (
     <footer className="bg-card border-t border-border mt-auto">
       <div className="mx-auto max-w-7xl px-4 py-12">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
           <div>
-            <p className="text-sm font-medium text-foreground mb-4">고객센터</p>
+            <p className="text-sm font-medium text-foreground mb-4">{t('customerService')}</p>
             <nav className="flex flex-col gap-2">
               {hasCmsData
                 ? renderNavLinks(rootItems.slice(0, 4))
-                : FALLBACK_LINKS.customerService.map((link) => (
+                : fallbackLinks.customerService.map((link) => (
                   <Link
                     key={link.id}
                     href={link.url}
@@ -94,11 +103,11 @@ export default function Footer() {
           </div>
 
           <div>
-            <p className="text-sm font-medium text-foreground mb-4">회사</p>
+            <p className="text-sm font-medium text-foreground mb-4">{t('company')}</p>
             <nav className="flex flex-col gap-2">
               {hasCmsData
                 ? renderNavLinks(rootItems.slice(4, 6))
-                : FALLBACK_LINKS.company.map((link) => (
+                : fallbackLinks.company.map((link) => (
                   <Link
                     key={link.id}
                     href={link.url}
@@ -111,11 +120,11 @@ export default function Footer() {
           </div>
 
           <div>
-            <p className="text-sm font-medium text-foreground mb-4">쇼핑</p>
+            <p className="text-sm font-medium text-foreground mb-4">{t('shop')}</p>
             <nav className="flex flex-col gap-2">
               {hasCmsData
                 ? renderNavLinks(rootItems.slice(6, 10))
-                : FALLBACK_LINKS.shop.map((link) => (
+                : fallbackLinks.shop.map((link) => (
                   <Link
                     key={link.id}
                     href={link.url}
@@ -128,10 +137,10 @@ export default function Footer() {
           </div>
 
           <div>
-            <Image src="/logo-okhwadang.png" alt="옥화당" width={120} height={34} className="object-contain mb-4" />
+            <Image src="/logo-okhwadang.png" alt={t('okhwadang')} width={120} height={34} className="object-contain mb-4" />
             <div className="flex flex-col gap-1 text-sm text-muted-foreground">
-              <p>자사호 · 보이차 · 다구</p>
-              <p>전문 쇼핑몰</p>
+              <p>{t('tagline')}</p>
+              <p>{t('specialty')}</p>
             </div>
             <div className="flex items-center gap-3 mt-4">
               {SOCIAL_LINKS.map((social) => (
@@ -140,7 +149,7 @@ export default function Footer() {
                   href={social.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  aria-label={social.label}
+                  aria-label={socialLabels[social.id]}
                   className="flex items-center justify-center w-9 h-9 rounded-full bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors"
                 >
                   <social.icon size={18} />
@@ -154,7 +163,7 @@ export default function Footer() {
         <div className="mt-12 pt-8 border-t border-dashed border-border">
           <div className="flex flex-col md:flex-row items-center justify-between gap-6">
             <div className="flex items-center gap-4">
-              <span className="font-display text-2xl text-foreground/80 tracking-wide">옥화당</span>
+              <span className="font-display text-2xl text-foreground/80 tracking-wide">{t('okhwadang')}</span>
               <span className="text-muted-foreground/40 text-lg">|</span>
               <span className="font-display text-lg text-muted-foreground/50">玉華堂</span>
             </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { ShoppingCart, Menu, X, Search, User, LogOut, LogIn, UserPlus, MessageSquare, Package } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import Logo from '@/components/Logo';
@@ -23,8 +24,9 @@ interface CartBadgeProps {
 }
 
 function CartBadge({ itemCount, className, iconSize = 'h-5 w-5' }: CartBadgeProps) {
+  const t = useTranslations('header');
   return (
-    <Link href="/cart" aria-label="장바구니" className={cn('relative', className)}>
+    <Link href="/cart" aria-label={t('cartLabel')} className={cn('relative', className)}>
       <ShoppingCart className={cn(iconSize, 'text-muted-foreground hover:text-foreground transition-colors')} />
       {itemCount > 0 && (
         <span
@@ -63,6 +65,8 @@ interface MobileMenuHeaderProps {
 }
 
 function MobileMenuHeader({ historyLength, currentTitle, onClose, onBack }: MobileMenuHeaderProps) {
+  const tNav = useTranslations('navigation');
+  const tHeader = useTranslations('header');
   return (
     <>
       <div className="flex items-center px-4 h-14 border-b border-border shrink-0">
@@ -70,7 +74,7 @@ function MobileMenuHeader({ historyLength, currentTitle, onClose, onBack }: Mobi
           type="button"
           onClick={onClose}
           className="p-2 -ml-2 mr-3 text-muted-foreground hover:text-foreground transition-all duration-200 active:scale-90"
-          aria-label="메뉴 닫기"
+          aria-label={tNav('closeMenu')}
         >
           <X className="h-5 w-5" />
         </button>
@@ -84,7 +88,7 @@ function MobileMenuHeader({ historyLength, currentTitle, onClose, onBack }: Mobi
             type="button"
             onClick={onBack}
             className="p-2 -ml-2 text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="뒤로"
+            aria-label={tHeader('menuBack')}
           >
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M12 5l-5 5 5 5" />
@@ -149,6 +153,7 @@ interface MobileMenuFooterProps {
 }
 
 function MobileMenuFooter({ isAuthenticated, userName, onLogout, onLinkClick }: MobileMenuFooterProps) {
+  const t = useTranslations('header');
   return (
     <div className="px-4 py-4 border-t border-border shrink-0">
       <div className="flex flex-col gap-1">
@@ -156,7 +161,7 @@ function MobileMenuFooter({ isAuthenticated, userName, onLogout, onLinkClick }: 
           <>
             <Link href="/my" onClick={onLinkClick} className="min-h-11 py-2 typo-body-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-3">
               <User className="h-4 w-4" />
-              {userName ?? '마이페이지'}
+              {userName ?? t('myPage')}
             </Link>
             <button
               type="button"
@@ -164,28 +169,28 @@ function MobileMenuFooter({ isAuthenticated, userName, onLogout, onLinkClick }: 
               className="min-h-11 py-2 typo-body-sm text-muted-foreground hover:text-foreground transition-colors text-left flex items-center gap-3"
             >
               <LogOut className="h-4 w-4" />
-              로그아웃
+              {t('logout')}
             </button>
           </>
         ) : (
           <>
             <Link href="/login" onClick={onLinkClick} className="min-h-11 py-2 typo-body-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-3">
               <LogIn className="h-4 w-4" />
-              로그인
+              {t('login')}
             </Link>
             <Link href="/signup" onClick={onLinkClick} className="min-h-11 py-2 typo-body-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-3">
               <UserPlus className="h-4 w-4" />
-              계정 만들기
+              {t('createAccount')}
             </Link>
           </>
         )}
         <Link href="/contact" onClick={onLinkClick} className="min-h-11 py-2 typo-body-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-3">
           <MessageSquare className="h-4 w-4" />
-          문의하기
+          {t('contact')}
         </Link>
         <Link href="/order-tracking" onClick={onLinkClick} className="min-h-11 py-2 typo-body-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-3">
           <Package className="h-4 w-4" />
-          주문조회
+          {t('orderTracking')}
         </Link>
       </div>
       <div className="mt-4">
@@ -209,9 +214,10 @@ function MobileMenuBackdrop({ visible, onClose }: { visible: boolean; onClose: (
 }
 
 function MobileMenuNav({ visible, children }: { visible: boolean; children: React.ReactNode }) {
+  const tNav = useTranslations('navigation');
   return (
     <nav
-      aria-label="모바일 메뉴"
+      aria-label={tNav('mobileMenu')}
       className={cn(
         'absolute left-0 top-0 h-full w-80 bg-background shadow-xl transition-transform duration-500 ease-out',
         visible ? 'translate-x-0' : '-translate-x-full',
@@ -227,9 +233,10 @@ function MobileMenuNav({ visible, children }: { visible: boolean; children: Reac
 }
 
 function MobileMenu({ isAuthenticated, userName, navItems, sidebarItems, visible, onClose, onLogout }: MobileMenuProps) {
+  const t = useTranslations('header');
   const menuItems = sidebarItems.length > 0 ? sidebarItems : navItems;
   const [history, setHistory] = useState<HistoryEntry[]>([]);
-  const current = history.length > 0 ? history[history.length - 1] : { title: '메뉴', items: menuItems };
+  const current = history.length > 0 ? history[history.length - 1] : { title: t('menuLabel'), items: menuItems };
 
   const handleItemClick = (item: NavigationItem) => {
     if (item.children && item.children.length > 0) {
@@ -284,6 +291,7 @@ interface MobileSearchOverlayProps {
 
 function MobileSearchOverlay({ isOpen, onClose }: MobileSearchOverlayProps) {
   const router = useRouter();
+  const t = useTranslations('header');
   const [query, setQuery] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -330,7 +338,7 @@ function MobileSearchOverlay({ isOpen, onClose }: MobileSearchOverlayProps) {
         )}
         style={{ top: '48px' }}
         role="search"
-        aria-label="모바일 검색"
+        aria-label={t('searchLabel')}
       >
         <form onSubmit={handleSubmit} className="flex items-center gap-3 px-4 py-3 border-b border-border">
           <Search className="h-5 w-5 text-muted-foreground shrink-0" />
@@ -339,14 +347,14 @@ function MobileSearchOverlay({ isOpen, onClose }: MobileSearchOverlayProps) {
             type="search"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="검색..."
-            aria-label="상품 검색"
+            placeholder={t('searchShort')}
+            aria-label={t('searchLabel')}
             className="flex-1 bg-transparent text-base text-foreground placeholder:text-muted-foreground focus:outline-none"
           />
           <button
             type="button"
             onClick={onClose}
-            aria-label="검색 닫기"
+            aria-label={t('searchClose')}
             className="p-1 text-muted-foreground hover:text-foreground transition-colors"
           >
             <X className="h-5 w-5" />
@@ -363,6 +371,7 @@ interface DesktopNavProps {
 }
 
 function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
+  const tNav = useTranslations('navigation');
   const [hoveredId, setHoveredId] = useState<number | null>(null);
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const hoveredItem = items.find((item) => item.id === hoveredId);
@@ -375,7 +384,7 @@ function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
 
   return (
     <nav
-      aria-label="메인 메뉴"
+      aria-label={tNav('mainMenu')}
       className={cn(
         'hidden md:flex items-center',
         fullWidth ? 'w-full gap-0' : 'gap-6',
@@ -454,6 +463,8 @@ function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
 
 export default function Header() {
   const router = useRouter();
+  const t = useTranslations('header');
+  const tNav = useTranslations('navigation');
   const { isAuthenticated, user, logout } = useAuth();
   const { itemCount } = useCart();
   const { items: navItems } = useNavigation('gnb');
@@ -525,7 +536,7 @@ export default function Header() {
             onClick={() => { setIsMenuOpen((p) => !p); setIsSearchOpen(false); }}
             aria-expanded={isMenuOpen}
             aria-controls="mobile-menu"
-            aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+            aria-label={isMenuOpen ? tNav('closeMenu') : tNav('openMenu')}
             className="p-2 transition-colors shrink-0 text-muted-foreground hover:text-foreground md:hidden"
           >
             {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -542,18 +553,18 @@ export default function Header() {
           <form
             onSubmit={handleDesktopSearch}
             role="search"
-            aria-label="상품 검색"
+            aria-label={t('searchLabel')}
             className="hidden md:flex relative items-center flex-1 max-w-lg mx-8"
           >
             <input
               type="search"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="상품 검색..."
-              aria-label="상품 검색"
+              placeholder={t('searchPlaceholder')}
+              aria-label={t('searchLabel')}
               className="w-full border-b border-muted-foreground/30 bg-transparent pl-1 pr-10 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:border-foreground transition-colors"
             />
-            <button type="submit" aria-label="검색" className="absolute right-3 transition-colors text-muted-foreground hover:text-foreground">
+            <button type="submit" aria-label={t('searchButton')} className="absolute right-3 transition-colors text-muted-foreground hover:text-foreground">
               <Search className="h-4 w-4" />
             </button>
           </form>
@@ -564,15 +575,15 @@ export default function Header() {
             <CartBadge itemCount={itemCount} />
             {isAuthenticated ? (
               <>
-                <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                <Link href="/my" aria-label={t('myPage')} className="p-2 text-muted-foreground hover:text-foreground transition-colors">
                   <User className="h-5 w-5" />
                 </Link>
-                <button type="button" onClick={() => void logout()} aria-label="로그아웃" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+                <button type="button" onClick={() => void logout()} aria-label={t('logout')} className="p-2 text-muted-foreground hover:text-foreground transition-colors">
                   <LogOut className="h-5 w-5" />
                 </button>
               </>
             ) : (
-              <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+              <Link href="/login" aria-label={t('login')} className="p-2 text-muted-foreground hover:text-foreground transition-colors">
                 <User className="h-5 w-5" />
               </Link>
             )}
@@ -583,18 +594,18 @@ export default function Header() {
             <button
               type="button"
               onClick={() => { setIsSearchOpen((p) => !p); setIsMenuOpen(false); }}
-              aria-label={isSearchOpen ? '검색 닫기' : '검색 열기'}
+              aria-label={isSearchOpen ? t('searchClose') : t('searchOpen')}
               aria-expanded={isSearchOpen}
               className="p-2 text-muted-foreground hover:text-foreground transition-colors"
             >
               {isSearchOpen ? <X className="h-5 w-5" /> : <Search className="h-5 w-5" />}
             </button>
             {isAuthenticated ? (
-              <Link href="/my" aria-label="마이페이지" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+              <Link href="/my" aria-label={t('myPage')} className="p-2 text-muted-foreground hover:text-foreground transition-colors">
                 <User className="h-5 w-5" />
               </Link>
             ) : (
-              <Link href="/login" aria-label="로그인" className="p-2 text-muted-foreground hover:text-foreground transition-colors">
+              <Link href="/login" aria-label={t('login')} className="p-2 text-muted-foreground hover:text-foreground transition-colors">
                 <User className="h-5 w-5" />
               </Link>
             )}

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -10,6 +10,19 @@ vi.mock('@/i18n/navigation', () => ({
   usePathname: () => '/',
 }));
 
+vi.mock('next-intl', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next-intl')>();
+  const messages = (await import('@/i18n/messages/ko.json')).default as Record<string, Record<string, string>>;
+  return {
+    ...actual,
+    useLocale: () => 'ko',
+    useTranslations: (namespace: string) => (key: string) => {
+      const ns = messages[namespace] ?? {};
+      return ns[key] ?? key;
+    },
+  };
+});
+
 describe('Footer', () => {
   it('renders 이용약관, 개인정보처리방침, 고객센터 links', () => {
     render(<Footer />);

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -20,9 +20,18 @@ vi.mock('@/i18n/navigation', () => ({
   usePathname: () => mockPathname,
 }));
 
-vi.mock('next-intl', () => ({
-  useLocale: () => 'ko',
-}));
+vi.mock('next-intl', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next-intl')>();
+  const messages = (await import('@/i18n/messages/ko.json')).default as Record<string, Record<string, string>>;
+  return {
+    ...actual,
+    useLocale: () => 'ko',
+    useTranslations: (namespace: string) => (key: string) => {
+      const ns = messages[namespace] ?? {};
+      return ns[key] ?? key;
+    },
+  };
+});
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -1,58 +1,53 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { useTranslations } from 'next-intl';
 import { navigationApi } from '@/lib/api';
 import type { NavigationItem } from '@/lib/api';
 
-const STATIC_GNB: NavigationItem[] = [
-  {
-    id: 0,
-    group: 'gnb',
-    label: '상품목록',
-    url: '/products',
-    sort_order: 0,
-    is_active: true,
-    parent_id: null,
-    children: [],
-  },
-  {
-    id: -1,
-    group: 'gnb',
-    label: '장인',
-    url: '/artist',
-    sort_order: 1,
-    is_active: true,
-    parent_id: null,
-    children: [],
-  },
-  {
-    id: -2,
-    group: 'gnb',
-    label: 'Archive',
-    url: '/archive',
-    sort_order: 2,
-    is_active: true,
-    parent_id: null,
-    children: [],
-  },
-];
-
-const STATIC_FOOTER: NavigationItem[] = [];
-const STATIC_SIDEBAR: NavigationItem[] = [];
-
-function getStaticFallback(group: 'gnb' | 'sidebar' | 'footer'): NavigationItem[] {
-  switch (group) {
-    case 'gnb':
-      return STATIC_GNB;
-    case 'footer':
-      return STATIC_FOOTER;
-    case 'sidebar':
-      return STATIC_SIDEBAR;
-  }
+function buildStaticGnb(t: (key: string) => string): NavigationItem[] {
+  return [
+    {
+      id: 0,
+      group: 'gnb',
+      label: t('products'),
+      url: '/products',
+      sort_order: 0,
+      is_active: true,
+      parent_id: null,
+      children: [],
+    },
+    {
+      id: -1,
+      group: 'gnb',
+      label: t('artist'),
+      url: '/artist',
+      sort_order: 1,
+      is_active: true,
+      parent_id: null,
+      children: [],
+    },
+    {
+      id: -2,
+      group: 'gnb',
+      label: t('archive'),
+      url: '/archive',
+      sort_order: 2,
+      is_active: true,
+      parent_id: null,
+      children: [],
+    },
+  ];
 }
 
 export function useNavigation(group: 'gnb' | 'sidebar' | 'footer') {
-  const [items, setItems] = useState<NavigationItem[]>(getStaticFallback(group));
+  const tNav = useTranslations('nav');
+  const fallback = useMemo<NavigationItem[]>(() => {
+    if (group === 'gnb') return buildStaticGnb(tNav);
+    return [];
+  }, [group, tNav]);
+
+  const [items, setItems] = useState<NavigationItem[]>(fallback);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -62,11 +57,11 @@ export function useNavigation(group: 'gnb' | 'sidebar' | 'footer') {
       try {
         const data = await navigationApi.getByGroup(group);
         if (!cancelled) {
-          setItems(data.length > 0 ? data : getStaticFallback(group));
+          setItems(data.length > 0 ? data : fallback);
         }
       } catch {
         if (!cancelled) {
-          setItems(getStaticFallback(group));
+          setItems(fallback);
         }
       } finally {
         if (!cancelled) {
@@ -79,7 +74,7 @@ export function useNavigation(group: 'gnb' | 'sidebar' | 'footer') {
     return () => {
       cancelled = true;
     };
-  }, [group]);
+  }, [group, fallback]);
 
   return { items, loading };
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -55,10 +55,18 @@
     "searchPlaceholder": "Search products...",
     "searchLabel": "Search products",
     "searchButton": "Search",
+    "searchShort": "Search...",
+    "searchOpen": "Open search",
+    "searchClose": "Close search",
     "cartLabel": "Cart",
     "myPage": "My Page",
     "logout": "Log Out",
     "login": "Log In",
+    "createAccount": "Create Account",
+    "contact": "Contact Us",
+    "orderTracking": "Order Tracking",
+    "menuLabel": "Menu",
+    "menuBack": "Back",
     "goBack": "Back",
     "goHome": "Home"
   },
@@ -589,6 +597,22 @@
   },
   "pages": {
     "adminPages": "Page Management"
+  },
+  "home": {
+    "metaTitle": "Okhwadang — Official Store",
+    "metaDescription": "Discover a curated selection of Yixing teapots, pu-erh tea and tea ware.",
+    "featuredProducts": "Featured Products",
+    "popularProducts": "Popular Products",
+    "promoTitle": "Shop Now",
+    "promoSubtitle": "Explore our curated collection.",
+    "promoCta": "Shop Now"
+  },
+  "nav": {
+    "products": "Products",
+    "artist": "Artist",
+    "archive": "Archive",
+    "collection": "Collection",
+    "journal": "Journal"
   },
   "errors": {
     "generic": "An error occurred.",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -55,10 +55,18 @@
     "searchPlaceholder": "상품 검색...",
     "searchLabel": "상품 검색",
     "searchButton": "검색",
+    "searchShort": "검색...",
+    "searchOpen": "검색 열기",
+    "searchClose": "검색 닫기",
     "cartLabel": "장바구니",
     "myPage": "마이페이지",
     "logout": "로그아웃",
     "login": "로그인",
+    "createAccount": "계정 만들기",
+    "contact": "문의하기",
+    "orderTracking": "주문조회",
+    "menuLabel": "메뉴",
+    "menuBack": "뒤로",
     "goBack": "뒤로가기",
     "goHome": "홈"
   },
@@ -589,6 +597,22 @@
   },
   "pages": {
     "adminPages": "페이지 관리"
+  },
+  "home": {
+    "metaTitle": "옥화당 — 공식 쇼핑몰",
+    "metaDescription": "다양한 상품을 만나보세요.",
+    "featuredProducts": "추천 상품",
+    "popularProducts": "인기 상품",
+    "promoTitle": "지금 바로 쇼핑하세요",
+    "promoSubtitle": "다양한 상품을 둘러보세요",
+    "promoCta": "쇼핑하기"
+  },
+  "nav": {
+    "products": "상품목록",
+    "artist": "장인",
+    "archive": "Archive",
+    "collection": "컬렉션",
+    "journal": "Journal"
   },
   "errors": {
     "generic": "오류가 발생했습니다.",


### PR DESCRIPTION
## Summary
- Header, Footer, Navigation, Home 페이지의 하드코딩된 한국어 텍스트를 i18n 번역 키로 교체
- 영어(`en`) 페이지에서도 각 언어 번역이 정상 표시되도록 수정

## Changes
- **Header.tsx**: aria-label, placeholder 등 모든 하드코딩 → `useTranslations('header')`/`useTranslations('navigation')`
- **Footer.tsx**: 섹션 헤딩, fallback 링크, 로고 alt → `useTranslations('footer')`
- **useNavigation.ts**: 정적 fallback GNB 라벨 → `useTranslations('nav')`
- **page.tsx**: `buildDefaultBlocks()` i18n 적용, `generateMetadata` 동적 번역
- **layout.tsx**: "본문으로 바로가기" → `getTranslations('navigation')`
- **ko.json/en.json**: 필요한 번역 키 추가

## Test Plan
- [x] `npm run build` 통과
- [x] `npm run test:run` — 367 tests pass (pre-existing directory-structure.test.ts 실패 제외)
- 테스트 파일 mock 업데이트: `Header.test.tsx`, `Footer.test.tsx`, `App.test.tsx`

## Closes
Closes #430