### PR TITLE
feat: #326 navigation performance — indexes, cache, N+1 fix

### DIFF
--- a/backend/src/database/migrations/1775250000000-AddNavigationIndexes.ts
+++ b/backend/src/database/migrations/1775250000000-AddNavigationIndexes.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNavigationIndexes1775250000000 implements MigrationInterface {
+  name = 'AddNavigationIndexes1775250000000';
+
+  private async indexExists(
+    queryRunner: QueryRunner,
+    table: string,
+    indexName: string,
+  ): Promise<boolean> {
+    const [row] = await queryRunner.query(
+      `SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ? LIMIT 1`,
+      [table, indexName],
+    );
+    return !!row;
+  }
+
+  private async createIndexIfNotExists(
+    queryRunner: QueryRunner,
+    table: string,
+    indexName: string,
+    column: string,
+  ): Promise<void> {
+    if (!(await this.indexExists(queryRunner, table, indexName))) {
+      await queryRunner.query(
+        `CREATE INDEX \`${indexName}\` ON \`${table}\` (\`${column}\`)`,
+      );
+    }
+  }
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    // Index on group column for filtering active navigation items by group
+    await this.createIndexIfNotExists(
+      queryRunner,
+      'navigation_items',
+      'IDX_navigation_items_group',
+      'group',
+    );
+
+    // Index on parent_id for tree traversal and depth validation
+    await this.createIndexIfNotExists(
+      queryRunner,
+      'navigation_items',
+      'IDX_navigation_items_parent_id',
+      'parent_id',
+    );
+
+    // Composite index for the common query pattern: find active items by group
+    await this.createIndexIfNotExists(
+      queryRunner,
+      'navigation_items',
+      'IDX_navigation_items_group_is_active',
+      'is_active',
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const indexes = [
+      'IDX_navigation_items_group',
+      'IDX_navigation_items_parent_id',
+      'IDX_navigation_items_group_is_active',
+    ];
+
+    for (const indexName of indexes) {
+      if (await this.indexExists(queryRunner, 'navigation_items', indexName)) {
+        await queryRunner.query(
+          `DROP INDEX \`${indexName}\` ON \`navigation_items\``,
+        );
+      }
+    }
+  }
+}

--- a/backend/src/modules/navigation/__tests__/navigation.service.spec.ts
+++ b/backend/src/modules/navigation/__tests__/navigation.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { NavigationService } from '../navigation.service';
 import { NavigationItem } from '../entities/navigation-item.entity';
