### PR TITLE
feat: #495 비밀번호 재설정 플로우 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -57,6 +57,26 @@ import { RolesGuard } from './common/guards/roles.guard';
         ttl: 60000,
         limit: 30,
       },
+      {
+        name: 'forgotPassword',
+        ttl: 60000,
+        limit: 1,
+        getTracker: (req) => {
+          const rawEmail =
+            typeof req.body === 'object' && req.body !== null && 'email' in req.body
+              ? req.body.email
+              : undefined;
+
+          if (typeof rawEmail === 'string') {
+            const normalizedEmail = rawEmail.trim().toLowerCase();
+            if (normalizedEmail.length > 0) {
+              return `forgot-password:${normalizedEmail}`;
+            }
+          }
+
+          return `forgot-password:${req.ip}`;
+        },
+      },
     ]),
     CacheModule,
     AuthModule,

--- a/backend/src/database/migrations/1778400000000-CreatePasswordResetTokensTable.ts
+++ b/backend/src/database/migrations/1778400000000-CreatePasswordResetTokensTable.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePasswordResetTokensTable1778400000000 implements MigrationInterface {
+  name = 'CreatePasswordResetTokensTable1778400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS \`password_reset_tokens\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`user_id\` bigint NOT NULL, \`token_hash\` varchar(64) NOT NULL, \`expires_at\` datetime NOT NULL, \`used_at\` datetime NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), UNIQUE INDEX \`IDX_password_reset_tokens_token_hash\` (\`token_hash\`), INDEX \`IDX_password_reset_tokens_user_id\` (\`user_id\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`password_reset_tokens\` ADD CONSTRAINT \`FK_password_reset_tokens_user_id\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`password_reset_tokens\` DROP FOREIGN KEY \`FK_password_reset_tokens_user_id\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_password_reset_tokens_user_id\` ON \`password_reset_tokens\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_password_reset_tokens_token_hash\` ON \`password_reset_tokens\``,
+    );
+    await queryRunner.query(`DROP TABLE \`password_reset_tokens\``);
+  }
+}

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { JwtService } from '@nestjs/jwt';
-import { ConflictException, UnauthorizedException, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ConflictException, UnauthorizedException, ForbiddenException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { AuthService } from '../auth.service';
 import { User, UserRole } from '../../users/entities/user.entity';
+import { PasswordResetToken } from '../entities/password-reset-token.entity';
+import { NotificationService } from '../../notification/notification.service';
 
 const mockUserRepository = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockPasswordResetTokenRepository = {
   findOne: jest.fn(),
   create: jest.fn(),
   save: jest.fn(),
@@ -16,6 +25,10 @@ const mockUserRepository = {
 const mockJwtService = {
   sign: jest.fn().mockReturnValue('mock-token'),
   verify: jest.fn().mockReturnValue({ sub: 1, email: 'test@example.com', role: 'user' }),
+};
+
+const mockNotificationService = {
+  sendPasswordReset: jest.fn(),
 };
 
 function makeUser(overrides: Partial<User> = {}): User {
@@ -38,19 +51,36 @@ function makeUser(overrides: Partial<User> = {}): User {
 
 describe('AuthService', () => {
   let service: AuthService;
+  let originalFrontendUrl: string | undefined;
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    originalFrontendUrl = process.env.FRONTEND_URL;
+    process.env.FRONTEND_URL = 'https://frontend.test';
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
         { provide: getRepositoryToken(User), useValue: mockUserRepository },
+        {
+          provide: getRepositoryToken(PasswordResetToken),
+          useValue: mockPasswordResetTokenRepository,
+        },
         { provide: JwtService, useValue: mockJwtService },
+        { provide: NotificationService, useValue: mockNotificationService },
       ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    if (originalFrontendUrl === undefined) {
+      delete process.env.FRONTEND_URL;
+      return;
+    }
+
+    process.env.FRONTEND_URL = originalFrontendUrl;
   });
 
   describe('register', () => {
@@ -157,6 +187,85 @@ describe('AuthService', () => {
       mockJwtService.verify.mockImplementationOnce(() => { throw new Error('invalid'); });
 
       await expect(service.refresh('invalid.token')).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('존재하지 않는 이메일에도 동일한 성공 응답을 반환하고 메일을 보내지 않음', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.forgotPassword({ email: 'missing@example.com' })).resolves.toEqual({
+        message: '가입된 계정이 있다면 비밀번호 재설정 링크를 이메일로 발송했습니다.',
+      });
+
+      expect(mockNotificationService.sendPasswordReset).not.toHaveBeenCalled();
+    });
+
+    it('존재하는 이메일이면 토큰을 저장하고 재설정 메일을 발송함', async () => {
+      const user = makeUser({ email: 'test@example.com', name: '홍길동' });
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockPasswordResetTokenRepository.create.mockImplementation((value) => value);
+      mockPasswordResetTokenRepository.save.mockResolvedValue(undefined);
+      mockPasswordResetTokenRepository.update.mockResolvedValue({ affected: 1 });
+      mockNotificationService.sendPasswordReset.mockResolvedValue(undefined);
+
+      await service.forgotPassword({ email: 'test@example.com' });
+
+      expect(mockPasswordResetTokenRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: user.id,
+          tokenHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          usedAt: null,
+        }),
+      );
+      expect(mockNotificationService.sendPasswordReset).toHaveBeenCalledWith(
+        'test@example.com',
+        expect.objectContaining({
+          recipientName: '홍길동',
+          resetUrl: expect.stringContaining('/reset-password?token='),
+          expiresInMinutes: 60,
+        }),
+      );
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('이미 사용된 토큰 재사용 시 BadRequestException', async () => {
+      mockPasswordResetTokenRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 1,
+        usedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+      await expect(
+        service.resetPassword({ token: 'used-token', newPassword: 'NewPass123!' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('유효한 토큰이면 새 비밀번호를 저장하고 토큰을 사용 처리함', async () => {
+      mockPasswordResetTokenRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 1,
+        usedAt: null,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      mockPasswordResetTokenRepository.update
+        .mockResolvedValueOnce({ affected: 1 })
+        .mockResolvedValueOnce({ affected: 0 });
+      mockUserRepository.update.mockResolvedValue(undefined);
+
+      await expect(
+        service.resetPassword({ token: 'valid-token', newPassword: 'NewPass123!' }),
+      ).resolves.toEqual({ message: '비밀번호가 재설정되었습니다.' });
+
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          password: expect.stringMatching(/^\$2[aby]\$/),
+          refreshToken: null,
+        }),
+      );
     });
   });
 

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -16,10 +16,12 @@ import { OAuthService } from './oauth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { OAuthCallbackDto } from './dto/oauth-callback.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import { Public } from '../../common/decorators/public.decorator';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
-import { Throttle } from '@nestjs/throttler';
+import { SkipThrottle, Throttle } from '@nestjs/throttler';
 
 interface JwtUser {
   id: number;
@@ -56,6 +58,7 @@ function clearAuthCookies(res: Response): void {
 }
 
 @Throttle({ auth: { limit: 30, ttl: 60000 } })
+@SkipThrottle({ forgotPassword: true })
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
@@ -85,6 +88,34 @@ export class AuthController {
     const { accessToken, refreshToken, user } = await this.authService.login(dto);
     setAuthCookies(res, accessToken, refreshToken);
     return { user };
+  }
+
+  @Post('forgot-password')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @SkipThrottle({ forgotPassword: false })
+  @Throttle({ forgotPassword: { limit: 1, ttl: 60000 } })
+  @ApiOperation({
+    summary: '비밀번호 재설정 요청',
+    description: '가입된 이메일이면 비밀번호 재설정 링크를 발송합니다. 존재하지 않는 이메일에도 동일한 응답을 반환합니다.',
+  })
+  @ApiResponse({ status: 200, description: '비밀번호 재설정 안내 처리 완료' })
+  @ApiResponse({ status: 429, description: '같은 이메일로 너무 많은 요청' })
+  async forgotPassword(@Body() dto: ForgotPasswordDto) {
+    return this.authService.forgotPassword(dto);
+  }
+
+  @Post('reset-password')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '비밀번호 재설정',
+    description: '이메일로 받은 재설정 토큰과 새 비밀번호로 비밀번호를 변경합니다.',
+  })
+  @ApiResponse({ status: 200, description: '비밀번호 재설정 성공' })
+  @ApiResponse({ status: 400, description: '토큰이 유효하지 않거나 만료됨' })
+  async resetPassword(@Body() dto: ResetPasswordDto) {
+    return this.authService.resetPassword(dto);
   }
 
   @Get('profile')

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { OAuthService } from './oauth.service';
+import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { User } from '../users/entities/user.entity';
 import { UserAuthentication } from '../users/entities/user-authentication.entity';
 
@@ -36,7 +37,7 @@ function getJwtPrivateKey(): string {
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, UserAuthentication]),
+    TypeOrmModule.forFeature([User, UserAuthentication, PasswordResetToken]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
       privateKey: getJwtPrivateKey(),

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -8,17 +8,31 @@ import {
   OnModuleInit,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { createHash, randomBytes } from 'crypto';
 import type ms from 'ms';
 import { User } from '../users/entities/user.entity';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+import { PasswordResetToken } from './entities/password-reset-token.entity';
+import { NotificationService } from '../notification/notification.service';
 
 const MAX_LOGIN_ATTEMPTS = 5;
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000;
+const PASSWORD_RESET_TTL_MS = 60 * 60 * 1000;
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
+const FORGOT_PASSWORD_RESPONSE = {
+  message: '가입된 계정이 있다면 비밀번호 재설정 링크를 이메일로 발송했습니다.',
+};
+const RESET_PASSWORD_SUCCESS_RESPONSE = {
+  message: '비밀번호가 재설정되었습니다.',
+};
+const INVALID_PASSWORD_RESET_TOKEN_MESSAGE =
+  '유효하지 않거나 만료된 비밀번호 재설정 토큰입니다.';
 
 export interface TokenPair {
   accessToken: string;
@@ -41,7 +55,10 @@ export class AuthService implements OnModuleInit {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @InjectRepository(PasswordResetToken)
+    private readonly passwordResetTokenRepository: Repository<PasswordResetToken>,
     private readonly jwtService: JwtService,
+    private readonly notificationService: NotificationService,
   ) {}
 
   onModuleInit() {
@@ -195,6 +212,79 @@ export class AuthService implements OnModuleInit {
     return tokens;
   }
 
+  async forgotPassword(dto: ForgotPasswordDto): Promise<{ message: string }> {
+    const normalizedEmail = dto.email.trim().toLowerCase();
+    const user = await this.userRepository.findOne({
+      where: { email: normalizedEmail },
+    });
+
+    if (!user || !user.isActive) {
+      return FORGOT_PASSWORD_RESPONSE;
+    }
+
+    await this.passwordResetTokenRepository.update(
+      { userId: user.id, usedAt: IsNull() },
+      { usedAt: new Date() },
+    );
+
+    const rawToken = randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + PASSWORD_RESET_TTL_MS);
+    const resetToken = this.passwordResetTokenRepository.create({
+      userId: user.id,
+      tokenHash: this.hashPasswordResetToken(rawToken),
+      expiresAt,
+      usedAt: null,
+    });
+    await this.passwordResetTokenRepository.save(resetToken);
+
+    await this.notificationService.sendPasswordReset(user.email, {
+      recipientName: user.name,
+      resetUrl: this.buildPasswordResetUrl(rawToken),
+      expiresInMinutes: PASSWORD_RESET_TTL_MS / 60000,
+    });
+
+    return FORGOT_PASSWORD_RESPONSE;
+  }
+
+  async resetPassword(dto: ResetPasswordDto): Promise<{ message: string }> {
+    if (!PASSWORD_REGEX.test(dto.newPassword)) {
+      throw new BadRequestException('비밀번호는 문자, 숫자, 특수문자를 포함해야 합니다.');
+    }
+
+    const tokenHash = this.hashPasswordResetToken(dto.token);
+    const resetToken = await this.passwordResetTokenRepository.findOne({
+      where: { tokenHash },
+    });
+
+    if (!resetToken || resetToken.usedAt || resetToken.expiresAt.getTime() <= Date.now()) {
+      throw new BadRequestException(INVALID_PASSWORD_RESET_TOKEN_MESSAGE);
+    }
+
+    const markUsedResult = await this.passwordResetTokenRepository.update(
+      { id: resetToken.id, usedAt: IsNull() },
+      { usedAt: new Date() },
+    );
+
+    if (markUsedResult.affected !== 1) {
+      throw new BadRequestException(INVALID_PASSWORD_RESET_TOKEN_MESSAGE);
+    }
+
+    const hashedPassword = await bcrypt.hash(dto.newPassword, 10);
+    await this.userRepository.update(resetToken.userId, {
+      password: hashedPassword,
+      refreshToken: null,
+      failedLoginAttempts: 0,
+      lockedUntil: null,
+    });
+
+    await this.passwordResetTokenRepository.update(
+      { userId: resetToken.userId, usedAt: IsNull() },
+      { usedAt: new Date() },
+    );
+
+    return RESET_PASSWORD_SUCCESS_RESPONSE;
+  }
+
   async logout(userId: number): Promise<void> {
     await this.userRepository.update(userId, { refreshToken: null });
     this.logger.log(`User logged out: ${userId}`);
@@ -220,5 +310,20 @@ export class AuthService implements OnModuleInit {
 
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private hashPasswordResetToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private buildPasswordResetUrl(token: string): string {
+    const baseUrl = process.env.FRONTEND_URL;
+    if (!baseUrl) {
+      throw new Error('FRONTEND_URL environment variable is required');
+    }
+
+    const url = new URL('/reset-password', baseUrl);
+    url.searchParams.set('token', token);
+    return url.toString();
   }
 }

--- a/backend/src/modules/auth/dto/forgot-password.dto.ts
+++ b/backend/src/modules/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @ApiProperty({ example: 'user@example.com', description: '비밀번호를 재설정할 이메일 주소' })
+  @IsEmail({}, { message: '올바른 이메일 형식을 입력해 주세요.' })
+  email!: string;
+}

--- a/backend/src/modules/auth/dto/reset-password.dto.ts
+++ b/backend/src/modules/auth/dto/reset-password.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @ApiProperty({
+    example: 'reset-token-from-email',
+    description: '이메일로 발송된 비밀번호 재설정 토큰',
+  })
+  @IsString({ message: '재설정 토큰을 입력해 주세요.' })
+  @IsNotEmpty({ message: '재설정 토큰을 입력해 주세요.' })
+  token!: string;
+
+  @ApiProperty({ example: 'NewPass123!', description: '새 비밀번호 (8자 이상)' })
+  @IsString({ message: '새 비밀번호를 입력해 주세요.' })
+  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+  @MaxLength(100, { message: '비밀번호는 최대 100자까지 입력 가능합니다.' })
+  newPassword!: string;
+}

--- a/backend/src/modules/auth/entities/password-reset-token.entity.ts
+++ b/backend/src/modules/auth/entities/password-reset-token.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('password_reset_tokens')
+@Index('IDX_password_reset_tokens_token_hash', ['tokenHash'], { unique: true })
+@Index('IDX_password_reset_tokens_user_id', ['userId'])
+export class PasswordResetToken {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user!: User;
+
+  @Column({ name: 'user_id', type: 'bigint' })
+  userId!: number;
+
+  @Column({ name: 'token_hash', type: 'varchar', length: 64 })
+  tokenHash!: string;
+
+  @Column({ name: 'expires_at', type: 'datetime' })
+  expiresAt!: Date;
+
+  @Column({ name: 'used_at', type: 'datetime', nullable: true })
+  usedAt!: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/backend/src/modules/notification/__tests__/notification.service.spec.ts
+++ b/backend/src/modules/notification/__tests__/notification.service.spec.ts
@@ -6,6 +6,7 @@ import {
   renderInquiryAnswered,
   renderOrderConfirmed,
   renderPaymentConfirmed,
+  renderPasswordReset,
   renderShippingUpdate,
 } from '../templates/render';
 
@@ -86,6 +87,17 @@ describe('render helpers', () => {
     expect(email.html).not.toContain('<script>');
     expect(email.html).toContain('&lt;script&gt;');
   });
+
+  it('renders password reset email with reset URL', () => {
+    const email = renderPasswordReset({
+      recipientName: '홍길동',
+      resetUrl: 'https://example.com/reset-password?token=abc123',
+      expiresInMinutes: 60,
+    });
+    expect(email.subject).toContain('비밀번호 재설정');
+    expect(email.text).toContain('https://example.com/reset-password?token=abc123');
+    expect(email.html).toContain('href="https://example.com/reset-password?token=abc123"');
+  });
 });
 
 describe('NotificationService', () => {
@@ -141,5 +153,18 @@ describe('NotificationService', () => {
       svc.sendEmail({ to: 'x@y.z', subject: 's', html: 'h' }),
     ).resolves.toBeUndefined();
     expect(failing.send).toHaveBeenCalled();
+  });
+
+  it('sends password reset email via the provider', async () => {
+    await service.sendPasswordReset('user@example.com', {
+      recipientName: '홍길동',
+      resetUrl: 'https://example.com/reset-password?token=abc123',
+      expiresInMinutes: 60,
+    });
+
+    const sent = mockAdapter.getSent();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].subject).toContain('비밀번호 재설정');
+    expect(sent[0].text).toContain('abc123');
   });
 });

--- a/backend/src/modules/notification/notification.service.ts
+++ b/backend/src/modules/notification/notification.service.ts
@@ -4,10 +4,12 @@ import {
   renderInquiryAnswered,
   renderOrderConfirmed,
   renderPaymentConfirmed,
+  renderPasswordReset,
   renderShippingUpdate,
   type InquiryAnsweredContext,
   type OrderConfirmedContext,
   type PaymentConfirmedContext,
+  type PasswordResetContext,
   type ShippingUpdateContext,
 } from './templates/render';
 
@@ -59,6 +61,11 @@ export class NotificationService {
 
   async sendInquiryAnswered(to: string, context: InquiryAnsweredContext): Promise<void> {
     const rendered = renderInquiryAnswered(context);
+    await this.sendEmail({ to, ...rendered });
+  }
+
+  async sendPasswordReset(to: string, context: PasswordResetContext): Promise<void> {
+    const rendered = renderPasswordReset(context);
     await this.sendEmail({ to, ...rendered });
   }
 }

--- a/backend/src/modules/notification/templates/render.ts
+++ b/backend/src/modules/notification/templates/render.ts
@@ -30,6 +30,13 @@ export interface InquiryAnsweredContext {
   locale?: 'ko' | 'en';
 }
 
+export interface PasswordResetContext {
+  recipientName: string;
+  resetUrl: string;
+  expiresInMinutes: number;
+  locale?: 'ko' | 'en';
+}
+
 export interface RenderedEmail {
   subject: string;
   html: string;
@@ -85,5 +92,17 @@ export function renderInquiryAnswered(ctx: InquiryAnsweredContext): RenderedEmai
     ? `${ctx.recipientName}님, 문의하신 "${ctx.inquiryTitle}"에 답변이 등록되었습니다.\n\n${ctx.answer}`
     : `Hi ${ctx.recipientName}, your inquiry "${ctx.inquiryTitle}" has been answered.\n\n${ctx.answer}`;
   const html = `<div><h2>${escapeHtml(subject)}</h2><p>${escapeHtml(text).replace(/\n/g, '<br>')}</p></div>`;
+  return { subject, html, text };
+}
+
+export function renderPasswordReset(ctx: PasswordResetContext): RenderedEmail {
+  const isKo = (ctx.locale ?? 'ko') === 'ko';
+  const subject = isKo
+    ? '[옥화당] 비밀번호 재설정 안내'
+    : '[Okhwadang] Reset your password';
+  const text = isKo
+    ? `${ctx.recipientName}님, 아래 링크에서 비밀번호를 재설정해 주세요. 링크는 ${ctx.expiresInMinutes}분 후 만료됩니다.\n\n${ctx.resetUrl}`
+    : `Hi ${ctx.recipientName}, use the link below to reset your password. It expires in ${ctx.expiresInMinutes} minutes.\n\n${ctx.resetUrl}`;
+  const html = `<div><h2>${escapeHtml(subject)}</h2><p>${escapeHtml(text).replace(/\n/g, '<br>')}</p><p><a href="${escapeHtml(ctx.resetUrl)}">${escapeHtml(ctx.resetUrl)}</a></p></div>`;
   return { subject, html, text };
 }

--- a/backend/test/auth-password-reset.e2e-spec.ts
+++ b/backend/test/auth-password-reset.e2e-spec.ts
@@ -1,0 +1,169 @@
+import 'dotenv/config';
+import { Module, ValidationPipe } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { INestApplication } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+import * as bcrypt from 'bcrypt';
+import { DataSource } from 'typeorm';
+import { AuthModule } from '../src/modules/auth/auth.module';
+import { NotificationModule } from '../src/modules/notification/notification.module';
+import { MockEmailAdapter } from '../src/modules/notification/adapters/mock.adapter';
+
+process.env.JWT_SECRET ??= 'test-secret-key-for-e2e-tests';
+process.env.FRONTEND_URL ??= 'http://localhost:5173';
+process.env.NOTIFICATION_PROVIDER ??= 'mock';
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL ?? '';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'mysql',
+      url: process.env.DATABASE_URL,
+      charset: 'utf8mb4',
+      autoLoadEntities: true,
+      synchronize: true,
+      dropSchema: true,
+    }),
+    ThrottlerModule.forRoot([
+      {
+        name: 'global',
+        ttl: 60000,
+        limit: 200,
+      },
+      {
+        name: 'auth',
+        ttl: 60000,
+        limit: 30,
+      },
+      {
+        name: 'forgotPassword',
+        ttl: 60000,
+        limit: 1,
+        getTracker: (req) => {
+          const rawEmail =
+            typeof req.body === 'object' && req.body !== null && 'email' in req.body
+              ? req.body.email
+              : undefined;
+
+          if (typeof rawEmail === 'string') {
+            const normalizedEmail = rawEmail.trim().toLowerCase();
+            if (normalizedEmail.length > 0) {
+              return `forgot-password:${normalizedEmail}`;
+            }
+          }
+
+          return `forgot-password:${req.ip}`;
+        },
+      },
+    ]),
+    NotificationModule,
+    AuthModule,
+  ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
+})
+class AuthPasswordResetTestModule {}
+
+describe('Auth password reset flow (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let mockEmailAdapter: MockEmailAdapter;
+
+  const password = 'Test1234!';
+  const forgotPasswordEmail = `auth-forgot-${Date.now()}@test.com`;
+  const tokenReuseEmail = `auth-reuse-${Date.now()}@test.com`;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AuthPasswordResetTestModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    dataSource = app.get(DataSource);
+    mockEmailAdapter = app.get(MockEmailAdapter);
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    await dataSource.query(
+      'INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())',
+      [forgotPasswordEmail, hashedPassword, '비밀번호분실유저', 'user', 1, 0],
+    );
+    await dataSource.query(
+      'INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())',
+      [tokenReuseEmail, hashedPassword, '토큰재사용유저', 'user', 1, 0],
+    );
+  });
+
+  beforeEach(() => {
+    mockEmailAdapter.clear();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns the same 200 response for existing and missing emails', async () => {
+    const existingRes = await request(app.getHttpServer())
+      .post('/api/auth/forgot-password')
+      .send({ email: forgotPasswordEmail })
+      .expect(200);
+
+    const missingRes = await request(app.getHttpServer())
+      .post('/api/auth/forgot-password')
+      .send({ email: 'missing-auth-e2e@test.com' })
+      .expect(200);
+
+    expect(existingRes.body).toEqual(missingRes.body);
+    expect(existingRes.body).toEqual({
+      message: '가입된 계정이 있다면 비밀번호 재설정 링크를 이메일로 발송했습니다.',
+    });
+    expect(mockEmailAdapter.getSent()).toHaveLength(1);
+  });
+
+  it('prevents reuse of a password reset token', async () => {
+    await request(app.getHttpServer())
+      .post('/api/auth/forgot-password')
+      .send({ email: tokenReuseEmail })
+      .expect(200);
+
+    const sentEmails = mockEmailAdapter.getSent();
+    expect(sentEmails).toHaveLength(1);
+    const text = sentEmails[0].text ?? '';
+    const match = text.match(/token=([A-Za-z0-9]+)/);
+    expect(match).not.toBeNull();
+    const token = match?.[1] ?? '';
+
+    await request(app.getHttpServer())
+      .post('/api/auth/reset-password')
+      .send({ token, newPassword: 'NewPass123!' })
+      .expect(200)
+      .expect({ message: '비밀번호가 재설정되었습니다.' });
+
+    await request(app.getHttpServer())
+      .post('/api/auth/reset-password')
+      .send({ token, newPassword: 'AnotherPass123!' })
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.message).toBe('유효하지 않거나 만료된 비밀번호 재설정 토큰입니다.');
+      });
+  });
+});

