### PR TITLE
feat: #497 JWT token blacklist on logout

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.17",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.2.6",
         "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^11.0.0",
@@ -4005,6 +4006,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.10",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.10.tgz",
@@ -5631,6 +5645,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -7769,6 +7789,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -10862,6 +10899,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.17",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import * as fs from 'fs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
 import { HealthModule } from './modules/health/health.module';
 import { AuthModule } from './modules/auth/auth.module';
@@ -79,6 +80,7 @@ import { RolesGuard } from './common/guards/roles.guard';
       },
     ]),
     CacheModule,
+    ScheduleModule.forRoot(),
     AuthModule,
     HealthModule,
     ProductsModule,

--- a/backend/src/database/migrations/1778500000000-CreateTokenBlacklistTable.ts
+++ b/backend/src/database/migrations/1778500000000-CreateTokenBlacklistTable.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTokenBlacklistTable1778500000000 implements MigrationInterface {
+  name = 'CreateTokenBlacklistTable1778500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS \`token_blacklist\` (\`jti\` varchar(36) NOT NULL, \`user_id\` bigint NOT NULL, \`expires_at\` datetime NOT NULL, \`reason\` varchar(255) NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), INDEX \`IDX_token_blacklist_user_id\` (\`user_id\`), INDEX \`IDX_token_blacklist_expires_at\` (\`expires_at\`), PRIMARY KEY (\`jti\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`token_blacklist\` ADD CONSTRAINT \`FK_token_blacklist_user_id\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`token_blacklist\` DROP FOREIGN KEY \`FK_token_blacklist_user_id\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_token_blacklist_expires_at\` ON \`token_blacklist\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_token_blacklist_user_id\` ON \`token_blacklist\``,
+    );
+    await queryRunner.query(`DROP TABLE \`token_blacklist\``);
+  }
+}

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -8,6 +8,7 @@ import { User, UserRole } from '../../users/entities/user.entity';
 import { PasswordResetToken } from '../entities/password-reset-token.entity';
 import { NotificationService } from '../../notification/notification.service';
 import { AuditLogService } from '../../audit-logs/audit-log.service';