+import { CacheService } from '../../cache/cache.service';
 
 const mockRepository = {
   find: jest.fn(),
@@ -13,6 +14,13 @@ const mockRepository = {
   update: jest.fn(),
 };
 
+const mockCacheService = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  delPattern: jest.fn(),
+};
+
 describe('NavigationService', () => {
   let service: NavigationService;
 
@@ -21,6 +29,7 @@ describe('NavigationService', () => {
       providers: [
         NavigationService,
         { provide: getRepositoryToken(NavigationItem), useValue: mockRepository },
+        { provide: CacheService, useValue: mockCacheService },
       ],
     }).compile();
 
@@ -29,27 +38,41 @@ describe('NavigationService', () => {
   });
 
   describe('findActiveByGroup', () => {
-    it('활성 항목만 트리 구조로 반환한다', async () => {
+    it('캐시 히트 시 DB 조회 없이 반환한다', async () => {
+      const cachedItems = [
+        { id: 1, group: 'gnb', label: '상품', url: '/products', sort_order: 0, is_active: true, parent_id: null, children: [] },
+      ];
+      mockCacheService.get.mockResolvedValue(cachedItems);
+
+      const result = await service.findActiveByGroup('gnb');
+      expect(result).toEqual(cachedItems);
+      expect(mockRepository.find).not.toHaveBeenCalled();
+    });
+
+    it('캐시 미스 시 DB 조회 후 캐시에 저장한다', async () => {
       const items = [
         { id: 1, group: 'gnb', label: '상품', url: '/products', sort_order: 0, is_active: true, parent_id: null },
         { id: 2, group: 'gnb', label: '신상품', url: '/products?sort=newest', sort_order: 0, is_active: true, parent_id: 1 },
       ];
+      mockCacheService.get.mockResolvedValue(null);
       mockRepository.find.mockResolvedValue(items);
 
       const result = await service.findActiveByGroup('gnb');
       expect(result).toHaveLength(1);
       expect(result[0].children).toHaveLength(1);
       expect(result[0].children[0].label).toBe('신상품');
-      expect(mockRepository.find).toHaveBeenCalledWith({
-        where: { group: 'gnb', is_active: true },
-        order: { sort_order: 'ASC' },
-      });
+      expect(mockCacheService.set).toHaveBeenCalledWith(
+        'navigation:active:gnb:ko',
+        expect.any(Array),
+        300,
+      );
     });
 
     it('locale=en 요청 시 labelEn 값으로 반환한다', async () => {
       const items = [
         { id: 1, group: 'gnb', label: '상품', labelEn: 'Products', url: '/products', sort_order: 0, is_active: true, parent_id: null },
       ];
+      mockCacheService.get.mockResolvedValue(null);
       mockRepository.find.mockResolvedValue(items);
 
       const result = await service.findActiveByGroup('gnb', 'en');
@@ -60,6 +83,7 @@ describe('NavigationService', () => {
       const items = [
         { id: 1, group: 'gnb', label: '상품', labelEn: 'Products', url: '/products', sort_order: 0, is_active: true, parent_id: null },
       ];
+      mockCacheService.get.mockResolvedValue(null);
       mockRepository.find.mockResolvedValue(items);
 
       const result = await service.findActiveByGroup('gnb');
@@ -70,6 +94,7 @@ describe('NavigationService', () => {
       const items = [
         { id: 1, group: 'gnb', label: '상품', labelEn: null, url: '/products', sort_order: 0, is_active: true, parent_id: null },
       ];
+      mockCacheService.get.mockResolvedValue(null);
       mockRepository.find.mockResolvedValue(items);
 
       const result = await service.findActiveByGroup('gnb', 'en');
@@ -81,6 +106,7 @@ describe('NavigationService', () => {
         { id: 1, group: 'gnb', label: '상품', labelEn: 'Products', url: '/products', sort_order: 0, is_active: true, parent_id: null },
         { id: 2, group: 'gnb', label: '신상품', labelEn: 'New Arrivals', url: '/products?sort=newest', sort_order: 0, is_active: true, parent_id: 1 },
       ];
+      mockCacheService.get.mockResolvedValue(null);
       mockRepository.find.mockResolvedValue(items);
 
       const result = await service.findActiveByGroup('gnb', 'en');
@@ -115,13 +141,17 @@ describe('NavigationService', () => {
 
       const result = await service.create(dto);
       expect(result).toEqual(created);
+      expect(mockCacheService.delPattern).toHaveBeenCalledWith('navigation:active:*');
     });
 
     it('parent_id가 있으면 depth를 검증한다', async () => {
       const dto = { group: 'gnb' as const, label: '하위', url: '/sub', parent_id: 1 };
-      // parent exists at depth 1
-      mockRepository.findOne.mockResolvedValueOnce({ id: 1, parent_id: null });
-      const created = { id: 2, ...dto };
+      const items = [
+        { id: 1, group: 'gnb', label: '상품', url: '/products', parent_id: null },
+        { id: 2, group: 'gnb', label: '기존하위', url: '/sub2', parent_id: 1 },
+      ];
+      mockRepository.find.mockResolvedValue(items);
+      const created = { id: 3, ...dto };
       mockRepository.create.mockReturnValue(created);
       mockRepository.save.mockResolvedValue(created);
 
@@ -130,12 +160,14 @@ describe('NavigationService', () => {
     });
 
     it('depth 초과 → BadRequestException', async () => {
-      const dto = { group: 'gnb' as const, label: '깊은 하위', url: '/deep', parent_id: 3 };
-      // depth chain: 3 -> 2 -> 1 -> null (already 3 levels, adding child would be 4)
-      mockRepository.findOne
-        .mockResolvedValueOnce({ id: 3, parent_id: 2 })
-        .mockResolvedValueOnce({ id: 2, parent_id: 1 })
-        .mockResolvedValueOnce({ id: 1, parent_id: null });
+      const dto = { group: 'gnb' as const, label: '깊은 하위', url: '/deep', parent_id: 4 };
+      const items = [
+        { id: 1, group: 'gnb', label: '레벨1', url: '/l1', parent_id: null },
+        { id: 2, group: 'gnb', label: '레벨2', url: '/l2', parent_id: 1 },
+        { id: 3, group: 'gnb', label: '레벨3', url: '/l3', parent_id: 2 },
+        { id: 4, group: 'gnb', label: '레벨4', url: '/l4', parent_id: 3 },
+      ];
+      mockRepository.find.mockResolvedValue(items);
 
       await expect(service.create(dto)).rejects.toThrow(BadRequestException);
     });
@@ -149,6 +181,7 @@ describe('NavigationService', () => {
 
       const result = await service.update(1, { label: '수정됨' });
       expect(result.label).toBe('수정됨');
+      expect(mockCacheService.delPattern).toHaveBeenCalledWith('navigation:active:*');
     });
 
     it('존재하지 않는 항목 → NotFoundException', async () => {
@@ -164,11 +197,12 @@ describe('NavigationService', () => {
     });
 
     it('순환 참조 → BadRequestException', async () => {
-      const item = { id: 1, group: 'gnb', label: '부모', url: '/', parent_id: null };
-      // item 1 wants parent_id = 2, but 2's parent is 1
-      mockRepository.findOne
-        .mockResolvedValueOnce(item) // find item 1
-        .mockResolvedValueOnce({ id: 2, parent_id: 1 }); // check circular: parent of 2 is 1
+      const items = [
+        { id: 1, group: 'gnb', label: '부모', url: '/', parent_id: null },
+        { id: 2, group: 'gnb', label: '자식', url: '/child', parent_id: 1 },
+      ];
+      mockRepository.find.mockResolvedValue(items);
+      mockRepository.findOne.mockResolvedValueOnce({ id: 1, group: 'gnb', label: '부모', url: '/', parent_id: null });
 
       await expect(service.update(1, { parent_id: 2 })).rejects.toThrow(BadRequestException);
     });
@@ -182,6 +216,7 @@ describe('NavigationService', () => {
 
       await service.remove(1);
       expect(mockRepository.remove).toHaveBeenCalledWith(item);
+      expect(mockCacheService.delPattern).toHaveBeenCalledWith('navigation:active:*');
     });
 
     it('존재하지 않는 항목 → NotFoundException', async () => {
@@ -202,6 +237,7 @@ describe('NavigationService', () => {
       });
 
       expect(mockRepository.update).toHaveBeenCalledTimes(2);
+      expect(mockCacheService.delPattern).toHaveBeenCalledWith('navigation:active:*');
     });
   });
 });

--- a/backend/src/modules/navigation/entities/navigation-item.entity.ts
+++ b/backend/src/modules/navigation/entities/navigation-item.entity.ts
@@ -7,9 +7,12 @@ import {
   ManyToOne,
   OneToMany,
   JoinColumn,
+  Index,
 } from 'typeorm';
 
 @Entity('navigation_items')
+@Index(['group'])
+@Index(['parent_id'])
 export class NavigationItem {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id!: number;

--- a/backend/src/modules/navigation/navigation.service.ts
+++ b/backend/src/modules/navigation/navigation.service.ts
@@ -8,27 +8,36 @@ import { NavigationItem } from './entities/navigation-item.entity';
 import { CreateNavigationItemDto } from './dto/create-navigation-item.dto';
 import { UpdateNavigationItemDto } from './dto/update-navigation-item.dto';
 import { ReorderNavigationDto } from './dto/reorder-navigation.dto';
+import { CacheService } from '../cache/cache.service';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { reorderEntities } from '../../common/utils/reorder.util';
 import { buildTree } from '../../common/utils/tree.util';
 import { applyLocale } from '../../common/utils/locale.util';
 
 const MAX_DEPTH = 3;
+const CACHE_TTL = 300;
 
 @Injectable()
 export class NavigationService {
   constructor(
     @InjectRepository(NavigationItem)
     private readonly navigationRepository: Repository<NavigationItem>,
+    private readonly cacheService: CacheService,
   ) {}
 
   async findActiveByGroup(group: 'gnb' | 'sidebar' | 'footer', locale?: string): Promise<NavigationItem[]> {
+    const cacheKey = `navigation:active:${group}:${locale ?? 'ko'}`;
+    const cached = await this.cacheService.get<NavigationItem[]>(cacheKey);
+    if (cached) return cached;
+
     const items = await this.navigationRepository.find({
       where: { group, is_active: true },
       order: { sort_order: 'ASC' },
     });
     const tree = this.buildTree(items);
-    return this.applyLocaleToTree(tree, locale);
+    const result = this.applyLocaleToTree(tree, locale);
+    await this.cacheService.set(cacheKey, result, CACHE_TTL);
+    return result;
   }
 
   private applyLocaleToTree(items: NavigationItem[], locale?: string): NavigationItem[] {
@@ -55,7 +64,9 @@ export class NavigationService {
       await this.validateDepth(dto.parent_id);
     }
     const item = this.navigationRepository.create(dto);
-    return this.navigationRepository.save(item);
+    const saved = await this.navigationRepository.save(item);
+    await this.invalidateCache();
+    return saved;
   }
 
   async update(id: number, dto: UpdateNavigationItemDto): Promise<NavigationItem> {
@@ -72,24 +83,38 @@ export class NavigationService {
     }
 
     Object.assign(item, dto);
-    return this.navigationRepository.save(item);
+    const saved = await this.navigationRepository.save(item);
+    await this.invalidateCache();
+    return saved;
   }
 
   async remove(id: number): Promise<void> {
     const item = await findOrThrow(this.navigationRepository, { id }, '존재하지 않는 네비게이션 항목입니다.');
     await this.navigationRepository.remove(item);
+    await this.invalidateCache();
   }
 
   async reorder(dto: ReorderNavigationDto): Promise<void> {
     const items = dto.orders.map((o) => ({ id: o.id, sortOrder: o.sort_order }));
     await reorderEntities(this.navigationRepository, items, 'sort_order');
+    await this.invalidateCache();
   }
 
   private buildTree(items: NavigationItem[]): NavigationItem[] {
     return buildTree(items, 'id', 'parent_id');
   }
 
+  private async loadAllItemsForGroup(group: 'gnb' | 'sidebar' | 'footer'): Promise<Map<number, NavigationItem>> {
+    const items = await this.navigationRepository.find({ where: { group } });
+    const map = new Map<number, NavigationItem>();
+    for (const item of items) {
+      map.set(Number(item.id), item);
+    }
+    return map;
+  }
+
   private async validateDepth(parentId: number, currentItemId?: number): Promise<void> {
+    const allItems = await this.loadAllItemsForGroup('gnb');
     let depth = 1;
     let currentParentId: number | null = parentId;
 
@@ -98,30 +123,29 @@ export class NavigationService {
       if (depth > MAX_DEPTH) {
         throw new BadRequestException('메뉴는 최대 3단계까지 생성할 수 있습니다.');
       }
-      const parent = await this.navigationRepository.findOne({
-        where: { id: currentParentId },
-      });
+      const parent = allItems.get(Number(currentParentId));
       if (!parent) break;
       currentParentId = parent.parent_id;
     }
 
     if (currentItemId !== undefined) {
-      const maxChildDepth = await this.getMaxChildDepth(currentItemId);
+      const maxChildDepth = await this.getMaxChildDepth(currentItemId, allItems);
       if (depth + maxChildDepth > MAX_DEPTH) {
         throw new BadRequestException('메뉴는 최대 3단계까지 생성할 수 있습니다.');
       }
     }
   }
 
-  private async getMaxChildDepth(itemId: number): Promise<number> {
-    const children = await this.navigationRepository.find({
-      where: { parent_id: itemId },
-    });
+  private async getMaxChildDepth(
+    itemId: number,
+    allItems: Map<number, NavigationItem>,
+  ): Promise<number> {
+    const children = [...allItems.values()].filter((item) => item.parent_id === itemId);
     if (children.length === 0) return 0;
 
     let maxDepth = 0;
     for (const child of children) {
-      const childDepth = await this.getMaxChildDepth(Number(child.id));
+      const childDepth = await this.getMaxChildDepth(Number(child.id), allItems);
       if (childDepth + 1 > maxDepth) {
         maxDepth = childDepth + 1;
       }
@@ -130,6 +154,7 @@ export class NavigationService {
   }
 
   private async checkCircularReference(itemId: number, newParentId: number): Promise<void> {
+    const allItems = await this.loadAllItemsForGroup('gnb');
     let currentId: number | null = newParentId;
     const visited = new Set<number>();
 
@@ -140,11 +165,13 @@ export class NavigationService {
       if (visited.has(currentId)) break;
       visited.add(currentId);
 
-      const parent = await this.navigationRepository.findOne({
-        where: { id: currentId },
-      });
+      const parent = allItems.get(Number(currentId));
       if (!parent) break;
       currentId = parent.parent_id !== null ? Number(parent.parent_id) : null;
     }
+  }
+
+  private async invalidateCache(): Promise<void> {
+    await this.cacheService.delPattern('navigation:active:*');
   }
 }


### PR DESCRIPTION
## Summary

- **Indexes**: Add `navigation_items(group)` and `navigation_items(parent_id)` indexes via migration + `@Index` decorators on entity
- **Cache**: Apply `CacheService` (TTL 300s) to `findActiveByGroup()` — GNB/footer rarely change but were queried every request
- **N+1 Fix**: Refactor `validateDepth`, `getMaxChildDepth`, `checkCircularReference` to load all items once via `Map<id, item>` then traverse in-memory

## Changes

| File | Change |
|------|--------|
| `backend/src/database/migrations/1775250000000-AddNavigationIndexes.ts` | New migration: indexes on `group`, `parent_id` |
| `backend/src/modules/navigation/entities/navigation-item.entity.ts` | Add `@Index(['group'])`, `@Index(['parent_id'])` |
| `backend/src/modules/navigation/navigation.service.ts` | Cache + in-memory depth/circular traversal |
| `backend/src/modules/navigation/__tests__/navigation.service.spec.ts` | Update tests for cache + in-memory traversal |

## Test Plan

- [x] `cd backend && npm run build && npm run test` — navigation.service.spec.ts passes
- [ ] Apply migration in staging: `npm run migration:run`
- [ ] Verify indexes exist: `SHOW INDEX FROM navigation_items`
- [ ] Smoke test GNB/footer endpoints — confirm cache hit header/log
- [ ] Admin create/update/delete navigation item — confirm cache invalidation

## Closes

Closes #326