### PR TITLE
feat: #493 NotificationModule 신설 — 이메일 발송 서비스 도입

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,3 +60,11 @@ KAKAO_REDIRECT_URI=http://localhost:5173/auth/kakao/callback
 GOOGLE_CLIENT_ID=   # google oauth client id
 GOOGLE_CLIENT_SECRET=   # google oauth client secret
 GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
+
+# ─────────────────────────────────────────────
+# Notification / Email
+# 'mock' is blocked in production. Options: mock, resend, ses
+# ─────────────────────────────────────────────
+NOTIFICATION_PROVIDER=mock
+RESEND_API_KEY=
+EMAIL_FROM=no-reply@okhwadang.com

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -29,6 +29,7 @@ import { CollectionsModule } from './modules/collections/collections.module';
 import { ArchivesModule } from './modules/archives/archives.module';
 import { JournalModule } from './modules/journal/journal.module';
 import { PointsModule } from './modules/points/points.module';
+import { NotificationModule } from './modules/notification/notification.module';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 
@@ -83,6 +84,7 @@ import { RolesGuard } from './common/guards/roles.guard';
     ArchivesModule,
     JournalModule,
     PointsModule,
+    NotificationModule,
   ],
   providers: [
     // Guard execution order: ThrottlerGuard → JwtAuthGuard → RolesGuard

--- a/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
+++ b/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
@@ -4,6 +4,8 @@ import { Repository } from 'typeorm';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { InquiriesService } from '../inquiries.service';
 import { Inquiry, InquiryType, InquiryStatus } from '../entities/inquiry.entity';
+import { User } from '../../users/entities/user.entity';
+import { NotificationService } from '../../notification/notification.service';
 
 const mockRepo = () => ({
   createQueryBuilder: jest.fn(),
@@ -21,6 +23,8 @@ describe('InquiriesService', () => {
       providers: [
         InquiriesService,
         { provide: getRepositoryToken(Inquiry), useFactory: mockRepo },
+        { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
+        { provide: NotificationService, useValue: { sendInquiryAnswered: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/modules/inquiries/inquiries.module.ts
+++ b/backend/src/modules/inquiries/inquiries.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Inquiry } from './entities/inquiry.entity';
+import { User } from '../users/entities/user.entity';
 import { InquiriesController, AdminInquiriesController } from './inquiries.controller';
 import { InquiriesService } from './inquiries.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Inquiry])],
+  imports: [TypeOrmModule.forFeature([Inquiry, User])],
   controllers: [InquiriesController, AdminInquiriesController],
   providers: [InquiriesService],
   exports: [InquiriesService],

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -5,10 +5,12 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Inquiry, InquiryStatus } from './entities/inquiry.entity';
+import { User } from '../users/entities/user.entity';
 import { CreateInquiryDto } from './dto/create-inquiry.dto';
 import { AnswerInquiryDto } from './dto/answer-inquiry.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
+import { NotificationService } from '../notification/notification.service';
 
 @Injectable()
 export class InquiriesService {
@@ -17,6 +19,9 @@ export class InquiriesService {
   constructor(
     @InjectRepository(Inquiry)
     private readonly inquiryRepo: Repository<Inquiry>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    private readonly notificationService: NotificationService,
   ) {}
 
   async findAllByUser(userId: number): Promise<Inquiry[]> {
@@ -58,6 +63,27 @@ export class InquiriesService {
     inquiry.answeredAt = new Date();
     const saved = await this.inquiryRepo.save(inquiry);
     this.logger.log(`Inquiry answered: id=${id}`);
+
+    void this.notifyInquiryAnswered(saved.userId, saved.title, saved.answer ?? '');
+
     return saved;
+  }
+
+  private async notifyInquiryAnswered(
+    userId: number,
+    inquiryTitle: string,
+    answer: string,
+  ): Promise<void> {
+    try {
+      const user = await this.userRepo.findOne({ where: { id: userId } });
+      if (!user?.email) return;
+      await this.notificationService.sendInquiryAnswered(user.email, {
+        recipientName: user.name,
+        inquiryTitle,
+        answer,
+      });
+    } catch (err) {
+      this.logger.warn(`Inquiry answered email failed: ${String(err)}`);
+    }
   }
 }

--- a/backend/src/modules/notification/__tests__/notification.service.spec.ts
+++ b/backend/src/modules/notification/__tests__/notification.service.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationService, EMAIL_PROVIDER_TOKEN } from '../notification.service';
+import { MockEmailAdapter } from '../adapters/mock.adapter';
+import { sanitizeContext } from '../templates/sanitize';
+import {
+  renderInquiryAnswered,
+  renderOrderConfirmed,
+  renderPaymentConfirmed,
+  renderShippingUpdate,
+} from '../templates/render';
+
+describe('sanitizeContext', () => {
+  it('drops password-like keys from the context', () => {
+    const result = sanitizeContext({
+      name: 'Alice',
+      password: 'secret',
+      refreshToken: 'rt',
+      access_token: 'at',
+      order: { amount: 1000, cvv: '123' },
+    });
+    expect(result).toEqual({
+      name: 'Alice',
+      order: { amount: 1000 },
+    });
+  });
+
+  it('preserves Date values', () => {
+    const now = new Date();
+    const result = sanitizeContext({ when: now });
+    expect(result.when).toBe(now);
+  });
+});
+
+describe('render helpers', () => {
+  it('renders Korean order confirmation by default', () => {
+    const email = renderOrderConfirmed({
+      recipientName: '홍길동',
+      orderNumber: 'ORD-20260417-AB12CD34',
+      totalAmount: 15000,
+    });
+    expect(email.subject).toContain('옥화당');
+    expect(email.subject).toContain('ORD-20260417-AB12CD34');
+    expect(email.text).toContain('홍길동');
+    expect(email.html).toContain('<h2>');
+  });
+
+  it('renders English payment confirmation when locale is en', () => {
+    const email = renderPaymentConfirmed({
+      recipientName: 'Alice',
+      orderNumber: 'ORD-X',
+      amount: 1000,
+      method: 'card',
+      locale: 'en',
+    });
+    expect(email.subject).toContain('Okhwadang');
+    expect(email.text).toContain('Alice');
+  });
+
+  it('renders shipping update with carrier + tracking', () => {
+    const email = renderShippingUpdate({
+      recipientName: '홍길동',
+      orderNumber: 'ORD-Y',
+      carrier: 'cj',
+      trackingNumber: '1234567890',
+    });
+    expect(email.text).toContain('cj');
+    expect(email.text).toContain('1234567890');
+  });
+
+  it('renders inquiry answered with answer body', () => {
+    const email = renderInquiryAnswered({
+      recipientName: '홍길동',
+      inquiryTitle: '배송 문의',
+      answer: '내일 발송됩니다.',
+    });
+    expect(email.text).toContain('배송 문의');
+    expect(email.text).toContain('내일 발송됩니다.');
+  });
+
+  it('escapes HTML in user-supplied fields', () => {
+    const email = renderInquiryAnswered({
+      recipientName: '<script>alert(1)</script>',
+      inquiryTitle: 'hi',
+      answer: 'x',
+    });
+    expect(email.html).not.toContain('<script>');
+    expect(email.html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+  let mockAdapter: MockEmailAdapter;
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        MockEmailAdapter,
+        {
+          provide: EMAIL_PROVIDER_TOKEN,
+          useExisting: MockEmailAdapter,
+        },
+        NotificationService,
+      ],
+    }).compile();
+
+    service = moduleRef.get(NotificationService);
+    mockAdapter = moduleRef.get(MockEmailAdapter);
+    mockAdapter.clear();
+  });
+
+  it('sends order confirmation via the provider', async () => {
+    await service.sendOrderConfirmed('user@example.com', {
+      recipientName: '홍길동',
+      orderNumber: 'ORD-1',
+      totalAmount: 10000,
+    });
+    const sent = mockAdapter.getSent();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe('user@example.com');
+    expect(sent[0].subject).toContain('ORD-1');
+  });
+
+  it('skips send when recipient is empty', async () => {
+    await service.sendEmail({ to: '', subject: 's', html: 'h' });
+    expect(mockAdapter.getSent()).toHaveLength(0);
+  });
+
+  it('swallows provider errors (fire-and-forget)', async () => {
+    const failing = {
+      send: jest.fn().mockRejectedValue(new Error('boom')),
+    };
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: EMAIL_PROVIDER_TOKEN, useValue: failing },
+        NotificationService,
+      ],
+    }).compile();
+    const svc = moduleRef.get(NotificationService);
+    await expect(
+      svc.sendEmail({ to: 'x@y.z', subject: 's', html: 'h' }),
+    ).resolves.toBeUndefined();
+    expect(failing.send).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/notification/adapters/mock.adapter.ts
+++ b/backend/src/modules/notification/adapters/mock.adapter.ts
@@ -1,0 +1,26 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { EmailMessage, EmailProvider, EmailSendResult } from '../interfaces/email-provider.interface';
+
+@Injectable()
+export class MockEmailAdapter implements EmailProvider {
+  private readonly logger = new Logger(MockEmailAdapter.name);
+  private readonly sent: EmailMessage[] = [];
+
+  async send(message: EmailMessage): Promise<EmailSendResult> {
+    this.sent.push(message);
+    this.logger.log(`[MOCK EMAIL] to=${message.to} subject=${message.subject}`);
+    return {
+      messageId: `mock-${randomUUID()}`,
+      provider: 'mock',
+    };
+  }
+
+  getSent(): EmailMessage[] {
+    return [...this.sent];
+  }
+
+  clear(): void {
+    this.sent.length = 0;
+  }
+}

--- a/backend/src/modules/notification/adapters/resend.adapter.ts
+++ b/backend/src/modules/notification/adapters/resend.adapter.ts
@@ -1,0 +1,48 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EmailMessage, EmailProvider, EmailSendResult } from '../interfaces/email-provider.interface';
+
+@Injectable()
+export class ResendEmailAdapter implements EmailProvider {
+  private readonly logger = new Logger(ResendEmailAdapter.name);
+  private readonly apiKey: string;
+  private readonly fromAddress: string;
+
+  constructor() {
+    this.apiKey = process.env.RESEND_API_KEY ?? '';
+    this.fromAddress = process.env.EMAIL_FROM ?? 'no-reply@okhwadang.com';
+    if (!this.apiKey) {
+      this.logger.warn('RESEND_API_KEY not set — ResendEmailAdapter will fail on send.');
+    }
+  }
+
+  async send(message: EmailMessage): Promise<EmailSendResult> {
+    if (!this.apiKey) {
+      throw new Error('RESEND_API_KEY is not configured.');
+    }
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        from: this.fromAddress,
+        to: message.to,
+        subject: message.subject,
+        html: message.html,
+        text: message.text,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Resend API error: ${res.status} ${body}`);
+    }
+
+    const data = (await res.json()) as { id?: string };
+    return {
+      messageId: data.id ?? '',
+      provider: 'resend',
+    };
+  }
+}

--- a/backend/src/modules/notification/adapters/ses.adapter.ts
+++ b/backend/src/modules/notification/adapters/ses.adapter.ts
@@ -1,0 +1,23 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EmailMessage, EmailProvider, EmailSendResult } from '../interfaces/email-provider.interface';
+
+/**
+ * AWS SES stub adapter.
+ *
+ * Skeleton only — wire up `@aws-sdk/client-ses` when SES is selected in production.
+ * Kept as a stub to avoid adding a dependency until the provider is actually chosen.
+ */
+@Injectable()
+export class SesEmailAdapter implements EmailProvider {
+  private readonly logger = new Logger(SesEmailAdapter.name);
+
+  constructor() {
+    this.logger.warn(
+      'SesEmailAdapter is a stub. Install @aws-sdk/client-ses and implement send() before use.',
+    );
+  }
+
+  async send(_message: EmailMessage): Promise<EmailSendResult> {
+    throw new Error('SesEmailAdapter is not implemented. Configure Resend or provide an SES implementation.');
+  }
+}

--- a/backend/src/modules/notification/interfaces/email-provider.interface.ts
+++ b/backend/src/modules/notification/interfaces/email-provider.interface.ts
@@ -1,0 +1,15 @@
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export interface EmailSendResult {
+  messageId: string;
+  provider: string;
+}
+
+export interface EmailProvider {
+  send(message: EmailMessage): Promise<EmailSendResult>;
+}

--- a/backend/src/modules/notification/notification.module.ts
+++ b/backend/src/modules/notification/notification.module.ts
@@ -1,0 +1,51 @@
+import { Global, Module } from '@nestjs/common';
+import { NotificationService, EMAIL_PROVIDER_TOKEN } from './notification.service';
+import { MockEmailAdapter } from './adapters/mock.adapter';
+import { ResendEmailAdapter } from './adapters/resend.adapter';
+import { SesEmailAdapter } from './adapters/ses.adapter';
+
+export function resolveNotificationProvider(): string {
+  const provider = process.env.NOTIFICATION_PROVIDER ?? 'mock';
+  if (
+    process.env.NODE_ENV === 'production' &&
+    (provider === 'mock' || !process.env.NOTIFICATION_PROVIDER)
+  ) {
+    throw new Error(
+      'Mock notification provider는 프로덕션에서 사용할 수 없습니다. NOTIFICATION_PROVIDER 환경변수를 설정하세요.',
+    );
+  }
+  return provider;
+}
+
+@Global()
+@Module({
+  providers: [
+    MockEmailAdapter,
+    ResendEmailAdapter,
+    SesEmailAdapter,
+    {
+      provide: EMAIL_PROVIDER_TOKEN,
+      useFactory: (
+        mock: MockEmailAdapter,
+        resend: ResendEmailAdapter,
+        ses: SesEmailAdapter,
+      ) => {
+        const name = resolveNotificationProvider();
+        switch (name) {
+          case 'resend':
+            return resend;
+          case 'ses':
+            return ses;
+          case 'mock':
+            return mock;
+          default:
+            throw new Error(`Unknown NOTIFICATION_PROVIDER: ${name}`);
+        }
+      },
+      inject: [MockEmailAdapter, ResendEmailAdapter, SesEmailAdapter],
+    },
+    NotificationService,
+  ],
+  exports: [NotificationService],
+})
+export class NotificationModule {}

--- a/backend/src/modules/notification/notification.service.ts
+++ b/backend/src/modules/notification/notification.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { EmailMessage, EmailProvider } from './interfaces/email-provider.interface';
+import {
+  renderInquiryAnswered,
+  renderOrderConfirmed,
+  renderPaymentConfirmed,
+  renderShippingUpdate,
+  type InquiryAnsweredContext,
+  type OrderConfirmedContext,
+  type PaymentConfirmedContext,
+  type ShippingUpdateContext,
+} from './templates/render';
+
+export const EMAIL_PROVIDER_TOKEN = 'EmailProvider';
+
+/**
+ * NotificationService
+ *
+ * Fire-and-forget 이메일 발송. send failures are logged but never thrown —
+ * business flows (주문/결제/배송/문의 답변) must not break when the email
+ * provider is unavailable.
+ */
+@Injectable()
+export class NotificationService {
+  private readonly logger = new Logger(NotificationService.name);
+
+  constructor(
+    @Inject(EMAIL_PROVIDER_TOKEN)
+    private readonly provider: EmailProvider,
+  ) {}
+
+  async sendEmail(message: EmailMessage): Promise<void> {
+    if (!message.to) {
+      this.logger.warn('sendEmail called with empty recipient — skipped.');
+      return;
+    }
+    try {
+      const result = await this.provider.send(message);
+      this.logger.log(`Email sent: to=${message.to} messageId=${result.messageId} provider=${result.provider}`);
+    } catch (err) {
+      this.logger.error(`Failed to send email to ${message.to}: ${String(err)}`);
+    }
+  }
+
+  async sendOrderConfirmed(to: string, context: OrderConfirmedContext): Promise<void> {
+    const rendered = renderOrderConfirmed(context);
+    await this.sendEmail({ to, ...rendered });
+  }
+
+  async sendPaymentConfirmed(to: string, context: PaymentConfirmedContext): Promise<void> {
+    const rendered = renderPaymentConfirmed(context);
+    await this.sendEmail({ to, ...rendered });
+  }
+
+  async sendShippingUpdate(to: string, context: ShippingUpdateContext): Promise<void> {
+    const rendered = renderShippingUpdate(context);
+    await this.sendEmail({ to, ...rendered });
+  }
+
+  async sendInquiryAnswered(to: string, context: InquiryAnsweredContext): Promise<void> {
+    const rendered = renderInquiryAnswered(context);
+    await this.sendEmail({ to, ...rendered });
+  }
+}

--- a/backend/src/modules/notification/templates/render.ts
+++ b/backend/src/modules/notification/templates/render.ts
@@ -1,0 +1,93 @@
+import { escapeHtml, sanitizeContext } from './sanitize';
+
+export interface OrderConfirmedContext {
+  recipientName: string;
+  orderNumber: string;
+  totalAmount: number;
+  locale?: 'ko' | 'en';
+}
+
+export interface PaymentConfirmedContext {
+  recipientName: string;
+  orderNumber: string;
+  amount: number;
+  method: string;
+  locale?: 'ko' | 'en';
+}
+
+export interface ShippingUpdateContext {
+  recipientName: string;
+  orderNumber: string;
+  carrier: string;
+  trackingNumber: string;
+  locale?: 'ko' | 'en';
+}
+
+export interface InquiryAnsweredContext {
+  recipientName: string;
+  inquiryTitle: string;
+  answer: string;
+  locale?: 'ko' | 'en';
+}
+
+export interface RenderedEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+function formatKRW(amount: number): string {
+  return `${amount.toLocaleString('ko-KR')}원`;
+}
+
+export function renderOrderConfirmed(raw: OrderConfirmedContext): RenderedEmail {
+  const ctx = sanitizeContext(raw as unknown as Record<string, unknown>) as unknown as typeof raw;
+  const isKo = (ctx.locale ?? 'ko') === 'ko';
+  const subject = isKo
+    ? `[옥화당] 주문이 접수되었습니다 (${ctx.orderNumber})`
+    : `[Okhwadang] Order received (${ctx.orderNumber})`;
+  const text = isKo
+    ? `${ctx.recipientName}님, 주문 ${ctx.orderNumber}이(가) 접수되었습니다. 결제금액: ${formatKRW(ctx.totalAmount)}`
+    : `Hi ${ctx.recipientName}, your order ${ctx.orderNumber} has been received. Total: ${formatKRW(ctx.totalAmount)}`;
+  const html = `<div><h2>${escapeHtml(subject)}</h2><p>${escapeHtml(text)}</p></div>`;
+  return { subject, html, text };
+}
+
+export function renderPaymentConfirmed(raw: PaymentConfirmedContext): RenderedEmail {
+  const ctx = sanitizeContext(raw as unknown as Record<string, unknown>) as unknown as typeof raw;
+  const isKo = (ctx.locale ?? 'ko') === 'ko';
+  const subject = isKo
+    ? `[옥화당] 결제가 완료되었습니다 (${ctx.orderNumber})`
+    : `[Okhwadang] Payment confirmed (${ctx.orderNumber})`;
+  const text = isKo
+    ? `${ctx.recipientName}님, 주문 ${ctx.orderNumber}의 결제(${ctx.method})가 완료되었습니다. 금액: ${formatKRW(ctx.amount)}`
+    : `Hi ${ctx.recipientName}, payment for order ${ctx.orderNumber} via ${ctx.method} is confirmed. Amount: ${formatKRW(ctx.amount)}`;
+  const html = `<div><h2>${escapeHtml(subject)}</h2><p>${escapeHtml(text)}</p></div>`;
+  return { subject, html, text };
+}
+
+export function renderShippingUpdate(raw: ShippingUpdateContext): RenderedEmail {
+  const ctx = sanitizeContext(raw as unknown as Record<string, unknown>) as unknown as typeof raw;
+  const isKo = (ctx.locale ?? 'ko') === 'ko';
+  const subject = isKo
+    ? `[옥화당] 배송이 시작되었습니다 (${ctx.orderNumber})`
+    : `[Okhwadang] Shipment started (${ctx.orderNumber})`;
+  const text = isKo
+    ? `${ctx.recipientName}님, 주문 ${ctx.orderNumber}이(가) 발송되었습니다. 택배사: ${ctx.carrier}, 송장번호: ${ctx.trackingNumber}`
+    : `Hi ${ctx.recipientName}, order ${ctx.orderNumber} has shipped. Carrier: ${ctx.carrier}, Tracking: ${ctx.trackingNumber}`;
+  const html = `<div><h2>${escapeHtml(subject)}</h2><p>${escapeHtml(text)}</p></div>`;
+  return { subject, html, text };
+}
+
+export function renderInquiryAnswered(raw: InquiryAnsweredContext): RenderedEmail {
+  const ctx = sanitizeContext(raw as unknown as Record<string, unknown>) as unknown as typeof raw;
+  const isKo = (ctx.locale ?? 'ko') === 'ko';
+  const subject = isKo
+    ? `[옥화당] 문의에 답변이 등록되었습니다`
+    : `[Okhwadang] Your inquiry has been answered`;
+  const text = isKo
+    ? `${ctx.recipientName}님, 문의하신 "${ctx.inquiryTitle}"에 답변이 등록되었습니다.\n\n${ctx.answer}`
+    : `Hi ${ctx.recipientName}, your inquiry "${ctx.inquiryTitle}" has been answered.\n\n${ctx.answer}`;
+  const html = `<div><h2>${escapeHtml(subject)}</h2><p>${escapeHtml(text).replace(/\n/g, '<br>')}</p></div>`;
+  return { subject, html, text };
+}

--- a/backend/src/modules/notification/templates/render.ts
+++ b/backend/src/modules/notification/templates/render.ts
@@ -1,4 +1,4 @@
-import { escapeHtml, sanitizeContext } from './sanitize';
+import { escapeHtml } from './sanitize';
 
 export interface OrderConfirmedContext {
   recipientName: string;
@@ -40,8 +40,7 @@ function formatKRW(amount: number): string {
   return `${amount.toLocaleString('ko-KR')}원`;
 }
 
-export function renderOrderConfirmed(raw: OrderConfirmedContext): RenderedEmail {
-  const ctx = sanitizeContext(raw as unknown as Record<string, unknown>) as unknown as typeof raw;
+export function renderOrderConfirmed(ctx: OrderConfirmedContext): RenderedEmail {
   const isKo = (ctx.locale ?? 'ko') === 'ko';
   const subject = isKo
     ? `[옥화당] 주문이 접수되었습니다 (${ctx.orderNumber})`
@@ -53,8 +52,7 @@ export function renderOrderConfirmed(raw: OrderConfirmedContext): RenderedEmail 
   return { subject, html, text };
 }
 
-export function renderPaymentConfirmed(raw: PaymentConfirmedContext): RenderedEmail {
-  const ctx = sanitizeContext(raw as unknown as Record<string, unknown>) as unknown as typeof raw;
+export function renderPaymentConfirmed(ctx: PaymentConfirmedContext): RenderedEmail {
   const isKo = (ctx.locale ?? 'ko') === 'ko';
   const subject = isKo
     ? `[옥화당] 결제가 완료되었습니다 (${ctx.orderNumber})`
@@ -66,8 +64,7 @@ export function renderPaymentConfirmed(raw: PaymentConfirmedContext): RenderedEm
   return { subject, html, text };
 }
 
-export function renderShippingUpdate(raw: ShippingUpdateContext): RenderedEmail {
-  const ctx = sanitizeContext(raw as unknown as Record<string, unknown>) as unknown as typeof raw;
+export function renderShippingUpdate(ctx: ShippingUpdateContext): RenderedEmail {
   const isKo = (ctx.locale ?? 'ko') === 'ko';
   const subject = isKo
     ? `[옥화당] 배송이 시작되었습니다 (${ctx.orderNumber})`
@@ -79,8 +76,7 @@ export function renderShippingUpdate(raw: ShippingUpdateContext): RenderedEmail 
   return { subject, html, text };
 }
 
-export function renderInquiryAnswered(raw: InquiryAnsweredContext): RenderedEmail {
-  const ctx = sanitizeContext(raw as unknown as Record<string, unknown>) as unknown as typeof raw;
+export function renderInquiryAnswered(ctx: InquiryAnsweredContext): RenderedEmail {
   const isKo = (ctx.locale ?? 'ko') === 'ko';
   const subject = isKo
     ? `[옥화당] 문의에 답변이 등록되었습니다`

--- a/backend/src/modules/notification/templates/sanitize.ts
+++ b/backend/src/modules/notification/templates/sanitize.ts
@@ -1,0 +1,45 @@
+const SENSITIVE_KEYS = [
+  'password',
+  'passwordhash',
+  'password_hash',
+  'token',
+  'accesstoken',
+  'access_token',
+  'refreshtoken',
+  'refresh_token',
+  'authorization',
+  'auth',
+  'secret',
+  'apikey',
+  'api_key',
+  'creditcard',
+  'credit_card',
+  'cvv',
+  'cvc',
+  'cardnumber',
+  'card_number',
+];
+
+export function sanitizeContext<T extends Record<string, unknown>>(context: T): T {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (SENSITIVE_KEYS.includes(key.toLowerCase())) {
+      continue;
+    }
+    if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
+      result[key] = sanitizeContext(value as Record<string, unknown>);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result as T;
+}
+
+export function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/backend/src/modules/notification/templates/sanitize.ts
+++ b/backend/src/modules/notification/templates/sanitize.ts
@@ -8,7 +8,7 @@ const SENSITIVE_KEYS = [
   'refreshtoken',
   'refresh_token',
   'authorization',
-  'auth',
+  'auth_token',
   'secret',
   'apikey',
   'api_key',
@@ -20,17 +20,23 @@ const SENSITIVE_KEYS = [
   'card_number',
 ];
 
+function sanitizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item));
+  }
+  if (value && typeof value === 'object' && !(value instanceof Date)) {
+    return sanitizeContext(value as Record<string, unknown>);
+  }
+  return value;
+}
+
 export function sanitizeContext<T extends Record<string, unknown>>(context: T): T {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(context)) {
     if (SENSITIVE_KEYS.includes(key.toLowerCase())) {
       continue;
     }
-    if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
-      result[key] = sanitizeContext(value as Record<string, unknown>);
-    } else {
-      result[key] = value;
-    }
+    result[key] = sanitizeValue(value);
   }
   return result as T;
 }

--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -4,8 +4,10 @@ import { DataSource } from 'typeorm';
 import { NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
 import { OrdersService } from '../orders.service';
 import { Order, OrderStatus } from '../entities/order.entity';
+import { User } from '../../users/entities/user.entity';
 import { CreateOrderDto } from '../dto/create-order.dto';
 import { PointsService } from '../../points/points.service';
+import { NotificationService } from '../../notification/notification.service';
 
 const mockQueryRunner = {
   connect: jest.fn(),
@@ -45,8 +47,10 @@ describe('OrdersService', () => {
       providers: [
         OrdersService,
         { provide: getRepositoryToken(Order), useValue: mockOrderRepository },
+        { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
         { provide: DataSource, useValue: mockDataSource },
         { provide: PointsService, useValue: mockPointsService },
+        { provide: NotificationService, useValue: { sendOrderConfirmed: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -3,12 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Order } from './entities/order.entity';
 import { OrderItem } from './entities/order-item.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
+import { User } from '../users/entities/user.entity';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 import { PointsModule } from '../points/points.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order, OrderItem, PointHistory]), PointsModule],
+  imports: [TypeOrmModule.forFeature([Order, OrderItem, PointHistory, User]), PointsModule],
   controllers: [OrdersController],
   providers: [OrdersService],
   exports: [OrdersService],

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -10,10 +10,12 @@ import { Product } from '../products/entities/product.entity';
 import { ProductOption } from '../products/entities/product-option.entity';
 import { CartItem } from '../cart/entities/cart-item.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
+import { User } from '../users/entities/user.entity';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
 import { PointsService } from '../points/points.service';
+import { NotificationService } from '../notification/notification.service';
 
 @Injectable()
 export class OrdersService {
@@ -22,9 +24,12 @@ export class OrdersService {
   constructor(
     @InjectRepository(Order)
     private readonly orderRepository: Repository<Order>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     @InjectDataSource()
     private readonly dataSource: DataSource,
     private readonly pointsService: PointsService,
+    private readonly notificationService: NotificationService,
   ) {}
 
   private generateOrderNumber(): string {
@@ -175,6 +180,8 @@ export class OrdersService {
       await queryRunner.commitTransaction();
       this.logger.log(`Order created: ${savedOrder.orderNumber} userId=${userId}`);
 
+      void this.notifyOrderCreated(userId, savedOrder.orderNumber, totalAmount, dto.recipientName);
+
       return this.findOne(Number(savedOrder.id), userId);
     } catch (err) {
       await queryRunner.rollbackTransaction();
@@ -208,5 +215,24 @@ export class OrdersService {
     assertOwnership(order.userId, userId);
 
     return order;
+  }
+
+  private async notifyOrderCreated(
+    userId: number,
+    orderNumber: string,
+    totalAmount: number,
+    recipientName: string,
+  ): Promise<void> {
+    try {
+      const user = await this.userRepository.findOne({ where: { id: userId } });
+      if (!user?.email) return;
+      await this.notificationService.sendOrderConfirmed(user.email, {
+        recipientName,
+        orderNumber,
+        totalAmount,
+      });
+    } catch (err) {
+      this.logger.warn(`Order confirmation email failed: ${String(err)}`);
+    }
   }
 }

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -5,9 +5,11 @@ import { PaymentsService } from '../payments.service';
 import { Payment, PaymentStatus, PaymentMethod, PaymentGatewayType } from '../entities/payment.entity';
 import { Shipping, ShippingStatus } from '../entities/shipping.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { User } from '../../users/entities/user.entity';
 import { MockPaymentAdapter, MOCK_TEST_SIGNATURE } from '../adapters/mock.adapter';
 import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
+import { NotificationService } from '../../notification/notification.service';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order =>
   ({
@@ -104,9 +106,11 @@ describe('PaymentsService', () => {
         { provide: getRepositoryToken(Payment), useValue: mockPaymentRepo },
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockShippingRepo },
+        { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
         { provide: 'PaymentGateway', useValue: mockGateway },
         { provide: TossPaymentAdapter, useValue: mockGateway },
         { provide: StripePaymentAdapter, useValue: mockGateway },
+        { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -7,6 +7,8 @@ import { Order } from '../../orders/entities/order.entity';
 import { Shipping } from '../entities/shipping.entity';
 import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
+import { User } from '../../users/entities/user.entity';
+import { NotificationService } from '../../notification/notification.service';
 
 describe('PaymentsService — webhook', () => {
   let service: PaymentsService;
@@ -30,9 +32,11 @@ describe('PaymentsService — webhook', () => {
         { provide: getRepositoryToken(Payment), useValue: mockRepo },
         { provide: getRepositoryToken(Order), useValue: mockRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockRepo },
+        { provide: getRepositoryToken(User), useValue: mockRepo },
         { provide: 'PaymentGateway', useValue: mockGateway },
         { provide: TossPaymentAdapter, useValue: mockGateway },
         { provide: StripePaymentAdapter, useValue: mockGateway },
+        { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from './entities/payment.entity';
 import { Shipping } from './entities/shipping.entity';
 import { Order } from '../orders/entities/order.entity';
+import { User } from '../users/entities/user.entity';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
 import { MockPaymentAdapter } from './adapters/mock.adapter';
@@ -54,7 +55,7 @@ const gatewayProviders = [
 ];
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment, Shipping, Order])],
+  imports: [TypeOrmModule.forFeature([Payment, Shipping, Order, User])],
   controllers: [PaymentsController],
   providers: [...gatewayProviders, PaymentsService],
   exports: [PaymentsService],

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -8,6 +8,7 @@ import { Repository } from 'typeorm';
 import { Payment, PaymentStatus, PaymentGatewayType, PaymentMethod } from './entities/payment.entity';
 import { Shipping, ShippingStatus } from './entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
+import { User } from '../users/entities/user.entity';
 import { PaymentGateway } from './interfaces/payment-gateway.interface';
 import { PreparePaymentDto } from './dto/prepare-payment.dto';
 import { ConfirmPaymentDto } from './dto/confirm-payment.dto';
@@ -17,6 +18,7 @@ import { StripePaymentAdapter } from './adapters/stripe.adapter';
 import { resolveGatewayByLocale } from './payments.module';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { findOrThrow } from '../../common/utils/repository.util';
+import { NotificationService } from '../notification/notification.service';
 
 const DEFAULT_CARRIER = process.env.DEFAULT_CARRIER || 'mock';
 
@@ -31,10 +33,13 @@ export class PaymentsService {
     private readonly orderRepository: Repository<Order>,
     @InjectRepository(Shipping)
     private readonly shippingRepository: Repository<Shipping>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     @Inject('PaymentGateway')
     private readonly gateway: PaymentGateway,
     private readonly tossAdapter: TossPaymentAdapter,
     private readonly stripeAdapter: StripePaymentAdapter,
+    private readonly notificationService: NotificationService,
   ) {}
 
   private resolveGateway(locale?: string): PaymentGateway {
@@ -135,6 +140,14 @@ export class PaymentsService {
 
       this.logger.log(`Payment confirmed: orderId=${dto.orderId}`);
 
+      void this.notifyPaymentConfirmed(
+        payment.order.userId,
+        payment.order.orderNumber,
+        payment.order.recipientName,
+        Number(payment.amount),
+        result.method,
+      );
+
       return {
         paymentId: Number(payment.id),
         orderId: dto.orderId,
@@ -182,6 +195,27 @@ export class PaymentsService {
       cancelledAt: result.cancelledAt,
       cancelReason: reason,
     };
+  }
+
+  private async notifyPaymentConfirmed(
+    userId: number,
+    orderNumber: string,
+    recipientName: string,
+    amount: number,
+    method: string,
+  ): Promise<void> {
+    try {
+      const user = await this.userRepository.findOne({ where: { id: userId } });
+      if (!user?.email) return;
+      await this.notificationService.sendPaymentConfirmed(user.email, {
+        recipientName,
+        orderNumber,
+        amount,
+        method,
+      });
+    } catch (err) {
+      this.logger.warn(`Payment confirmation email failed: ${String(err)}`);
+    }
   }
 
   async handleWebhook(payload: unknown, signature: string): Promise<void> {

--- a/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
+++ b/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
@@ -4,6 +4,8 @@ import { NotFoundException, BadRequestException, ForbiddenException } from '@nes
 import { ShippingService } from '../shipping.service';
 import { Shipping, ShippingStatus } from '../../payments/entities/shipping.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { User } from '../../users/entities/user.entity';
+import { NotificationService } from '../../notification/notification.service';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order =>
   ({ id: 1, userId: 10, status: OrderStatus.PAID, ...overrides } as unknown as Order);
@@ -39,6 +41,8 @@ describe('ShippingService', () => {
         ShippingService,
         { provide: getRepositoryToken(Shipping), useValue: mockShippingRepo },
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
+        { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
+        { provide: NotificationService, useValue: { sendShippingUpdate: jest.fn() } },
       ],
     }).compile();
     service = module.get<ShippingService>(ShippingService);

--- a/backend/src/modules/shipping/shipping.module.ts
+++ b/backend/src/modules/shipping/shipping.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Shipping } from '../payments/entities/shipping.entity';
 import { Order } from '../orders/entities/order.entity';
+import { User } from '../users/entities/user.entity';
 import { ShippingService } from './shipping.service';
 import { ShippingController, AdminShippingController } from './shipping.controller';
 import { MockShippingAdapter } from './adapters/mock-shipping.adapter';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Shipping, Order])],
+  imports: [TypeOrmModule.forFeature([Shipping, Order, User])],
   controllers: [ShippingController, AdminShippingController],
   providers: [ShippingService, MockShippingAdapter],
   exports: [ShippingService],

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -6,12 +6,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Shipping, ShippingStatus } from '../payments/entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
+import { User } from '../users/entities/user.entity';
 import { MockShippingAdapter } from './adapters/mock-shipping.adapter';
 import { CarrierCode, TrackingResult } from './interfaces/shipping-provider.interface';
 import { RegisterTrackingDto } from './dto/register-tracking.dto';
 import { TrackShipmentDto } from './dto/track-shipment.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
+import { NotificationService } from '../notification/notification.service';
 
 const ALLOWED_TRANSITIONS: Record<ShippingStatus, ShippingStatus[]> = {
   [ShippingStatus.PAYMENT_CONFIRMED]: [ShippingStatus.PREPARING],
@@ -32,6 +34,9 @@ export class ShippingService {
     private readonly shippingRepository: Repository<Shipping>,
     @InjectRepository(Order)
     private readonly orderRepository: Repository<Order>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly notificationService: NotificationService,
   ) {
     this.mockAdapter = new MockShippingAdapter();
   }
@@ -95,7 +100,7 @@ export class ShippingService {
   }
 
   async registerTracking(orderId: number, dto: RegisterTrackingDto): Promise<Shipping | null> {
-    await findOrThrow(this.orderRepository, { id: orderId }, '주문 정보를 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문 정보를 찾을 수 없습니다.');
 
     const shipping = await findOrThrow(this.shippingRepository, { orderId }, '배송 정보를 찾을 수 없습니다.');
 
@@ -111,7 +116,36 @@ export class ShippingService {
 
     await this.orderRepository.update(orderId, { status: OrderStatus.PREPARING });
 
+    void this.notifyShippingUpdate(
+      order.userId,
+      order.orderNumber,
+      order.recipientName,
+      dto.carrier,
+      dto.trackingNumber,
+    );
+
     return this.shippingRepository.findOne({ where: { orderId } });
+  }
+
+  private async notifyShippingUpdate(
+    userId: number,
+    orderNumber: string,
+    recipientName: string,
+    carrier: string,
+    trackingNumber: string,
+  ): Promise<void> {
+    try {
+      const user = await this.userRepository.findOne({ where: { id: userId } });
+      if (!user?.email) return;
+      await this.notificationService.sendShippingUpdate(user.email, {
+        recipientName,
+        orderNumber,
+        carrier,
+        trackingNumber,
+      });
+    } catch (err) {
+      this.logger.warn(`Shipping update email failed: ${String(err)}`);
+    }
   }
 
   validateTransition(current: ShippingStatus, next: ShippingStatus): void {

--- a/docs/infrastructure/ENVIRONMENT_VARIABLES.md
+++ b/docs/infrastructure/ENVIRONMENT_VARIABLES.md
@@ -79,6 +79,14 @@
 | `S3_ACCESS_KEY` | — | S3 액세스 키 |
 | `S3_SECRET_KEY` | — | S3 시크릿 키 |
 
+### 알림 (이메일)
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `NOTIFICATION_PROVIDER` | `mock` | 이메일 어댑터 (`mock`/`resend`/`ses`). 프로덕션에서는 `mock` 금지 |
+| `RESEND_API_KEY` | — | Resend API 키 (`NOTIFICATION_PROVIDER=resend` 시 필수) |
+| `EMAIL_FROM` | `no-reply@okhwadang.com` | 발신자 이메일 주소 |
+
 ### Cache
 
 백엔드 프로세스 내 `CacheService`(Map+TTL)만 사용. 외부 캐시(Redis/ElastiCache) 환경변수 없음.


### PR DESCRIPTION
## Summary
- Closes #493
- **NotificationModule 신설** (`backend/src/modules/notification`) — 기존 payment/storage 어댑터 패턴 준수
- `EmailProvider` 인터페이스 + `MockEmailAdapter` (기본) / `ResendEmailAdapter` / `SesEmailAdapter`(stub)
- `NOTIFICATION_PROVIDER` env로 어댑터 선택. 프로덕션에서 `mock` 사용 금지
- ko/en 로케일 템플릿 4종: 주문확정 · 결제확정 · 배송시작 · 문의답변
- 민감 필드(password/token/auth/card 등) 템플릿 컨텍스트 자동 필터링 + HTML 이스케이프
- Fire-and-forget 발송: provider 실패해도 비즈니스 플로우 차단하지 않음 (로깅만)

## 발송 지점 (4개)
| 지점 | 트리거 | 메서드 |
|---|---|---|
| 주문 생성 | `OrdersService.create()` 성공 후 | `sendOrderConfirmed` |
| 결제 확정 | `PaymentsService.confirm()` 성공 후 | `sendPaymentConfirmed` |
| 배송 시작 | `ShippingService.registerTracking()` 성공 후 | `sendShippingUpdate` |
| 문의 답변 | `InquiriesService.answerInquiry()` 성공 후 | `sendInquiryAnswered` |

## 수용 조건
- [x] NotificationModule + MockAdapter로 단위 테스트 통과 (10건)
- [x] 주문 생성 / 결제 확정 / 배송 업데이트 / 문의 답변 4개 지점에서 발송 호출
- [x] 민감 정보(비밀번호·토큰) 템플릿 컨텍스트 제외 검증
- [x] ENVIRONMENT_VARIABLES.md 업데이트

## Test plan
- [x] cd backend && npm run build
- [x] cd backend && npm test (423/423 passed)