### PR TITLE
chore: deploy 시 원격 EC2의 .env/keys 를 그대로 사용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,6 @@ jobs:
           cache-dependency-path: backend/package-lock.json
 
       - name: EC2에 배포
-        env:
-          BACKEND_ENV_PRODUCTION: ${{ secrets.BACKEND_ENV_PRODUCTION }}
-          JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
-          JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
         run: |
           set -e
 
@@ -42,16 +38,14 @@ jobs:
           git reset --hard origin/main
 
           # ------------------------------------------------------------------
-          # 2. 환경변수 복원 (.gitignored)
+          # 2. 환경변수 확인 — EC2 내부 .env / keys/ 를 신뢰한다.
+          #    (GitHub Secret 으로 덮어쓰지 않음. 로컬 수정은
+          #     scripts/remote-env-sync.sh push 로 반영)
           # ------------------------------------------------------------------
-          printf '%s' "$BACKEND_ENV_PRODUCTION" > .env
-          chmod 600 .env
-
-          # JWT RSA 키 복원 (.gitignored)
-          mkdir -p keys
-          printf '%s' "$JWT_PRIVATE_KEY" > keys/jwt-private.pem
-          printf '%s' "$JWT_PUBLIC_KEY" > keys/jwt-public.pem
-          chmod 600 keys/jwt-private.pem keys/jwt-public.pem
+          [ -f .env ] || { echo "ERROR: backend/.env 가 원격에 없습니다. remote-env-sync.sh push 로 먼저 업로드하세요." >&2; exit 1; }
+          [ -f keys/jwt-private.pem ] || { echo "ERROR: keys/jwt-private.pem 가 원격에 없습니다." >&2; exit 1; }
+          [ -f keys/jwt-public.pem ] || { echo "ERROR: keys/jwt-public.pem 가 원격에 없습니다." >&2; exit 1; }
+          chmod 600 .env keys/jwt-private.pem keys/jwt-public.pem
 
           # ------------------------------------------------------------------
           # 3. 의존성 설치 및 빌드


### PR DESCRIPTION
## Summary
- GitHub Secret 으로 `.env` / `keys/*.pem` 을 매 배포마다 덮어쓰던 로직 제거
- 앞으로 환경변수는 `scripts/remote-env-sync.sh push` 로 EC2 에 직접 반영
- 원격에 `.env` 또는 JWT 키가 없으면 배포 단계에서 즉시 fail 하도록 가드 추가

## Why
- 민감 정보의 단일 출처(source of truth)를 GitHub Secret 과 EC2 두 곳에서 EC2 한 곳으로 통일
- Secret 업데이트 없이 즉시 적용 가능 (remote-env-sync.sh push → pm2 restart)

## Pre-merge 체크
- [x] 로컬 .env.production 의 새 KAKAO 값 EC2 push 완료 (`remote-env-sync.sh push`)
- [x] EC2 `backend/.env`, `backend/keys/jwt-*.pem` 존재 확인
- [x] 프로덕션 health check 200 OK

## Test plan
- [ ] 머지 후 `Deploy Backend` 워크플로우가 자동 트리거되어 성공하는지 확인
- [ ] pm2 프로세스 재시작 후 `https://ockhwadang.com/api/health` 200 응답
- [ ] 카카오 로그인 흐름 스모크 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)