### PR TITLE
fix: #536 Docker Desktop 부팅 대기 핸들링 개선

### DIFF
--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -44,16 +44,32 @@ echo ""
 USE_LOCAL_DB=$(echo "${LOCAL_DATABASE_URL:-}" | grep -qE "localhost:330[67]|127\.0\.0\.1:330[67]" && echo "yes" || echo "no")
 
 # Docker Desktop 확인/시작
+# DOCKER_BOOT_TIMEOUT 환경변수로 대기 시간 override 가능 (기본 120초)
 if [ "$USE_LOCAL_DB" = "yes" ] && command -v docker > /dev/null 2>&1; then
     if ! docker info > /dev/null 2>&1; then
         echo -e "${YELLOW}⚠️  Docker Desktop 시작 중...${NC}"
-        open -ga Docker 2>/dev/null || true
-        echo -e "${YELLOW}⏳ Docker Desktop 시작 대기 (최대 60초)...${NC}"
-        for i in {1..60}; do
-            docker info > /dev/null 2>&1 && break
-            [ $i -eq 60 ] && echo -e "${RED}❌ Docker Desktop 시작 실패${NC}" && exit 1
+        if ! open -ga Docker 2>&1; then
+            echo -e "${RED}❌ Docker Desktop 실행 실패 — 미설치 또는 권한 문제일 수 있습니다.${NC}"
+            echo -e "${YELLOW}   설치: https://www.docker.com/products/docker-desktop/${NC}"
+            exit 1
+        fi
+        DOCKER_BOOT_TIMEOUT="${DOCKER_BOOT_TIMEOUT:-120}"
+        echo -e "${YELLOW}⏳ Docker Desktop 시작 대기 (최대 ${DOCKER_BOOT_TIMEOUT}초)...${NC}"
+        for ((i=1; i<=DOCKER_BOOT_TIMEOUT; i++)); do
+            if docker info > /dev/null 2>&1; then
+                break
+            fi
+            if [ $((i % 10)) -eq 0 ]; then
+                echo -e "${YELLOW}   ⏳ Docker Desktop 부팅 중... (${i}s 경과)${NC}"
+            fi
             sleep 1
         done
+        # 타임아웃 후에도 한 번 더 시도 (race condition 방어)
+        if ! docker info > /dev/null 2>&1; then
+            echo -e "${RED}❌ Docker Desktop 시작 실패 (${DOCKER_BOOT_TIMEOUT}초 경과)${NC}"
+            echo -e "${YELLOW}   타임아웃 상향: DOCKER_BOOT_TIMEOUT=180 bash scripts/start-local.sh${NC}"
+            exit 1
+        fi
         echo -e "${GREEN}✅ Docker Desktop 준비 완료${NC}"
     fi
 fi

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -47,13 +47,24 @@ USE_LOCAL_DB=$(echo "${LOCAL_DATABASE_URL:-}" | grep -qE "localhost:330[67]|127\
 # DOCKER_BOOT_TIMEOUT 환경변수로 대기 시간 override 가능 (기본 120초)
 if [ "$USE_LOCAL_DB" = "yes" ] && command -v docker > /dev/null 2>&1; then
     if ! docker info > /dev/null 2>&1; then
-        echo -e "${YELLOW}⚠️  Docker Desktop 시작 중...${NC}"
-        if ! open -ga Docker 2>&1; then
-            echo -e "${RED}❌ Docker Desktop 실행 실패 — 미설치 또는 권한 문제일 수 있습니다.${NC}"
+        # macOS Docker Desktop 미설치를 확실히 감지 (open 명령은 미설치 시에도 0 반환 가능)
+        if [[ "$OSTYPE" == "darwin"* ]] && [ ! -d "/Applications/Docker.app" ]; then
+            echo -e "${RED}❌ Docker Desktop 미설치${NC}"
             echo -e "${YELLOW}   설치: https://www.docker.com/products/docker-desktop/${NC}"
             exit 1
         fi
         DOCKER_BOOT_TIMEOUT="${DOCKER_BOOT_TIMEOUT:-120}"
+        if ! [[ "$DOCKER_BOOT_TIMEOUT" =~ ^[0-9]+$ ]]; then
+            echo -e "${RED}❌ DOCKER_BOOT_TIMEOUT 값이 정수가 아닙니다: ${DOCKER_BOOT_TIMEOUT}${NC}"
+            exit 1
+        fi
+        echo -e "${YELLOW}⚠️  Docker Desktop 시작 중...${NC}"
+        # macOS 에서만 GUI 앱 자동 기동, Linux 는 사용자가 직접 daemon 시작
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            open -ga Docker 2>/dev/null || true
+        else
+            echo -e "${YELLOW}   Docker daemon 을 수동으로 시작해주세요 (예: sudo systemctl start docker)${NC}"
+        fi
         echo -e "${YELLOW}⏳ Docker Desktop 시작 대기 (최대 ${DOCKER_BOOT_TIMEOUT}초)...${NC}"
         for ((i=1; i<=DOCKER_BOOT_TIMEOUT; i++)); do
             if docker info > /dev/null 2>&1; then
@@ -64,7 +75,6 @@ if [ "$USE_LOCAL_DB" = "yes" ] && command -v docker > /dev/null 2>&1; then
             fi
             sleep 1
         done
-        # 타임아웃 후에도 한 번 더 시도 (race condition 방어)
         if ! docker info > /dev/null 2>&1; then
             echo -e "${RED}❌ Docker Desktop 시작 실패 (${DOCKER_BOOT_TIMEOUT}초 경과)${NC}"
             echo -e "${YELLOW}   타임아웃 상향: DOCKER_BOOT_TIMEOUT=180 bash scripts/start-local.sh${NC}"


### PR DESCRIPTION
## Summary
- Closes #536
- `scripts/start-local.sh` 의 Docker daemon 기동 분기 4 가지 개선

## Changes
1. **타임아웃 60s → 120s 상향, env override 지원**
   - macOS 콜드 스타트 / 강제 종료 직후 재기동 시 60s 부족 사례 다수
   - `DOCKER_BOOT_TIMEOUT=180 bash scripts/start-local.sh` 로 override 가능
2. **`open -ga Docker` silent 실패 제거**
   - 종료 코드 검사 후 미설치/권한 문제 메시지 + exit
   - 설치 안내 URL 함께 출력
3. **10초 마다 진행 메시지**
   - "⏳ Docker Desktop 부팅 중... (Ns 경과)"
   - 사용자가 hang 인지 멈춤인지 판단 가능
4. **타임아웃 후 race condition 방어**
   - 폴링 종료 직후 `docker info` 한 번 더 시도
   - daemon 가용해진 직전 시점 false-fail 방지

## Test plan
- [x] `bash -n scripts/start-local.sh` syntax 검증 OK
- [x] arithmetic loop `for ((i=1; i<=DOCKER_BOOT_TIMEOUT; i++))` env override 동작 검증
- [x] 10s tick 메시지 출력 검증 (DOCKER_BOOT_TIMEOUT=25 → "tick 10", "tick 20" 출력)
- [ ] 실제 Docker Desktop 종료 → 재기동 시나리오 (사용자 환경에서 검증 필요)

## Related
- Closes #536
- 사례: PR #530 ship 직후 false-fail 발생