### PR TITLE
fix: Archive NiloType en 로케일에서 한글 잔여 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ cd backend && docker compose down -v # Reset DB
 ## Issue Tracker
 * Phase 0-7 (Setup → MVP → Core → Payment → Admin → CMS → Polish → Ops)
 * Labels: `phase-N`, `backend`, `frontend`, `infra`, `P0`~`P3`
-* Latest merged PR: #438
+* Latest merged PR: #459
 
 ## Rules Reference
 | Subject | File |

--- a/backend/src/database/migrations/1778100000000-AddNiloCharacteristicsEn.ts
+++ b/backend/src/database/migrations/1778100000000-AddNiloCharacteristicsEn.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * nilo_types.characteristics_en (JSON) 컬럼 추가 및 영어 특성 백필.
+ *
+ * idempotent — 컬럼 존재 체크 후 ADD, 비어있는 row 만 UPDATE.
+ */
+export class AddNiloCharacteristicsEn1778100000000 implements MigrationInterface {
+  name = 'AddNiloCharacteristicsEn1778100000000';
+
+  private async columnExists(queryRunner: QueryRunner, table: string, column: string): Promise<boolean> {
+    const rows = await queryRunner.query(
+      `SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+      [table, column],
+    );
+    return (rows as Array<{ cnt: string | number }>)[0].cnt.toString() !== '0';
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await this.columnExists(queryRunner, 'nilo_types', 'characteristics_en'))) {
+      await queryRunner.query(
+        `ALTER TABLE \`nilo_types\` ADD \`characteristics_en\` JSON NULL AFTER \`characteristics\``,
+      );
+    }
+
+    // 한글 특성 → 영어 번역 매핑 (id 기반 UPDATE)
+    const translations: Array<[number, string[]]> = [
+      [1, ['Reddish Amber', 'High Shrinkage', 'Fast Heat Conduction', 'High-mountain Oolong & Black Tea']],
+      [2, ['Purple Hue', 'Excellent Porosity', 'Ideal for Fermented Tea', 'Develops Sheen']],
+      [3, ['Bright Yellow Tone', 'Light Color', 'Clean Taste', 'Green/White/Light-Oxidized Oolong']],
+      [4, ['Deep Black', 'Substantial Presence', 'Excellent Heat Retention', 'Aged Shucha & Black Tea']],
+      [5, ['Blue-Gray Tone', 'Subtle Palette', 'Refined Aesthetic', 'Sheng Pu-erh & White Tea']],
+      [6, ['Green Tone', 'Cool Presence', 'Clean Profile', 'Green Tea & White Tea']],
+    ];
+
+    for (const [id, chars] of translations) {
+      await queryRunner.query(
+        `UPDATE \`nilo_types\` SET characteristics_en = ? WHERE id = ? AND characteristics_en IS NULL`,
+        [JSON.stringify(chars), id],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (await this.columnExists(queryRunner, 'nilo_types', 'characteristics_en')) {
+      await queryRunner.query(`ALTER TABLE \`nilo_types\` DROP COLUMN \`characteristics_en\``);
+    }
+  }
+}

--- a/backend/src/modules/archives/archives.service.ts
+++ b/backend/src/modules/archives/archives.service.ts
@@ -26,7 +26,16 @@ export class ArchivesService {
   ) {}
 
   private applyLocaleToNiloType(entity: NiloType, locale?: string): NiloType {
-    return applyLocale(entity, locale, ['name', 'description']);
+    const localized = applyLocale(entity, locale, ['name', 'description', 'region']);
+    if (locale && locale !== 'ko') {
+      // nameKo 는 한글 고정 컬럼이므로 en 로케일에서는 name(localized)으로 override
+      if (localized.name) localized.nameKo = localized.name;
+      // characteristics 는 JSON 배열이므로 characteristicsEn 이 있으면 치환
+      if (entity.characteristicsEn && entity.characteristicsEn.length > 0) {
+        localized.characteristics = entity.characteristicsEn;
+      }
+    }
+    return localized;
   }
 
   private applyLocaleToProcessStep(entity: ProcessStep, locale?: string): ProcessStep {

--- a/backend/src/modules/archives/entities/archive.entity.ts
+++ b/backend/src/modules/archives/entities/archive.entity.ts
@@ -35,6 +35,9 @@ export class NiloType {
   @Column({ type: 'json' })
   characteristics!: string[];
 
+  @Column({ name: 'characteristics_en', type: 'json', nullable: true })
+  characteristicsEn!: string[] | null;
+
   @Column({ name: 'product_url', type: 'varchar', length: 500 })
   productUrl!: string;
 


### PR DESCRIPTION
## Summary
/en/archive 에서 nilo_types 의 'nameKo'(주니), 'region'(Fuchun (복건)), 'characteristics'(["적색~황갈색"...]) 가 한글로 노출되던 문제 해결.

- ArchivesService.applyLocaleToNiloType: region 을 locale 필드에 추가
- en 로케일에서 nameKo 를 name(localized) 로 override
- characteristics_en 컬럼 추가 및 6종 니료 특성 영어 백필 (마이그레이션 1778100000000)

## Test plan
- [x] 로컬 DB 마이그레이션 적용 완료
- [x] Backend build 성공
- [ ] 배포 후 /en/archive 에서 한글 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)