### PR TITLE
fix: Category 엔티티 descriptionEn 속성 추가

### DIFF
--- a/backend/src/modules/products/entities/category.entity.ts
+++ b/backend/src/modules/products/entities/category.entity.ts
@@ -46,6 +46,9 @@ export class Category {
   @Column({ type: 'text', nullable: true })
   description!: string | null;
 
+  @Column({ name: 'description_en', type: 'text', nullable: true })
+  descriptionEn!: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 


### PR DESCRIPTION
DB description_en 컬럼 값이 있었지만 엔티티 속성 누락으로 TypeORM 이 응답에 포함 안 시키던 버그 수정.