### PR TITLE
feat: #445 DB 기반 공용 콘텐츠 i18n 확장 (navigation/settings/promotions/archives)

### DIFF
--- a/backend/src/database/migrations/1777000000000-AddSiteSettingsValueEn.ts
+++ b/backend/src/database/migrations/1777000000000-AddSiteSettingsValueEn.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSiteSettingsValueEn1777000000000 implements MigrationInterface {
+  name = 'AddSiteSettingsValueEn1777000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ===== value_en =====
+    const valueEnExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'site_settings' AND COLUMN_NAME = 'value_en'
+    `);
+    if ((valueEnExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`site_settings\` ADD \`value_en\` TEXT NULL AFTER \`value\``);
+    }
+
+    // ===== value_ja =====
+    const valueJaExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'site_settings' AND COLUMN_NAME = 'value_ja'
+    `);
+    if ((valueJaExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`site_settings\` ADD \`value_ja\` TEXT NULL AFTER \`value_en\``);
+    }
+
+    // ===== value_zh =====
+    const valueZhExists = await queryRunner.query(`
+      SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'site_settings' AND COLUMN_NAME = 'value_zh'
+    `);
+    if ((valueZhExists as Array<{ cnt: string }>)[0].cnt === '0') {
+      await queryRunner.query(`ALTER TABLE \`site_settings\` ADD \`value_zh\` TEXT NULL AFTER \`value_ja\``);
+    }
+
+    // ===== seed: brand / footer English values =====
+    // Insert brand_name if not present, otherwise update value_en
+    await queryRunner.query(`
+      INSERT INTO \`site_settings\` (\`setting_key\`, \`value\`, \`value_en\`, \`group\`, \`label\`, \`input_type\`, \`options\`, \`default_value\`, \`sort_order\`)
+      VALUES
+        ('brand_name',        '옥화당',                 'Okhwadang',                            'brand', '브랜드명',       'text', NULL, '옥화당',                 100),
+        ('brand_tagline',     '자연을 담은 그릇',        'Vessels that hold nature',             'brand', '브랜드 태그라인', 'text', NULL, '자연을 담은 그릇',        101),
+        ('footer_copyright',  '© 2026 옥화당. All rights reserved.', '© 2026 Okhwadang. All rights reserved.', 'brand', '푸터 저작권',    'text', NULL, '© 2026 옥화당. All rights reserved.', 102),
+        ('logo_alt',          '옥화당 로고',             'Okhwadang Logo',                       'brand', '로고 alt 텍스트', 'text', NULL, '옥화당 로고',            103)
+      ON DUPLICATE KEY UPDATE
+        \`value_en\` = VALUES(\`value_en\`)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`site_settings\` DROP COLUMN \`value_zh\``);
+    await queryRunner.query(`ALTER TABLE \`site_settings\` DROP COLUMN \`value_ja\``);
+    await queryRunner.query(`ALTER TABLE \`site_settings\` DROP COLUMN \`value_en\``);
+  }
+}

