### PR TITLE
feat: #479 OrderStatus enum에 COMPLETED·REFUND_REQUESTED 상태 및 전이 추가

### DIFF
--- a/backend/src/database/migrations/1778400000000-AddOrderStatusCompletedAndRefundRequested.ts
+++ b/backend/src/database/migrations/1778400000000-AddOrderStatusCompletedAndRefundRequested.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #479: OrderStatus enum에 COMPLETED와 REFUND_REQUESTED 상태 추가
+ * - delivered → completed 경로 추가 (배송 완료 후 구매 확정)
+ * - delivered → refund_requested 경로 추가 (배송 완료 후 환불 요청)
+ * - refund_requested → refunded 경로 추가 (관리자가 환불 처리)
+ * - completed는 종단 상태 (이후 상태 전이 불가)
+ */
+export class AddOrderStatusCompletedAndRefundRequested1778400000000 implements MigrationInterface {
+  name = 'AddOrderStatusCompletedAndRefundRequested1778400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`SET NAMES utf8mb4`);
+
+    // ALTER TABLE orders CHANGE COLUMN status ENUM 추가
+    // 기존 ENUM: pending, paid, preparing, shipped, delivered, cancelled, refunded
+    // 새 ENUM: pending, paid, preparing, shipped, delivered, completed, cancelled, refund_requested, refunded
+    await queryRunner.query(`
+      ALTER TABLE \`orders\`
+      CHANGE COLUMN \`status\`
+        \`status\` ENUM('pending', 'paid', 'preparing', 'shipped', 'delivered', 'completed', 'cancelled', 'refund_requested', 'refunded')
+        NOT NULL DEFAULT 'pending'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 이전 ENUM으로 복원
+    await queryRunner.query(`
+      ALTER TABLE \`orders\`
+      CHANGE COLUMN \`status\`
+        \`status\` ENUM('pending', 'paid', 'preparing', 'shipped', 'delivered', 'cancelled', 'refunded')
+        NOT NULL DEFAULT 'pending'
+    `);
+  }
+}

--- a/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
@@ -143,6 +143,53 @@ describe('AdminOrdersService', () => {
       await service.updateStatus(1, OrderStatus.CANCELLED);
       expect(orderRepo.update).toHaveBeenCalledWith(1, { status: OrderStatus.CANCELLED });
     });
+
+    it('delivered → completed: allowed', async () => {
+      orderRepo.findOne
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.DELIVERED })
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.COMPLETED });
+      orderRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateStatus(1, OrderStatus.COMPLETED);
+      expect(orderRepo.update).toHaveBeenCalledWith(1, { status: OrderStatus.COMPLETED });
+    });
+
+    it('delivered → refund_requested: allowed', async () => {
+      orderRepo.findOne
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.DELIVERED })
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUND_REQUESTED });
+      orderRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateStatus(1, OrderStatus.REFUND_REQUESTED);
+      expect(orderRepo.update).toHaveBeenCalledWith(1, { status: OrderStatus.REFUND_REQUESTED });
+    });
+
+    it('refund_requested → refunded: allowed', async () => {
+      orderRepo.findOne
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUND_REQUESTED })
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUNDED });
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 1 });
+      paymentRepo.update.mockResolvedValue({ affected: 1 });
+      orderRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateStatus(1, OrderStatus.REFUNDED);
+      expect(paymentRepo.update).toHaveBeenCalledWith(10, expect.objectContaining({
+        status: PaymentStatus.REFUNDED,
+        cancelReason: '관리자 환불 처리',
+      }));
+    });
+
+    it('completed → any: not allowed (terminal state)', async () => {
+      orderRepo.findOne.mockResolvedValueOnce({ id: 1, status: OrderStatus.COMPLETED });
+      await expect(service.updateStatus(1, OrderStatus.DELIVERED))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('delivered → refunded directly: not allowed (must go through refund_requested)', async () => {
+      orderRepo.findOne.mockResolvedValueOnce({ id: 1, status: OrderStatus.DELIVERED });
+      await expect(service.updateStatus(1, OrderStatus.REFUNDED))
+        .rejects.toThrow(BadRequestException);
+    });
   });
 
   describe('registerShipping', () => {

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -17,8 +17,10 @@ const ALLOWED_ORDER_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   [OrderStatus.PAID]: [OrderStatus.PREPARING, OrderStatus.CANCELLED, OrderStatus.REFUNDED],
   [OrderStatus.PREPARING]: [OrderStatus.SHIPPED, OrderStatus.CANCELLED, OrderStatus.REFUNDED],
   [OrderStatus.SHIPPED]: [OrderStatus.DELIVERED, OrderStatus.REFUNDED],
-  [OrderStatus.DELIVERED]: [OrderStatus.REFUNDED],
+  [OrderStatus.DELIVERED]: [OrderStatus.COMPLETED, OrderStatus.REFUND_REQUESTED],
+  [OrderStatus.COMPLETED]: [],
   [OrderStatus.CANCELLED]: [],
+  [OrderStatus.REFUND_REQUESTED]: [OrderStatus.REFUNDED],
   [OrderStatus.REFUNDED]: [],
 };
 

--- a/backend/src/modules/orders/entities/order.entity.ts
+++ b/backend/src/modules/orders/entities/order.entity.ts
@@ -11,7 +11,9 @@ export enum OrderStatus {
   PREPARING = 'preparing',
   SHIPPED = 'shipped',
   DELIVERED = 'delivered',
+  COMPLETED = 'completed',
   CANCELLED = 'cancelled',
+  REFUND_REQUESTED = 'refund_requested',
   REFUNDED = 'refunded',
 }
 

--- a/backend/test/suites/admin-orders.e2e-spec.ts
+++ b/backend/test/suites/admin-orders.e2e-spec.ts
@@ -10,9 +10,25 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
     let adminToken: string;
     let userToken: string;
     let orderId: number;
+    let refundOrderId: number;
+    let productId: number;
 
     const adminEmail = `admin-orders-admin-${Date.now()}@test.com`;
     const userEmail = `admin-orders-user-${Date.now()}@test.com`;
+
+    async function createOrder(): Promise<number> {
+      const orderRes = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({
+          items: [{ productId, quantity: 1 }],
+          recipientName: '테스트',
+          recipientPhone: '010-1234-5678',
+          zipcode: '12345',
+          address: '서울시 강남구',
+        });
+      return (orderRes.body as { id: number }).id;
+    }
 
     beforeAll(async () => {
       app = getApp();
@@ -42,20 +58,10 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
         .post('/api/products')
         .set('Authorization', `Bearer ${adminToken}`)
         .send({ name: '주문테스트상품', slug, price: 10000, stock: 100, status: 'active' });
-      const productId = (productRes.body as { id: number }).id;
+      productId = (productRes.body as { id: number }).id;
 
-      // Create order
-      const orderRes = await request(app.getHttpServer())
-        .post('/api/orders')
-        .set('Authorization', `Bearer ${userToken}`)
-        .send({
-          items: [{ productId, quantity: 1 }],
-          recipientName: '테스트',
-          recipientPhone: '010-1234-5678',
-          zipcode: '12345',
-          address: '서울시 강남구',
-        });
-      orderId = (orderRes.body as { id: number }).id;
+      orderId = await createOrder();
+      refundOrderId = await createOrder();
     });
 
     describe('GET /api/admin/orders', () => {
@@ -176,7 +182,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       });
     });
 
