### PR TITLE
feat: #498 Implement audit log system for admin actions

### DIFF
--- a/backend/src/common/decorators/audit-log.decorator.ts
+++ b/backend/src/common/decorators/audit-log.decorator.ts
@@ -1,0 +1,14 @@
+import { SetMetadata } from '@nestjs/common';
+import { AuditAction } from '../../modules/audit-logs/entities/audit-log.entity';
+
+export const AUDIT_LOG_KEY = 'audit_log';
+export const AUDIT_ACTION_KEY = 'audit_action';
+
+export interface AuditLogOptions {
+  action: AuditAction;
+  resourceType: string;
+  getResourceId?: (args: unknown[]) => number | null;
+}
+
+export const AuditLog = (options: AuditLogOptions) =>
+  SetMetadata(AUDIT_LOG_KEY, options);

--- a/backend/src/common/interceptors/audit-log.interceptor.spec.ts
+++ b/backend/src/common/interceptors/audit-log.interceptor.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { AuditLogInterceptor } from './audit-log.interceptor';
+import { AuditLogService } from '../../modules/audit-logs/audit-log.service';
+import { AuditAction } from '../../modules/audit-logs/entities/audit-log.entity';
+
+describe('AuditLogInterceptor', () => {
+  let interceptor: AuditLogInterceptor;
+  let auditLogService: jest.Mocked<AuditLogService>;
+
+  const mockAuditLogService = {
+    log: jest.fn(),
+  };
+
+  const mockReflector = {
+    get: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditLogInterceptor,
+        { provide: Reflector, useValue: mockReflector },
+        { provide: AuditLogService, useValue: mockAuditLogService },
+      ],
+    }).compile();
+
+    interceptor = module.get<AuditLogInterceptor>(AuditLogInterceptor);
+    auditLogService = module.get(AuditLogService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createMockExecutionContext(user?: { id: number; role: string }, body?: Record<string, unknown>): ExecutionContext {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user,
+          body,
+          params: { id: '123' },
+          ip: '192.168.1.1',
+          headers: { 'user-agent': 'Mozilla/5.0' },
+          connection: { remoteAddress: '192.168.1.1' },
+        }),
+      }),
+      getHandler: () => ({}),
+      getParamTypes: () => [],
+    } as unknown as ExecutionContext;
+  }
+
+  function createMockCallHandler(responseBody?: unknown): CallHandler {
+    return {
+      handle: () => of(responseBody),
+    };
+  }
+
+  it('should not log when no audit options are set', (done) => {
+    mockReflector.get.mockReturnValue(null);
+    const context = createMockExecutionContext({ id: 1, role: 'admin' }, {});
+    const handler = createMockCallHandler({ id: 123 });
+
+    interceptor.intercept(context, handler).subscribe({
+      next: () => {
+        expect(auditLogService.log).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('should log successful actions', (done) => {
+    mockReflector.get.mockReturnValue({
+      action: AuditAction.ORDER_STATUS_UPDATE,
+      resourceType: 'order',
+    });
+    const context = createMockExecutionContext({ id: 1, role: 'admin' }, { status: 'paid' });
+    const handler = createMockCallHandler({ id: 123, status: 'paid' });
+
+    auditLogService.log.mockResolvedValue({ id: 1 } as never);
+
+    interceptor.intercept(context, handler).subscribe({
+      next: () => {
+        expect(auditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            actorId: 1,
+            actorRole: 'admin',
+            action: AuditAction.ORDER_STATUS_UPDATE,
+            resourceType: 'order',
+          }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('should log failed actions', (done) => {
+    mockReflector.get.mockReturnValue({
+      action: AuditAction.ORDER_STATUS_UPDATE,
+      resourceType: 'order',
+    });
+    const context = createMockExecutionContext({ id: 1, role: 'admin' }, {});
+    const handler = {
+      handle: () => throwError(() => new Error('Bad Request')),
+    };
+
+    auditLogService.log.mockResolvedValue({ id: 1 } as never);
+
+    interceptor.intercept(context, handler as CallHandler).subscribe({
+      error: () => {
+        setTimeout(() => {
+          expect(auditLogService.log).toHaveBeenCalled();
+          done();
+        }, 0);
+      },
+    });
+  });
+
+  it('should extract ip from x-forwarded-for header', (done) => {
+    mockReflector.get.mockReturnValue({
+      action: AuditAction.LOGIN_FAILURE,
+      resourceType: 'auth',
+    });
+
+    const reqWithProxy = {
+      user: { id: 0, role: 'anonymous' },
+      body: { email: 'test@example.com' },
+      params: {},
+      headers: {
+        'x-forwarded-for': '10.0.0.1, 192.168.1.1',
+        'user-agent': 'Test Agent',
+      },
+      ip: '127.0.0.1',
+      connection: { remoteAddress: '192.168.1.1' },
+    };
+
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => reqWithProxy,
+      }),
+      getHandler: () => ({}),
+      getParamTypes: () => [],
+    } as unknown as ExecutionContext;
+
+    const handler = createMockCallHandler(null);
+    auditLogService.log.mockResolvedValue({ id: 1 } as never);
+
+    interceptor.intercept(context, handler).subscribe({
+      next: () => {
+        expect(auditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ip: '10.0.0.1',
+          }),
+        );
+        done();
+      },
+    });
+  });
+});

--- a/backend/src/common/interceptors/audit-log.interceptor.ts
+++ b/backend/src/common/interceptors/audit-log.interceptor.ts
@@ -1,0 +1,99 @@
+import {
+  Injectable,
+  Logger,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+import { Reflector } from '@nestjs/core';
+import { AUDIT_LOG_KEY } from '../decorators/audit-log.decorator';
+import { AuditLogService } from '../../modules/audit-logs/audit-log.service';
+import { redactSensitiveFields } from '../utils/redaction.util';
+
+@Injectable()
+export class AuditLogInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(AuditLogInterceptor.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly auditLogService: AuditLogService,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const auditOptions = this.reflector.get<{ action: string; resourceType: string; getResourceId?: (args: unknown[]) => number | null }>(
+      AUDIT_LOG_KEY,
+      context.getHandler(),
+    );
+
+    if (!auditOptions) return next.handle();
+
+    return next.handle().pipe(
+      tap((responseBody) => {
+        void this.logAction(context, auditOptions, responseBody, null);
+      }),
+      catchError((error) => {
+        void this.logAction(context, auditOptions, null, error);
+        throw error;
+      }),
+    );
+  }
+
+  private async logAction(
+    context: ExecutionContext,
+    options: { action: string; resourceType: string; getResourceId?: (args: unknown[]) => number | null },
+    responseBody: unknown,
+    error: Error | null,
+  ): Promise<void> {
+    try {
+      const request = context.switchToHttp().getRequest<{
+        user?: { id?: number; role?: string };
+        body?: Record<string, unknown>;
+        params?: Record<string, string>;
+        ip?: string;
+        headers?: Record<string, string | string[] | undefined>;
+        connection?: { remoteAddress?: string };
+      }>();
+      const user = request.user;
+      const actorId = user?.id ?? 0;
+      const actorRole = user?.role ?? 'anonymous';
+
+      const xForwardedFor = request.headers?.['x-forwarded-for'];
+      const ip = typeof xForwardedFor === 'string'
+        ? xForwardedFor.split(',')[0].trim()
+        : request.ip ?? request.connection?.remoteAddress ?? null;
+      const userAgent = request.headers?.['user-agent'] ?? null;
+
+      const resourceId = request.params?.id ? parseInt(request.params.id, 10) || null : null;
+
+      const beforeJson = error ? null : redactSensitiveFields(request.body ?? null);
+      const afterJson = error
+        ? null
+        : redactSensitiveFields(this.extractResponseData(responseBody));
+
+      await this.auditLogService.log({
+        actorId,
+        actorRole,
+        action: options.action as never,
+        resourceType: options.resourceType,
+        resourceId,
+        beforeJson,
+        afterJson,
+        ip,
+        userAgent: typeof userAgent === 'string' ? userAgent : null,
+      });
+    } catch (err) {
+      this.logger.error('Failed to write audit log', err);
+    }
+  }
+
+  private extractResponseData(responseBody: unknown): Record<string, unknown> | null {
+    if (!responseBody || typeof responseBody !== 'object') return null;
+    const data = responseBody as Record<string, unknown>;
+    return {
+      id: data.id ?? null,
+      status: data.status ?? null,
+    };
+  }
+}

--- a/backend/src/common/utils/redaction.util.ts
+++ b/backend/src/common/utils/redaction.util.ts
@@ -1,0 +1,35 @@
+export const SENSITIVE_FIELDS = [
+  'password',
+  'token',
+  'authorization',
+  'creditcard',
+  'credit_card',
+  'cvv',
+  'cardnumber',
+  'accountnumber',
+  'bankaccount',
+  'cardno',
+  'refreshtoken',
+  'secret',
+  'ssn',
+  'phone',
+  'address',
+  'clientSecret',
+];
+
+export function redactSensitiveFields<T extends Record<string, unknown>>(
+  obj: T | null | undefined,
+): T | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const redacted: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (SENSITIVE_FIELDS.some((f) => k.toLowerCase().includes(f))) {
+      redacted[k] = '[REDACTED]';
+    } else if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      redacted[k] = redactSensitiveFields(v as Record<string, unknown>);
+    } else {
+      redacted[k] = v;
+    }
+  }
+  return redacted as T;
+}