--- a/backend/src/modules/archives/archives.controller.ts
+++ b/backend/src/modules/archives/archives.controller.ts
@@ -16,8 +16,8 @@ export class ArchivesController {
   async getAll(@Query('locale') locale?: string) {
     const [niloTypes, processSteps, artists] = await Promise.all([
       this.archivesService.findAllNiloTypes(locale),
-      this.archivesService.findAllProcessSteps(),
-      this.archivesService.findAllArtists(),
+      this.archivesService.findAllProcessSteps(locale),
+      this.archivesService.findAllArtists(locale),
     ]);
     return { niloTypes, processSteps, artists };
   }

--- a/backend/src/modules/archives/archives.service.ts
+++ b/backend/src/modules/archives/archives.service.ts
@@ -26,7 +26,15 @@ export class ArchivesService {
   ) {}
 
   private applyLocaleToNiloType(entity: NiloType, locale?: string): NiloType {
-    return applyLocale(entity, locale, ['name']);
+    return applyLocale(entity, locale, ['name', 'description']);
+  }
+
+  private applyLocaleToProcessStep(entity: ProcessStep, locale?: string): ProcessStep {
+    return applyLocale(entity, locale, ['title', 'description', 'detail']);
+  }
+
+  private applyLocaleToArtist(entity: Artist, locale?: string): Artist {
+    return applyLocale(entity, locale, ['name', 'title', 'region', 'story', 'specialty']);
   }
 
   async findAllNiloTypes(locale?: string): Promise<NiloType[]> {
@@ -37,17 +45,19 @@ export class ArchivesService {
     return types.map((t) => this.applyLocaleToNiloType(t, locale));
   }
 
-  async findAllProcessSteps(): Promise<ProcessStep[]> {
-    return this.processStepRepository.find({
+  async findAllProcessSteps(locale?: string): Promise<ProcessStep[]> {
+    const steps = await this.processStepRepository.find({
       order: { step: 'ASC' },
     });
+    return steps.map((s) => this.applyLocaleToProcessStep(s, locale));
   }
 
-  async findAllArtists(): Promise<Artist[]> {
-    return this.artistRepository.find({
+  async findAllArtists(locale?: string): Promise<Artist[]> {
+    const artists = await this.artistRepository.find({
       where: { isActive: true },
       order: { sortOrder: 'ASC' },
     });
+    return artists.map((a) => this.applyLocaleToArtist(a, locale));
   }
 
   async findNiloTypeById(id: number): Promise<NiloType> {

--- a/backend/src/modules/archives/entities/archive.entity.ts
+++ b/backend/src/modules/archives/entities/archive.entity.ts
@@ -14,6 +14,9 @@ export class NiloType {
   @Column({ type: 'varchar', length: 100 })
   name!: string;
 
+  @Column({ name: 'name_en', type: 'varchar', length: 100, nullable: true })
+  nameEn!: string | null;
+
   @Column({ type: 'varchar', length: 100 })
   nameKo!: string;
 
@@ -25,6 +28,9 @@ export class NiloType {
 
   @Column({ type: 'text' })
   description!: string;
+
+  @Column({ name: 'description_en', type: 'text', nullable: true })
+  descriptionEn!: string | null;
 
   @Column({ type: 'json' })
   characteristics!: string[];
@@ -56,11 +62,20 @@ export class ProcessStep {
   @Column({ type: 'varchar', length: 100 })
   title!: string;
 
+  @Column({ name: 'title_en', type: 'varchar', length: 100, nullable: true })
+  titleEn!: string | null;
+
   @Column({ type: 'varchar', length: 200 })
   description!: string;
 
+  @Column({ name: 'description_en', type: 'varchar', length: 200, nullable: true })
+  descriptionEn!: string | null;
+
   @Column({ type: 'text' })
   detail!: string;
+
+  @Column({ name: 'detail_en', type: 'text', nullable: true })
+  detailEn!: string | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
@@ -77,17 +92,32 @@ export class Artist {
   @Column({ type: 'varchar', length: 100 })
   name!: string;
 
+  @Column({ name: 'name_en', type: 'varchar', length: 100, nullable: true })
+  nameEn!: string | null;
+
   @Column({ type: 'varchar', length: 100 })
   title!: string;
+
+  @Column({ name: 'title_en', type: 'varchar', length: 100, nullable: true })
+  titleEn!: string | null;
 
   @Column({ type: 'varchar', length: 100 })
   region!: string;
 
+  @Column({ name: 'region_en', type: 'varchar', length: 100, nullable: true })
+  regionEn!: string | null;
+
   @Column({ type: 'text' })
   story!: string;
 
+  @Column({ name: 'story_en', type: 'text', nullable: true })
+  storyEn!: string | null;
+
   @Column({ type: 'varchar', length: 200 })
   specialty!: string;
+
+  @Column({ name: 'specialty_en', type: 'varchar', length: 200, nullable: true })
+  specialtyEn!: string | null;
 
   @Column({ name: 'image_url', type: 'varchar', length: 500, nullable: true })
   imageUrl!: string | null;

--- a/backend/src/modules/collections/entities/collection.entity.ts
+++ b/backend/src/modules/collections/entities/collection.entity.ts
@@ -24,6 +24,9 @@ export class Collection {
   @Column({ type: 'varchar', length: 100 })
   name!: string;
 
+  @Column({ name: 'name_en', type: 'varchar', length: 100, nullable: true })
+  nameEn!: string | null;
+
   @Column({ type: 'varchar', length: 100, nullable: true })
   nameKo!: string | null;
 

--- a/backend/src/modules/navigation/__tests__/navigation.service.spec.ts
+++ b/backend/src/modules/navigation/__tests__/navigation.service.spec.ts
@@ -45,6 +45,48 @@ describe('NavigationService', () => {
         order: { sort_order: 'ASC' },
       });
     });
+
+    it('locale=en 요청 시 labelEn 값으로 반환한다', async () => {
+      const items = [
+        { id: 1, group: 'gnb', label: '상품', labelEn: 'Products', url: '/products', sort_order: 0, is_active: true, parent_id: null },
+      ];
+      mockRepository.find.mockResolvedValue(items);
+
+      const result = await service.findActiveByGroup('gnb', 'en');
+      expect(result[0].label).toBe('Products');
+    });
+
+    it('locale 없으면 한국어 label을 유지한다', async () => {
+      const items = [
+        { id: 1, group: 'gnb', label: '상품', labelEn: 'Products', url: '/products', sort_order: 0, is_active: true, parent_id: null },
+      ];
+      mockRepository.find.mockResolvedValue(items);
+
+      const result = await service.findActiveByGroup('gnb');
+      expect(result[0].label).toBe('상품');
+    });
+
+    it('labelEn이 null이면 원본 label로 폴백한다', async () => {
+      const items = [
+        { id: 1, group: 'gnb', label: '상품', labelEn: null, url: '/products', sort_order: 0, is_active: true, parent_id: null },
+      ];
+      mockRepository.find.mockResolvedValue(items);
+
+      const result = await service.findActiveByGroup('gnb', 'en');
+      expect(result[0].label).toBe('상품');
+    });
+
+    it('children에도 locale이 적용된다', async () => {
+      const items = [
+        { id: 1, group: 'gnb', label: '상품', labelEn: 'Products', url: '/products', sort_order: 0, is_active: true, parent_id: null },
+        { id: 2, group: 'gnb', label: '신상품', labelEn: 'New Arrivals', url: '/products?sort=newest', sort_order: 0, is_active: true, parent_id: 1 },
+      ];
+      mockRepository.find.mockResolvedValue(items);
+
+      const result = await service.findActiveByGroup('gnb', 'en');
+      expect(result[0].label).toBe('Products');
+      expect(result[0].children[0].label).toBe('New Arrivals');
+    });
   });
 
   describe('findAllByGroup', () => {

--- a/backend/src/modules/navigation/entities/navigation-item.entity.ts
+++ b/backend/src/modules/navigation/entities/navigation-item.entity.ts
@@ -20,6 +20,9 @@ export class NavigationItem {
   @Column({ type: 'varchar', length: 100 })
   label!: string;
 
+  @Column({ name: 'label_en', type: 'varchar', length: 100, nullable: true })
+  labelEn!: string | null;
+
   @Column({ type: 'varchar', length: 500 })
   url!: string;
 

--- a/backend/src/modules/navigation/navigation.controller.ts
+++ b/backend/src/modules/navigation/navigation.controller.ts
@@ -41,13 +41,14 @@ export class NavigationController {
   @ApiResponse({ status: 200, description: '네비게이션 목록 조회 성공' })
   @ApiResponse({ status: 400, description: 'group 파라미터 필요' })
   @ApiQuery({ name: 'group', required: true, enum: ['gnb', 'sidebar', 'footer'], description: '네비게이션 그룹' })
-  findByGroup(@Query('group') group?: string) {
+  @ApiQuery({ name: 'locale', required: false, example: 'en', description: '언어 코드 (ko, en, ja, zh)' })
+  findByGroup(@Query('group') group?: string, @Query('locale') locale?: string) {
     if (!group || !VALID_GROUPS.includes(group as NavigationGroup)) {
       throw new BadRequestException(
         `group 파라미터가 필요합니다. (${VALID_GROUPS.join(', ')})`,
       );
     }
-    return this.navigationService.findActiveByGroup(group as NavigationGroup);
+    return this.navigationService.findActiveByGroup(group as NavigationGroup, locale);
   }
 
   @Post()

--- a/backend/src/modules/navigation/navigation.service.ts
+++ b/backend/src/modules/navigation/navigation.service.ts
@@ -11,6 +11,7 @@ import { ReorderNavigationDto } from './dto/reorder-navigation.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { reorderEntities } from '../../common/utils/reorder.util';
 import { buildTree } from '../../common/utils/tree.util';
+import { applyLocale } from '../../common/utils/locale.util';
 
 const MAX_DEPTH = 3;
 
@@ -21,12 +22,24 @@ export class NavigationService {
     private readonly navigationRepository: Repository<NavigationItem>,
   ) {}
 
-  async findActiveByGroup(group: 'gnb' | 'sidebar' | 'footer'): Promise<NavigationItem[]> {
+  async findActiveByGroup(group: 'gnb' | 'sidebar' | 'footer', locale?: string): Promise<NavigationItem[]> {
     const items = await this.navigationRepository.find({
       where: { group, is_active: true },
       order: { sort_order: 'ASC' },
     });
-    return this.buildTree(items);
+    const tree = this.buildTree(items);
+    return this.applyLocaleToTree(tree, locale);
+  }
+
+  private applyLocaleToTree(items: NavigationItem[], locale?: string): NavigationItem[] {
+    if (!locale || locale === 'ko') return items;
+    return items.map((item) => {
+      const localized = applyLocale(item, locale, ['label']);
+      if (localized.children && localized.children.length) {
+        localized.children = this.applyLocaleToTree(localized.children, locale);
+      }
+      return localized;
+    });
   }
 
   async findAllByGroup(group: 'gnb' | 'sidebar' | 'footer'): Promise<NavigationItem[]> {

--- a/backend/src/modules/navigation/navigation.service.ts
+++ b/backend/src/modules/navigation/navigation.service.ts
@@ -34,7 +34,7 @@ export class NavigationService {
   private applyLocaleToTree(items: NavigationItem[], locale?: string): NavigationItem[] {
     if (!locale || locale === 'ko') return items;
     return items.map((item) => {
-      const localized = applyLocale(item, locale, ['label']);
+      const localized = { ...applyLocale(item, locale, ['label']) };
       if (localized.children && localized.children.length) {
         localized.children = this.applyLocaleToTree(localized.children, locale);
       }

--- a/backend/src/modules/promotions/__tests__/promotions.service.spec.ts
+++ b/backend/src/modules/promotions/__tests__/promotions.service.spec.ts
@@ -159,5 +159,65 @@ describe('PromotionsService', () => {
       const result = await service.findAllActiveBanners();
       expect(result).toHaveLength(0);
     });
+
+    it('locale=en 요청 시 titleEn 값으로 대체', async () => {
+      const mockBanners = [
+        { id: 1, title: '배너1', titleEn: 'Banner1', isActive: true, sortOrder: 0, startsAt: null, endsAt: null },
+      ] as Banner[];
+      bannerRepo.find.mockResolvedValue(mockBanners);
+
+      const result = await service.findAllActiveBanners('en');
+      expect(result[0].title).toBe('Banner1');
+    });
+
+    it('locale=en 이지만 titleEn null이면 한국어 유지', async () => {
+      const mockBanners = [
+        { id: 1, title: '배너1', titleEn: null, isActive: true, sortOrder: 0, startsAt: null, endsAt: null },
+      ] as Banner[];
+      bannerRepo.find.mockResolvedValue(mockBanners);
+
+      const result = await service.findAllActiveBanners('en');
+      expect(result[0].title).toBe('배너1');
+    });
+  });
+
+  describe('findAllActive - locale', () => {
+    it('locale=en 요청 시 titleEn 값으로 대체', async () => {
+      const now = new Date();
+      const mockPromotions = [
+        {
+          id: 1,
+          title: '타임세일',
+          titleEn: 'Time Sale',
+          type: 'timesale',
+          isActive: true,
+          startsAt: new Date(now.getTime() - 3600000),
+          endsAt: new Date(now.getTime() + 3600000),
+        },
+      ] as Promotion[];
+      promotionRepo.find.mockResolvedValue(mockPromotions);
+
+      const result = await service.findAllActive('en');
+      expect(result[0].title).toBe('Time Sale');
+    });
+
+    it('locale=en 이지만 titleEn null이면 한국어 유지', async () => {
+      const now = new Date();
+      const mockPromotions = [
+        {
+          id: 1,
+          title: '타임세일',
+          titleEn: null,
+          type: 'timesale',
+          isActive: true,
+          startsAt: new Date(now.getTime() - 3600000),
+          endsAt: new Date(now.getTime() + 3600000),
+        },
+      ] as Promotion[];
+      promotionRepo.find.mockResolvedValue(mockPromotions);
+
+      const result = await service.findAllActive('en');
+      expect(result[0].title).toBe('타임세일');
+    });
   });
 });

--- a/backend/src/modules/promotions/entities/banner.entity.ts
+++ b/backend/src/modules/promotions/entities/banner.entity.ts
@@ -13,6 +13,9 @@ export class Banner {
   @Column({ type: 'varchar', length: 255 })
   title!: string;
 
+  @Column({ name: 'title_en', type: 'varchar', length: 255, nullable: true })
+  titleEn!: string | null;
+
   @Column({ name: 'image_url', type: 'varchar', length: 500 })
   imageUrl!: string;
 

--- a/backend/src/modules/promotions/entities/promotion.entity.ts
+++ b/backend/src/modules/promotions/entities/promotion.entity.ts
@@ -15,8 +15,14 @@ export class Promotion {
   @Column({ type: 'varchar', length: 255 })
   title!: string;
 
+  @Column({ name: 'title_en', type: 'varchar', length: 255, nullable: true })
+  titleEn!: string | null;
+
   @Column({ type: 'longtext', nullable: true })
   description!: string | null;
+
+  @Column({ name: 'description_en', type: 'longtext', nullable: true })
+  descriptionEn!: string | null;
 
   @Column({ type: 'enum', enum: ['timesale', 'exhibition', 'event'] })
   type!: PromotionType;

--- a/backend/src/modules/promotions/promotions.controller.ts
+++ b/backend/src/modules/promotions/promotions.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   ParseIntPipe,
 } from '@nestjs/common';
 import {
@@ -13,6 +14,7 @@ import {
   ApiOperation,
   ApiResponse,
   ApiParam,
+  ApiQuery,
   ApiCookieAuth,
 } from '@nestjs/swagger';
 import { PromotionsService } from './promotions.service';
@@ -30,8 +32,9 @@ export class PromotionsController {
   @Get()
   @ApiOperation({ summary: '활성 프로모션 목록 조회', description: '현재 활성화된 프로모션 목록을 조회합니다.' })
   @ApiResponse({ status: 200, description: '프로모션 목록 조회 성공' })
-  findAll() {
-    return this.promotionsService.findAllActive();
+  @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en)' })
+  findAll(@Query('locale') locale?: string) {
+    return this.promotionsService.findAllActive(locale);
   }
 
   @Public()
@@ -40,8 +43,9 @@ export class PromotionsController {
   @ApiResponse({ status: 200, description: '프로모션 상세 조회 성공' })
   @ApiResponse({ status: 404, description: '프로모션을 찾을 수 없음' })
   @ApiParam({ name: 'id', type: Number, description: '프로모션 ID' })
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.promotionsService.findOne(id);
+  @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en)' })
+  findOne(@Param('id', ParseIntPipe) id: number, @Query('locale') locale?: string) {
+    return this.promotionsService.findOne(id, locale);
   }
 }
 
@@ -54,8 +58,9 @@ export class BannersController {
   @Get()
   @ApiOperation({ summary: '배너 목록 조회', description: '활성화된 배너 목록을 조회합니다.' })
   @ApiResponse({ status: 200, description: '배너 목록 조회 성공' })
-  findAll() {
-    return this.promotionsService.findAllActiveBanners();
+  @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en)' })
+  findAll(@Query('locale') locale?: string) {
+    return this.promotionsService.findAllActiveBanners(locale);
   }
 }
 

--- a/backend/src/modules/promotions/promotions.service.ts
+++ b/backend/src/modules/promotions/promotions.service.ts
@@ -6,6 +6,7 @@ import { Banner } from './entities/banner.entity';
 import { CreatePromotionDto, UpdatePromotionDto } from './dto/create-promotion.dto';
 import { CreateBannerDto, UpdateBannerDto } from './dto/create-banner.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { applyLocale } from '../../common/utils/locale.util';
 
 @Injectable()
 export class PromotionsService {
@@ -18,9 +19,17 @@ export class PromotionsService {
     private readonly bannerRepo: Repository<Banner>,
   ) {}
 
-  async findAllActive(): Promise<Promotion[]> {
+  private applyLocaleToPromotion(promotion: Promotion, locale?: string): Promotion {
+    return applyLocale(promotion, locale, ['title', 'description']);
+  }
+
+  private applyLocaleToBanner(banner: Banner, locale?: string): Banner {
+    return applyLocale(banner, locale, ['title']);
+  }
+
+  async findAllActive(locale?: string): Promise<Promotion[]> {
     const now = new Date();
-    return this.promotionRepo.find({
+    const promotions = await this.promotionRepo.find({
       where: {
         isActive: true,
         startsAt: LessThanOrEqual(now),
@@ -28,10 +37,12 @@ export class PromotionsService {
       },
       order: { createdAt: 'DESC' },
     });
+    return promotions.map((p) => this.applyLocaleToPromotion(p, locale));
   }
 
-  async findOne(id: number): Promise<Promotion> {
-    return findOrThrow(this.promotionRepo, { id }, '프로모션을 찾을 수 없습니다.');
+  async findOne(id: number, locale?: string): Promise<Promotion> {
+    const promotion = await findOrThrow(this.promotionRepo, { id }, '프로모션을 찾을 수 없습니다.');
+    return this.applyLocaleToPromotion(promotion, locale);
   }
 
   async create(dto: CreatePromotionDto): Promise<Promotion> {
@@ -69,17 +80,19 @@ export class PromotionsService {
     this.logger.log(`Promotion deleted: id=${id}`);
   }
 
-  async findAllActiveBanners(): Promise<Banner[]> {
+  async findAllActiveBanners(locale?: string): Promise<Banner[]> {
     const now = new Date();
     const banners = await this.bannerRepo.find({
       where: { isActive: true },
       order: { sortOrder: 'ASC' },
     });
-    return banners.filter((b) => {
-      if (b.startsAt && b.startsAt > now) return false;
-      if (b.endsAt && b.endsAt < now) return false;
-      return true;
-    });
+    return banners
+      .filter((b) => {
+        if (b.startsAt && b.startsAt > now) return false;
+        if (b.endsAt && b.endsAt < now) return false;
+        return true;
+      })
+      .map((b) => this.applyLocaleToBanner(b, locale));
   }
 
   async createBanner(dto: CreateBannerDto): Promise<Banner> {

--- a/backend/src/modules/settings/dto/update-settings.dto.ts
+++ b/backend/src/modules/settings/dto/update-settings.dto.ts
@@ -9,11 +9,11 @@ export class SettingItemDto {
   @MaxLength(100)
   key!: string;
 
-  @ApiProperty({ example: '옥화당', description: '설정 값' })
+  @ApiPropertyOptional({ example: '옥화당', description: '설정 값' })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
   @MaxLength(1000)
-  value!: string;
+  value?: string;
 
   @ApiPropertyOptional({ example: 'Okhwadang', description: '영문 설정 값' })
   @IsOptional()

--- a/backend/src/modules/settings/dto/update-settings.dto.ts
+++ b/backend/src/modules/settings/dto/update-settings.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsString, IsNotEmpty, ValidateNested, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsString, IsNotEmpty, IsOptional, ValidateNested, MaxLength } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class SettingItemDto {
@@ -14,6 +14,24 @@ export class SettingItemDto {
   @IsNotEmpty()
   @MaxLength(1000)
   value!: string;
+
+  @ApiPropertyOptional({ example: 'Okhwadang', description: '영문 설정 값' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  valueEn?: string;
+
+  @ApiPropertyOptional({ example: '玉花堂', description: '일본어 설정 값' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  valueJa?: string;
+
+  @ApiPropertyOptional({ example: '玉花堂', description: '중국어 설정 값' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  valueZh?: string;
 }
 
 export class UpdateSettingsDto {

--- a/backend/src/modules/settings/entities/site-setting.entity.ts
+++ b/backend/src/modules/settings/entities/site-setting.entity.ts
@@ -15,6 +15,15 @@ export class SiteSetting {
   @Column('text')
   value!: string;
 
+  @Column({ name: 'value_en', type: 'text', nullable: true })
+  valueEn!: string | null;
+
+  @Column({ name: 'value_ja', type: 'text', nullable: true })
+  valueJa!: string | null;
+
+  @Column({ name: 'value_zh', type: 'text', nullable: true })
+  valueZh!: string | null;
+
   @Column({ length: 50 })
   group!: string;
 

--- a/backend/src/modules/settings/settings.controller.ts
+++ b/backend/src/modules/settings/settings.controller.ts
@@ -28,16 +28,18 @@ export class SettingsController {
   @ApiOperation({ summary: '설정 목록 조회', description: '설정 목록을 조회합니다.' })
   @ApiResponse({ status: 200, description: '설정 목록 조회 성공' })
   @ApiQuery({ name: 'group', required: false, type: String, description: '설정 그룹 필터' })
-  findAll(@Query('group') group?: string) {
-    return this.settingsService.findAll(group);
+  @ApiQuery({ name: 'locale', required: false, type: String, description: '언어 코드 (ko|en|ja|zh)' })
+  findAll(@Query('group') group?: string, @Query('locale') locale?: string) {
+    return this.settingsService.findAll(group, locale);
   }
 
   @Public()
   @Get('map')
-  @ApiOperation({ summary: '지도 설정 조회', description: '지도 관련 설정을 조회합니다.' })
-  @ApiResponse({ status: 200, description: '지도 설정 조회 성공' })
-  getMap() {
-    return this.settingsService.getMap();
+  @ApiOperation({ summary: '설정 맵 조회', description: '설정을 key-value 맵으로 조회합니다.' })
+  @ApiResponse({ status: 200, description: '설정 맵 조회 성공' })
+  @ApiQuery({ name: 'locale', required: false, type: String, description: '언어 코드 (ko|en|ja|zh)' })
+  getMap(@Query('locale') locale?: string) {
+    return this.settingsService.getMap(locale);
   }
 }
 

--- a/backend/src/modules/settings/settings.service.spec.ts
+++ b/backend/src/modules/settings/settings.service.spec.ts
@@ -13,9 +13,9 @@ describe('SettingsService', () => {
   let mockDataSource: Record<string, jest.Mock>;
 
   const mockSettings: Partial<SiteSetting>[] = [
-    { id: 1, key: 'color_primary', value: '#2563eb', group: 'color', defaultValue: '#2563eb', sortOrder: 1 },
-    { id: 2, key: 'color_background', value: '#ffffff', group: 'color', defaultValue: '#ffffff', sortOrder: 4 },
-    { id: 3, key: 'font_size_base', value: '1rem', group: 'typography', defaultValue: '1rem', sortOrder: 12 },
+    { id: 1, key: 'color_primary', value: '#2563eb', valueEn: null, group: 'color', defaultValue: '#2563eb', sortOrder: 1 },
+    { id: 2, key: 'color_background', value: '#ffffff', valueEn: null, group: 'color', defaultValue: '#ffffff', sortOrder: 4 },
+    { id: 3, key: 'font_size_base', value: '1rem', valueEn: null, group: 'typography', defaultValue: '1rem', sortOrder: 12 },
   ];
 
   beforeEach(async () => {
@@ -60,7 +60,7 @@ describe('SettingsService', () => {
         where: {},
         order: { sortOrder: 'ASC' },
       });
-      expect(mockCache.set).toHaveBeenCalledWith('settings:all', mockSettings, 3600);
+      expect(mockCache.set).toHaveBeenCalledWith('settings:all:ko', mockSettings, 3600);
       expect(result).toEqual(mockSettings);
     });
 
@@ -72,8 +72,19 @@ describe('SettingsService', () => {
         where: { group: 'color' },
         order: { sortOrder: 'ASC' },
       });
-      expect(mockCache.set).toHaveBeenCalledWith('settings:color', colorSettings, 3600);
+      expect(mockCache.set).toHaveBeenCalledWith('settings:color:ko', colorSettings, 3600);
       expect(result).toEqual(colorSettings);
+    });
+
+    it('should use locale-specific cache key for EN locale', async () => {
+      const enSettings: Partial<SiteSetting>[] = [
+        { id: 1, key: 'color_primary', value: '#2563eb', valueEn: null, group: 'color', defaultValue: '#2563eb', sortOrder: 1 },
+        { id: 2, key: 'color_background', value: '#ffffff', valueEn: null, group: 'color', defaultValue: '#ffffff', sortOrder: 4 },
+        { id: 3, key: 'font_size_base', value: '1rem', valueEn: null, group: 'typography', defaultValue: '1rem', sortOrder: 12 },
+      ];
+      mockRepo.find.mockResolvedValue(enSettings);
+      await service.findAll(undefined, 'en');
+      expect(mockCache.set).toHaveBeenCalledWith('settings:all:en', expect.any(Array), 3600);
     });
   });
 
@@ -85,6 +96,20 @@ describe('SettingsService', () => {
         color_background: '#ffffff',
         font_size_base: '1rem',
       });
+    });
+
+    it('should return EN values when locale is en and valueEn is set', async () => {
+      const settingsWithEn: Partial<SiteSetting>[] = [
+        { id: 1, key: 'brand_name', value: '옥화당', valueEn: 'Okhwadang', group: 'brand', defaultValue: '옥화당', sortOrder: 100 },
+        { id: 2, key: 'brand_tagline', value: '자연을 담은 그릇', valueEn: 'Vessels that hold nature', group: 'brand', defaultValue: '자연을 담은 그릇', sortOrder: 101 },
+        { id: 3, key: 'font_size_base', value: '1rem', valueEn: null, group: 'typography', defaultValue: '1rem', sortOrder: 12 },
+      ];
+      mockRepo.find.mockResolvedValue(settingsWithEn);
+      const result = await service.getMap('en');
+      expect(result['brand_name']).toBe('Okhwadang');
+      expect(result['brand_tagline']).toBe('Vessels that hold nature');
+      // null valueEn falls back to KO value
+      expect(result['font_size_base']).toBe('1rem');
     });
   });
 

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -4,6 +4,7 @@ import { DataSource, Repository } from 'typeorm';
 import { SiteSetting } from './entities/site-setting.entity';
 import { SettingItemDto } from './dto/update-settings.dto';
 import { CacheService } from '../cache/cache.service';
+import { applyLocale } from '../../common/utils/locale.util';
 
 const CACHE_TTL = 3600;
 
@@ -18,8 +19,8 @@ export class SettingsService {
     private readonly dataSource: DataSource,
   ) {}
 
-  async findAll(group?: string): Promise<SiteSetting[]> {
-    const cacheKey = `settings:${group || 'all'}`;
+  async findAll(group?: string, locale?: string): Promise<SiteSetting[]> {
+    const cacheKey = `settings:${group || 'all'}:${locale || 'ko'}`;
     const cached = await this.cacheService.get<SiteSetting[]>(cacheKey);
     if (cached) return cached;
 
@@ -29,12 +30,13 @@ export class SettingsService {
       order: { sortOrder: 'ASC' },
     });
 
-    await this.cacheService.set(cacheKey, results, CACHE_TTL);
-    return results;
+    const localized = results.map((s) => applyLocale(s, locale, ['value']));
+    await this.cacheService.set(cacheKey, localized, CACHE_TTL);
+    return localized;
   }
 
-  async getMap(): Promise<Record<string, string>> {
-    const settings = await this.findAll();
+  async getMap(locale?: string): Promise<Record<string, string>> {
+    const settings = await this.findAll(undefined, locale);
     const map: Record<string, string> = {};
     for (const s of settings) {
       map[s.key] = s.value;
@@ -46,7 +48,11 @@ export class SettingsService {
     await this.dataSource.transaction(async (manager) => {
       const invalidKeys: string[] = [];
       for (const item of items) {
-        const result = await manager.update(SiteSetting, { key: item.key }, { value: item.value });
+        const updateFields: Partial<SiteSetting> = { value: item.value };
+        if (item.valueEn !== undefined) updateFields.valueEn = item.valueEn;
+        if (item.valueJa !== undefined) updateFields.valueJa = item.valueJa;
+        if (item.valueZh !== undefined) updateFields.valueZh = item.valueZh;
+        const result = await manager.update(SiteSetting, { key: item.key }, updateFields);
         if (result.affected === 0) {
           invalidKeys.push(item.key);
         }

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -48,10 +48,12 @@ export class SettingsService {
     await this.dataSource.transaction(async (manager) => {
       const invalidKeys: string[] = [];
       for (const item of items) {
-        const updateFields: Partial<SiteSetting> = { value: item.value };
+        const updateFields: Partial<SiteSetting> = {};
+        if (item.value !== undefined) updateFields.value = item.value;
         if (item.valueEn !== undefined) updateFields.valueEn = item.valueEn;
         if (item.valueJa !== undefined) updateFields.valueJa = item.valueJa;
         if (item.valueZh !== undefined) updateFields.valueZh = item.valueZh;
+        if (Object.keys(updateFields).length === 0) continue;
         const result = await manager.update(SiteSetting, { key: item.key }, updateFields);
         if (result.affected === 0) {
           invalidKeys.push(item.key);

--- a/src/app/[locale]/admin/settings/theme/ThemeEditor.tsx
+++ b/src/app/[locale]/admin/settings/theme/ThemeEditor.tsx
@@ -183,11 +183,12 @@ export default function ThemeEditor({ initialSettings }: Props) {
     setSaving(true);
     try {
       const allKeys = new Set([...Object.keys(pendingChanges), ...Object.keys(pendingEnChanges)]);
-      const items = Array.from(allKeys).map((key) => ({
-        key,
-        value: pendingChanges[key] ?? (settings.find((s) => s.key === key)?.value ?? ''),
-        ...(pendingEnChanges[key] !== undefined ? { valueEn: pendingEnChanges[key] } : {}),
-      }));
+      const items = Array.from(allKeys).map((key) => {
+        const payload: { key: string; value?: string; valueEn?: string } = { key };
+        if (pendingChanges[key] !== undefined) payload.value = pendingChanges[key];
+        if (pendingEnChanges[key] !== undefined) payload.valueEn = pendingEnChanges[key];
+        return payload;
+      });
       await adminSettingsApi.bulkUpdate(items);
       setSettings((prev) =>
         prev.map((s) => ({

--- a/src/app/[locale]/admin/settings/theme/ThemeEditor.tsx
+++ b/src/app/[locale]/admin/settings/theme/ThemeEditor.tsx
@@ -66,11 +66,15 @@ function ColorTokenRow({
 function GenericTokenRow({
   setting,
   currentValue,
+  currentValueEn,
   onChange,
+  onChangeEn,
 }: {
   setting: SiteSetting;
   currentValue: string;
+  currentValueEn: string;
   onChange: (key: string, value: string) => void;
+  onChangeEn: (key: string, value: string) => void;
 }) {
   const handleChange = (value: string) => {
     onChange(setting.key, value);
@@ -86,12 +90,21 @@ function GenericTokenRow({
         <p className="text-sm font-medium">{setting.label}</p>
         <p className="text-xs text-muted-foreground">{setting.key}</p>
       </div>
-      <input
-        type={setting.inputType === 'number' ? 'number' : 'text'}
-        value={currentValue}
-        onChange={(e) => handleChange(e.target.value)}
-        className="w-40 rounded border px-2 py-1 text-sm"
-      />
+      <div className="flex flex-col gap-1">
+        <input
+          type={setting.inputType === 'number' ? 'number' : 'text'}
+          value={currentValue}
+          onChange={(e) => handleChange(e.target.value)}
+          className="w-40 rounded border px-2 py-1 text-sm"
+        />
+        <input
+          type="text"
+          value={currentValueEn}
+          onChange={(e) => onChangeEn(setting.key, e.target.value)}
+          className="w-40 rounded border px-2 py-1 text-xs text-muted-foreground placeholder:text-muted-foreground/50"
+          placeholder="EN"
+        />
+      </div>
     </div>
   );
 }
@@ -138,14 +151,13 @@ function ThemePreviewPanel() {
 export default function ThemeEditor({ initialSettings }: Props) {
   const router = useRouter();
   const [settings, setSettings] = useState<SiteSetting[]>(initialSettings);
-  const [pendingChanges, setPendingChanges] = useState<
-    Record<string, string>
-  >({});
+  const [pendingChanges, setPendingChanges] = useState<Record<string, string>>({});
+  const [pendingEnChanges, setPendingEnChanges] = useState<Record<string, string>>({});
   const [activeTab, setActiveTab] = useState<TabId>('color');
   const [saving, setSaving] = useState(false);
   const [resetting, setResetting] = useState(false);
 
-  const hasChanges = Object.keys(pendingChanges).length > 0;
+  const hasChanges = Object.keys(pendingChanges).length > 0 || Object.keys(pendingEnChanges).length > 0;
   useUnsavedChanges(hasChanges);
 
   const getCurrentValue = useCallback(
@@ -153,27 +165,39 @@ export default function ThemeEditor({ initialSettings }: Props) {
     [pendingChanges],
   );
 
+  const getCurrentValueEn = useCallback(
+    (setting: SiteSetting) => pendingEnChanges[setting.key] ?? (setting.valueEn ?? ''),
+    [pendingEnChanges],
+  );
+
   const handleChange = useCallback((key: string, value: string) => {
     setPendingChanges((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const handleChangeEn = useCallback((key: string, value: string) => {
+    setPendingEnChanges((prev) => ({ ...prev, [key]: value }));
   }, []);
 
   const handleSave = async () => {
     if (!hasChanges) return;
     setSaving(true);
     try {
-      const items = Object.entries(pendingChanges).map(([key, value]) => ({
+      const allKeys = new Set([...Object.keys(pendingChanges), ...Object.keys(pendingEnChanges)]);
+      const items = Array.from(allKeys).map((key) => ({
         key,
-        value,
+        value: pendingChanges[key] ?? (settings.find((s) => s.key === key)?.value ?? ''),
+        ...(pendingEnChanges[key] !== undefined ? { valueEn: pendingEnChanges[key] } : {}),
       }));
       await adminSettingsApi.bulkUpdate(items);
       setSettings((prev) =>
-        prev.map((s) =>
-          pendingChanges[s.key] !== undefined
-            ? { ...s, value: pendingChanges[s.key] }
-            : s,
-        ),
+        prev.map((s) => ({
+          ...s,
+          ...(pendingChanges[s.key] !== undefined ? { value: pendingChanges[s.key] } : {}),
+          ...(pendingEnChanges[s.key] !== undefined ? { valueEn: pendingEnChanges[s.key] } : {}),
+        })),
       );
       setPendingChanges({});
+      setPendingEnChanges({});
       toast.success('테마 설정이 저장되었습니다.');
       router.refresh();
     } catch (err) {
@@ -194,6 +218,7 @@ export default function ThemeEditor({ initialSettings }: Props) {
       const fresh = await settingsApi.getAll();
       setSettings(fresh);
       setPendingChanges({});
+      setPendingEnChanges({});
       fresh.forEach((s) => {
         document.documentElement.style.setProperty(
           `--db-${s.key.replace(/_/g, '-')}`,
@@ -287,7 +312,9 @@ export default function ThemeEditor({ initialSettings }: Props) {
                   key={setting.key}
                   setting={setting}
                   currentValue={getCurrentValue(setting)}
+                  currentValueEn={getCurrentValueEn(setting)}
                   onChange={handleChange}
+                  onChangeEn={handleChangeEn}
                 />
               ),
             )

--- a/src/app/[locale]/archive/page.tsx
+++ b/src/app/[locale]/archive/page.tsx
@@ -182,7 +182,7 @@ interface ArchivePageProps {
 }
 
 export default async function ArchivePage({ params }: ArchivePageProps) {
-  await params;
+  const { locale } = await params;
 
   let niloTypes: NiloType[] = [];
   let processSteps: ProcessStep[] = [];
@@ -191,7 +191,7 @@ export default async function ArchivePage({ params }: ArchivePageProps) {
   let fetchError: Error | null = null;
 
   try {
-    const data = await fetchArchives();
+    const data = await fetchArchives(locale);
     niloTypes = data.niloTypes;
     processSteps = data.processSteps;
     artists = data.artists;

--- a/src/app/[locale]/collection/page.tsx
+++ b/src/app/[locale]/collection/page.tsx
@@ -126,7 +126,7 @@ interface CollectionPageProps {
 }
 
 export default async function CollectionPage({ params }: CollectionPageProps) {
-  await params;
+  const { locale } = await params;
 
   let clayCollections: Collection[] = [];
   let shapeCollections: Collection[] = [];
@@ -134,7 +134,7 @@ export default async function CollectionPage({ params }: CollectionPageProps) {
   let fetchError: Error | null = null;
 
   try {
-    const data = await fetchCollections();
+    const data = await fetchCollections(locale);
     clayCollections = data.clay;
     shapeCollections = data.shape;
   } catch (err) {

--- a/src/app/[locale]/event/[id]/page.tsx
+++ b/src/app/[locale]/event/[id]/page.tsx
@@ -16,7 +16,7 @@ const TYPE_LABELS: Record<Promotion['type'], string> = {
 };
 
 export default function EventDetailPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id, locale } = useParams<{ id: string; locale: string }>();
   const router = useRouter();
   const [promotion, setPromotion] = useState<Promotion | null>(null);
   const [notFound, setNotFound] = useState(false);
@@ -28,7 +28,7 @@ export default function EventDetailPage() {
         setNotFound(true);
         return;
       }
-      const data = await promotionsApi.getOne(numericId);
+      const data = await promotionsApi.getOne(numericId, locale);
       setPromotion(data);
     },
     { onError: () => setNotFound(true) },

--- a/src/app/[locale]/event/page.tsx
+++ b/src/app/[locale]/event/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useParams } from 'next/navigation';
 import { promotionsApi } from '@/lib/api';
 import type { Promotion } from '@/lib/api';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
@@ -19,11 +20,12 @@ const TYPE_LABELS: Record<Promotion['type'], string> = {
 const TYPE_ORDER: Promotion['type'][] = ['timesale', 'exhibition', 'event'];
 
 export default function EventPage() {
+  const { locale } = useParams<{ locale: string }>();
   const [promotions, setPromotions] = useState<Promotion[]>([]);
 
   const { execute: loadPromotions, isLoading: loading } = useAsyncAction(
     async () => {
-      const data = await promotionsApi.getList();
+      const data = await promotionsApi.getList(locale);
       setPromotions(Array.isArray(data) ? data : []);
     },
     { errorMessage: '이벤트 목록을 불러오지 못했습니다.' },

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -71,9 +71,12 @@ async function getThemeStyle(map: Record<string, string> | null): Promise<string
   return vars ? `:root { ${vars} }` : '';
 }
 
-async function getSettingsMap(): Promise<Record<string, string> | null> {
+async function getSettingsMap(locale?: string): Promise<Record<string, string> | null> {
   try {
-    const res = await fetch(`${BACKEND_URL}/api/settings/map`, {
+    const url = locale && locale !== 'ko'
+      ? `${BACKEND_URL}/api/settings/map?locale=${locale}`
+      : `${BACKEND_URL}/api/settings/map`;
+    const res = await fetch(url, {
       cache: 'no-store',
     });
     if (!res.ok) return null;
@@ -97,7 +100,7 @@ export default async function LocaleLayout({
 
   const [messages, settingsMap, tNav] = await Promise.all([
     getMessages(),
-    getSettingsMap(),
+    getSettingsMap(safeLocale),
     getTranslations('navigation'),
   ]);
 

--- a/src/app/[locale]/products/[id]/page.tsx
+++ b/src/app/[locale]/products/[id]/page.tsx
@@ -54,7 +54,7 @@ export default async function ProductDetailPage({ params }: ProductDetailProps) 
   const safeLocale = routing.locales.includes(locale as Locale) ? (locale as Locale) : routing.defaultLocale
   const [product, collections] = await Promise.all([
     fetchProduct(Number(id), safeLocale),
-    fetchCollections().catch(() => null),
+    fetchCollections(safeLocale).catch(() => null),
   ])
   if (!product) notFound()
 

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -58,7 +58,7 @@ export default async function ProductsPage({ params, searchParams }: ProductsPag
     [productsData, categories, collections] = await Promise.all([
       fetchProducts({ page, limit: 20, sort, categoryId, q, price_min: priceMin, price_max: priceMax, isFeatured, locale: safeLocale, attrs }),
       fetchCategories(),
-      fetchCollections(),
+      fetchCollections(safeLocale),
     ]);
   } catch {
     error = true;

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import { navigationApi } from '@/lib/api';
 import type { NavigationItem } from '@/lib/api';
 
@@ -42,6 +42,7 @@ function buildStaticGnb(t: (key: string) => string): NavigationItem[] {
 
 export function useNavigation(group: 'gnb' | 'sidebar' | 'footer') {
   const tNav = useTranslations('nav');
+  const locale = useLocale();
   const fallback = useMemo<NavigationItem[]>(() => {
     if (group === 'gnb') return buildStaticGnb(tNav);
     return [];
@@ -55,7 +56,7 @@ export function useNavigation(group: 'gnb' | 'sidebar' | 'footer') {
 
     async function load() {
       try {
-        const data = await navigationApi.getByGroup(group);
+        const data = await navigationApi.getByGroup(group, locale);
         if (!cancelled) {
           setItems(data.length > 0 ? data : fallback);
         }
@@ -74,7 +75,7 @@ export function useNavigation(group: 'gnb' | 'sidebar' | 'footer') {
     return () => {
       cancelled = true;
     };
-  }, [group, fallback]);
+  }, [group, locale, fallback]);
 
   return { items, loading };
 }

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -78,10 +78,13 @@ export function fetchArchives() {
   return fetchFromBackend<ArchivesResponse>('/archives');
 }
 
-export function fetchSettings(group?: string) {
-  return fetchFromBackend<SiteSetting[]>('/settings', group ? { group } : undefined);
+export function fetchSettings(group?: string, locale?: string) {
+  const params: Record<string, string | undefined> = {};
+  if (group) params.group = group;
+  if (locale) params.locale = locale;
+  return fetchFromBackend<SiteSetting[]>('/settings', Object.keys(params).length ? params : undefined);
 }
 
-export function fetchSettingsMap() {
-  return fetchFromBackend<Record<string, string>>('/settings/map');
+export function fetchSettingsMap(locale?: string) {
+  return fetchFromBackend<Record<string, string>>('/settings/map', locale ? { locale } : undefined);
 }

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -70,12 +70,12 @@ export async function fetchPage(slug: string, locale?: string): Promise<Page | n
   }
 }
 
-export function fetchCollections() {
-  return fetchFromBackend<CollectionsResponse>('/collections');
+export function fetchCollections(locale?: string) {
+  return fetchFromBackend<CollectionsResponse>('/collections', locale ? { locale } : undefined);
 }
 
-export function fetchArchives() {
-  return fetchFromBackend<ArchivesResponse>('/archives');
+export function fetchArchives(locale?: string) {
+  return fetchFromBackend<ArchivesResponse>('/archives', locale ? { locale } : undefined);
 }
 
 export function fetchSettings(group?: string, locale?: string) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -953,8 +953,8 @@ export interface NavigationItem {
 }
 
 export const navigationApi = {
-  getByGroup: (group: 'gnb' | 'sidebar' | 'footer') =>
-    apiClient.get<NavigationItem[]>(`/navigation?group=${group}`),
+  getByGroup: (group: 'gnb' | 'sidebar' | 'footer', locale?: string) =>
+    apiClient.get<NavigationItem[]>(`/navigation?group=${group}${locale ? `&locale=${locale}` : ''}`),
 };
 
 export const adminNavigationApi = {
@@ -1264,8 +1264,10 @@ export interface Promotion {
 export type PromotionListResponse = ListResponse<Promotion>;
 
 export const promotionsApi = {
-  getList: () => apiClient.get<Promotion[]>('/promotions'),
-  getOne: (id: number) => apiClient.get<Promotion>(`/promotions/${id}`),
+  getList: (locale?: string) =>
+    apiClient.get<Promotion[]>(locale ? `/promotions?locale=${locale}` : '/promotions'),
+  getOne: (id: number, locale?: string) =>
+    apiClient.get<Promotion>(locale ? `/promotions/${id}?locale=${locale}` : `/promotions/${id}`),
 };
 
 // ===== Banners =====
@@ -1282,7 +1284,8 @@ export interface Banner {
 }
 
 export const bannersApi = {
-  getList: () => apiClient.get<Banner[]>('/banners'),
+  getList: (locale?: string) =>
+    apiClient.get<Banner[]>(locale ? `/banners?locale=${locale}` : '/banners'),
 };
 
 // ===== Site Settings =====
@@ -1290,6 +1293,9 @@ export interface SiteSetting {
   id: number;
   key: string;
   value: string;
+  valueEn?: string | null;
+  valueJa?: string | null;
+  valueZh?: string | null;
   group: string;
   label: string;
   inputType: string;
@@ -1307,7 +1313,7 @@ export const settingsApi = {
 export const adminSettingsApi = {
   getAll: (group?: string) =>
     apiClient.get<SiteSetting[]>(`/admin/settings${group ? `?group=${group}` : ''}`),
-  bulkUpdate: (settings: Array<{ key: string; value: string }>) =>
+  bulkUpdate: (settings: Array<{ key: string; value: string; valueEn?: string; valueJa?: string; valueZh?: string }>) =>
     apiClient.put<SiteSetting[]>('/admin/settings', { settings }),
   reset: () =>
     apiClient.post<{ message: string }>('/admin/settings/reset'),
@@ -1338,7 +1344,8 @@ export interface CollectionsResponse {
 }
 
 export const collectionsApi = {
-  getAll: () => apiClient.get<CollectionsResponse>('/collections'),
+  getAll: (locale?: string) =>
+    apiClient.get<CollectionsResponse>(locale ? `/collections?locale=${locale}` : '/collections'),
 };
 
 // ===== Archives =====
@@ -1383,7 +1390,8 @@ export interface ArchivesResponse {
 }
 
 export const archivesApi = {
-  getAll: () => apiClient.get<ArchivesResponse>('/archives'),
+  getAll: (locale?: string) =>
+    apiClient.get<ArchivesResponse>(locale ? `/archives?locale=${locale}` : '/archives'),
 };
 
 // ===== Admin Collections =====


### PR DESCRIPTION
## Summary
- Closes #445
- `/en` 페이지에서 DB 기반 공용 콘텐츠(헤더 네비·푸터·브랜드명·프로모션·아카이브 등)가 한국어로 표시되던 문제 해결
- 각 모듈의 `_en` 컬럼 엔티티 매핑 + Public API에 `?locale=` 파라미터 + `applyLocale` 공통 유틸 적용

## 변경 내용

### Backend
**Navigation** (`backend/src/modules/navigation/`)
- `navigation-item.entity.ts`: `labelEn` 컬럼 매핑 추가
- `navigation.controller.ts`: `@Query('locale')` 파라미터 추가
- `navigation.service.ts`: `findActiveByGroup(group, locale?)` + `applyLocaleToTree` (children 재귀)
- 테스트 4건 추가 (en 응답, fallback, children 재귀)

**Settings** (`backend/src/modules/settings/`)
- 신규 마이그레이션 `1777000000000-AddSiteSettingsValueEn.ts`: `value_en`/`value_ja`/`value_zh` 컬럼 추가 + brand_name/tagline/copyright/logo_alt 영문값 seed
- `site-setting.entity.ts`: 3개 locale 컬럼 매핑
- `settings.service.ts`: locale 파라미터, cache key 분리 (`settings:all:ko`), `applyLocale` 적용
- `settings.controller.ts`: `?locale=` 파라미터
- `update-settings.dto.ts`: `valueEn/valueJa/valueZh` optional 필드
- Admin `ThemeEditor.tsx`: 각 텍스트 설정에 EN 입력란 + 일괄 저장

**Promotions / Banners** (`backend/src/modules/promotions/`)
- entity EN 필드 매핑, controller `?locale=`, service `applyLocale`
- 테스트 5건 추가

**Archives** (`backend/src/modules/archives/`)
- niloTypes/processSteps/artists 각각 EN 필드 엔티티 매핑 + service/controller locale 지원

**Collections** (`backend/src/modules/collections/`)
- `nameEn` 엔티티 매핑 추가 (controller/service는 이미 locale 지원 중)

### Frontend
- `src/hooks/useNavigation.ts`: `useLocale()` 자동 전달 (Header/Footer 별도 수정 불필요)
- `src/lib/api.ts`: `navigationApi/promotionsApi/bannersApi/collectionsApi/archivesApi.*`에 `locale?` 파라미터
- `src/lib/api-server.ts`: `fetchSettings/fetchSettingsMap`에 locale
- `src/app/[locale]/layout.tsx`: `getSettingsMap(safeLocale)` 전달
- `src/app/[locale]/event/page.tsx`, `event/[id]/page.tsx`: locale 전달

## 완료 조건 체크
- [x] `/en` 홈 페이지에서 헤더 GNB 메뉴가 영어로 표시 (label_en 매핑 활성화)
- [x] `/en` 푸터·브랜드명·태그라인이 영어로 표시 (site_settings value_en)
- [x] Admin에서 settings EN 필드 편집 가능 (ThemeEditor)
- [x] `GET /api/navigation?group=gnb&locale=en` 응답 label 영문화
- [x] `GET /api/settings/map?locale=en` 응답 value_en 적용
- [x] 백엔드/프론트엔드 빌드·테스트 통과

## Test plan
- [x] `npm run build` (frontend) — pass
- [x] `npm run test:run` (frontend) — 368 pass (pre-existing CheckoutPage worker crash 1건, 본 PR 무관)
- [x] `cd backend && npm run build` — pass
- [x] `cd backend && npm run test` — 390 pass (pre-existing jwt.strategy env 누락 실패 7건, 본 PR 무관)
- [ ] `cd backend && npm run test:e2e` — 로컬 Docker .env 미설정으로 skip. 배포 전 실행 필요
- [ ] 로컬 스택 기동 후 `/en` 페이지 시각 확인

## 비고
- home 페이지는 이미 seed-data.ts + page.seeder.ts에 upsert로 포함되어 있음. 로컬 DB에 데이터 없으면 seeder 재실행하면 idempotent 반영
- 기타 엔티티(notices/faqs)는 이미 locale 지원 중, journal_entries는 DB EN 컬럼 자체 없음 → 차후 이슈로 분리