### PR TITLE
fix: start-local.sh Docker open 플래그 정정

### DIFF
--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -47,7 +47,7 @@ USE_LOCAL_DB=$(echo "${LOCAL_DATABASE_URL:-}" | grep -qE "localhost:330[67]|127\
 if [ "$USE_LOCAL_DB" = "yes" ] && command -v docker > /dev/null 2>&1; then
     if ! docker info > /dev/null 2>&1; then
         echo -e "${YELLOW}⚠️  Docker Desktop 시작 중...${NC}"
-        open --new -a Docker 2>/dev/null || true
+        open -ga Docker 2>/dev/null || true
         echo -e "${YELLOW}⏳ Docker Desktop 시작 대기 (최대 60초)...${NC}"
         for i in {1..60}; do
             docker info > /dev/null 2>&1 && break


### PR DESCRIPTION
## 문제

\`open --new -a Docker\` 는 이미 Docker Desktop 이 실행 중인 경우에도 새 인스턴스를 요청하면서 재시작을 유발하거나 상태가 불안정해질 수 있음. 사용자 환경에서 \`./scripts/start-local.sh\` / \`stop-local.sh\` 이후 Docker Desktop 이 꺼지는 증상이 관측됨.

## 수정

\`-ga\` 플래그로 변경:
- \`-g\` : background (포그라운드로 Docker UI 를 앞으로 끌어오지 않음)
- \`-a\` : 앱 이름 지정 (기존 인스턴스 재사용, 새 인스턴스 강제 실행 아님)

\`--new\` 는 완전히 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)