### PR TITLE
refactor: replace magic literals with enums/constants (#334)

### DIFF
--- a/backend/src/modules/coupons/coupons.service.ts
+++ b/backend/src/modules/coupons/coupons.service.ts
@@ -64,6 +64,7 @@ export interface PointsResponse {
 }
 
 const SHIPPING_FEE = 3000;
+const FREE_SHIPPING_THRESHOLD = 30000;
 
 @Injectable()
 export class CouponsService {
@@ -166,7 +167,7 @@ export class CouponsService {
 
     const pointsDiscount = Math.min(pointsToUse, orderAmount - couponDiscount);
     const afterDiscount = Math.max(0, orderAmount - couponDiscount - pointsDiscount);
-    const shippingFee = afterDiscount >= 30000 ? 0 : SHIPPING_FEE;
+    const shippingFee = afterDiscount >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_FEE;
     const finalAmount = afterDiscount;
     const totalPayable = Math.max(0, finalAmount + shippingFee);
 

--- a/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
+++ b/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
@@ -3,7 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { InquiriesService } from '../inquiries.service';
-import { Inquiry } from '../entities/inquiry.entity';
+import { Inquiry, InquiryType, InquiryStatus } from '../entities/inquiry.entity';
 
 const mockRepo = () => ({
   createQueryBuilder: jest.fn(),
@@ -34,8 +34,8 @@ describe('InquiriesService', () => {
 
   describe('create', () => {
     it('문의 작성 성공', async () => {
-      const dto = { type: '상품' as const, title: '문의 제목', content: '내용' };
-      const created = { id: 1, userId: 10, status: 'pending', ...dto };
+      const dto = { type: InquiryType.PRODUCT, title: '문의 제목', content: '내용' };
+      const created = { id: 1, userId: 10, status: InquiryStatus.PENDING, ...dto };
       repo.create.mockReturnValue(created as never);
       repo.save.mockResolvedValue(created as never);
 
@@ -61,12 +61,12 @@ describe('InquiriesService', () => {
 
   describe('answer', () => {
     it('답변 작성 → status answered 변경', async () => {
-      const inquiry = { id: 1, status: 'pending', answer: null } as Inquiry;
+      const inquiry = { id: 1, status: InquiryStatus.PENDING, answer: null } as Inquiry;
       repo.findOne.mockResolvedValue(inquiry);
-      repo.save.mockResolvedValue({ ...inquiry, status: 'answered', answer: '답변 내용' } as never);
+      repo.save.mockResolvedValue({ ...inquiry, status: InquiryStatus.ANSWERED, answer: '답변 내용' } as never);
 
       const result = await service.answerInquiry(1, { answer: '답변 내용' });
-      expect(result.status).toBe('answered');
+      expect(result.status).toBe(InquiryStatus.ANSWERED);
       expect(result.answer).toBe('답변 내용');
     });
   });

--- a/backend/src/modules/inquiries/dto/create-inquiry.dto.ts
+++ b/backend/src/modules/inquiries/dto/create-inquiry.dto.ts
@@ -3,8 +3,8 @@ import { IsString, IsNotEmpty, IsEnum, MaxLength } from 'class-validator';
 import { InquiryType } from '../entities/inquiry.entity';
 
 export class CreateInquiryDto {
-  @ApiProperty({ example: '상품', enum: ['상품', '배송', '결제', '교환/반품', '기타'], description: '문의 유형' })
-  @IsEnum(['상품', '배송', '결제', '교환/반품', '기타'])
+  @ApiProperty({ example: InquiryType.PRODUCT, enum: InquiryType, description: '문의 유형' })
+  @IsEnum(InquiryType)
   type!: InquiryType;
 
   @ApiProperty({ example: '이 상품의 원산지가 어디인가요?', description: '문의 제목' })

--- a/backend/src/modules/inquiries/entities/inquiry.entity.ts
+++ b/backend/src/modules/inquiries/entities/inquiry.entity.ts
@@ -9,8 +9,18 @@ import {
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
-export type InquiryType = '상품' | '배송' | '결제' | '교환/반품' | '기타';
-export type InquiryStatus = 'pending' | 'answered';
+export enum InquiryType {
+  PRODUCT = '상품',
+  DELIVERY = '배송',
+  PAYMENT = '결제',
+  EXCHANGE_RETURN = '교환/반품',
+  OTHER = '기타',
+}
+
+export enum InquiryStatus {
+  PENDING = 'pending',
+  ANSWERED = 'answered',
+}
 
 @Entity('inquiries')
 export class Inquiry {
@@ -20,7 +30,7 @@ export class Inquiry {
   @Column({ name: 'user_id', type: 'bigint' })
   userId!: number;
 
-  @Column({ type: 'enum', enum: ['상품', '배송', '결제', '교환/반품', '기타'] })
+  @Column({ type: 'enum', enum: InquiryType })
   type!: InquiryType;
 
   @Column({ type: 'varchar', length: 255 })
@@ -29,7 +39,7 @@ export class Inquiry {
   @Column({ type: 'longtext' })
   content!: string;
 
-  @Column({ type: 'enum', enum: ['pending', 'answered'], default: 'pending' })
+  @Column({ type: 'enum', enum: InquiryStatus, default: InquiryStatus.PENDING })
   status!: InquiryStatus;
 
   @Column({ type: 'longtext', nullable: true })

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -4,7 +4,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Inquiry } from './entities/inquiry.entity';
+import { Inquiry, InquiryStatus } from './entities/inquiry.entity';
 import { CreateInquiryDto } from './dto/create-inquiry.dto';
 import { AnswerInquiryDto } from './dto/answer-inquiry.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
@@ -54,7 +54,7 @@ export class InquiriesService {
   async answerInquiry(id: number, dto: AnswerInquiryDto): Promise<Inquiry> {
     const inquiry = await findOrThrow(this.inquiryRepo, { id }, '문의를 찾을 수 없습니다.');
     inquiry.answer = dto.answer;
-    inquiry.status = 'answered';
+    inquiry.status = InquiryStatus.ANSWERED;
     inquiry.answeredAt = new Date();
     const saved = await this.inquiryRepo.save(inquiry);
     this.logger.log(`Inquiry answered: id=${id}`);

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -18,6 +18,8 @@ import { resolveGatewayByLocale } from './payments.module';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { findOrThrow } from '../../common/utils/repository.util';
 
+const DEFAULT_CARRIER = process.env.DEFAULT_CARRIER || 'mock';
+
 @Injectable()
 export class PaymentsService {
   private readonly logger = new Logger(PaymentsService.name);
@@ -110,7 +112,7 @@ export class PaymentsService {
         await this.shippingRepository.save(
           this.shippingRepository.create({
             orderId: dto.orderId,
-            carrier: 'mock',
+            carrier: DEFAULT_CARRIER,
             status: ShippingStatus.PAYMENT_CONFIRMED,
           }),
         );

--- a/backend/src/modules/search/search.controller.ts
+++ b/backend/src/modules/search/search.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Public } from '../../common/decorators/public.decorator';
 
+const POPULAR_SEARCH_KEYWORDS = ['자사호', '보이차', '다구', '찻잔', '개완', '숙차', '생차', '다반'] as const;
+
 @ApiTags('검색')
 @Controller('search')
 export class SearchController {
@@ -9,7 +11,7 @@ export class SearchController {
   @Public()
   @ApiOperation({ summary: '인기 검색어 조회', description: '현재 인기 있는 검색어 목록을 조회합니다.' })
   @ApiResponse({ status: 200, description: '인기 검색어 조회 성공' })
-  popular(): { keywords: string[] } {
-    return { keywords: ['자사호', '보이차', '다구', '찻잔', '개완', '숙차', '생차', '다반'] };
+  popular(): { keywords: readonly string[] } {
+    return { keywords: POPULAR_SEARCH_KEYWORDS };
   }
 }


### PR DESCRIPTION
## Summary
Replace magic literals with proper enums/constants for maintainability.

## Changes

### 1. InquiryStatus/InquiryType Enums
- Converted string union types to actual enums
- Updated entity columns to use enum references
- Service uses InquiryStatus.ANSWERED instead of 'answered' string

### 2. FREE_SHIPPING_THRESHOLD Constant
- Extracted 30000 threshold to const

### 3. POPULAR_SEARCH_KEYWORDS Constant
- Extracted hardcoded keywords to const

### 4. DEFAULT_CARRIER Constant
- Added env-based constant with fallback

### 5. Test Updates
- Updated to use enum values

## Verification
- Build: passed
- Tests: 39 passed (2 pre-existing failures unrelated)

Closes #334