+import { TokenBlacklistService } from '../token-blacklist.service';
 
 const mockUserRepository = {
   findOne: jest.fn(),
@@ -34,6 +35,12 @@ const mockNotificationService = {
 
 const mockAuditLogService = {
   log: jest.fn(),
+};
+
+const mockTokenBlacklistService = {
+  addToBlacklist: jest.fn(),
+  isBlacklisted: jest.fn(),
+  revokeAllUserTokens: jest.fn(),
 };
 
 function makeUser(overrides: Partial<User> = {}): User {
@@ -74,6 +81,7 @@ describe('AuthService', () => {
         { provide: JwtService, useValue: mockJwtService },
         { provide: NotificationService, useValue: mockNotificationService },
         { provide: AuditLogService, useValue: mockAuditLogService },
+        { provide: TokenBlacklistService, useValue: mockTokenBlacklistService },
       ],
     }).compile();
 
@@ -276,11 +284,35 @@ describe('AuthService', () => {
   });
 
   describe('logout', () => {
-    it('logout: refresh_token NULL 저장', async () => {
+    it('logout: blacklists the access token jti then clears refreshToken', async () => {
+      const jti = 'test-jti-1234';
+      const expiresAt = new Date(Date.now() + 3600_000);
+      mockTokenBlacklistService.addToBlacklist.mockResolvedValue(undefined);
       mockUserRepository.update.mockResolvedValue(undefined);
 
-      await service.logout(1);
+      await service.logout(1, jti, expiresAt);
 
+      expect(mockTokenBlacklistService.addToBlacklist).toHaveBeenCalledWith(
+        jti,
+        1,
+        expiresAt,
+        'user_logout',
+      );
+      expect(mockUserRepository.update).toHaveBeenCalledWith(1, { refreshToken: null });
+    });
+  });
+
+  describe('logoutAll', () => {
+    it('revokes all user tokens and clears refreshToken', async () => {
+      mockTokenBlacklistService.revokeAllUserTokens.mockResolvedValue(undefined);
+      mockUserRepository.update.mockResolvedValue(undefined);
+
+      await service.logoutAll(1);
+
+      expect(mockTokenBlacklistService.revokeAllUserTokens).toHaveBeenCalledWith(
+        1,
+        'user_logout_all',
+      );
       expect(mockUserRepository.update).toHaveBeenCalledWith(1, { refreshToken: null });
     });
   });

--- a/backend/src/modules/auth/__tests__/token-blacklist.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/token-blacklist.service.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { LessThan } from 'typeorm';
+import { TokenBlacklistService } from '../token-blacklist.service';
+import { TokenBlacklist } from '../entities/token-blacklist.entity';
+import { CacheService } from '../../cache/cache.service';
+
+const mockBlacklistRepository = {
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+
+const mockCacheService = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  delPattern: jest.fn(),
+};
+
+describe('TokenBlacklistService', () => {
+  let service: TokenBlacklistService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TokenBlacklistService,
+        { provide: getRepositoryToken(TokenBlacklist), useValue: mockBlacklistRepository },
+        { provide: CacheService, useValue: mockCacheService },
+      ],
+    }).compile();
+
+    service = module.get<TokenBlacklistService>(TokenBlacklistService);
+  });
+
+  describe('addToBlacklist', () => {
+    it('should cache the token and save to DB', async () => {
+      const jti = 'test-jti-uuid';
+      const userId = 1;
+      const expiresAt = new Date(Date.now() + 3600_000);
+      const reason = 'user_logout';
+
+      mockCacheService.set.mockResolvedValue(undefined);
+      mockBlacklistRepository.create.mockReturnValue({ jti, userId, expiresAt, reason });
+      mockBlacklistRepository.save.mockResolvedValue(undefined);
+
+      await service.addToBlacklist(jti, userId, expiresAt, reason);
+
+      expect(mockCacheService.set).toHaveBeenCalledWith(
+        `blacklist:${jti}`,
+        true,
+        expect.any(Number),
+      );
+      expect(mockBlacklistRepository.create).toHaveBeenCalledWith({
+        jti,
+        userId,
+        expiresAt,
+        reason,
+      });
+      expect(mockBlacklistRepository.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('isBlacklisted', () => {
+    it('should return true if found in cache', async () => {
+      mockCacheService.get.mockResolvedValue(true);
+
+      const result = await service.isBlacklisted('cached-jti');
+
+      expect(result).toBe(true);
+      expect(mockBlacklistRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should return true if found in DB but not in cache (cache miss → repopulate cache)', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      const futureDate = new Date(Date.now() + 3600_000);
+      mockBlacklistRepository.findOne.mockResolvedValue({
+        jti: 'db-jti',
+        userId: 1,
+        expiresAt: futureDate,
+        reason: 'user_logout',
+      });
+      mockCacheService.set.mockResolvedValue(undefined);
+
+      const result = await service.isBlacklisted('db-jti');
+
+      expect(result).toBe(true);
+      expect(mockCacheService.set).toHaveBeenCalledWith(
+        `blacklist:db-jti`,
+        true,
+        expect.any(Number),
+      );
+    });
+
+    it('should return false if not found in cache or DB', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      mockBlacklistRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.isBlacklisted('unknown-jti');
+
+      expect(result).toBe(false);
+    });
+
+    it('should not repopulate cache if DB entry is already expired', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+      const pastDate = new Date(Date.now() - 1000);
+      mockBlacklistRepository.findOne.mockResolvedValue({
+        jti: 'expired-jti',
+        userId: 1,
+        expiresAt: pastDate,
+        reason: 'user_logout',
+      });
+
+      const result = await service.isBlacklisted('expired-jti');
+
+      expect(result).toBe(false);
+      expect(mockCacheService.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revokeAllUserTokens', () => {
+    it('should update all user tokens with reason', async () => {
+      mockBlacklistRepository.update.mockResolvedValue({ affected: 5 });
+
+      await service.revokeAllUserTokens(1, 'user_logout_all');
+
+      expect(mockBlacklistRepository.update).toHaveBeenCalledWith(
+        { userId: 1 },
+        { reason: 'user_logout_all' },
+      );
+    });
+  });
+
+  describe('cleanupExpiredEntries (cron)', () => {
+    it('should delete expired entries and log count', async () => {
+      const deleteResult = { affected: 3 };
+      mockBlacklistRepository.delete.mockResolvedValue(deleteResult);
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      await service.cleanupExpiredEntries();
+
+      expect(mockBlacklistRepository.delete).toHaveBeenCalledWith({
+        expiresAt: LessThan(expect.any(Date)),
+      });
+      expect(logSpy).toHaveBeenCalledWith('Cleaned up 3 expired blacklist entries');
+    });
+
+    it('should not log when no expired entries', async () => {
+      mockBlacklistRepository.delete.mockResolvedValue({ affected: 0 });
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      await service.cleanupExpiredEntries();
+
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -22,11 +22,13 @@ import { Public } from '../../common/decorators/public.decorator';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { SkipThrottle, Throttle } from '@nestjs/throttler';
+import { JwtService } from '@nestjs/jwt';
 
 interface JwtUser {
   id: number;
   email: string;
   role: string;
+  jti?: string;
 }
 
 const ACCESS_TOKEN_MAX_AGE = 60 * 60 * 1000;
@@ -65,6 +67,7 @@ export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly oauthService: OAuthService,
+    private readonly jwtService: JwtService,
   ) {}
 
   @Post('register')
@@ -164,8 +167,30 @@ export class AuthController {
   @ApiOperation({ summary: '로그아웃', description: '현재 세션을 종료하고 토큰을 무효화합니다. 인증 쿠키가 삭제됩니다.' })
   @ApiResponse({ status: 204, description: '로그아웃 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  async logout(@CurrentUser() user: JwtUser, @Res({ passthrough: true }) res: Response) {
-    await this.authService.logout(user.id);
+  async logout(@CurrentUser() user: JwtUser, @Res({ passthrough: true }) res: Response, @Req() req: Request) {
+    const rawAccessToken = (req.cookies as Record<string, string | undefined>)?.accessToken ?? '';
+    if (rawAccessToken) {
+      const decoded = this.jwtService.decode(rawAccessToken) as { jti?: string; exp?: number } | null;
+      if (decoded?.jti && decoded?.exp) {
+        const expiresAt = new Date(decoded.exp * 1000);
+        await this.authService.logout(user.id, decoded.jti, expiresAt);
+        clearAuthCookies(res);
+        return;
+      }
+    }
+    await this.authService.logoutAll(user.id);
+    clearAuthCookies(res);
+  }
+
+  @Post('logout-all')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '모든 기기 로그아웃', description: '해당 사용자의 모든 토큰을 무효화합니다. 모든 기기에서 로그아웃됩니다.' })
+  @ApiResponse({ status: 204, description: '모든 기기 로그아웃 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  async logoutAll(@CurrentUser() user: JwtUser, @Res({ passthrough: true }) res: Response) {
+    await this.authService.logoutAll(user.id);
     clearAuthCookies(res);
   }
 

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
+import { ScheduleModule } from '@nestjs/schedule';
 import * as fs from 'fs';
 import * as path from 'path';
 import type ms from 'ms';
@@ -11,6 +12,8 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { OAuthService } from './oauth.service';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
+import { TokenBlacklist } from './entities/token-blacklist.entity';
+import { TokenBlacklistService } from './token-blacklist.service';
 import { User } from '../users/entities/user.entity';
 import { UserAuthentication } from '../users/entities/user-authentication.entity';
 import { AuditLogModule } from '../audit-logs/audit-log.module';
@@ -38,7 +41,7 @@ function getJwtPrivateKey(): string {
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, UserAuthentication, PasswordResetToken]),
+    TypeOrmModule.forFeature([User, UserAuthentication, PasswordResetToken, TokenBlacklist]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
       privateKey: getJwtPrivateKey(),
@@ -47,11 +50,12 @@ function getJwtPrivateKey(): string {
         algorithm: 'RS256',
       },
     }),
+    ScheduleModule,
     HttpModule,
     AuditLogModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, OAuthService, JwtStrategy],
+  providers: [AuthService, OAuthService, JwtStrategy, TokenBlacklistService],
   exports: [PassportModule, JwtModule, AuditLogModule],
 })
 export class AuthModule {}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -11,7 +11,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
-import { createHash, randomBytes } from 'crypto';
+import { createHash, randomBytes, randomUUID } from 'crypto';
 import type ms from 'ms';
 import { User } from '../users/entities/user.entity';
 import { RegisterDto } from './dto/register.dto';
@@ -22,6 +22,7 @@ import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { NotificationService } from '../notification/notification.service';
 import { AuditLogService } from '../audit-logs/audit-log.service';
 import { AuditAction } from '../audit-logs/entities/audit-log.entity';
+import { TokenBlacklistService } from './token-blacklist.service';
 
 const MAX_LOGIN_ATTEMPTS = 5;
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000;
@@ -62,6 +63,7 @@ export class AuthService implements OnModuleInit {
     private readonly jwtService: JwtService,
     private readonly notificationService: NotificationService,
     private readonly auditLogService: AuditLogService,
+    private readonly tokenBlacklistService: TokenBlacklistService,
   ) {}
 
   onModuleInit() {
@@ -318,15 +320,23 @@ export class AuthService implements OnModuleInit {
     return RESET_PASSWORD_SUCCESS_RESPONSE;
   }
 
-  async logout(userId: number): Promise<void> {
+  async logout(userId: number, jti: string, expiresAt: Date): Promise<void> {
+    await this.tokenBlacklistService.addToBlacklist(jti, userId, expiresAt, 'user_logout');
     await this.userRepository.update(userId, { refreshToken: null });
-    this.logger.log(`User logged out: ${userId}`);
+    this.logger.log(`User logged out: userId=${userId}, jti=${jti}`);
+  }
+
+  async logoutAll(userId: number): Promise<void> {
+    await this.tokenBlacklistService.revokeAllUserTokens(userId, 'user_logout_all');
+    await this.userRepository.update(userId, { refreshToken: null });
+    this.logger.log(`All tokens revoked for user: ${userId}`);
   }
 
   private generateTokens(user: User): TokenPair {
     const payload = { sub: user.id, email: user.email, role: user.role };
-    // accessToken includes tokenType: 'access' to prevent refresh tokens from being used as access tokens
-    const accessToken = this.jwtService.sign({ ...payload, tokenType: 'access' });
+    const jti = randomUUID();
+    // accessToken includes tokenType: 'access' and jti (JWT ID) for blacklist tracking
+    const accessToken = this.jwtService.sign({ ...payload, tokenType: 'access', jti });
     // refreshToken uses longer expiry; cast to ms.StringValue required by jsonwebtoken types
     const refreshExpiresIn = (process.env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue;
     const refreshSecret = process.env.JWT_REFRESH_SECRET;

--- a/backend/src/modules/auth/entities/token-blacklist.entity.ts
+++ b/backend/src/modules/auth/entities/token-blacklist.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('token_blacklist')
+@Index(['userId'])
+@Index(['expiresAt'])
+export class TokenBlacklist {
+  @PrimaryColumn({ name: 'jti', type: 'varchar', length: 36 })
+  jti!: string;
+
+  @Column({ name: 'user_id', type: 'bigint' })
+  userId!: number;
+
+  @Column({ name: 'expires_at', type: 'datetime' })
+  expiresAt!: Date;
+
+  @Column({ name: 'reason', type: 'varchar', length: 255, nullable: true })
+  reason!: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -2,18 +2,30 @@ import { UnauthorizedException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { JwtStrategy } from './jwt.strategy';
 import { User } from '../../users/entities/user.entity';
+import { TokenBlacklistService } from '../token-blacklist.service';
+
+const mockUserRepository = {
+  findOne: jest.fn(),
+};
+
+const mockTokenBlacklistService = {
+  addToBlacklist: jest.fn(),
+  isBlacklisted: jest.fn(),
+  revokeAllUserTokens: jest.fn(),
+};
 
 describe('JwtStrategy', () => {
   let strategy: JwtStrategy;
-  let userRepository: jest.Mocked<Pick<Repository<User>, 'findOne'>>;
 
   beforeEach(() => {
     process.env.JWT_SECRET = 'test-secret';
     process.env.JWT_PUBLIC_KEY = 'test-public-key';
-    userRepository = {
-      findOne: jest.fn(),
-    };
-    strategy = new JwtStrategy(userRepository as unknown as Repository<User>);
+    jest.clearAllMocks();
+
+    strategy = new JwtStrategy(
+      mockUserRepository as unknown as Repository<User>,
+      mockTokenBlacklistService as unknown as TokenBlacklistService,
+    );
   });
 
   afterEach(() => {
@@ -22,17 +34,19 @@ describe('JwtStrategy', () => {
 
   describe('validate()', () => {
     it('should return user object for valid access token payload without tokenType', async () => {
-      userRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockTokenBlacklistService.isBlacklisted.mockResolvedValue(false);
       const payload = { sub: 1, email: 'test@test.com', role: 'user' };
       const result = await strategy.validate(payload);
-      expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user' });
+      expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user', jti: undefined });
     });
 
     it('should return user object for payload with tokenType: access', async () => {
-      userRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockTokenBlacklistService.isBlacklisted.mockResolvedValue(false);
       const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access' };
       const result = await strategy.validate(payload);
-      expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user' });
+      expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user', jti: undefined });
     });
 
     it('should throw UnauthorizedException when tokenType is refresh', async () => {
@@ -48,21 +62,44 @@ describe('JwtStrategy', () => {
     });
 
     it('should throw UnauthorizedException when user is not found', async () => {
-      userRepository.findOne.mockResolvedValue(null);
+      mockUserRepository.findOne.mockResolvedValue(null);
       const payload = { sub: 99, email: 'ghost@test.com', role: 'user' };
       await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
     });
 
     it('should throw UnauthorizedException when user isActive is false', async () => {
-      userRepository.findOne.mockResolvedValue({ id: 1, isActive: false } as User);
+      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: false } as User);
       const payload = { sub: 1, email: 'test@test.com', role: 'user' };
       await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
     });
 
     it('should throw UnauthorizedException with correct message for inactive user', async () => {
-      userRepository.findOne.mockResolvedValue({ id: 1, isActive: false } as User);
+      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: false } as User);
       const payload = { sub: 1, email: 'test@test.com', role: 'user' };
       await expect(strategy.validate(payload)).rejects.toThrow('비활성화된 계정입니다.');
+    });
+
+    it('should throw UnauthorizedException when token is blacklisted', async () => {
+      mockTokenBlacklistService.isBlacklisted.mockResolvedValue(true);
+      const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access', jti: 'blacklisted-jti' };
+      await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
+      await expect(strategy.validate(payload)).rejects.toThrow('토큰이 무효화되었습니다.');
+    });
+
+    it('should not check blacklist when jti is absent', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access' };
+      await strategy.validate(payload);
+      expect(mockTokenBlacklistService.isBlacklisted).not.toHaveBeenCalled();
+    });
+
+    it('should check blacklist and return user with jti when token is not blacklisted', async () => {
+      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockTokenBlacklistService.isBlacklisted.mockResolvedValue(false);
+      const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access', jti: 'valid-jti' };
+      const result = await strategy.validate(payload);
+      expect(mockTokenBlacklistService.isBlacklisted).toHaveBeenCalledWith('valid-jti');
+      expect(result).toEqual({ id: 1, email: 'test@test.com', role: 'user', jti: 'valid-jti' });
     });
   });
 });

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -7,11 +7,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Request } from 'express';
 import { User } from '../../users/entities/user.entity';
+import { TokenBlacklistService } from '../token-blacklist.service';
 
 export interface JwtPayload {
   sub: number;
   email: string;
   role: string;
+  jti?: string;
+  tokenType?: string;
 }
 
 function cookieExtractor(req: Request): string | null {
@@ -37,9 +40,12 @@ function getJwtPublicKey(): string {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
+  private readonly logger = new Logger(JwtStrategy.name);
+
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    private readonly tokenBlacklistService: TokenBlacklistService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
@@ -53,9 +59,17 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: JwtPayload & { tokenType?: string }) {
+  async validate(payload: JwtPayload) {
     if (payload.tokenType === 'refresh') {
       throw new UnauthorizedException('Refresh tokens cannot be used for API access');
+    }
+
+    if (payload.jti) {
+      const isBlacklisted = await this.tokenBlacklistService.isBlacklisted(payload.jti);
+      if (isBlacklisted) {
+        this.logger.warn(`Blacklisted token used: jti=${payload.jti}, sub=${payload.sub}`);
+        throw new UnauthorizedException('토큰이 무효화되었습니다.');
+      }
     }
 
     const user = await this.userRepository.findOne({ where: { id: payload.sub } });
@@ -63,6 +77,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('비활성화된 계정입니다.');
     }
 
-    return { id: payload.sub, email: payload.email, role: payload.role };
+    return { id: payload.sub, email: payload.email, role: payload.role, jti: payload.jti };
   }
 }

--- a/backend/src/modules/auth/token-blacklist.service.ts
+++ b/backend/src/modules/auth/token-blacklist.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { CacheService } from '../cache/cache.service';
+import { TokenBlacklist } from './entities/token-blacklist.entity';
+
+const BLACKLIST_CACHE_PREFIX = 'blacklist:';
+
+@Injectable()
+export class TokenBlacklistService {
+  private readonly logger = new Logger(TokenBlacklistService.name);
+
+  constructor(
+    @InjectRepository(TokenBlacklist)
+    private readonly blacklistRepository: Repository<TokenBlacklist>,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  /**
+   * Add a token JTI to the blacklist.
+   * Cached in CacheService (hot path) and persisted to DB for durability.
+   */
+  async addToBlacklist(jti: string, userId: number, expiresAt: Date, reason: string): Promise<void> {
+    const ttlSeconds = Math.max(0, Math.ceil((expiresAt.getTime() - Date.now()) / 1000));
+
+    await this.cacheService.set(`${BLACKLIST_CACHE_PREFIX}${jti}`, true, ttlSeconds);
+
+    const entry = this.blacklistRepository.create({ jti, userId, expiresAt, reason });
+    await this.blacklistRepository.save(entry);
+
+    this.logger.log(`Token blacklisted: jti=${jti}, userId=${userId}, reason=${reason}`);
+  }
+
+  /**
+   * Check if a token JTI is blacklisted.
+   * Checks CacheService first (hot path), falls back to DB.
+   */
+  async isBlacklisted(jti: string): Promise<boolean> {
+    const cached = await this.cacheService.get<boolean>(`${BLACKLIST_CACHE_PREFIX}${jti}`);
+    if (cached !== null) {
+      return true;
+    }
+
+    const entry = await this.blacklistRepository.findOne({ where: { jti } });
+    if (entry) {
+      const ttlSeconds = Math.max(0, Math.ceil((entry.expiresAt.getTime() - Date.now()) / 1000));
+      if (ttlSeconds > 0) {
+        await this.cacheService.set(`${BLACKLIST_CACHE_PREFIX}${jti}`, true, ttlSeconds);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Revoke all tokens for a specific user (logout everywhere).
+   * Adds all existing user tokens to blacklist — note: only tokens already issued
+   * can be revoked; future tokens will naturally be blacklisted when they are used.
+   */
+  async revokeAllUserTokens(userId: number, reason: string): Promise<void> {
+    await this.blacklistRepository.update(
+      { userId },
+      { reason },
+    );
+    this.logger.log(`All tokens revoked for userId=${userId}, reason=${reason}`);
+  }
+
+  /**
+   * Cron job: clean up expired blacklist entries from DB.
+   * Runs every hour. CacheService handles TTL-based eviction automatically.
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async cleanupExpiredEntries(): Promise<void> {
+    const result = await this.blacklistRepository.delete({
+      expiresAt: LessThan(new Date()),
+    });
+
+    if (result.affected && result.affected > 0) {
+      this.logger.log(`Cleaned up ${result.affected} expired blacklist entries`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `token_blacklist` table (`jti`, `user_id`, `expires_at`, `reason`) for immediate access token revocation on logout
- Access tokens now carry a `jti` (UUID) for unique identification per RFC 7519
- `logout()` blacklists the current access token's `jti` **before** clearing `refreshToken`
- `JwtAuthGuard` / `JwtStrategy` checks the blacklist via `CacheService` (hot path) with DB fallback
- `TokenBlacklistService`: hourly cron cleans up expired blacklist entries
- `POST /auth/logout-all`: revokes all tokens for a user (logout everywhere)

## Acceptance Criteria
- [x] `token_blacklist` table (jti, user_id, expires_at, reason)
- [x] logout 시 현재 access token의 jti 등록 + 만료 시각 저장
- [x] JwtAuthGuard에서 블랙리스트 조회 (in-memory CacheService로 hot path 캐싱)
- [x] Cron: expires_at 지난 blacklist 레코드 정리
- [x] "전체 로그아웃" 엔드포인트 (해당 사용자의 모든 토큰 블랙리스트)

## Tests
- `token-blacklist.service.spec.ts` — addToBlacklist, isBlacklisted (cache hit/miss/expired), revokeAllUserTokens, cleanupExpiredEntries cron
- `auth.service.spec.ts` — updated logout (blacklist → clear refreshToken), logoutAll
- `jwt.strategy.spec.ts` — blacklist check in validate(), blacklisted token throws 401

## Validation
- Backend lint: ✅ `npm run lint` — 0 errors
- Backend build: ✅ `npm run build` — success
- Backend tests: ✅ `npm run test` — 487 passed

Closes #497