### PR TITLE
feat: #480 Admin refund reverses PG charge

### DIFF
--- a/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
@@ -5,6 +5,7 @@ import { AdminOrdersService } from '../admin-orders.service';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { Payment, PaymentStatus } from '../../payments/entities/payment.entity';
 import { Shipping } from '../../payments/entities/shipping.entity';
+import { PaymentsService } from '../../payments/payments.service';
 
 function createMockRepository() {
   return {
@@ -30,11 +31,15 @@ describe('AdminOrdersService', () => {
   let orderRepo: ReturnType<typeof createMockRepository>;
   let paymentRepo: ReturnType<typeof createMockRepository>;
   let shippingRepo: ReturnType<typeof createMockRepository>;
+  let paymentsService: jest.Mocked<PaymentsService>;
 
   beforeEach(async () => {
     orderRepo = createMockRepository();
     paymentRepo = createMockRepository();
     shippingRepo = createMockRepository();
+    paymentsService = {
+      cancelAdmin: jest.fn(),
+    } as unknown as jest.Mocked<PaymentsService>;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -42,6 +47,7 @@ describe('AdminOrdersService', () => {
         { provide: getRepositoryToken(Order), useValue: orderRepo },
         { provide: getRepositoryToken(Payment), useValue: paymentRepo },
         { provide: getRepositoryToken(Shipping), useValue: shippingRepo },
+        { provide: PaymentsService, useValue: paymentsService },
       ],
     }).compile();
 
@@ -119,19 +125,21 @@ describe('AdminOrdersService', () => {
         .rejects.toThrow(BadRequestException);
     });
 
-    it('paid → refunded: should update payment status', async () => {
+    it('paid → refunded: should call paymentsService.cancelAdmin (PG cancel)', async () => {
       orderRepo.findOne
         .mockResolvedValueOnce({ id: 1, status: OrderStatus.PAID })
         .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUNDED });
       paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 1 });
-      paymentRepo.update.mockResolvedValue({ affected: 1 });
+      paymentsService.cancelAdmin.mockResolvedValue({
+        paymentId: 10,
+        status: PaymentStatus.REFUNDED,
+        cancelledAt: new Date(),
+        cancelReason: '관리자 환불 처리',
+      });
       orderRepo.update.mockResolvedValue({ affected: 1 });
 
       await service.updateStatus(1, OrderStatus.REFUNDED);
-      expect(paymentRepo.update).toHaveBeenCalledWith(10, expect.objectContaining({
-        status: PaymentStatus.REFUNDED,
-        cancelReason: '관리자 환불 처리',
-      }));
+      expect(paymentsService.cancelAdmin).toHaveBeenCalledWith(1, '관리자 환불 처리');
     });
 
     it('paid → cancelled: allowed', async () => {
@@ -164,19 +172,21 @@ describe('AdminOrdersService', () => {
       expect(orderRepo.update).toHaveBeenCalledWith(1, { status: OrderStatus.REFUND_REQUESTED });
     });
 
-    it('refund_requested → refunded: allowed', async () => {
+    it('refund_requested → refunded: should call paymentsService.cancelAdmin', async () => {
       orderRepo.findOne
         .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUND_REQUESTED })
         .mockResolvedValueOnce({ id: 1, status: OrderStatus.REFUNDED });
       paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 1 });
-      paymentRepo.update.mockResolvedValue({ affected: 1 });
+      paymentsService.cancelAdmin.mockResolvedValue({
+        paymentId: 10,
+        status: PaymentStatus.REFUNDED,
+        cancelledAt: new Date(),
+        cancelReason: '관리자 환불 처리',
+      });
       orderRepo.update.mockResolvedValue({ affected: 1 });
 
       await service.updateStatus(1, OrderStatus.REFUNDED);
-      expect(paymentRepo.update).toHaveBeenCalledWith(10, expect.objectContaining({
-        status: PaymentStatus.REFUNDED,
-        cancelReason: '관리자 환불 처리',
-      }));
+      expect(paymentsService.cancelAdmin).toHaveBeenCalledWith(1, '관리자 환불 처리');
     });
 
     it('completed → any: not allowed (terminal state)', async () => {

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -5,8 +5,9 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
-import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
+import { Payment } from '../payments/entities/payment.entity';
 import { Shipping, ShippingStatus } from '../payments/entities/shipping.entity';
+import { PaymentsService } from '../payments/payments.service';
 import { AdminOrderQueryDto } from './dto/admin-order-query.dto';
 import { RegisterShippingDto } from './dto/register-shipping.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
@@ -35,6 +36,7 @@ export class AdminOrdersService {
     private readonly paymentRepository: Repository<Payment>,
     @InjectRepository(Shipping)
     private readonly shippingRepository: Repository<Shipping>,
+    private readonly paymentsService: PaymentsService,
   ) {}
 
   async findAll(query: AdminOrderQueryDto): Promise<PaginatedResult<Order>> {
@@ -91,11 +93,7 @@ export class AdminOrdersService {
     if (nextStatus === OrderStatus.REFUNDED) {
       const payment = await this.paymentRepository.findOne({ where: { orderId } });
       if (payment) {
-        await this.paymentRepository.update(payment.id, {
-          status: PaymentStatus.REFUNDED,
-          cancelledAt: new Date(),
-          cancelReason: '관리자 환불 처리',
-        });
+        await this.paymentsService.cancelAdmin(orderId, '관리자 환불 처리');
       }
     }
 

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -13,9 +13,13 @@ import { Payment } from '../payments/entities/payment.entity';
 import { Shipping } from '../payments/entities/shipping.entity';
 import { User } from '../users/entities/user.entity';
 import { Product } from '../products/entities/product.entity';
+import { PaymentsModule } from '../payments/payments.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order, Payment, Shipping, User, Product])],
+  imports: [
+    TypeOrmModule.forFeature([Order, Payment, Shipping, User, Product]),
+    PaymentsModule,
+  ],
   controllers: [AdminController, AdminDashboardController, AdminOrdersController, AdminMembersController],
   providers: [AdminService, AdminDashboardService, AdminOrdersService, AdminMembersService],
 })

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -233,6 +233,40 @@ export class PaymentsService {
     };
   }
 
+  async cancelAdmin(orderId: number, reason: string): Promise<{
+    paymentId: number;
+    status: PaymentStatus;
+    cancelledAt: Date;
+    cancelReason: string;
+  }> {
+    const payment = await findOrThrow(
+      this.paymentRepository,
+      { orderId },
+      '결제 정보를 찾을 수 없습니다.',
+    );
+
+    if (payment.status !== PaymentStatus.CONFIRMED) {
+      throw new BadRequestException('환불 가능한 상태가 아닙니다.');
+    }
+
+    const cancelGateway = this.resolveGatewayByType(payment.gateway);
+    const result = await cancelGateway.cancel(payment.paymentKey!, reason);
+
+    await this.paymentRepository.update(payment.id, {
+      status: PaymentStatus.REFUNDED,
+      cancelledAt: result.cancelledAt,
+      cancelReason: reason,
+      rawResponse: result.rawResponse as object,
+    });
+
+    return {
+      paymentId: Number(payment.id),
+      status: PaymentStatus.REFUNDED,
+      cancelledAt: result.cancelledAt,
+      cancelReason: reason,
+    };
+  }
+
   private async notifyPaymentConfirmed(
     userId: number,
     orderNumber: string,


### PR DESCRIPTION
## Summary
- **Issue**: #480 Admin refund does not reverse the payment gateway charge
- Admin sets order to `REFUNDED` → only local payment record updated → PG cancel never called → customer sees "refunded" but money never returns

## Changes

### `payments.service.ts`
- Add `cancelAdmin(orderId, reason)`: calls PG cancel, updates local Payment status to `REFUNDED` (no userId ownership check for admin)

### `admin-orders.service.ts`
- Inject `PaymentsService`
- When `newStatus === OrderStatus.REFUNDED`, call `paymentsService.cancelAdmin()` BEFORE local order status update

### `admin.module.ts`
- Import `PaymentsModule` for DI

### `admin-orders.service.spec.ts`
- Unit test: admin changes order to REFUNDED → `paymentsService.cancelAdmin()` is called with correct args

## Testing
- ✅ Backend lint: 0 errors
- ✅ Backend build: success
- ✅ Backend tests: 449 passed
- ✅ Frontend lint: 0 errors  
- ✅ Frontend build: success
- ✅ Frontend tests: 388 passed

Closes #480