### PR TITLE
feat: #479 OrderStatus enum에 COMPLETED·REFUND_REQUESTED 상태 및 전이 추가

### DIFF
--- a/backend/src/database/migrations/1778400000000-AddOrderStatusCompletedAndRefundRequested.ts
+++ b/backend/src/database/migrations/1778400000000-AddOrderStatusCompletedAndRefundRequested.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #479: OrderStatus enum에 COMPLETED와 REFUND_REQUESTED 상태 추가
+ * - delivered → completed 경로 추가 (배송 완료 후 구매 확정)
+ * - delivered → refund_requested 경로 추가 (배송 완료 후 환불 요청)
+ * - refund_requested → refunded 경로 추가 (관리자가 환불 처리)
+ * - completed는 종단 상태 (이후 상태 전이 불가)
+ */
+export class AddOrderStatusCompletedAndRefundRequested1778400000000 implements MigrationInterface {
+  name = 'AddOrderStatusCompletedAndRefundRequested1778400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET NAMES utf8mb4`);
+
+    // ALTER TABLE orders CHANGE COLUMN status ENUM 추가
+    // 기존 ENUM: pending, paid, preparing, shipped, delivered, cancelled, refunded
+    // 새 ENUM: pending, paid, preparing, shipped, delivered, completed, cancelled, refund_requested, refunded
+    await queryRunner.query(`
+      ALTER TABLE \`orders\`
+      CHANGE COLUMN \`status\`
+        \`status\` ENUM('pending', 'paid', 'preparing', 'shipped', 'delivered', 'completed', 'cancelled', 'refund_requested', 'refunded')
+        NOT NULL DEFAULT 'pending'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 이전 ENUM으로 복원
+    await queryRunner.query(`
+      ALTER TABLE \`orders\`
+      CHANGE COLUMN \`status\`
+        \`status\` ENUM('pending', 'paid', 'preparing', 'shipped', 'delivered', 'cancelled', 'refunded')
+        NOT NULL DEFAULT 'pending'
+    `);
+  }
+}

--- a/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
@@ -143,6 +143,53 @@ describe('AdminOrdersService', () => {
       await service.updateStatus(1, OrderStatus.CANCELLED);
       expect(orderRepo.update).toHaveBeenCalledWith(1, { status: OrderStatus.CANCELLED });
     });
+
+    it('delivered → completed: allowed', async () => {
+      orderRepo.findOne
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.DELIVERED })
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.COMPLETED });
+      orderRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateStatus(1, OrderStatus.COMPLETED);
+      expect(orderRepo.update).toHaveBeenCalledWith(1, { status: OrderStatus.COMPLETED });
+    });
+
+    it('delivered → refund_requested: allowed', async () => {
+      orderRepo.findOne
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.DELIVERED })
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUND_REQUESTED });
+      orderRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateStatus(1, OrderStatus.REFUND_REQUESTED);
+      expect(orderRepo.update).toHaveBeenCalledWith(1, { status: OrderStatus.REFUND_REQUESTED });
+    });
+
+    it('refund_requested → refunded: allowed', async () => {
+      orderRepo.findOne
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUND_REQUESTED })
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUNDED });
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 1 });
+      paymentRepo.update.mockResolvedValue({ affected: 1 });
+      orderRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateStatus(1, OrderStatus.REFUNDED);
+      expect(paymentRepo.update).toHaveBeenCalledWith(10, expect.objectContaining({
+        status: PaymentStatus.REFUNDED,
+        cancelReason: '관리자 환불 처리',
+      }));
+    });
+
+    it('completed → any: not allowed (terminal state)', async () => {
+      orderRepo.findOne.mockResolvedValueOnce({ id: 1, status: OrderStatus.COMPLETED });
+      await expect(service.updateStatus(1, OrderStatus.DELIVERED))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('delivered → refunded directly: not allowed (must go through refund_requested)', async () => {
+      orderRepo.findOne.mockResolvedValueOnce({ id: 1, status: OrderStatus.DELIVERED });
+      await expect(service.updateStatus(1, OrderStatus.REFUNDED))
+        .rejects.toThrow(BadRequestException);
+    });
   });
 
   describe('registerShipping', () => {

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -17,8 +17,10 @@ const ALLOWED_ORDER_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   [OrderStatus.PAID]: [OrderStatus.PREPARING, OrderStatus.CANCELLED, OrderStatus.REFUNDED],
   [OrderStatus.PREPARING]: [OrderStatus.SHIPPED, OrderStatus.CANCELLED, OrderStatus.REFUNDED],
   [OrderStatus.SHIPPED]: [OrderStatus.DELIVERED, OrderStatus.REFUNDED],
-  [OrderStatus.DELIVERED]: [OrderStatus.REFUNDED],
+  [OrderStatus.DELIVERED]: [OrderStatus.COMPLETED, OrderStatus.REFUND_REQUESTED],
+  [OrderStatus.COMPLETED]: [],
   [OrderStatus.CANCELLED]: [],
+  [OrderStatus.REFUND_REQUESTED]: [OrderStatus.REFUNDED],
   [OrderStatus.REFUNDED]: [],
 };
 

--- a/backend/src/modules/orders/entities/order.entity.ts
+++ b/backend/src/modules/orders/entities/order.entity.ts
@@ -11,7 +11,9 @@ export enum OrderStatus {
   PREPARING = 'preparing',
   SHIPPED = 'shipped',
   DELIVERED = 'delivered',
+  COMPLETED = 'completed',
   CANCELLED = 'cancelled',
+  REFUND_REQUESTED = 'refund_requested',
   REFUNDED = 'refunded',
 }
 


### PR DESCRIPTION
## 작업内容

**Issue:** #479

### 변경 사항

1. **OrderStatus enum 확장** (`order.entity.ts`)
   - `COMPLETED = 'completed'` 추가
   - `REFUND_REQUESTED = 'refund_requested'` 추가

2. **전이 맵 업데이트** (`admin-orders.service.ts`)
   - `delivered → [completed, refund_requested]` (기존: delivered → refunded only)
   - `completed → []` (종단 상태)
   - `refund_requested → [refunded]` (관리자 환불 처리)

3. **TypeORM Migration 추가**
   - `1778400000000-AddOrderStatusCompletedAndRefundRequested.ts`
   - DB ENUM 변경: `pending, paid, preparing, shipped, delivered, completed, cancelled, refund_requested, refunded`

4. **테스트 커버리지** (`admin-orders.service.spec.ts`)
   - `delivered → completed` allowed ✓
   - `delivered → refund_requested` allowed ✓
   - `refund_requested → refunded` allowed ✓
   - `completed → any` not allowed ✓
   - `delivered → refunded directly` not allowed ✓

### 상태 머신 (배송 완료 후)

```
delivered → completed  (구매 확정)
         → refund_requested → refunded  (환불 요청 → 처리)
```

Closes #479