--- a/backend/src/modules/admin/admin-members.controller.ts
+++ b/backend/src/modules/admin/admin-members.controller.ts
@@ -7,6 +7,7 @@ import {
   Query,
   ParseIntPipe,
   Request,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -17,10 +18,13 @@ import {
   ApiCookieAuth,
 } from '@nestjs/swagger';
 import { Roles } from '../../common/decorators/roles.decorator';
+import { AuditLog } from '../../common/decorators/audit-log.decorator';
+import { AuditLogInterceptor } from '../../common/interceptors/audit-log.interceptor';
 import { AdminMembersService } from './admin-members.service';
 import { AdminMembersQueryDto } from './dto/admin-members-query.dto';
 import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import { UserRole } from '../users/entities/user.entity';
+import { AuditAction } from '../audit-logs/entities/audit-log.entity';
 
 interface RequestWithUser {
   user: { id: number; email: string; role: string };
@@ -47,6 +51,8 @@ export class AdminMembersController {
   }
 
   @Patch('members/:id')
+  @UseInterceptors(AuditLogInterceptor)
+  @AuditLog({ action: AuditAction.MEMBER_ROLE_CHANGE, resourceType: 'member' })
   @ApiCookieAuth()
   @ApiOperation({ summary: '회원 역할 수정', description: '회원의 역할을 수정합니다.' })
   @ApiResponse({ status: 200, description: '회원 역할 수정 성공' })

--- a/backend/src/modules/admin/admin-orders.controller.ts
+++ b/backend/src/modules/admin/admin-orders.controller.ts
@@ -1,6 +1,6 @@
 import {
   Controller, Get, Patch, Post, Param, Body, Query,
-  ParseIntPipe,
+  ParseIntPipe, UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -11,11 +11,14 @@ import {
   ApiCookieAuth,
 } from '@nestjs/swagger';
 import { Roles } from '../../common/decorators/roles.decorator';
+import { AuditLog } from '../../common/decorators/audit-log.decorator';
+import { AuditLogInterceptor } from '../../common/interceptors/audit-log.interceptor';
 import { AdminOrdersService } from './admin-orders.service';
 import { AdminOrderQueryDto } from './dto/admin-order-query.dto';
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
 import { RegisterShippingDto } from './dto/register-shipping.dto';
 import { OrderStatus } from '../orders/entities/order.entity';
+import { AuditAction } from '../audit-logs/entities/audit-log.entity';
 
 @ApiTags('관리자 - 주문')
 @Controller('admin')
@@ -38,6 +41,8 @@ export class AdminOrdersController {
   }
 
   @Patch('orders/:id')
+  @UseInterceptors(AuditLogInterceptor)
+  @AuditLog({ action: AuditAction.ORDER_STATUS_UPDATE, resourceType: 'order' })
   @ApiCookieAuth()
   @ApiOperation({ summary: '주문 상태 수정', description: '주문의 상태를 수정합니다.' })
   @ApiResponse({ status: 200, description: '주문 상태 수정 성공' })
@@ -53,6 +58,8 @@ export class AdminOrdersController {
   }
 
   @Post('shipping/:orderId')
+  @UseInterceptors(AuditLogInterceptor)
+  @AuditLog({ action: AuditAction.ORDER_SHIPPING_REGISTER, resourceType: 'order' })
   @ApiCookieAuth()
   @ApiOperation({ summary: '배송 정보 등록', description: '주문에 배송 정보를 등록합니다.' })
   @ApiResponse({ status: 201, description: '배송 정보 등록 성공' })

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -13,9 +13,10 @@ import { Payment } from '../payments/entities/payment.entity';
 import { Shipping } from '../payments/entities/shipping.entity';
 import { User } from '../users/entities/user.entity';
 import { Product } from '../products/entities/product.entity';
+import { AuditLogModule } from '../audit-logs/audit-log.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order, Payment, Shipping, User, Product])],
+  imports: [TypeOrmModule.forFeature([Order, Payment, Shipping, User, Product]), AuditLogModule],
   controllers: [AdminController, AdminDashboardController, AdminOrdersController, AdminMembersController],
   providers: [AdminService, AdminDashboardService, AdminOrdersService, AdminMembersService],
 })

--- a/backend/src/modules/audit-logs/__tests__/audit-log.service.spec.ts
+++ b/backend/src/modules/audit-logs/__tests__/audit-log.service.spec.ts
@@ -1,0 +1,211 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuditLogService, CreateAuditLogDto } from '../audit-log.service';
+import { AuditLog, AuditAction } from '../entities/audit-log.entity';
+
+describe('AuditLogService', () => {
+  let service: AuditLogService;
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findAndCount: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditLogService,
+        {
+          provide: getRepositoryToken(AuditLog),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuditLogService>(AuditLogService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('log', () => {
+    it('should create and save an audit log entry', async () => {
+      const dto: CreateAuditLogDto = {
+        actorId: 1,
+        actorRole: 'admin',
+        action: AuditAction.ORDER_STATUS_UPDATE,
+        resourceType: 'order',
+        resourceId: 123,
+        beforeJson: { status: 'pending' },
+        afterJson: { status: 'paid' },
+        ip: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+      };
+
+      const mockEntry = { id: 1, ...dto, createdAt: new Date() };
+      mockRepository.create.mockReturnValue(mockEntry as AuditLog);
+      mockRepository.save.mockResolvedValue(mockEntry as AuditLog);
+
+      const result = await service.log(dto);
+
+      expect(mockRepository.create).toHaveBeenCalledWith({
+        actorId: 1,
+        actorRole: 'admin',
+        action: AuditAction.ORDER_STATUS_UPDATE,
+        resourceType: 'order',
+        resourceId: 123,
+        beforeJson: { status: 'pending' },
+        afterJson: { status: 'paid' },
+        ip: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+      });
+      expect(mockRepository.save).toHaveBeenCalledWith(mockEntry);
+      expect(result).toEqual(mockEntry);
+    });
+
+    it('should handle null resourceId', async () => {
+      const dto: CreateAuditLogDto = {
+        actorId: 1,
+        actorRole: 'anonymous',
+        action: AuditAction.LOGIN_FAILURE,
+        resourceType: 'auth',
+        beforeJson: { email: 'test@example.com' },
+        afterJson: { reason: 'user_not_found' },
+      };
+
+      const mockEntry = { id: 1, ...dto, resourceId: null, createdAt: new Date() };
+      mockRepository.create.mockReturnValue(mockEntry as AuditLog);
+      mockRepository.save.mockResolvedValue(mockEntry as AuditLog);
+
+      const result = await service.log(dto);
+
+      expect(mockRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: null }),
+      );
+      expect(result.resourceId).toBeNull();
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated results', async () => {
+      const mockLogs = [
+        { id: 1, actorId: 1, action: AuditAction.LOGIN_SUCCESS },
+        { id: 2, actorId: 2, action: AuditAction.LOGIN_FAILURE },
+      ];
+      mockRepository.findAndCount.mockResolvedValue([mockLogs as AuditLog[], 2]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result).toEqual({
+        data: mockLogs,
+        total: 2,
+        page: 1,
+        limit: 20,
+      });
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.any(Object),
+          order: { createdAt: 'DESC' },
+          skip: 0,
+          take: 20,
+        }),
+      );
+    });
+
+    it('should apply actorId filter', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[] as AuditLog[], 0]);
+
+      await service.findAll({ actorId: 1, page: 1, limit: 20 });
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ actorId: 1 }),
+        }),
+      );
+    });
+
+    it('should apply action filter', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[] as AuditLog[], 0]);
+
+      await service.findAll({ action: AuditAction.LOGIN_SUCCESS, page: 1, limit: 20 });
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ action: AuditAction.LOGIN_SUCCESS }),
+        }),
+      );
+    });
+
+    it('should apply date range filter', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[] as AuditLog[], 0]);
+      const startDate = new Date('2024-01-01');
+      const endDate = new Date('2024-12-31');
+
+      await service.findAll({ startDate, endDate, page: 1, limit: 20 });
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            createdAt: expect.any(Object),
+          }),
+        }),
+      );
+    });
+
+    it('should handle pagination correctly', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[] as AuditLog[], 50]);
+
+      const result = await service.findAll({ page: 3, limit: 10 });
+
+      expect(result.page).toBe(3);
+      expect(result.limit).toBe(10);
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 20,
+          take: 10,
+        }),
+      );
+    });
+  });
+
+  describe('findByResource', () => {
+    it('should find logs by resource type and id', async () => {
+      const mockLogs = [
+        { id: 1, resourceType: 'order', resourceId: 123 },
+        { id: 2, resourceType: 'order', resourceId: 123 },
+      ];
+      mockRepository.find.mockResolvedValue(mockLogs as AuditLog[]);
+
+      const result = await service.findByResource('order', 123);
+
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        where: { resourceType: 'order', resourceId: 123 },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toEqual(mockLogs);
+    });
+  });
+
+  describe('findByActor', () => {
+    it('should find logs by actor id with pagination', async () => {
+      const mockLogs = [
+        { id: 1, actorId: 5 },
+        { id: 2, actorId: 5 },
+      ];
+      mockRepository.findAndCount.mockResolvedValue([mockLogs as AuditLog[], 2]);
+
+      const result = await service.findByActor(5, 1, 20);
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith({
+        where: { actorId: 5 },
+        order: { createdAt: 'DESC' },
+        skip: 0,
+        take: 20,
+      });
+      expect(result).toEqual({ data: mockLogs, total: 2 });
+    });
+  });
+});

