### PR TITLE
feat: #476 Payment confirm이 locale별 gateway를 사용하도록 수정

### DIFF
--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -104,7 +104,21 @@ describe('PaymentsService', () => {
     save: jest.fn(),
   };
 
-  const mockGateway = {
+  const mockDefaultGateway = {
+    prepare: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    verifyWebhook: jest.fn(),
+  };
+
+  const mockTossAdapter = {
+    prepare: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    verifyWebhook: jest.fn(),
+  };
+
+  const mockStripeAdapter = {
     prepare: jest.fn(),
     confirm: jest.fn(),
     cancel: jest.fn(),
@@ -124,9 +138,9 @@ describe('PaymentsService', () => {
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockShippingRepo },
         { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
-        { provide: 'PaymentGateway', useValue: mockGateway },
-        { provide: TossPaymentAdapter, useValue: mockGateway },
-        { provide: StripePaymentAdapter, useValue: mockGateway },
+        { provide: 'PaymentGateway', useValue: mockDefaultGateway },
+        { provide: TossPaymentAdapter, useValue: mockTossAdapter },
+        { provide: StripePaymentAdapter, useValue: mockStripeAdapter },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
         { provide: DataSource, useValue: mockDataSource },
       ],
@@ -143,7 +157,7 @@ describe('PaymentsService', () => {
       const savedPayment = makePayment();
       mockPaymentRepo.create.mockReturnValue(savedPayment);
       mockPaymentRepo.save.mockResolvedValue(savedPayment);
-      mockGateway.prepare.mockResolvedValue({ clientKey: 'mock_client_key', orderId: '1' });
+      mockDefaultGateway.prepare.mockResolvedValue({ clientKey: 'mock_client_key', orderId: '1' });
 
       const result = await service.prepare({ orderId: 1 }, 10);
       expect(result.clientKey).toBe('mock_client_key');
@@ -170,7 +184,7 @@ describe('PaymentsService', () => {
     it('amount match → confirmed', async () => {
       const payment = makePayment();
       mockPaymentRepo.findOne.mockResolvedValue(payment);
-      mockGateway.confirm.mockResolvedValue({
+      mockDefaultGateway.confirm.mockResolvedValue({
         paymentKey: 'pay_abc',
         method: 'mock',
         amount: 30000,
@@ -185,7 +199,7 @@ describe('PaymentsService', () => {
     it('confirm() — dataSource.transaction() 이 1회 호출되어야 함', async () => {
       const payment = makePayment();
       mockPaymentRepo.findOne.mockResolvedValue(payment);
-      mockGateway.confirm.mockResolvedValue({
+      mockDefaultGateway.confirm.mockResolvedValue({
         paymentKey: 'pay_abc',
         method: 'mock',
         amount: 30000,
@@ -201,7 +215,7 @@ describe('PaymentsService', () => {
     it('confirm() — 트랜잭션 내에서 payment·order·shipping 모두 업데이트', async () => {
       const payment = makePayment();
       mockPaymentRepo.findOne.mockResolvedValue(payment);
-      mockGateway.confirm.mockResolvedValue({
+      mockDefaultGateway.confirm.mockResolvedValue({
         paymentKey: 'pay_abc',
         method: 'mock',
         amount: 30000,
@@ -224,7 +238,7 @@ describe('PaymentsService', () => {
     it('shipping save 실패 → 트랜잭션 롤백 → payment FAILED 마킹 → InternalServerErrorException', async () => {
       const payment = makePayment();
       mockPaymentRepo.findOne.mockResolvedValue(payment);
-      mockGateway.confirm.mockResolvedValue({
+      mockDefaultGateway.confirm.mockResolvedValue({
         paymentKey: 'pay_abc',
         method: 'mock',
         amount: 30000,
@@ -264,7 +278,7 @@ describe('PaymentsService', () => {
     it('gateway throws → InternalServerErrorException, payment marked failed', async () => {
       const payment = makePayment();
       mockPaymentRepo.findOne.mockResolvedValue(payment);
-      mockGateway.confirm.mockRejectedValue(new Error('gateway error'));
+      mockDefaultGateway.confirm.mockRejectedValue(new Error('gateway error'));
       mockPaymentRepo.update.mockResolvedValue({});
 
       await expect(
@@ -272,13 +286,41 @@ describe('PaymentsService', () => {
       ).rejects.toThrow('결제 승인에 실패했습니다.');
       expect(mockPaymentRepo.update).toHaveBeenCalledWith(payment.id, { status: PaymentStatus.FAILED });
     });
+
+    it('locale=ko prepare → confirm 시 Toss adapter의 confirm()이 호출되어야 함', async () => {
+      const order = makeOrder();
+      mockOrderRepo.findOne.mockResolvedValue(order);
+      mockPaymentRepo.findOne.mockResolvedValue(null);
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.TOSS });
+      mockPaymentRepo.create.mockReturnValue(savedPayment);
+      mockPaymentRepo.save.mockResolvedValue(savedPayment);
+      mockTossAdapter.prepare.mockResolvedValue({ clientKey: 'toss_client_key', orderId: '1' });
+
+      const prepareResult = await service.prepare({ orderId: 1, locale: 'ko' }, 10);
+      expect(prepareResult.gateway).toBe('toss');
+
+      const paymentForConfirm = makePayment({ gateway: PaymentGatewayType.TOSS });
+      mockPaymentRepo.findOne.mockResolvedValue(paymentForConfirm);
+      mockTossAdapter.confirm.mockResolvedValue({
+        paymentKey: 'pay_toss_abc',
+        method: 'card',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: { toss: true },
+      });
+
+      const confirmResult = await service.confirm({ orderId: 1, paymentKey: 'pay_toss_abc', amount: 30000 }, 10);
+      expect(confirmResult.status).toBe(PaymentStatus.CONFIRMED);
+      expect(mockTossAdapter.confirm).toHaveBeenCalledWith('pay_toss_abc', 30000, 'ORD-20240101-ABCD1');
+      expect(mockDefaultGateway.confirm).not.toHaveBeenCalled();
+    });
   });
 
   describe('cancel()', () => {
     it('confirmed payment → cancelled', async () => {
       const payment = makePayment({ status: PaymentStatus.CONFIRMED, paymentKey: 'pay_abc' });
       mockPaymentRepo.findOne.mockResolvedValue(payment);
-      mockGateway.cancel.mockResolvedValue({ cancelledAt: new Date(), rawResponse: { mock: true } });
+      mockDefaultGateway.cancel.mockResolvedValue({ cancelledAt: new Date(), rawResponse: { mock: true } });
       mockPaymentRepo.update.mockResolvedValue({});
       mockOrderRepo.update.mockResolvedValue({});
 

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -332,5 +332,25 @@ describe('PaymentsService', () => {
       mockPaymentRepo.findOne.mockResolvedValue(makePayment({ status: PaymentStatus.PENDING }));
       await expect(service.cancel({ orderId: 1 }, 10)).rejects.toThrow(BadRequestException);
     });
+
+    it('payment.gateway=TOSS → cancel 시 Toss adapter의 cancel()이 호출되어야 함', async () => {
+      // confirm()과 동일한 class of bug: 저장된 gateway를 무시하고 default를 쓰면
+      // Toss로 결제된 건을 Mock으로 환불 요청하게 되어 실제 환불이 일어나지 않음.
+      const payment = makePayment({
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: 'pay_toss_abc',
+        gateway: PaymentGatewayType.TOSS,
+      });
+      mockPaymentRepo.findOne.mockResolvedValue(payment);
+      mockTossAdapter.cancel.mockResolvedValue({ cancelledAt: new Date(), rawResponse: { toss: true } });
+      mockPaymentRepo.update.mockResolvedValue({});
+      mockOrderRepo.update.mockResolvedValue({});
+
+      const result = await service.cancel({ orderId: 1 }, 10);
+
+      expect(result.status).toBe(PaymentStatus.CANCELLED);
+      expect(mockTossAdapter.cancel).toHaveBeenCalledWith('pay_toss_abc', '고객 요청');
+      expect(mockDefaultGateway.cancel).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -4,7 +4,7 @@ import { DataSource } from 'typeorm';
 import { NotFoundException, BadRequestException, ConflictException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
 import { PaymentsService } from '../payments.service';
 import { Payment, PaymentStatus, PaymentMethod, PaymentGatewayType } from '../entities/payment.entity';
-import { Shipping, ShippingStatus } from '../entities/shipping.entity';
+import { Shipping } from '../entities/shipping.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { User } from '../../users/entities/user.entity';
 import { MockPaymentAdapter, MOCK_TEST_SIGNATURE } from '../adapters/mock.adapter';

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -51,6 +51,31 @@ export class PaymentsService {
     return this.gateway;
   }
 
+  private resolveGatewayByType(gatewayType: PaymentGatewayType): PaymentGateway {
+    switch (gatewayType) {
+      case PaymentGatewayType.TOSS:
+        return this.tossAdapter;
+      case PaymentGatewayType.INICIS:
+        return this.stripeAdapter;
+      case PaymentGatewayType.MOCK:
+      default:
+        return this.gateway;
+    }
+  }
+
+  private gatewayNameToType(name: string): PaymentGatewayType {
+    switch (name) {
+      case 'toss':
+        return PaymentGatewayType.TOSS;
+      case 'stripe':
+      case 'inicis':
+        return PaymentGatewayType.INICIS;
+      case 'mock':
+      default:
+        return PaymentGatewayType.MOCK;
+    }
+  }
+
   async prepare(dto: PreparePaymentDto, userId: number): Promise<{
     paymentId: number;
     orderId: number;
@@ -75,9 +100,14 @@ export class PaymentsService {
         amount: Number(order.totalAmount),
         status: PaymentStatus.PENDING,
         method: PaymentMethod.MOCK,
-        gateway: PaymentGatewayType.MOCK,
+        gateway: this.gatewayNameToType(gatewayName),
       });
       payment = await this.paymentRepository.save(payment);
+    } else {
+      await this.paymentRepository.update(payment.id, {
+        gateway: this.gatewayNameToType(gatewayName),
+      });
+      payment = await findOrThrow(this.paymentRepository, { id: payment.id }, '결제 정보를 찾을 수 없습니다.');
     }
 
     const result = await selectedGateway.prepare(String(dto.orderId), Number(order.totalAmount));
@@ -116,7 +146,8 @@ export class PaymentsService {
     }
 
     try {
-      const result = await this.gateway.confirm(dto.paymentKey, Number(payment.amount), payment.order.orderNumber);
+      const confirmGateway = this.resolveGatewayByType(payment.gateway);
+      const result = await confirmGateway.confirm(dto.paymentKey, Number(payment.amount), payment.order.orderNumber);
 
       await this.dataSource.transaction(async (manager) => {
         await manager.update(Payment, payment.id, {

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -51,12 +51,15 @@ export class PaymentsService {
     return this.gateway;
   }
 
+  // NOTE: PaymentGatewayType enum에는 아직 STRIPE 값이 없어서 INICIS를 overseas 게이트웨이
+  // placeholder로 겸용 중 (stripe/inicis 문자열 → INICIS enum). 실제 Inicis 연동을 추가하려면
+  // enum에 STRIPE를 추가하고 마이그레이션으로 기존 INICIS 데이터를 재분류해야 한다. (#476 후속)
   private resolveGatewayByType(gatewayType: PaymentGatewayType): PaymentGateway {
     switch (gatewayType) {
       case PaymentGatewayType.TOSS:
         return this.tossAdapter;
       case PaymentGatewayType.INICIS:
-        return this.stripeAdapter;
+        return this.stripeAdapter; // 임시: INICIS enum이 stripe 어댑터를 의미함 (위 NOTE 참고)
       case PaymentGatewayType.MOCK:
       default:
         return this.gateway;
@@ -69,7 +72,7 @@ export class PaymentsService {
         return PaymentGatewayType.TOSS;
       case 'stripe':
       case 'inicis':
-        return PaymentGatewayType.INICIS;
+        return PaymentGatewayType.INICIS; // 임시: stripe도 INICIS enum으로 저장 (위 NOTE 참고)
       case 'mock':
       default:
         return PaymentGatewayType.MOCK;
@@ -210,7 +213,8 @@ export class PaymentsService {
     }
 
     const reason = dto.reason ?? '고객 요청';
-    const result = await this.gateway.cancel(payment.paymentKey!, reason);
+    const cancelGateway = this.resolveGatewayByType(payment.gateway);
+    const result = await cancelGateway.cancel(payment.paymentKey!, reason);
 
     await this.paymentRepository.update(payment.id, {
       status: PaymentStatus.CANCELLED,


### PR DESCRIPTION
## Summary
- `prepare()`에서 locale 기반으로 선택된 gateway type을 `payment.gateway` 컬럼에 저장
- `confirm()`에서 `payment.gateway`를 기반으로 해당하는 adapter(`tossAdapter`, `stripeAdapter`, `mockAdapter`)를 동적으로 선택하여 confirm 호출
- 기존 버그: `confirm()`이 항상 주입된 기본 gateway(`this.gateway`)를 사용해서 사용자가 Toss로 prepare했어도 Mock gateway로 confirm 시도

## Changes
- `PaymentsService`에 `resolveGatewayByType()` 메서드 추가: `PaymentGatewayType` enum을 해당 adapter로 매핑
- `prepare()`에서 `gatewayNameToType()`을 사용하여 gateway type 저장 (기존: 항상 MOCK)
- `confirm()`에서 `this.gateway.confirm()` 대신 `this.resolveGatewayByType(payment.gateway).confirm()` 사용

## Test Plan
- [x] Unit test: locale='ko'로 prepare → confirm 시 Toss adapter의 confirm()이 호출되는지 검증
- [x] 기존 모든 payment 관련 unit test 통과 확인
- [x] Backend build 및 test 통과 (`npm run build && npm run test`)

## Closes #476