### PR TITLE
feat: #394 SEO 최적화 — 자사호 쇼핑몰 키워드 노출 강화

### DIFF
--- a/src/app/[locale]/products/[id]/page.tsx
+++ b/src/app/[locale]/products/[id]/page.tsx
@@ -68,6 +68,8 @@ export default async function ProductDetailPage({ params }: ProductDetailProps) 
     description: product.description,
     image: product.images?.map(img => img.url) ?? [],
     sku: product.sku,
+    brand: { '@type': 'Brand', name: '옥화당' },
+    url: `${SITE_URL}/${safeLocale}/products/${id}`,
     offers: {
       '@type': 'Offer',
       priceCurrency: 'KRW',

--- a/src/app/__tests__/seo.test.ts
+++ b/src/app/__tests__/seo.test.ts
@@ -18,13 +18,14 @@ describe('SEO', () => {
   });
 
   describe('robots.ts', () => {
-    it('disallows admin, my, checkout paths', () => {
+    it('disallows admin, my, checkout, api paths', () => {
       const result = robots();
       const rule = result.rules;
       const firstRule = Array.isArray(rule) ? rule[0] : rule;
       expect(firstRule.disallow).toContain('/admin/');
       expect(firstRule.disallow).toContain('/my/');
       expect(firstRule.disallow).toContain('/checkout/');
+      expect(firstRule.disallow).toContain('/api/');
     });
 
     it('allows root path', () => {
@@ -102,6 +103,8 @@ describe('SEO', () => {
         description: product.description,
         image: product.images?.map((img) => img.url) ?? [],
         sku: product.sku,
+        brand: { '@type': 'Brand', name: '옥화당' },
+        url: `https://ockhwadang.com/ko/products/${product.id}`,
         offers: {
           '@type': 'Offer',
           priceCurrency: 'KRW',
@@ -115,6 +118,8 @@ describe('SEO', () => {
       expect(jsonLd['@type']).toBe('Product');
       expect(jsonLd.name).toBe('Test Product');
       expect(jsonLd.sku).toBe('TEST-001');
+      expect(jsonLd.brand).toEqual({ '@type': 'Brand', name: '옥화당' });
+      expect(jsonLd.url).toBe('https://ockhwadang.com/ko/products/1');
       expect(jsonLd.offers.price).toBe(25000);
       expect(jsonLd.offers.priceCurrency).toBe('KRW');
       expect(jsonLd.offers.availability).toBe('https://schema.org/InStock');
@@ -125,6 +130,18 @@ describe('SEO', () => {
       const stock = 0;
       const availability = stock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock';
       expect(availability).toBe('https://schema.org/OutOfStock');
+    });
+  });
+
+  describe('root layout metadata', () => {
+    it('includes 자사호 keyword in default title and keywords', async () => {
+      const { metadata } = await import('@/app/layout');
+      const title = typeof metadata.title === 'object' && metadata.title !== null && 'default' in metadata.title
+        ? (metadata.title as { default: string }).default
+        : String(metadata.title);
+      expect(title).toContain('자사호');
+      expect(metadata.description).toContain('자사호');
+      expect(metadata.keywords).toEqual(expect.arrayContaining(['자사호', '보이차', '다구', '옥화당']));
     });
   });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,10 +4,11 @@ import { SITE_URL } from '@/lib/site-url';
 
 export const metadata: Metadata = {
   title: {
-    default: '옥화당',
+    default: '옥화당 - 자사호 전문 쇼핑몰',
     template: '%s | 옥화당',
   },
-  description: '자사호·보이차·다구 전문 쇼핑몰',
+  description: '옥화당은 자사호, 보이차, 다구 전문 브랜드입니다. 한국 전통차 문화를 다양한 자사호 제품과 함께 전해드립니다.',
+  keywords: ['자사호', '보이차', '다구', '한국차', '옥화당', '자사호 쇼핑몰', '차 도구', '전통차'],
   metadataBase: new URL(SITE_URL),
   openGraph: {
     siteName: '옥화당',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,7 +4,7 @@ import { SITE_URL } from '@/lib/site-url';
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
-      { userAgent: '*', allow: '/', disallow: ['/admin/', '/my/', '/checkout/'] },
+      { userAgent: '*', allow: '/', disallow: ['/admin/', '/my/', '/checkout/', '/api/'] },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,
   };


### PR DESCRIPTION
## Summary
- Closes #394
- 구글 검색에서 '자사호 쇼핑몰' 키워드로 옥화당 노출을 강화하기 위한 SEO 메타데이터/구조화 데이터 보강

## Changes
- **robots.ts**: `disallow` 목록에 `/api/` 추가 (크롤러 불필요 경로 탐색 방지)
- **layout.tsx**:
  - `title.default`: `옥화당` → `옥화당 - 자사호 전문 쇼핑몰` (브랜드+카테고리 키워드 결합)
  - `description`: 자사호/보이차/다구 키워드가 풍부한 문구로 확장
  - `keywords`: `['자사호', '보이차', '다구', '한국차', '옥화당', '자사호 쇼핑몰', '차 도구', '전통차']`
- **Product JSON-LD** (`[locale]/products/[id]/page.tsx`):
  - `brand`: `{ @type: 'Brand', name: '옥화당' }` 추가
  - `url`: canonical 상품 URL 추가 (Google Shopping Graph 식별자)
- **seo.test.ts**: 신규 필드/키워드 검증 테스트 보강

## 비고
- Search Console 사이트맵 제출 및 aggregateRating 적용은 이슈에 명시된 운영/후속 작업 (리뷰 집계 API 준비 후 추가 예정)
- sitemap.ts는 이미 정적 + 동적 상품 라우트 모두 생성 중 (변경 불필요)

## Test plan
- [x] `npm run build` — 성공
- [x] `npx vitest run src/app/__tests__/seo.test.ts` — 11/11 passed
- [x] robots.ts: `/api/` disallow 확인
- [x] layout.tsx metadata: 자사호 키워드 포함 검증
- [x] Product JSON-LD: brand, url 필드 검증