--- a/backend/src/modules/audit-logs/__tests__/redaction.util.spec.ts
+++ b/backend/src/modules/audit-logs/__tests__/redaction.util.spec.ts
@@ -1,0 +1,91 @@
+import { redactSensitiveFields, SENSITIVE_FIELDS } from '../../../common/utils/redaction.util';
+
+describe('redactSensitiveFields', () => {
+  it('should return null for null input', () => {
+    expect(redactSensitiveFields(null)).toBeNull();
+  });
+
+  it('should return null for undefined input', () => {
+    expect(redactSensitiveFields(undefined)).toBeNull();
+  });
+
+  it('should return empty object for empty object input', () => {
+    expect(redactSensitiveFields({})).toEqual({});
+  });
+
+  it('should not redact non-sensitive fields', () => {
+    const input = { name: 'John', email: 'john@example.com', id: 123 };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should redact password field', () => {
+    const input = { email: 'john@example.com', password: 'secret123' };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual({ email: 'john@example.com', password: '[REDACTED]' });
+  });
+
+  it('should redact nested sensitive fields', () => {
+    const input = { user: { name: 'John', password: 'secret123' } };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual({ user: { name: 'John', password: '[REDACTED]' } });
+  });
+
+  it('should redact token field', () => {
+    const input = { token: 'jwt-token-here', name: 'John' };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual({ token: '[REDACTED]', name: 'John' });
+  });
+
+  it('should redact refreshtoken field', () => {
+    const input = { email: 'john@example.com', refreshtoken: 'refresh-token-here' };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual({ email: 'john@example.com', refreshtoken: '[REDACTED]' });
+  });
+
+  it('should redact creditcard field', () => {
+    const input = { amount: 100, creditcard: '4111111111111111' };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual({ amount: 100, creditcard: '[REDACTED]' });
+  });
+
+  it('should handle partial field name matches', () => {
+    const input = { user_password: 'secret', password_hash: 'hash123' };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual({ user_password: '[REDACTED]', password_hash: '[REDACTED]' });
+  });
+
+  it('should not recurse into arrays', () => {
+    const input = { users: [{ name: 'John', password: 'secret' }] };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual({ users: [{ name: 'John', password: 'secret' }] });
+  });
+
+  it('should handle mixed sensitive and non-sensitive fields', () => {
+    const input = {
+      id: 1,
+      name: 'John',
+      email: 'john@example.com',
+      password: 'secret',
+      token: 'jwt-token',
+    };
+    const result = redactSensitiveFields(input);
+    expect(result).toEqual({
+      id: 1,
+      name: 'John',
+      email: 'john@example.com',
+      password: '[REDACTED]',
+      token: '[REDACTED]',
+    });
+  });
+});
+
+describe('SENSITIVE_FIELDS constant', () => {
+  it('should contain expected sensitive field names', () => {
+    expect(SENSITIVE_FIELDS).toContain('password');
+    expect(SENSITIVE_FIELDS).toContain('token');
+    expect(SENSITIVE_FIELDS).toContain('refreshtoken');
+    expect(SENSITIVE_FIELDS).toContain('creditcard');
+    expect(SENSITIVE_FIELDS).toContain('ssn');
+  });
+});

