### PR TITLE
fix(cache): resolve issue #328 - non-blocking delPattern (Redis removed)

### DIFF
--- a/backend/src/modules/cache/cache.service.ts
+++ b/backend/src/modules/cache/cache.service.ts
@@ -28,6 +28,11 @@ export class CacheService {
     this.store.delete(key);
   }
 
+  /**
+   * Deletes all keys matching the given glob pattern.
+   * Uses regex-based iteration over an in-memory Map — non-blocking, no Redis KEYS command.
+   * Resolves issue #328: replaced blocking Redis KEYS O(N) scan with non-blocking Map iteration.
+   */
   async delPattern(pattern: string): Promise<void> {
     const regex = new RegExp('^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$');
     for (const key of this.store.keys()) {


### PR DESCRIPTION
## Summary

- Resolves issue #328: CacheService.delPattern was using Redis KEYS command which is O(N) blocking
- The Redis dependency was removed entirely (commit 9eb6c073), migrating to an in-memory Map-based CacheService
- delPattern now uses regex-based iteration over the in-memory Map, which is non-blocking

## Changes

| File | Change |
|------|--------|
| backend/src/modules/cache/cache.service.ts | Added JSDoc to delPattern documenting the fix and linking to issue #328 |

## Architecture Decision

The blocking KEYS problem no longer applies because:
1. No Redis client is used - CacheService uses an in-memory Map
2. delPattern iterates over Map.keys() with regex matching - no external service call, no event loop blocking
3. This is the correct pattern for the current architecture (in-memory caching as documented in README)

## Test Plan

- npm run build - passes
- npm run test - cache service tests pass (cache.service.spec.ts - 5 tests)
- Existing delPattern tests verify glob pattern matching (products:* style)

Closes #328