### PR TITLE
feat(backend): add ReorderItemsDto for reorder endpoints (Closes #331)

### DIFF
--- a/backend/src/modules/archives/__tests__/reorder.dto.spec.ts
+++ b/backend/src/modules/archives/__tests__/reorder.dto.spec.ts
@@ -1,0 +1,70 @@
+import { validate } from 'class-validator';
+import { IsInt, Min } from 'class-validator';
+import { ReorderItemDto, ReorderItemsDto } from '../dto/reorder.dto';
+
+describe('Reorder DTO', () => {
+  describe('ReorderItemDto', () => {
+    it('유효한 데이터로 통과', async () => {
+      const dto = new ReorderItemDto();
+      dto.id = 1;
+      dto.sortOrder = 0;
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('id가 정수가 아니면 실패', async () => {
+      const dto = new ReorderItemDto();
+      (dto as any).id = 'not-a-number';
+      dto.sortOrder = 0;
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('id');
+    });
+
+    it('sortOrder가 음수면 실패', async () => {
+      const dto = new ReorderItemDto();
+      dto.id = 1;
+      dto.sortOrder = -1;
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('sortOrder');
+    });
+  });
+
+  describe('ReorderItemsDto', () => {
+    it('유효한 orders 배열로 통과', async () => {
+      const dto = new ReorderItemsDto();
+      dto.orders = [
+        Object.assign(new ReorderItemDto(), { id: 1, sortOrder: 0 }),
+        Object.assign(new ReorderItemDto(), { id: 2, sortOrder: 1 }),
+      ];
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('orders가 배열이 아니면 실패', async () => {
+      const dto = new ReorderItemsDto();
+      (dto as any).orders = 'not-an-array';
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('orders');
+    });
+
+    it('orders가 비어있으면 통과 (빈 배열 허용)', async () => {
+      const dto = new ReorderItemsDto();
+      dto.orders = [];
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('orders 내 각 아이템이 유효하지 않으면 실패', async () => {
+      const dto = new ReorderItemsDto();
+      dto.orders = [
+        Object.assign(new ReorderItemDto(), { id: 1, sortOrder: 0 }),
+        Object.assign(new ReorderItemDto(), { id: 2, sortOrder: -1 }),
+      ];
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/backend/src/modules/archives/admin-archives.controller.ts
+++ b/backend/src/modules/archives/admin-archives.controller.ts
@@ -26,6 +26,7 @@ import {
   CreateArtistDto,
   UpdateArtistDto,
 } from './dto/archive.dto';
+import { ReorderItemsDto } from './dto/reorder.dto';
 import { Roles } from '../../common/decorators/roles.decorator';
 
 @ApiTags('관리자 - 아카이브')
@@ -72,8 +73,8 @@ export class AdminArchivesController {
   @ApiResponse({ status: 200, description: '이ilo 유형 순서 변경 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
-  async reorderNiloTypes(@Body() items: { id: number; sortOrder: number }[]) {
-    await this.archivesService.reorderNiloTypes(items);
+  async reorderNiloTypes(@Body() dto: ReorderItemsDto) {
+    await this.archivesService.reorderNiloTypes(dto.orders);
   }
 
   @Patch('nilo-types/:id')
@@ -202,8 +203,8 @@ export class AdminArchivesController {
   @ApiResponse({ status: 200, description: '작가 순서 변경 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
-  async reorderArtists(@Body() items: { id: number; sortOrder: number }[]) {
-    await this.archivesService.reorderArtists(items);
+  async reorderArtists(@Body() dto: ReorderItemsDto) {
+    await this.archivesService.reorderArtists(dto.orders);
   }
 
   @Patch('artists/:id')

--- a/backend/src/modules/archives/dto/reorder.dto.ts
+++ b/backend/src/modules/archives/dto/reorder.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, ValidateNested, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ReorderItemDto {
+  @ApiProperty({ example: 1, description: 'ID' })
+  @IsInt()
+  id!: number;
+
+  @ApiProperty({ example: 0, description: '정렬 순서' })
+  @IsInt()
+  @Min(0)
+  sortOrder!: number;
+}
+
+export class ReorderItemsDto {
+  @ApiProperty({ type: [ReorderItemDto], description: '정렬 순서 목록' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ReorderItemDto)
+  orders!: ReorderItemDto[];
+}

--- a/backend/src/modules/collections/__tests__/reorder.dto.spec.ts
+++ b/backend/src/modules/collections/__tests__/reorder.dto.spec.ts
@@ -1,0 +1,50 @@
+import { validate } from 'class-validator';
+import { ReorderItemDto, ReorderItemsDto } from '../dto/reorder.dto';
+
+describe('Reorder DTO (collections)', () => {
+  describe('ReorderItemDto', () => {
+    it('유효한 데이터로 통과', async () => {
+      const dto = new ReorderItemDto();
+      dto.id = 1;
+      dto.sortOrder = 0;
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('id가 정수가 아니면 실패', async () => {
+      const dto = new ReorderItemDto();
+      (dto as any).id = 'not-a-number';
+      dto.sortOrder = 0;
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('sortOrder가 음수면 실패', async () => {
+      const dto = new ReorderItemDto();
+      dto.id = 1;
+      dto.sortOrder = -5;
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ReorderItemsDto', () => {
+    it('유효한 orders 배열로 통과', async () => {
+      const dto = new ReorderItemsDto();
+      dto.orders = [
+        Object.assign(new ReorderItemDto(), { id: 1, sortOrder: 0 }),
+        Object.assign(new ReorderItemDto(), { id: 2, sortOrder: 1 }),
+        Object.assign(new ReorderItemDto(), { id: 3, sortOrder: 2 }),
+      ];
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('orders가 비어있으면 통과', async () => {
+      const dto = new ReorderItemsDto();
+      dto.orders = [];
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/backend/src/modules/collections/admin-collections.controller.ts
+++ b/backend/src/modules/collections/admin-collections.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/swagger';
 import { CollectionsService } from './collections.service';
 import { CreateCollectionDto, UpdateCollectionDto } from './dto/collection.dto';
+import { ReorderItemsDto } from './dto/reorder.dto';
 import { Roles } from '../../common/decorators/roles.decorator';
 
 @ApiTags('관리자 - 컬렉션')
@@ -65,8 +66,8 @@ export class AdminCollectionsController {
   @ApiResponse({ status: 200, description: '컬렉션 순서 변경 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
-  async reorder(@Body() items: { id: number; sortOrder: number }[]) {
-    await this.collectionsService.reorder(items);
+  async reorder(@Body() dto: ReorderItemsDto) {
+    await this.collectionsService.reorder(dto.orders);
   }
 
   @Patch(':id')

--- a/backend/src/modules/collections/dto/reorder.dto.ts
+++ b/backend/src/modules/collections/dto/reorder.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, ValidateNested, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ReorderItemDto {
+  @ApiProperty({ example: 1, description: 'ID' })
+  @IsInt()
+  id!: number;
+
+  @ApiProperty({ example: 0, description: '정렬 순서' })
+  @IsInt()
+  @Min(0)
+  sortOrder!: number;
+}
+
+export class ReorderItemsDto {
+  @ApiProperty({ type: [ReorderItemDto], description: '정렬 순서 목록' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ReorderItemDto)
+  orders!: ReorderItemDto[];
+}


### PR DESCRIPTION
## Summary
- Add `ReorderItemsDto` + `ReorderItemDto` DTO classes with `class-validator` decorators (`@IsInt`, `@Min(0)`, `@IsArray`, `@ValidateNested`)
- Replace inline `@Body() items: { id: number; sortOrder: number }[]` with typed DTO in archives controller (`reorderNiloTypes`, `reorderArtists`) and collections controller (`reorder`)
- ValidationPipe now applies proper validation to reorder body payloads

## Changed Files
| File | Change |
|------|--------|
| `backend/src/modules/archives/dto/reorder.dto.ts` | new — ReorderItemDto + ReorderItemsDto |
| `backend/src/modules/collections/dto/reorder.dto.ts` | new — ReorderItemDto + ReorderItemsDto |
| `backend/src/modules/archives/admin-archives.controller.ts` | use `ReorderItemsDto` for reorderNiloTypes, reorderArtists |
| `backend/src/modules/collections/admin-collections.controller.ts` | use `ReorderItemsDto` for reorder |
| `backend/src/modules/archives/__tests__/reorder.dto.spec.ts` | new — DTO unit tests |
| `backend/src/modules/collections/__tests__/reorder.dto.spec.ts` | new — DTO unit tests |

## Test Plan
- [x] `npm run build` — passes (nest build)
- [x] `npm run test -- --testPathPattern=reorder.dto` — 12 tests pass (valid/invalid id, sortOrder validation)
- [x] Pre-existing test failures (`categories.service.spec.ts`, `jwt.strategy.spec.ts`) unchanged — not caused by this PR

## Closes #331