--- a/backend/src/modules/audit-logs/audit-log.controller.ts
+++ b/backend/src/modules/audit-logs/audit-log.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiCookieAuth,
+} from '@nestjs/swagger';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { AuditLogService } from './audit-log.service';
+import { AuditLogQueryDto } from './dto/audit-log-query.dto';
+
+@ApiTags('관리자 - 감사 로그')
+@Controller('admin/audit-logs')
+@Roles('admin', 'super_admin')
+export class AuditLogController {
+  constructor(private readonly auditLogService: AuditLogService) {}
+
+  @Get()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '감사 로그 목록 조회', description: '페이지네이션 및 필터링된 감사 로그를 조회합니다.' })
+  @ApiResponse({ status: 200, description: '감사 로그 목록 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  findAll(@Query() query: AuditLogQueryDto) {
+    return this.auditLogService.findAll({
+      page: query.page,
+      limit: query.limit,
+      actorId: query.actorId,
+      actorRole: query.actorRole,
+      action: query.action,
+      resourceType: query.resourceType,
+      resourceId: query.resourceId,
+      ip: query.ip,
+      startDate: query.startDate ? new Date(query.startDate) : undefined,
+      endDate: query.endDate ? new Date(query.endDate) : undefined,
+    });
+  }
+}

--- a/backend/src/modules/audit-logs/audit-log.module.ts
+++ b/backend/src/modules/audit-logs/audit-log.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuditLog } from './entities/audit-log.entity';
+import { AuditLogService } from './audit-log.service';
+import { AuditLogController } from './audit-log.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AuditLog])],
+  controllers: [AuditLogController],
+  providers: [AuditLogService],
+  exports: [AuditLogService],
+})
+export class AuditLogModule {}

