### PR TITLE
test: #532 e2e 쿠키 인증 헬퍼 구현

### DIFF
--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import request from 'supertest';
+import cookieParser from 'cookie-parser';
 import { AppModule } from '../src/app.module';
 import { registerAuthSuite } from './suites/auth.e2e-spec';
 import { registerCartSuite } from './suites/cart.e2e-spec';
@@ -28,6 +29,7 @@ describe('App (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
     app.setGlobalPrefix('api');
     app.useGlobalPipes(
       new ValidationPipe({

--- a/backend/test/helpers/auth-cookie.helper.ts
+++ b/backend/test/helpers/auth-cookie.helper.ts
@@ -1,0 +1,77 @@
+import type { INestApplication } from '@nestjs/common';
+import type { Response as SupertestResponse } from 'supertest';
+import request from 'supertest';
+
+export interface AuthCookies {
+  accessToken: string;
+  refreshToken: string;
+  raw: string[];
+}
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export interface RegisterPayload extends LoginCredentials {
+  name: string;
+}
+
+const ACCESS_TOKEN_COOKIE = 'accessToken';
+const REFRESH_TOKEN_COOKIE = 'refreshToken';
+
+function parseCookieValue(cookies: string[], cookieName: string): string {
+  const match = cookies.find((c) => c.startsWith(`${cookieName}=`));
+  if (!match) {
+    throw new Error(`Cookie "${cookieName}" not found in set-cookie header`);
+  }
+  const value = match.split(';')[0].split('=')[1];
+  if (!value) {
+    throw new Error(`Cookie "${cookieName}" has empty value`);
+  }
+  return value;
+}
+
+export function extractAuthCookies(res: SupertestResponse): AuthCookies {
+  const raw = res.headers['set-cookie'] as unknown;
+  if (!raw || !Array.isArray(raw) || raw.length === 0) {
+    throw new Error('No set-cookie header on response');
+  }
+  const cookies = raw as string[];
+  return {
+    accessToken: parseCookieValue(cookies, ACCESS_TOKEN_COOKIE),
+    refreshToken: parseCookieValue(cookies, REFRESH_TOKEN_COOKIE),
+    raw: cookies,
+  };
+}
+
+export function cookieHeader(cookies: AuthCookies): string[] {
+  return cookies.raw.map((c) => c.split(';')[0]);
+}
+
+export async function registerAndGetCookies(
+  app: INestApplication,
+  payload: RegisterPayload,
+): Promise<{ cookies: AuthCookies; body: { user: { id: number } } }> {
+  const res = await request(app.getHttpServer())
+    .post('/api/auth/register')
+    .send(payload)
+    .expect(201);
+
+  return {
+    cookies: extractAuthCookies(res),
+    body: res.body as { user: { id: number } },
+  };
+}
+
+export async function loginAndGetCookies(
+  app: INestApplication,
+  credentials: LoginCredentials,
+): Promise<AuthCookies> {
+  const res = await request(app.getHttpServer())
+    .post('/api/auth/login')
+    .send(credentials)
+    .expect(200);
+
+  return extractAuthCookies(res);
+}


### PR DESCRIPTION
## Summary
- Closes #532
- `backend/test/helpers/auth-cookie.helper.ts` 추가 — register/login 응답의 `set-cookie` 헤더에서 `accessToken`/`refreshToken` 을 추출해 후속 요청에 재사용할 수 있는 공용 헬퍼
  - `extractAuthCookies(res)` — 응답에서 쿠키 파싱
  - `cookieHeader(cookies)` — `.set('Cookie', ...)` 에 바로 넣을 수 있는 name=value 문자열 배열
  - `loginAndGetCookies(app, {email,password})` / `registerAndGetCookies(app, payload)` — 한 번에 로그인/가입하고 쿠키 리턴
- `backend/test/app.e2e-spec.ts` — `cookieParser` 미들웨어 적용 (프로덕션 `main.ts` 와 동일하게. cookie 인증 / refresh 라우트가 `req.cookies` 의존)
- 컨트롤러/프로덕션 코드 변경 없음 — cookie-only 전송 유지 (보안상 옵션 3 미채택)

## Test plan
- [x] `cd backend && npm run lint`
- [x] `cd backend && npm run build`
- [x] `cd backend && npm run test`
- e2e 스위트 리팩토링은 후속 이슈(#533/#534/#535) 에서 진행

## Related
- 원본: #531
- 후속: #533, #534, #535 (이 헬퍼를 소비)