### PR TITLE
fix: explicit Promise<T> return types on 11 public async methods (#330)

### DIFF
--- a/backend/src/modules/admin/admin-members.service.ts
+++ b/backend/src/modules/admin/admin-members.service.ts
@@ -9,7 +9,7 @@ import { Repository } from 'typeorm';
 import { User, UserRole } from '../users/entities/user.entity';
 import { AdminMembersQueryDto } from './dto/admin-members-query.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
-import { paginate } from '../../common/utils/pagination.util';
+import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
 
 export interface SafeUser {
   id: number;
@@ -44,7 +44,7 @@ export class AdminMembersService {
     private readonly userRepository: Repository<User>,
   ) {}
 
-  async findAll(query: AdminMembersQueryDto) {
+  async findAll(query: AdminMembersQueryDto): Promise<PaginatedResult<SafeUser>> {
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
 

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -10,7 +10,7 @@ import { Shipping, ShippingStatus } from '../payments/entities/shipping.entity';
 import { AdminOrderQueryDto } from './dto/admin-order-query.dto';
 import { RegisterShippingDto } from './dto/register-shipping.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
-import { paginate } from '../../common/utils/pagination.util';
+import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
 
 const ALLOWED_ORDER_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   [OrderStatus.PENDING]: [OrderStatus.PAID],
@@ -35,7 +35,7 @@ export class AdminOrdersService {
     private readonly shippingRepository: Repository<Shipping>,
   ) {}
 
-  async findAll(query: AdminOrderQueryDto) {
+  async findAll(query: AdminOrderQueryDto): Promise<PaginatedResult<Order>> {
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
 
@@ -67,7 +67,7 @@ export class AdminOrdersService {
     return paginate(qb, { page, limit });
   }
 
-  async updateStatus(orderId: number, nextStatus: OrderStatus) {
+  async updateStatus(orderId: number, nextStatus: OrderStatus): Promise<Order | null> {
     const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
 
     const currentStatus = order.status;
@@ -107,7 +107,7 @@ export class AdminOrdersService {
     });
   }
 
-  async registerShipping(orderId: number, dto: RegisterShippingDto) {
+  async registerShipping(orderId: number, dto: RegisterShippingDto): Promise<Shipping | null> {
     await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
 
     const existing = await this.shippingRepository.findOne({ where: { orderId } });

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -43,7 +43,14 @@ export class PaymentsService {
     return this.gateway;
   }
 
-  async prepare(dto: PreparePaymentDto, userId: number) {
+  async prepare(dto: PreparePaymentDto, userId: number): Promise<{
+    paymentId: number;
+    orderId: number;
+    orderNumber: string;
+    amount: number;
+    gateway: string;
+    clientKey: string;
+  }> {
     const order = await findOrThrow(this.orderRepository, { id: dto.orderId }, '주문을 찾을 수 없습니다.');
     assertOwnership(order.userId, userId);
     if (order.status !== OrderStatus.PENDING) {
@@ -77,7 +84,15 @@ export class PaymentsService {
     };
   }
 
-  async confirm(dto: ConfirmPaymentDto, userId: number) {
+  async confirm(dto: ConfirmPaymentDto, userId: number): Promise<{
+    paymentId: number;
+    orderId: number;
+    orderNumber: string;
+    status: PaymentStatus;
+    method: string;
+    amount: number;
+    paidAt: Date;
+  }> {
     const payment = await findOrThrow(this.paymentRepository, { orderId: dto.orderId }, '결제 정보를 찾을 수 없습니다.', ['order']);
     assertOwnership(payment.order.userId, userId);
 
@@ -134,7 +149,12 @@ export class PaymentsService {
     }
   }
 
-  async cancel(dto: CancelPaymentDto, userId: number) {
+  async cancel(dto: CancelPaymentDto, userId: number): Promise<{
+    paymentId: number;
+    status: PaymentStatus;
+    cancelledAt: Date;
+    cancelReason: string;
+  }> {
     const payment = await findOrThrow(this.paymentRepository, { orderId: dto.orderId }, '결제 정보를 찾을 수 없습니다.', ['order']);
     assertOwnership(payment.order.userId, userId);
 

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -36,7 +36,16 @@ export class ShippingService {
     this.mockAdapter = new MockShippingAdapter();
   }
 
-  async getByOrderId(orderId: number, userId: number) {
+  async getByOrderId(orderId: number, userId: number): Promise<{
+    id: number;
+    order_id: number;
+    carrier: string | null;
+    tracking_number: string | null;
+    status: ShippingStatus;
+    shipped_at: Date | null;
+    delivered_at: Date | null;
+    tracking: TrackingResult | null;
+  }> {
     const order = await findOrThrow(this.orderRepository, { id: orderId }, '배송 정보를 찾을 수 없습니다.');
     assertOwnership(order.userId, userId);
 
@@ -66,7 +75,12 @@ export class ShippingService {
     };
   }
 
-  async track(dto: TrackShipmentDto) {
+  async track(dto: TrackShipmentDto): Promise<{
+    carrier: string;
+    trackingNumber: string;
+    status: string;
+    steps: unknown[];
+  }> {
     try {
       const result = await this.mockAdapter.getTrackingStatus(dto.trackingNumber, dto.carrier);
       return {
@@ -80,7 +94,7 @@ export class ShippingService {
     }
   }
 
-  async registerTracking(orderId: number, dto: RegisterTrackingDto) {
+  async registerTracking(orderId: number, dto: RegisterTrackingDto): Promise<Shipping | null> {
     await findOrThrow(this.orderRepository, { id: orderId }, '주문 정보를 찾을 수 없습니다.');
 
     const shipping = await findOrThrow(this.shippingRepository, { orderId }, '배송 정보를 찾을 수 없습니다.');


### PR DESCRIPTION
## Summary
- Add explicit Promise<T> return types to all 11 public async methods across 4 backend services
- No behavioral changes — only type annotations added

## Changes
| Service | Methods |
|---------|---------|
| AdminOrdersService | findAll, updateStatus, registerShipping |
| AdminMembersService | findAll |
| PaymentsService | prepare, confirm, cancel |
| ShippingService | getByOrderId, track, registerTracking |

## Verification
- Build: cd backend && npx nest build passed
- Tests: 39/41 suites passed (2 pre-existing failures: categories.service.spec.ts and jwt.strategy.spec.ts, both pre-existing)

Closes #330