### PR TITLE
feat: #475 payment confirm을 dataSource.transaction()으로 원자적 처리

### DIFF
--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { NotFoundException, BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { NotFoundException, BadRequestException, ConflictException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
 import { PaymentsService } from '../payments.service';
 import { Payment, PaymentStatus, PaymentMethod, PaymentGatewayType } from '../entities/payment.entity';
 import { Shipping, ShippingStatus } from '../entities/shipping.entity';
@@ -33,6 +34,19 @@ const makePayment = (overrides: Partial<Payment> = {}): Payment =>
     order: makeOrder(),
     ...overrides,
   } as unknown as Payment);
+
+const makeTransactionManager = (overrides: Record<string, jest.Mock> = {}) => ({
+  update: jest.fn().mockResolvedValue({}),
+  findOne: jest.fn().mockResolvedValue(null),
+  save: jest.fn().mockResolvedValue({}),
+  create: jest.fn().mockImplementation((_entity: unknown, data: unknown) => data),
+  ...overrides,
+});
+
+const makeDataSourceMock = (manager = makeTransactionManager()) => ({
+  transaction: jest.fn(async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(manager)),
+  _manager: manager,
+});
 
 describe('MockPaymentAdapter', () => {
   let adapter: MockPaymentAdapter;
@@ -97,8 +111,11 @@ describe('PaymentsService', () => {
     verifyWebhook: jest.fn(),
   };
 
+  let mockDataSource: ReturnType<typeof makeDataSourceMock>;
+
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockDataSource = makeDataSourceMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -111,6 +128,7 @@ describe('PaymentsService', () => {
         { provide: TossPaymentAdapter, useValue: mockGateway },
         { provide: StripePaymentAdapter, useValue: mockGateway },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
+        { provide: DataSource, useValue: mockDataSource },
       ],
     }).compile();
 
@@ -159,14 +177,74 @@ describe('PaymentsService', () => {
         status: 'confirmed',
         rawResponse: { mock: true },
       });
-      mockPaymentRepo.update.mockResolvedValue({});
-      mockOrderRepo.update.mockResolvedValue({});
-      mockShippingRepo.findOne.mockResolvedValue(null);
-      mockShippingRepo.create.mockReturnValue({ orderId: 1, carrier: 'mock', status: ShippingStatus.PAYMENT_CONFIRMED });
-      mockShippingRepo.save.mockResolvedValue({});
 
       const result = await service.confirm({ orderId: 1, paymentKey: 'pay_abc', amount: 30000 }, 10);
       expect(result.status).toBe(PaymentStatus.CONFIRMED);
+    });
+
+    it('confirm() — dataSource.transaction() 이 1회 호출되어야 함', async () => {
+      const payment = makePayment();
+      mockPaymentRepo.findOne.mockResolvedValue(payment);
+      mockGateway.confirm.mockResolvedValue({
+        paymentKey: 'pay_abc',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: { mock: true },
+      });
+
+      await service.confirm({ orderId: 1, paymentKey: 'pay_abc', amount: 30000 }, 10);
+
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('confirm() — 트랜잭션 내에서 payment·order·shipping 모두 업데이트', async () => {
+      const payment = makePayment();
+      mockPaymentRepo.findOne.mockResolvedValue(payment);
+      mockGateway.confirm.mockResolvedValue({
+        paymentKey: 'pay_abc',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: { mock: true },
+      });
+
+      await service.confirm({ orderId: 1, paymentKey: 'pay_abc', amount: 30000 }, 10);
+
+      const manager = mockDataSource._manager;
+      expect(manager.update).toHaveBeenCalledWith(
+        Payment,
+        payment.id,
+        expect.objectContaining({ status: PaymentStatus.CONFIRMED }),
+      );
+      expect(manager.update).toHaveBeenCalledWith(Order, 1, { status: OrderStatus.PAID });
+      expect(manager.save).toHaveBeenCalled();
+    });
+
+    it('shipping save 실패 → 트랜잭션 롤백 → payment FAILED 마킹 → InternalServerErrorException', async () => {
+      const payment = makePayment();
+      mockPaymentRepo.findOne.mockResolvedValue(payment);
+      mockGateway.confirm.mockResolvedValue({
+        paymentKey: 'pay_abc',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: { mock: true },
+      });
+      mockPaymentRepo.update.mockResolvedValue({});
+
+      const failingManager = makeTransactionManager({
+        save: jest.fn().mockRejectedValue(new Error('DB 오류 — shipping insert 실패')),
+      });
+      mockDataSource.transaction.mockImplementation(
+        async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager),
+      );
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pay_abc', amount: 30000 }, 10),
+      ).rejects.toThrow(InternalServerErrorException);
+
+      expect(mockPaymentRepo.update).toHaveBeenCalledWith(payment.id, { status: PaymentStatus.FAILED });
     });
 
     it('amount mismatch → BadRequestException', async () => {

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UnauthorizedException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 import { PaymentsService } from '../payments.service';
 import { Payment } from '../entities/payment.entity';
 import { Order } from '../../orders/entities/order.entity';
@@ -37,6 +38,7 @@ describe('PaymentsService — webhook', () => {
         { provide: TossPaymentAdapter, useValue: mockGateway },
         { provide: StripePaymentAdapter, useValue: mockGateway },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
+        { provide: DataSource, useValue: { transaction: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -4,7 +4,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { Payment, PaymentStatus, PaymentGatewayType, PaymentMethod } from './entities/payment.entity';
 import { Shipping, ShippingStatus } from './entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
@@ -40,6 +40,7 @@ export class PaymentsService {
     private readonly tossAdapter: TossPaymentAdapter,
     private readonly stripeAdapter: StripePaymentAdapter,
     private readonly notificationService: NotificationService,
+    private readonly dataSource: DataSource,
   ) {}
 
   private resolveGateway(locale?: string): PaymentGateway {
@@ -117,26 +118,26 @@ export class PaymentsService {
     try {
       const result = await this.gateway.confirm(dto.paymentKey, Number(payment.amount), payment.order.orderNumber);
 
-      await this.paymentRepository.update(payment.id, {
-        status: PaymentStatus.CONFIRMED,
-        paymentKey: dto.paymentKey,
-        method: result.method as PaymentMethod,
-        paidAt: new Date(),
-        rawResponse: result.rawResponse as object,
-      });
+      await this.dataSource.transaction(async (manager) => {
+        await manager.update(Payment, payment.id, {
+          status: PaymentStatus.CONFIRMED,
+          paymentKey: dto.paymentKey,
+          method: result.method as PaymentMethod,
+          paidAt: new Date(),
+          rawResponse: result.rawResponse as object,
+        });
 
-      await this.orderRepository.update(dto.orderId, { status: OrderStatus.PAID });
+        await manager.update(Order, dto.orderId, { status: OrderStatus.PAID });
 
-      const existing = await this.shippingRepository.findOne({ where: { orderId: dto.orderId } });
-      if (!existing) {
-        await this.shippingRepository.save(
-          this.shippingRepository.create({
+        const existing = await manager.findOne(Shipping, { where: { orderId: dto.orderId } });
+        if (!existing) {
+          await manager.save(Shipping, {
             orderId: dto.orderId,
             carrier: DEFAULT_CARRIER,
             status: ShippingStatus.PAYMENT_CONFIRMED,
-          }),
-        );
-      }
+          });
+        }
+      });
 
       this.logger.log(`Payment confirmed: orderId=${dto.orderId}`);
 


### PR DESCRIPTION
## Summary

- `PaymentsService.confirm()` 내부에서 payment 상태 업데이트, order 상태 업데이트, shipping 레코드 생성 3개의 DB 쓰기가 트랜잭션 없이 순차 실행되어 중간 실패 시 inconsistent state가 발생하는 P0 버그를 수정합니다.
- `DataSource`를 주입받아 3개의 쓰기를 `dataSource.transaction()` 단일 트랜잭션으로 묶어 원자성을 보장합니다.
- 트랜잭션이 실패하면 외부 catch 블록에서 payment를 `FAILED` 상태로 마킹합니다 (외부 결제 게이트웨이 confirm 후 DB가 실패하는 케이스 포함).

## Changes

| 파일 | 변경 내용 |
|------|---------|
| `backend/src/modules/payments/payments.service.ts` | `DataSource` 주입 추가, confirm DB 쓰기 3개를 `dataSource.transaction()` 으로 래핑 |
| `backend/src/modules/payments/__tests__/payments.service.spec.ts` | `DataSource` mock 주입, 트랜잭션 검증 테스트 2개 추가 (transaction 호출 확인, shipping save 실패 시 롤백+FAILED 마킹 확인) |
| `backend/src/modules/payments/__tests__/payments.webhook.spec.ts` | `DataSource` mock provider 추가 (서비스 생성자 의존성 해소) |

## Test Plan

```bash
# Backend build
cd backend && npm run build

# Unit tests (payments 모듈 전체)
cd backend && npm run test -- --testPathPattern="payments"
# → 53 passed

# 전체 백엔드 테스트
cd backend && npm run test
# → 419 passed, 7 failed (jwt.strategy.spec.ts — JWT_PUBLIC_KEY 미설정 기존 실패)
```

### 새로 추가된 핵심 테스트 케이스

1. `confirm() — dataSource.transaction() 이 1회 호출되어야 함` — 트랜잭션 래핑 보장
2. `confirm() — 트랜잭션 내에서 payment·order·shipping 모두 업데이트` — EntityManager를 통한 3개 쓰기 검증
3. `shipping save 실패 → 트랜잭션 롤백 → payment FAILED 마킹 → InternalServerErrorException` — 핵심 버그 시나리오 롤백 검증

Closes #475