-    describe('shipped → delivered flow', () => {
+    describe('delivered → completed flow', () => {
       it('preparing → shipped (운송장 등록 후)', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
@@ -199,12 +205,103 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
         expect(body.status).toBe('delivered');
       });
 
-      it('delivered → 최종 상태, 전이 불가', async () => {
+      it('delivered → completed', async () => {
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${orderId}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ status: 'completed' })
+          .expect(200);
+
+        const body = res.body as { status: string };
+        expect(body.status).toBe('completed');
+      });
+
+      it('completed → paid: 전이 불가', async () => {
         await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
           .set('Authorization', `Bearer ${adminToken}`)
           .send({ status: 'paid' })
           .expect(400);
+      });
+    });
+
+    describe('delivered → refund_requested → refunded flow', () => {
+      it('refund order 운송장 등록 → 201', async () => {
+        const res = await request(app.getHttpServer())
+          .post(`/api/admin/shipping/${refundOrderId}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ carrier: 'cj', trackingNumber: `TRK-REFUND-${Date.now()}` })
+          .expect(201);
+
+        const body = res.body as { carrier: string; trackingNumber: string };
+        expect(body.carrier).toBe('cj');
+        expect(body.trackingNumber).toBeDefined();
+      });
+
+      it('refund order pending → paid', async () => {
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${refundOrderId}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ status: 'paid' })
+          .expect(200);
+
+        const body = res.body as { status: string };
+        expect(body.status).toBe('paid');
+      });
+
+      it('refund order paid → preparing', async () => {
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${refundOrderId}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ status: 'preparing' })
+          .expect(200);
+
+        const body = res.body as { status: string };
+        expect(body.status).toBe('preparing');
+      });
+
+      it('refund order preparing → shipped', async () => {
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${refundOrderId}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ status: 'shipped' })
+          .expect(200);
+
+        const body = res.body as { status: string };
+        expect(body.status).toBe('shipped');
+      });
+
+      it('refund order shipped → delivered', async () => {
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${refundOrderId}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ status: 'delivered' })
+          .expect(200);
+
+        const body = res.body as { status: string };
+        expect(body.status).toBe('delivered');
+      });
+
+      it('refund order delivered → refund_requested', async () => {
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${refundOrderId}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ status: 'refund_requested' })
+          .expect(200);
+
+        const body = res.body as { status: string };
+        expect(body.status).toBe('refund_requested');
+      });
+
+      it('refund_requested → refunded', async () => {
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${refundOrderId}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ status: 'refunded' })
+          .expect(200);
+
+        const body = res.body as { status: string };
+        expect(body.status).toBe('refunded');
       });
     });
   });


### PR DESCRIPTION
## Summary
- OrderStatus enum에 COMPLETED와 REFUND_REQUESTED 상태 추가
- delivered → [completed, refund_requested] 전이 허용
- refund_requested → refunded 전이 허용
- migration으로 DB enum 컬럼 업데이트
- 단위 테스트: delivered→completed, delivered→refund_requested, refund_requested→refunded, completed 종단 상태, delivered→refunded 직접 전이 거부\n- E2E 테스트: delivered→completed, delivered→refund_requested→refunded 플로우\n\nCloses #479