### PR TITLE
fix: #429 hydration mismatch — SSR data-theme 주입

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -108,11 +108,14 @@ export default async function LocaleLayout({
 
   const mobileBottomNavVisible = settingsMap?.mobile_bottom_nav_visible !== 'false';
 
-  // FOUC 방지 인라인 스크립트: JS hydrate 전에 data-theme 세팅 (신뢰할 수 없는 입력 없음)
-  const foucScript = "(function(){try{var s=localStorage.getItem('theme');var l=document.documentElement.lang;var d=l==='ko'?'dark':'light';document.documentElement.dataset.theme=s&&(s==='dark'||s==='light')?s:d;}catch(e){}})();";
+  // SSR 단계에서 data-theme 기본값을 locale 기반으로 설정 — hydration mismatch 방지.
+  // 클라이언트의 FOUC 스크립트가 localStorage 에 저장된 사용자 선호가 있으면 즉시 덮어씀.
+  const initialTheme = safeLocale === 'ko' ? 'dark' : 'light';
+
+  const foucScript = "(function(){try{var s=localStorage.getItem('theme');if(s==='dark'||s==='light'){document.documentElement.dataset.theme=s;}}catch(e){}})();";
 
   return (
-    <html lang={safeLocale}>
+    <html lang={safeLocale} data-theme={initialTheme} suppressHydrationWarning>
       <head>
         {/* eslint-disable-next-line react/no-danger */}
         <script dangerouslySetInnerHTML={{ __html: foucScript }} />


### PR DESCRIPTION
## 문제

PR #448 머지 후 로컬에서 hydration mismatch warning 발생:

\`\`\`
A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.
<html lang="en"
-  data-theme="light"
\`\`\`

서버 렌더 HTML 에는 \`data-theme\` 가 없는데 클라이언트에서 FOUC 스크립트가 \`data-theme\` 를 주입하면서 mismatch.

## 수정

- \`<html>\` 태그에 locale 기반 \`initialTheme\` 을 SSR 단계부터 부여 (ko=dark, 그 외=light)
- \`suppressHydrationWarning\` — FOUC 스크립트가 localStorage 선호값으로 덮어쓸 때의 의도된 mismatch 억제
- FOUC 스크립트는 저장된 선호값이 있을 때만 dataset 갱신하도록 단순화 (SSR 기본값은 이미 서버에서 설정됨)

## 검증

- \`npm run build\` 통과
- 기능 동일: ko=dark, en=light 기본값 + 토글 + localStorage 유지

Related: #429 (Part 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)