### PR TITLE
feat: #477 주문 생성 시 쿠폰 할인 적용

### DIFF
--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -8,6 +8,7 @@ import { User } from '../../users/entities/user.entity';
 import { CreateOrderDto } from '../dto/create-order.dto';
 import { PointsService } from '../../points/points.service';
 import { NotificationService } from '../../notification/notification.service';
+import { CouponsService } from '../../coupons/coupons.service';
 
 const mockQueryRunner = {
   connect: jest.fn(),
@@ -36,6 +37,11 @@ const mockPointsService = {
   getUserPointBalance: jest.fn(),
 };
 
+const mockCouponsService = {
+  calculate: jest.fn(),
+  useCoupon: jest.fn(),
+};
+
 describe('OrdersService', () => {
   let service: OrdersService;
 
@@ -51,6 +57,7 @@ describe('OrdersService', () => {
         { provide: DataSource, useValue: mockDataSource },
         { provide: PointsService, useValue: mockPointsService },
         { provide: NotificationService, useValue: { sendOrderConfirmed: jest.fn() } },
+        { provide: CouponsService, useValue: mockCouponsService },
       ],
     }).compile();
 
@@ -246,6 +253,108 @@ describe('OrdersService', () => {
       );
       expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
       expect(mockDeleteQb.execute).toHaveBeenCalled();
+    });
+
+    it('valid dto with userCouponId → applies coupon discount, sets discountAmount, calls useCoupon', async () => {
+      const dto: CreateOrderDto = {
+        items: [{ productId: 1, quantity: 2 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+        address: '서울시 강남구',
+        pointsUsed: 0,
+        userCouponId: 10,
+      };
+
+      const mockProduct = { id: 1, name: '상품', price: 10000, salePrice: 9000, stock: 5 };
+      const mockSavedOrder = {
+        id: 42,
+        orderNumber: 'ORD-20240101-XYZ12',
+        userId: 1,
+        status: OrderStatus.PENDING,
+        totalAmount: 18000,
+        discountAmount: 2000,
+        items: [],
+      } as unknown as Order;
+
+      const mockProductQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockProduct),
+      };
+      const mockDeleteQb = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({}),
+      };
+
+      mockQueryRunner.manager.createQueryBuilder
+        .mockReturnValueOnce(mockProductQb)
+        .mockReturnValueOnce(mockDeleteQb);
+      mockQueryRunner.manager.update.mockResolvedValue({});
+      mockQueryRunner.manager.create.mockReturnValue(mockSavedOrder);
+      mockQueryRunner.manager.save
+        .mockResolvedValueOnce(mockSavedOrder)
+        .mockResolvedValue([]);
+
+      // Mock couponsService.calculate to return discount
+      mockCouponsService.calculate.mockResolvedValue({
+        originalAmount: 18000,
+        couponDiscount: 2000,
+        pointsDiscount: 0,
+        finalAmount: 16000,
+        shippingFee: 3000,
+        totalPayable: 19000,
+      });
+      mockCouponsService.useCoupon.mockResolvedValue(undefined);
+
+      const mockOrderQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockSavedOrder),
+      };
+      mockOrderRepository.createQueryBuilder.mockReturnValue(mockOrderQb);
+
+      const result = await service.create(1, dto);
+      expect(result).toBe(mockSavedOrder);
+      expect(mockCouponsService.calculate).toHaveBeenCalledWith(1, {
+        orderAmount: 18000,
+        userCouponId: 10,
+        pointsToUse: 0,
+      });
+      expect(mockCouponsService.useCoupon).toHaveBeenCalledWith(10, 1, 42);
+      // discountAmount should be set in the created order
+      expect(mockQueryRunner.manager.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ discountAmount: 2000 }),
+      );
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it('userCouponId but coupon calculate throws → BadRequestException + rollback', async () => {
+      const dto: CreateOrderDto = {
+        items: [{ productId: 1, quantity: 1 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+        address: '서울시',
+        userCouponId: 10,
+      };
+
+      const mockProduct = { id: 1, name: '상품', price: 10000, salePrice: null, stock: 5 };
+      const mockQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockProduct),
+      };
+      mockQueryRunner.manager.createQueryBuilder.mockReturnValue(mockQb);
+
+      mockCouponsService.calculate.mockRejectedValue(new BadRequestException('만료된 쿠폰입니다.'));
+
+      await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/orders/dto/create-order.dto.ts
+++ b/backend/src/modules/orders/dto/create-order.dto.ts
@@ -70,4 +70,9 @@ export class CreateOrderDto {
   @IsInt({ message: '포인트 사용량은 정수여야 합니다.' })
   @Min(0, { message: '포인트 사용량은 0 이상이어야 합니다.' })
   pointsUsed?: number;
+
+  @ApiProperty({ example: 1, description: '사용할 쿠폰 ID (사용자 발급 쿠폰)', required: false })
+  @IsOptional()
+  @IsInt({ message: '쿠폰 ID는 정수여야 합니다.' })
+  userCouponId?: number;
 }

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -7,9 +7,10 @@ import { User } from '../users/entities/user.entity';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 import { PointsModule } from '../points/points.module';
+import { CouponsModule } from '../coupons/coupons.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order, OrderItem, PointHistory, User]), PointsModule],
+  imports: [TypeOrmModule.forFeature([Order, OrderItem, PointHistory, User]), PointsModule, CouponsModule],
   controllers: [OrdersController],
   providers: [OrdersService],
   exports: [OrdersService],

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -16,6 +16,8 @@ import { assertOwnership } from '../../common/utils/ownership.util';
 import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
 import { PointsService } from '../points/points.service';
 import { NotificationService } from '../notification/notification.service';
+import { CouponsService } from '../coupons/coupons.service';
+import { CalculateDiscountDto } from '../coupons/dto/calculate-discount.dto';
 
 @Injectable()
 export class OrdersService {
@@ -30,6 +32,7 @@ export class OrdersService {
     private readonly dataSource: DataSource,
     private readonly pointsService: PointsService,
     private readonly notificationService: NotificationService,
+    private readonly couponsService: CouponsService,
   ) {}
 
   private generateOrderNumber(): string {
@@ -127,12 +130,24 @@ export class OrdersService {
         });
       }
 
+      let discountAmount = 0;
+      if (dto.userCouponId) {
+        const calculateDto: CalculateDiscountDto = {
+          orderAmount: totalAmount,
+          userCouponId: dto.userCouponId,
+          pointsToUse,
+        };
+        const discountResult = await this.couponsService.calculate(userId, calculateDto);
+        discountAmount = discountResult.couponDiscount;
+        totalAmount = discountResult.finalAmount;
+      }
+
       const order = queryRunner.manager.create(Order, {
         userId,
         orderNumber: this.generateOrderNumber(),
         status: OrderStatus.PENDING,
         totalAmount,
-        discountAmount: 0,
+        discountAmount,
         shippingFee: 0,
         recipientName: dto.recipientName,
         recipientPhone: dto.recipientPhone,
@@ -143,6 +158,10 @@ export class OrdersService {
         pointsUsed: pointsToUse,
       });
       const savedOrder = await queryRunner.manager.save(Order, order);
+
+      if (dto.userCouponId) {
+        await this.couponsService.useCoupon(dto.userCouponId, userId, Number(savedOrder.id));
+      }
 
       if (pointsToUse > 0) {
         const latestPoint = await queryRunner.manager.getRepository(PointHistory).findOne({


### PR DESCRIPTION
## Summary
- `CreateOrderDto`에 `userCouponId?: number` 필드 추가
- `OrdersService.create()`에서 쿠폰 할인 계산(`couponsService.calculate()`) 및 사용(`couponsService.useCoupon()`) 로직 추가
- `OrdersModule`에 `CouponsModule` 임포트

## 변경 파일
- `backend/src/modules/orders/dto/create-order.dto.ts` - userCouponId 필드 추가
- `backend/src/modules/orders/orders.service.ts` - 쿠폰 할인 적용 로직
- `backend/src/modules/orders/orders.module.ts` - CouponsModule 임포트
- `backend/src/modules/orders/__tests__/orders.service.spec.ts` - 쿠폰 할인 테스트

## 테스트 체크리스트
- [x] `npm run build` 통과 (frontend + backend)
- [x] `npm run test` (backend) 통과 - 418개 테스트 passed
- [x] `npm run test:run` (frontend) - pre-existing 실패 12개 (i18n translations, context providers) 존재, 본 변경과 무관

## 동작 검증
1. `userCouponId` 없이 주문 생성 → 기존과 동일 (할인 없음)
2. `userCouponId` 포함하여 주문 생성 → `couponsService.calculate()` 호출 → `discountAmount` 설정 → `couponsService.useCoupon()` 호출
3. 쿠폰 만료/사용済み 시 → `BadRequestException` 발생 → transaction rollback

Closes #477