### PR TITLE
fix: 마이그레이션 JSON 이스케이프 버그 수정

### DIFF
--- a/backend/src/database/migrations/1777100000000-UpsertPageBlockTranslationFields.ts
+++ b/backend/src/database/migrations/1777100000000-UpsertPageBlockTranslationFields.ts
@@ -7,7 +7,10 @@ export class UpsertPageBlockTranslationFields1777100000000 implements MigrationI
     const query = (sql: string) => queryRunner.query(sql);
 
     const updateBlockContent = async (id: number, content: Record<string, unknown>): Promise<void> => {
-      await query(`UPDATE \`page_blocks\` SET content = '${JSON.stringify(content).replace(/'/g, "\\'")}' WHERE id = ${id}`);
+      await queryRunner.query(
+        `UPDATE \`page_blocks\` SET content = ? WHERE id = ?`,
+        [JSON.stringify(content), id],
+      );
     };
 
     const heroBlock = await query(`SELECT id, content FROM \`page_blocks\` WHERE page_id = 1 AND type = 'hero_banner' LIMIT 1`);
@@ -131,7 +134,10 @@ export class UpsertPageBlockTranslationFields1777100000000 implements MigrationI
         for (const key of keys) {
           delete content[key];
         }
-        await query(`UPDATE \`page_blocks\` SET content = '${JSON.stringify(content).replace(/'/g, "\\'")}' WHERE id = ${id}`);
+        await queryRunner.query(
+          `UPDATE \`page_blocks\` SET content = ? WHERE id = ?`,
+          [JSON.stringify(content), id],
+        );
       }
     };
 
@@ -146,7 +152,10 @@ export class UpsertPageBlockTranslationFields1777100000000 implements MigrationI
             delete s.cta_text_en;
             return s;
           });
-          await query(`UPDATE \`page_blocks\` SET content = '${JSON.stringify(content).replace(/'/g, "\\'")}' WHERE id = ${b.id}`);
+          await queryRunner.query(
+            `UPDATE \`page_blocks\` SET content = ? WHERE id = ?`,
+            [JSON.stringify(content), b.id],
+          );
         } else {
           await cleanEnFields(b.id, ['title_en', 'subtitle_en', 'description_en', 'cta_text_en']);
         }

--- a/backend/src/database/migrations/1777200000000-UpsertRemainingPageBlockEnFields.ts
+++ b/backend/src/database/migrations/1777200000000-UpsertRemainingPageBlockEnFields.ts
@@ -7,7 +7,10 @@ export class UpsertRemainingPageBlockEnFields1777200000000 implements MigrationI
     const query = (sql: string) => queryRunner.query(sql);
 
     const updateBlockContent = async (id: number, content: Record<string, unknown>): Promise<void> => {
-      await query(`UPDATE \`page_blocks\` SET content = '${JSON.stringify(content).replace(/'/g, "\\'")}' WHERE id = ${id}`);
+      await queryRunner.query(
+        `UPDATE \`page_blocks\` SET content = ? WHERE id = ?`,
+        [JSON.stringify(content), id],
+      );
     };
 
     const heroBlock = await query(`SELECT id, content FROM \`page_blocks\` WHERE page_id = 6 AND type = 'hero_banner' LIMIT 1`);
@@ -211,7 +214,10 @@ export class UpsertRemainingPageBlockEnFields1777200000000 implements MigrationI
       if (content.cta_text_en) { delete content.cta_text_en; changed = true; }
       if (content.html_en) { delete content.html_en; changed = true; }
       if (changed) {
-        await query(`UPDATE \`page_blocks\` SET content = '${JSON.stringify(content).replace(/'/g, "\\'")}' WHERE id = ${block.id}`);
+        await queryRunner.query(
+          `UPDATE \`page_blocks\` SET content = ? WHERE id = ?`,
+          [JSON.stringify(content), block.id],
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- `UpsertPageBlockTranslationFields1777100000000`, `UpsertRemainingPageBlockEnFields1777200000000` 에서 JSON.stringify 결과를 문자열 replace 로 이스케이프하던 방식이 MySQL JSON 파서에서 "Invalid JSON text" 에러 유발
- `queryRunner.query(sql, [params])` 파라미터 바인딩으로 전환
- 배포 파이프라인 fail → 해결

## Test plan
- [x] backend 빌드 통과
- [ ] 머지 후 Deploy workflow 재실행, 烟雾测试(`/api/health`) 200 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)