--- a/backend/test/suites/auth.e2e-spec.ts
+++ b/backend/test/suites/auth.e2e-spec.ts
@@ -1,13 +1,18 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { MockEmailAdapter } from '../../src/modules/notification/adapters/mock.adapter';
 
 let app: INestApplication;
 let dataSource: DataSource;
+let mockEmailAdapter: MockEmailAdapter;
 
 export function registerAuthSuite(getApp: () => INestApplication) {
   describe('Auth (e2e)', () => {
     const email = `auth-e2e-${Date.now()}@test.com`;
+    const forgotPasswordEmail = `auth-forgot-${Date.now()}@test.com`;
+    const tokenReuseEmail = `auth-reuse-${Date.now()}@test.com`;
     const password = 'Test1234!';
     const name = '테스트유저';
 
@@ -18,10 +23,29 @@ export function registerAuthSuite(getApp: () => INestApplication) {
     beforeAll(async () => {
       app = getApp();
       dataSource = app.get(DataSource);
+      mockEmailAdapter = app.get(MockEmailAdapter);
+
+      const hashedPassword = await bcrypt.hash(password, 10);
+      await dataSource.query(
+        'INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())',
+        [forgotPasswordEmail, hashedPassword, '비밀번호분실유저', 'user', 1, 0],
+      );
+      await dataSource.query(
+        'INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())',
+        [tokenReuseEmail, hashedPassword, '토큰재사용유저', 'user', 1, 0],
+      );
     });
 
     afterAll(async () => {
+      await dataSource.query('DELETE FROM password_reset_tokens WHERE user_id = ?', [userId]);
       await dataSource.query('DELETE FROM users WHERE email = ?', [email]);
+      await dataSource.query('DELETE FROM users WHERE email = ?', [forgotPasswordEmail]);
+      await dataSource.query('DELETE FROM users WHERE email = ?', [tokenReuseEmail]);
+      await dataSource.query('DELETE FROM users WHERE email = ?', ['missing-auth-e2e@test.com']);
+    });
+
+    beforeEach(() => {
+      mockEmailAdapter.clear();
     });
 
     describe('POST /api/auth/register', () => {
@@ -100,7 +124,7 @@ export function registerAuthSuite(getApp: () => INestApplication) {
       it('유효한 refreshToken → 200, 새 토큰 쌍 반환', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/auth/refresh')
-          .send({ refreshToken })
+          .set('Cookie', [`refreshToken=${refreshToken}`])
           .expect(200);
 
         const body = res.body as { accessToken: string; refreshToken: string };
@@ -108,6 +132,50 @@ export function registerAuthSuite(getApp: () => INestApplication) {
         expect(body.refreshToken).toBeDefined();
         accessToken = body.accessToken;
         refreshToken = body.refreshToken;
+      });
+    });
+
+    describe('POST /api/auth/forgot-password', () => {
+      it('존재하는 이메일과 존재하지 않는 이메일 모두 동일한 200 응답을 반환함', async () => {
+        const existingRes = await request(app.getHttpServer())
+          .post('/api/auth/forgot-password')
+          .send({ email: forgotPasswordEmail })
+          .expect(200);
+
+        const missingRes = await request(app.getHttpServer())
+          .post('/api/auth/forgot-password')
+          .send({ email: 'missing-auth-e2e@test.com' })
+          .expect(200);
+
+        expect(existingRes.body).toEqual(missingRes.body);
+        expect(existingRes.body).toEqual({
+          message: '가입된 계정이 있다면 비밀번호 재설정 링크를 이메일로 발송했습니다.',
+        });
+      });
+
+      it('같은 재설정 토큰을 두 번 사용할 수 없음', async () => {
+        await request(app.getHttpServer())
+          .post('/api/auth/forgot-password')
+          .send({ email: tokenReuseEmail })
+          .expect(200);
+
+        const sentEmails = mockEmailAdapter.getSent();
+        expect(sentEmails).toHaveLength(1);
+        const text = sentEmails[0].text ?? '';
+        const match = text.match(/token=([A-Za-z0-9]+)/);
+        expect(match).not.toBeNull();
+        const token = match?.[1] ?? '';
+
+        await request(app.getHttpServer())
+          .post('/api/auth/reset-password')
+          .send({ token, newPassword: 'NewPass123!' })
+          .expect(200)
+          .expect({ message: '비밀번호가 재설정되었습니다.' });
+
+        await request(app.getHttpServer())
+          .post('/api/auth/reset-password')
+          .send({ token, newPassword: 'AnotherPass123!' })
+          .expect(400);
       });
     });
 


### PR DESCRIPTION
## Summary
- `password_reset_tokens` 테이블/엔티티/마이그레이션과 `POST /auth/forgot-password`, `POST /auth/reset-password`를 추가해 이메일 기반 비밀번호 재설정 플로우를 구현했습니다.
- NotificationModule 이메일 템플릿/서비스를 확장해 재설정 링크를 발송하고, 토큰 해시 저장·단일 사용 처리·비존재 이메일에 대한 동일 200 응답을 적용했습니다.
- 이메일 기준 분당 1회 rate limit과 단위/E2E 테스트를 추가했습니다.

## Validation
- ✅ `npm run build`
- ✅ `npm run test:run`
- ✅ `cd backend && npm run lint`
- ✅ `cd backend && npm run build`
- ✅ `cd backend && npm test -- --runInBand`
- ✅ `cd backend && npm run test:e2e -- --runInBand test/auth-password-reset.e2e-spec.ts`
- ⚠️ `cd backend && npm run test:e2e` fails in the existing shared `commerce_test` baseline because unrelated tables such as `pages`, `navigation_items`, and `products` are missing in `test/app.e2e-spec.ts`.

Closes #495