--- a/backend/src/modules/audit-logs/audit-log.service.ts
+++ b/backend/src/modules/audit-logs/audit-log.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindOptionsWhere, Between, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
+import { AuditLog, AuditAction } from './entities/audit-log.entity';
+
+export interface AuditLogQuery {
+  actorId?: number;
+  actorRole?: string;
+  action?: AuditAction;
+  resourceType?: string;
+  resourceId?: number;
+  ip?: string;
+  startDate?: Date;
+  endDate?: Date;
+  page?: number;
+  limit?: number;
+}
+
+export interface CreateAuditLogDto {
+  actorId: number;
+  actorRole: string;
+  action: AuditAction;
+  resourceType: string;
+  resourceId?: number | null;
+  beforeJson?: Record<string, unknown> | null;
+  afterJson?: Record<string, unknown> | null;
+  ip?: string | null;
+  userAgent?: string | null;
+}
+
+@Injectable()
+export class AuditLogService {
+  private readonly logger = new Logger(AuditLogService.name);
+
+  constructor(
+    @InjectRepository(AuditLog)
+    private readonly auditLogRepository: Repository<AuditLog>,
+  ) {}
+
+  async log(dto: CreateAuditLogDto): Promise<AuditLog> {
+    const entry = this.auditLogRepository.create({
+      actorId: dto.actorId,
+      actorRole: dto.actorRole,
+      action: dto.action,
+      resourceType: dto.resourceType,
+      resourceId: dto.resourceId ?? null,
+      beforeJson: dto.beforeJson ?? null,
+      afterJson: dto.afterJson ?? null,
+      ip: dto.ip ?? null,
+      userAgent: dto.userAgent ?? null,
+    });
+    const saved = await this.auditLogRepository.save(entry);
+    this.logger.log(`Audit log created: ${dto.action} by ${dto.actorId} on ${dto.resourceType}`);
+    return saved;
+  }
+
+  async findAll(query: AuditLogQuery): Promise<{ data: AuditLog[]; total: number; page: number; limit: number }> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    const where: FindOptionsWhere<AuditLog> = {};
+    if (query.actorId) where.actorId = query.actorId;
+    if (query.actorRole) where.actorRole = query.actorRole;
+    if (query.action) where.action = query.action;
+    if (query.resourceType) where.resourceType = query.resourceType;
+    if (query.resourceId) where.resourceId = query.resourceId;
+    if (query.ip) where.ip = query.ip;
+
+    let dateCondition: FindOptionsWhere<AuditLog> = {};
+    if (query.startDate && query.endDate) {
+      dateCondition = { createdAt: Between(query.startDate, query.endDate) } as FindOptionsWhere<AuditLog>;
+    } else if (query.startDate) {
+      dateCondition = { createdAt: MoreThanOrEqual(query.startDate) } as FindOptionsWhere<AuditLog>;
+    } else if (query.endDate) {
+      dateCondition = { createdAt: LessThanOrEqual(query.endDate) } as FindOptionsWhere<AuditLog>;
+    }
+
+    const finalWhere: FindOptionsWhere<AuditLog> = { ...where, ...dateCondition };
+
+    const [data, total] = await this.auditLogRepository.findAndCount({
+      where: finalWhere,
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { data, total, page, limit };
+  }
+
+  async findByResource(resourceType: string, resourceId: number): Promise<AuditLog[]> {
+    return this.auditLogRepository.find({
+      where: { resourceType, resourceId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findByActor(actorId: number, page = 1, limit = 20): Promise<{ data: AuditLog[]; total: number }> {
+    const [data, total] = await this.auditLogRepository.findAndCount({
+      where: { actorId },
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { data, total };
+  }
+}

--- a/backend/src/modules/audit-logs/dto/audit-log-query.dto.ts
+++ b/backend/src/modules/audit-logs/dto/audit-log-query.dto.ts
@@ -1,0 +1,63 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsInt, Min, Max, IsString, IsDateString, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { AuditAction } from '../entities/audit-log.entity';
+
+export class AuditLogQueryDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  actorId?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  actorRole?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEnum(AuditAction)
+  action?: AuditAction;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  resourceType?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  resourceId?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  ip?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}

--- a/backend/src/modules/audit-logs/entities/audit-log.entity.ts
+++ b/backend/src/modules/audit-logs/entities/audit-log.entity.ts
@@ -1,0 +1,68 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum AuditAction {
+  // Admin order actions
+  ORDER_STATUS_UPDATE = 'ORDER_STATUS_UPDATE',
+  ORDER_SHIPPING_REGISTER = 'ORDER_SHIPPING_REGISTER',
+  // Admin member actions
+  MEMBER_SUSPEND = 'MEMBER_SUSPEND',
+  MEMBER_UNSUSPEND = 'MEMBER_UNSUSPEND',
+  MEMBER_ROLE_CHANGE = 'MEMBER_ROLE_CHANGE',
+  // Admin product actions
+  PRODUCT_CREATE = 'PRODUCT_CREATE',
+  PRODUCT_UPDATE = 'PRODUCT_UPDATE',
+  PRODUCT_DELETE = 'PRODUCT_DELETE',
+  // Admin coupon actions
+  COUPON_CREATE = 'COUPON_CREATE',
+  COUPON_UPDATE = 'COUPON_UPDATE',
+  COUPON_DELETE = 'COUPON_DELETE',
+  // Auth actions
+  LOGIN_SUCCESS = 'LOGIN_SUCCESS',
+  LOGIN_FAILURE = 'LOGIN_FAILURE',
+  LOGOUT = 'LOGOUT',
+}
+
+@Entity('audit_logs')
+@Index(['actorId', 'createdAt'])
+@Index(['resourceType', 'resourceId'])
+@Index(['action', 'createdAt'])
+export class AuditLog {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: 'int', nullable: false })
+  actorId!: number;
+
+  @Column({ type: 'varchar', length: 50, nullable: false })
+  actorRole!: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: false })
+  action!: AuditAction;
+
+  @Column({ type: 'varchar', length: 100, nullable: false })
+  resourceType!: string;
+
+  @Column({ type: 'int', nullable: true })
+  resourceId!: number | null;
+
+  @Column({ type: 'json', nullable: true })
+  beforeJson!: Record<string, unknown> | null;
+
+  @Column({ type: 'json', nullable: true })
+  afterJson!: Record<string, unknown> | null;
+
+  @Column({ type: 'varchar', length: 45, nullable: true })
+  ip!: string | null;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  userAgent!: string | null;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -7,6 +7,7 @@ import { AuthService } from '../auth.service';
 import { User, UserRole } from '../../users/entities/user.entity';
 import { PasswordResetToken } from '../entities/password-reset-token.entity';
 import { NotificationService } from '../../notification/notification.service';
+import { AuditLogService } from '../../audit-logs/audit-log.service';
 
 const mockUserRepository = {
   findOne: jest.fn(),
@@ -29,6 +30,10 @@ const mockJwtService = {
 
 const mockNotificationService = {
   sendPasswordReset: jest.fn(),
+};
+
+const mockAuditLogService = {
+  log: jest.fn(),
 };
 
 function makeUser(overrides: Partial<User> = {}): User {
@@ -68,6 +73,7 @@ describe('AuthService', () => {
         },
         { provide: JwtService, useValue: mockJwtService },
         { provide: NotificationService, useValue: mockNotificationService },
+        { provide: AuditLogService, useValue: mockAuditLogService },
       ],
     }).compile();
 

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -84,8 +84,14 @@ export class AuthController {
   @ApiOperation({ summary: '로그인', description: '이메일/비밀번호로 로그인합니다. 성공 시 accessToken과 refreshToken이 쿠키에 저장됩니다.' })
   @ApiResponse({ status: 200, description: '로그인 성공' })
   @ApiResponse({ status: 401, description: '이메일 또는 비밀번호 오류' })
-  async login(@Body() dto: LoginDto, @Res({ passthrough: true }) res: Response) {
-    const { accessToken, refreshToken, user } = await this.authService.login(dto);
+  async login(@Body() dto: LoginDto, @Res({ passthrough: true }) res: Response, @Req() req: Request) {
+    const ip =
+      (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
+      req.ip ||
+      req.socket?.remoteAddress ||
+      null;
+    const userAgent = req.headers['user-agent'] ?? null;
+    const { accessToken, refreshToken, user } = await this.authService.login(dto, ip, userAgent);
     setAuthCookies(res, accessToken, refreshToken);
     return { user, accessToken, refreshToken };
   }

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { OAuthService } from './oauth.service';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { User } from '../users/entities/user.entity';
 import { UserAuthentication } from '../users/entities/user-authentication.entity';
+import { AuditLogModule } from '../audit-logs/audit-log.module';
 
 function getJwtPrivateKey(): string {
   if (process.env.JWT_PRIVATE_KEY) {
@@ -47,9 +48,10 @@ function getJwtPrivateKey(): string {
       },
     }),
     HttpModule,
+    AuditLogModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, OAuthService, JwtStrategy],
-  exports: [PassportModule, JwtModule],
+  exports: [PassportModule, JwtModule, AuditLogModule],
 })
 export class AuthModule {}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -20,6 +20,8 @@ import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { NotificationService } from '../notification/notification.service';
+import { AuditLogService } from '../audit-logs/audit-log.service';
+import { AuditAction } from '../audit-logs/entities/audit-log.entity';
 
 const MAX_LOGIN_ATTEMPTS = 5;
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000;
@@ -59,6 +61,7 @@ export class AuthService implements OnModuleInit {
     private readonly passwordResetTokenRepository: Repository<PasswordResetToken>,
     private readonly jwtService: JwtService,
     private readonly notificationService: NotificationService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   onModuleInit() {
@@ -103,11 +106,21 @@ export class AuthService implements OnModuleInit {
     };
   }
 
-  async login(dto: LoginDto): Promise<AuthResponse> {
+  async login(dto: LoginDto, ip?: string | null, userAgent?: string | null): Promise<AuthResponse> {
     const user = await this.userRepository.findOne({
       where: { email: dto.email },
     });
     if (!user) {
+      await this.auditLogService.log({
+        actorId: 0,
+        actorRole: 'anonymous',
+        action: AuditAction.LOGIN_FAILURE,
+        resourceType: 'auth',
+        beforeJson: { email: dto.email },
+        afterJson: { reason: 'user_not_found' },
+        ip: ip ?? null,
+        userAgent: userAgent ?? null,
+      });
       throw new UnauthorizedException('가입되지 않은 이메일입니다.');
     }
     if (!user.password) {
@@ -143,6 +156,16 @@ export class AuthService implements OnModuleInit {
       });
       const delaySec = Math.pow(2, attempts);
       await this.delay(delaySec * 1000);
+      await this.auditLogService.log({
+        actorId: user.id,
+        actorRole: user.role,
+        action: AuditAction.LOGIN_FAILURE,
+        resourceType: 'auth',
+        beforeJson: { email: dto.email },
+        afterJson: { reason: 'invalid_password', attempts },
+        ip: ip ?? null,
+        userAgent: userAgent ?? null,
+      });
       throw new UnauthorizedException('비밀번호가 올바르지 않습니다.');
     }
 
@@ -162,6 +185,16 @@ export class AuthService implements OnModuleInit {
     await this.userRepository.update(user.id, { refreshToken: hashedRefresh });
 
     this.logger.log(`User logged in: ${dto.email}`);
+    await this.auditLogService.log({
+      actorId: user.id,
+      actorRole: user.role,
+      action: AuditAction.LOGIN_SUCCESS,
+      resourceType: 'auth',
+      beforeJson: { email: dto.email },
+      afterJson: { userId: user.id },
+      ip: ip ?? null,
+      userAgent: userAgent ?? null,
+    });
     return {
       ...tokens,
       user: { id: user.id, email: user.email, name: user.name, role: user.role },


### PR DESCRIPTION
## Summary
- Add `audit_logs` table entity with actor_id, actor_role, action, resource_type, resource_id, before_json, after_json, ip, user_agent, created_at
- Add `AuditLogInterceptor` with `@AuditLog('ACTION_NAME')` decorator for admin controller methods
- Add `GET /admin/audit-logs` endpoint with pagination and filtering (page, limit, actorId, actorRole, action, resourceType, resourceId, ip, startDate, endDate)
- Log login success/failure events in `AuthService`
- Add sensitive field redaction utility (password, token, creditcard, etc. → `[REDACTED]`)

## Acceptance Criteria
- [x] `audit_logs` 테이블 (actor_id, actor_role, action, resource_type, resource_id, before_json, after_json, ip, user_agent, created_at)
- [x] `AuditLogInterceptor` — 관리자 컨트롤러 메서드에 `@AuditLog('ACTION_NAME')` 데코레이터
- [x] 조회 엔드포인트: `GET /admin/audit-logs` (페이지네이션 + 필터)
- [x] 로그인 성공/실패도 기록
- [x] 민감 필드(password, tokens) 저장 시 자동 redaction

## Changes
- `backend/src/modules/audit-logs/` — audit log module (entity, service, controller, DTO)
- `backend/src/common/decorators/audit-log.decorator.ts` — `@AuditLog()` decorator
- `backend/src/common/interceptors/audit-log.interceptor.ts` — interceptor
- `backend/src/common/utils/redaction.util.ts` — sensitive field redaction
- `backend/src/modules/admin/admin-orders.controller.ts` — `@AuditLog` on `PATCH /admin/orders/:id` and `POST /admin/shipping/:orderId`
- `backend/src/modules/admin/admin-members.controller.ts` — `@AuditLog` on `PATCH /admin/members/:id`
- `backend/src/modules/auth/auth.service.ts` — login success/failure logging
- Tests for audit-log service and redaction utility

## Test Results
- `npm run lint` ✓
- `npm run build` ✓
- `npm run test` — 475 passed

Closes #498