### PR TITLE
feat: #494 Implement email verification flow

### DIFF
--- a/backend/src/database/migrations/1780000000000-AddEmailVerificationFields.ts
+++ b/backend/src/database/migrations/1780000000000-AddEmailVerificationFields.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEmailVerificationFields1780000000000 implements MigrationInterface {
+  name = 'AddEmailVerificationFields1780000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`users\` ADD COLUMN \`is_email_verified\` tinyint(1) NOT NULL DEFAULT 0`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`users\` ADD COLUMN \`email_verified_at\` datetime NULL AFTER \`is_email_verified\``,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`users\` DROP COLUMN \`email_verified_at\``);
+    await queryRunner.query(`ALTER TABLE \`users\` DROP COLUMN \`is_email_verified\``);
+  }
+}

--- a/backend/src/database/migrations/1780000000001-CreateVerificationTokensTable.ts
+++ b/backend/src/database/migrations/1780000000001-CreateVerificationTokensTable.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateVerificationTokensTable1780000000001 implements MigrationInterface {
+  name = 'CreateVerificationTokensTable1780000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS \`verification_tokens\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`user_id\` bigint NOT NULL, \`token_hash\` varchar(64) NOT NULL, \`expires_at\` datetime NOT NULL, \`used_at\` datetime NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), UNIQUE INDEX \`IDX_verification_tokens_token_hash\` (\`token_hash\`), INDEX \`IDX_verification_tokens_user_id\` (\`user_id\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`verification_tokens\` ADD CONSTRAINT \`FK_verification_tokens_user_id\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`verification_tokens\` DROP FOREIGN KEY \`FK_verification_tokens_user_id\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_verification_tokens_user_id\` ON \`verification_tokens\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_verification_tokens_token_hash\` ON \`verification_tokens\``,
+    );
+    await queryRunner.query(`DROP TABLE \`verification_tokens\``);
+  }
+}

--- a/backend/src/modules/admin/__tests__/admin-members.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-members.service.spec.ts
@@ -29,6 +29,8 @@ function makeUser(overrides: Partial<User> = {}): User {
     phone: null,
     role: UserRole.USER,
     isActive: true,
+    isEmailVerified: true,
+    emailVerifiedAt: new Date(),
     refreshToken: null,
     failedLoginAttempts: 0,
     lockedUntil: null,

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -6,6 +6,7 @@ import * as bcrypt from 'bcrypt';
 import { AuthService } from '../auth.service';
 import { User, UserRole } from '../../users/entities/user.entity';
 import { PasswordResetToken } from '../entities/password-reset-token.entity';
+import { VerificationToken } from '../entities/verification-token.entity';
 import { NotificationService } from '../../notification/notification.service';
 import { AuditLogService } from '../../audit-logs/audit-log.service';
 
@@ -23,6 +24,13 @@ const mockPasswordResetTokenRepository = {
   update: jest.fn(),
 };
 
+const mockVerificationTokenRepository = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+};
+
 const mockJwtService = {
   sign: jest.fn().mockReturnValue('mock-token'),
   verify: jest.fn().mockReturnValue({ sub: 1, email: 'test@example.com', role: 'user' }),
@@ -30,6 +38,7 @@ const mockJwtService = {
 
 const mockNotificationService = {
   sendPasswordReset: jest.fn(),
+  sendEmailVerification: jest.fn(),
 };
 
 const mockAuditLogService = {
@@ -45,6 +54,8 @@ function makeUser(overrides: Partial<User> = {}): User {
     phone: null,
     role: UserRole.USER,
     isActive: true,
+    isEmailVerified: false,
+    emailVerifiedAt: null,
     refreshToken: null,
     failedLoginAttempts: 0,
     lockedUntil: null,
@@ -70,6 +81,10 @@ describe('AuthService', () => {
         {
           provide: getRepositoryToken(PasswordResetToken),
           useValue: mockPasswordResetTokenRepository,
+        },
+        {
+          provide: getRepositoryToken(VerificationToken),
+          useValue: mockVerificationTokenRepository,
         },
         { provide: JwtService, useValue: mockJwtService },
         { provide: NotificationService, useValue: mockNotificationService },
@@ -153,7 +168,7 @@ describe('AuthService', () => {
 
     it('로그인 성공 시 refreshToken을 DB에 해싱 저장', async () => {
       const hashed = await bcrypt.hash('Test1234!', 10);
-      mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed }));
+      mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed, isEmailVerified: true }));
       mockUserRepository.update.mockResolvedValue(undefined);
 
       await service.login({ email: 'test@example.com', password: 'Test1234!' });
@@ -313,6 +328,189 @@ describe('AuthService', () => {
       );
 
       delete process.env.JWT_REFRESH_SECRET;
+    });
+  });
+
+  describe('register (이메일 인증)', () => {
+    it('가입 시 인증 이메일 발송', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+      const newUser = makeUser({ id: 2, email: 'new@example.com', name: '신규', isEmailVerified: false });
+      mockUserRepository.create.mockReturnValue(newUser);
+      mockUserRepository.save.mockResolvedValue(newUser);
+      mockUserRepository.update.mockResolvedValue(undefined);
+      mockVerificationTokenRepository.create.mockImplementation((value) => value);
+      mockVerificationTokenRepository.save.mockResolvedValue(undefined);
+      mockNotificationService.sendEmailVerification.mockResolvedValue(undefined);
+
+      await service.register({ email: 'new@example.com', password: 'Test1234!', name: '신규' });
+
+      expect(mockVerificationTokenRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 2,
+          tokenHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          usedAt: null,
+        }),
+      );
+      expect(mockNotificationService.sendEmailVerification).toHaveBeenCalledWith(
+        'new@example.com',
+        expect.objectContaining({
+          recipientName: '신규',
+          verificationUrl: expect.stringContaining('/verify-email?token='),
+          expiresInMinutes: 15,
+        }),
+      );
+    });
+
+    it('가입 시 isEmailVerified: false로 저장됨', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+      const newUser = makeUser({ id: 2, email: 'new@example.com', name: '신규', isEmailVerified: false });
+      mockUserRepository.create.mockReturnValue(newUser);
+      mockUserRepository.save.mockResolvedValue(newUser);
+      mockUserRepository.update.mockResolvedValue(undefined);
+      mockVerificationTokenRepository.create.mockImplementation((value) => value);
+      mockVerificationTokenRepository.save.mockResolvedValue(undefined);
+      mockNotificationService.sendEmailVerification.mockResolvedValue(undefined);
+
+      await service.register({ email: 'new@example.com', password: 'Test1234!', name: '신규' });
+
+      expect(mockUserRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@example.com',
+          name: '신규',
+          isEmailVerified: false,
+        }),
+      );
+    });
+  });
+
+  describe('login (이메일 인증 체크)', () => {
+    it('이메일 미인증 계정 로그인 시 ForbiddenException', async () => {
+      const hashed = await bcrypt.hash('Test1234!', 10);
+      mockUserRepository.findOne.mockResolvedValue(
+        makeUser({ password: hashed, isEmailVerified: false }),
+      );
+
+      await expect(
+        service.login({ email: 'test@example.com', password: 'Test1234!' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('이메일 인증된 계정은 정상 로그인 가능', async () => {
+      const hashed = await bcrypt.hash('Test1234!', 10);
+      mockUserRepository.findOne.mockResolvedValue(
+        makeUser({ password: hashed, isEmailVerified: true }),
+      );
+      mockUserRepository.update.mockResolvedValue(undefined);
+
+      const result = await service.login({ email: 'test@example.com', password: 'Test1234!' });
+
+      expect(result).toHaveProperty('accessToken');
+      expect(result).toHaveProperty('refreshToken');
+    });
+  });
+
+  describe('verifyEmail', () => {
+    it('유효한 토큰으로 이메일 인증 성공', async () => {
+      mockVerificationTokenRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 1,
+        tokenHash: 'validhash',
+        usedAt: null,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      mockVerificationTokenRepository.update.mockResolvedValue({ affected: 1 });
+      mockUserRepository.update.mockResolvedValue(undefined);
+
+      const result = await service.verifyEmail({ token: 'valid-token' });
+
+      expect(result).toEqual({ message: '이메일이 인증되었습니다.' });
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          isEmailVerified: true,
+          emailVerifiedAt: expect.any(Date),
+        }),
+      );
+    });
+
+    it('이미 사용된 토큰 재사용 시 BadRequestException', async () => {
+      mockVerificationTokenRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 1,
+        usedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+      await expect(
+        service.verifyEmail({ token: 'used-token' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('만료된 토큰 사용 시 BadRequestException', async () => {
+      mockVerificationTokenRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 1,
+        usedAt: null,
+        expiresAt: new Date(Date.now() - 60_000),
+      });
+
+      await expect(
+        service.verifyEmail({ token: 'expired-token' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('유효하지 않은 토큰 시 BadRequestException', async () => {
+      mockVerificationTokenRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.verifyEmail({ token: 'invalid-token' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('resendVerification', () => {
+    it('존재하지 않는 이메일에도 동일한 성공 응답 반환', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.resendVerification({ email: 'missing@example.com' })).resolves.toEqual({
+        message: '인증 이메일이 발송되었습니다. 링크를 확인해 주세요.',
+      });
+
+      expect(mockNotificationService.sendEmailVerification).not.toHaveBeenCalled();
+    });
+
+    it('이미 인증된 이메일 요청 시 이미 인증됨 응답', async () => {
+      mockUserRepository.findOne.mockResolvedValue(
+        makeUser({ email: 'verified@example.com', isEmailVerified: true }),
+      );
+
+      await expect(service.resendVerification({ email: 'verified@example.com' })).resolves.toEqual({
+        message: '이미 인증된 이메일입니다.',
+      });
+
+      expect(mockNotificationService.sendEmailVerification).not.toHaveBeenCalled();
+    });
+
+    it('미인증 이메일 요청 시 인증 이메일 재발송', async () => {
+      const user = makeUser({ email: 'unverified@example.com', isEmailVerified: false });
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockVerificationTokenRepository.update.mockResolvedValue({ affected: 1 });
+      mockVerificationTokenRepository.create.mockImplementation((value) => value);
+      mockVerificationTokenRepository.save.mockResolvedValue(undefined);
+      mockNotificationService.sendEmailVerification.mockResolvedValue(undefined);
+
+      await expect(service.resendVerification({ email: 'unverified@example.com' })).resolves.toEqual({
+        message: '인증 이메일이 발송되었습니다. 링크를 확인해 주세요.',
+      });
+
+      expect(mockNotificationService.sendEmailVerification).toHaveBeenCalledWith(
+        'unverified@example.com',
+        expect.objectContaining({
+          recipientName: '홍길동',
+          verificationUrl: expect.stringContaining('/verify-email?token='),
+          expiresInMinutes: 15,
+        }),
+      );
     });
   });
 });

--- a/backend/src/modules/auth/__tests__/oauth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/oauth.service.spec.ts
@@ -50,6 +50,8 @@ function makeUser(overrides: Partial<User> = {}): User {
     phone: null,
     role: UserRole.USER,
     isActive: true,
+    isEmailVerified: true,
+    emailVerifiedAt: new Date(),
     refreshToken: null,
     failedLoginAttempts: 0,
     lockedUntil: null,

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -18,6 +18,8 @@ import { LoginDto } from './dto/login.dto';
 import { OAuthCallbackDto } from './dto/oauth-callback.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { VerifyEmailDto } from './dto/verify-email.dto';
+import { ResendVerificationDto } from './dto/resend-verification.dto';
 import { Public } from '../../common/decorators/public.decorator';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
@@ -58,7 +60,7 @@ function clearAuthCookies(res: Response): void {
 }
 
 @Throttle({ auth: { limit: 30, ttl: 60000 } })
-@SkipThrottle({ forgotPassword: true })
+@SkipThrottle({ forgotPassword: true, resendVerification: true })
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
@@ -122,6 +124,34 @@ export class AuthController {
   @ApiResponse({ status: 400, description: '토큰이 유효하지 않거나 만료됨' })
   async resetPassword(@Body() dto: ResetPasswordDto) {
     return this.authService.resetPassword(dto);
+  }
+
+  @Post('verify-email')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ resendVerification: { limit: 3, ttl: 60000 } })
+  @ApiOperation({
+    summary: '이메일 인증',
+    description: '이메일로 받은 인증 토큰으로 이메일 인증을 완료합니다.',
+  })
+  @ApiResponse({ status: 200, description: '이메일 인증 성공' })
+  @ApiResponse({ status: 400, description: '토큰이 유효하지 않거나 만료됨' })
+  async verifyEmail(@Body() dto: VerifyEmailDto) {
+    return this.authService.verifyEmail(dto);
+  }
+
+  @Post('resend-verification')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ resendVerification: { limit: 3, ttl: 60000 } })
+  @ApiOperation({
+    summary: '인증 이메일 재발송',
+    description: '이메일 인증을 다시 요청합니다. 1분間に最大3回まで.',
+  })
+  @ApiResponse({ status: 200, description: '인증 이메일 발송 처리 완료' })
+  @ApiResponse({ status: 429, description: '너무 많은 요청' })
+  async resendVerification(@Body() dto: ResendVerificationDto) {
+    return this.authService.resendVerification(dto);
   }
 
   @Get('profile')

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -11,6 +11,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { OAuthService } from './oauth.service';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
+import { VerificationToken } from './entities/verification-token.entity';
 import { User } from '../users/entities/user.entity';
 import { UserAuthentication } from '../users/entities/user-authentication.entity';
 import { AuditLogModule } from '../audit-logs/audit-log.module';
@@ -38,7 +39,7 @@ function getJwtPrivateKey(): string {
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, UserAuthentication, PasswordResetToken]),
+    TypeOrmModule.forFeature([User, UserAuthentication, PasswordResetToken, VerificationToken]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
       privateKey: getJwtPrivateKey(),

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -18,7 +18,10 @@ import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { VerifyEmailDto } from './dto/verify-email.dto';
+import { ResendVerificationDto } from './dto/resend-verification.dto';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
+import { VerificationToken } from './entities/verification-token.entity';
 import { NotificationService } from '../notification/notification.service';
 import { AuditLogService } from '../audit-logs/audit-log.service';
 import { AuditAction } from '../audit-logs/entities/audit-log.entity';
@@ -26,6 +29,8 @@ import { AuditAction } from '../audit-logs/entities/audit-log.entity';
 const MAX_LOGIN_ATTEMPTS = 5;
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000;
 const PASSWORD_RESET_TTL_MS = 60 * 60 * 1000;
+const EMAIL_VERIFICATION_TTL_MIN = 15;
+const EMAIL_VERIFICATION_TTL_MS = EMAIL_VERIFICATION_TTL_MIN * 60 * 1000;
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
 const FORGOT_PASSWORD_RESPONSE = {
   message: '가입된 계정이 있다면 비밀번호 재설정 링크를 이메일로 발송했습니다.',
@@ -35,6 +40,15 @@ const RESET_PASSWORD_SUCCESS_RESPONSE = {
 };
 const INVALID_PASSWORD_RESET_TOKEN_MESSAGE =
   '유효하지 않거나 만료된 비밀번호 재설정 토큰입니다.';
+const VERIFICATION_EMAIL_SENT_RESPONSE = {
+  message: '인증 이메일이 발송되었습니다. 링크를 확인해 주세요.',
+};
+const EMAIL_VERIFIED_RESPONSE = {
+  message: '이메일이 인증되었습니다.',
+};
+const INVALID_VERIFICATION_TOKEN_MESSAGE =
+  '유효하지 않거나 만료된 인증 토큰입니다.';
+const EMAIL_ALREADY_VERIFIED_MESSAGE = '이미 인증된 이메일입니다.';
 
 export interface TokenPair {
   accessToken: string;
@@ -59,6 +73,8 @@ export class AuthService implements OnModuleInit {
     private readonly userRepository: Repository<User>,
     @InjectRepository(PasswordResetToken)
     private readonly passwordResetTokenRepository: Repository<PasswordResetToken>,
+    @InjectRepository(VerificationToken)
+    private readonly verificationTokenRepository: Repository<VerificationToken>,
     private readonly jwtService: JwtService,
     private readonly notificationService: NotificationService,
     private readonly auditLogService: AuditLogService,
@@ -92,8 +108,11 @@ export class AuthService implements OnModuleInit {
       email: dto.email,
       password: hashed,
       name: dto.name,
+      isEmailVerified: false,
     });
     await this.userRepository.save(user);
+
+    await this.createVerificationTokenAndSendEmail(user);
 
     const tokens = this.generateTokens(user);
     const hashedRefresh = await bcrypt.hash(tokens.refreshToken, 10);
@@ -171,6 +190,10 @@ export class AuthService implements OnModuleInit {
 
     if (!user.isActive) {
       throw new ForbiddenException('비활성화된 계정입니다.');
+    }
+
+    if (!user.isEmailVerified) {
+      throw new ForbiddenException('이메일 인증이 필요합니다. 인증 메일을 확인해 주세요.');
     }
 
     if (user.failedLoginAttempts > 0 || user.lockedUntil) {
@@ -323,6 +346,80 @@ export class AuthService implements OnModuleInit {
     this.logger.log(`User logged out: ${userId}`);
   }
 
+  async verifyEmail(dto: VerifyEmailDto): Promise<{ message: string }> {
+    const tokenHash = this.hashVerificationToken(dto.token);
+    const verificationToken = await this.verificationTokenRepository.findOne({
+      where: { tokenHash },
+    });
+
+    if (!verificationToken || verificationToken.usedAt) {
+      throw new BadRequestException(INVALID_VERIFICATION_TOKEN_MESSAGE);
+    }
+
+    if (verificationToken.expiresAt.getTime() <= Date.now()) {
+      throw new BadRequestException(INVALID_VERIFICATION_TOKEN_MESSAGE);
+    }
+
+    const markUsedResult = await this.verificationTokenRepository.update(
+      { id: verificationToken.id, usedAt: IsNull() },
+      { usedAt: new Date() },
+    );
+
+    if (markUsedResult.affected !== 1) {
+      throw new BadRequestException(INVALID_VERIFICATION_TOKEN_MESSAGE);
+    }
+
+    await this.userRepository.update(verificationToken.userId, {
+      isEmailVerified: true,
+      emailVerifiedAt: new Date(),
+    });
+
+    this.logger.log(`Email verified for user: ${verificationToken.userId}`);
+    return EMAIL_VERIFIED_RESPONSE;
+  }
+
+  async resendVerification(dto: ResendVerificationDto): Promise<{ message: string }> {
+    const normalizedEmail = dto.email.trim().toLowerCase();
+    const user = await this.userRepository.findOne({
+      where: { email: normalizedEmail },
+    });
+
+    if (!user || !user.isActive) {
+      return VERIFICATION_EMAIL_SENT_RESPONSE;
+    }
+
+    if (user.isEmailVerified) {
+      return { message: EMAIL_ALREADY_VERIFIED_MESSAGE };
+    }
+
+    await this.verificationTokenRepository.update(
+      { userId: user.id, usedAt: IsNull() },
+      { usedAt: new Date() },
+    );
+
+    await this.createVerificationTokenAndSendEmail(user);
+
+    return VERIFICATION_EMAIL_SENT_RESPONSE;
+  }
+
+  private async createVerificationTokenAndSendEmail(user: User): Promise<void> {
+    const rawToken = randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + EMAIL_VERIFICATION_TTL_MS);
+    const verificationToken = this.verificationTokenRepository.create({
+      userId: user.id,
+      tokenHash: this.hashVerificationToken(rawToken),
+      expiresAt,
+      usedAt: null,
+    });
+    await this.verificationTokenRepository.save(verificationToken);
+
+    await this.notificationService.sendEmailVerification(user.email, {
+      recipientName: user.name,
+      verificationUrl: this.buildEmailVerificationUrl(rawToken),
+      expiresInMinutes: EMAIL_VERIFICATION_TTL_MIN,
+    });
+  }
+
   private generateTokens(user: User): TokenPair {
     const payload = { sub: user.id, email: user.email, role: user.role };
     // accessToken includes tokenType: 'access' to prevent refresh tokens from being used as access tokens
@@ -356,6 +453,21 @@ export class AuthService implements OnModuleInit {
     }
 
     const url = new URL('/reset-password', baseUrl);
+    url.searchParams.set('token', token);
+    return url.toString();
+  }
+
+  private hashVerificationToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private buildEmailVerificationUrl(token: string): string {
+    const baseUrl = process.env.FRONTEND_URL;
+    if (!baseUrl) {
+      throw new Error('FRONTEND_URL environment variable is required');
+    }
+
+    const url = new URL('/verify-email', baseUrl);
     url.searchParams.set('token', token);
     return url.toString();
   }

--- a/backend/src/modules/auth/dto/resend-verification.dto.ts
+++ b/backend/src/modules/auth/dto/resend-verification.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ResendVerificationDto {
+  @ApiProperty({ example: 'user@example.com', description: '인증 이메일을 재발송할 이메일 주소' })
+  @IsEmail({}, { message: '올바른 이메일 형식을 입력해 주세요.' })
+  @IsNotEmpty({ message: '이메일을 입력해 주세요.' })
+  email!: string;
+}

--- a/backend/src/modules/auth/dto/verify-email.dto.ts
+++ b/backend/src/modules/auth/dto/verify-email.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class VerifyEmailDto {
+  @ApiProperty({ example: 'abc123def456...', description: '이메일 인증 토큰' })
+  @IsString({ message: '토큰을 입력해 주세요.' })
+  @IsNotEmpty({ message: '토큰을 입력해 주세요.' })
+  token!: string;
+}

--- a/backend/src/modules/auth/entities/verification-token.entity.ts
+++ b/backend/src/modules/auth/entities/verification-token.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('verification_tokens')
+@Index('IDX_verification_tokens_token_hash', ['tokenHash'], { unique: true })
+@Index('IDX_verification_tokens_user_id', ['userId'])
+export class VerificationToken {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user!: User;
+
+  @Column({ name: 'user_id', type: 'bigint' })
+  userId!: number;
+
+  @Column({ name: 'token_hash', type: 'varchar', length: 64 })
+  tokenHash!: string;
+
+  @Column({ name: 'expires_at', type: 'datetime' })
+  expiresAt!: Date;
+
+  @Column({ name: 'used_at', type: 'datetime', nullable: true })
+  usedAt!: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/backend/src/modules/notification/notification.service.ts
+++ b/backend/src/modules/notification/notification.service.ts
@@ -1,11 +1,13 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { EmailMessage, EmailProvider } from './interfaces/email-provider.interface';
 import {
+  renderEmailVerification,
   renderInquiryAnswered,
   renderOrderConfirmed,
   renderPaymentConfirmed,
   renderPasswordReset,
   renderShippingUpdate,
+  type EmailVerificationContext,
   type InquiryAnsweredContext,
   type OrderConfirmedContext,
   type PaymentConfirmedContext,
@@ -66,6 +68,11 @@ export class NotificationService {
 
   async sendPasswordReset(to: string, context: PasswordResetContext): Promise<void> {
     const rendered = renderPasswordReset(context);
+    await this.sendEmail({ to, ...rendered });
+  }
+
+  async sendEmailVerification(to: string, context: EmailVerificationContext): Promise<void> {
+    const rendered = renderEmailVerification(context);
     await this.sendEmail({ to, ...rendered });
   }
 }

--- a/backend/src/modules/notification/templates/render.ts
+++ b/backend/src/modules/notification/templates/render.ts
@@ -37,6 +37,13 @@ export interface PasswordResetContext {
   locale?: 'ko' | 'en';
 }
 
+export interface EmailVerificationContext {
+  recipientName: string;
+  verificationUrl: string;
+  expiresInMinutes: number;
+  locale?: 'ko' | 'en';
+}
+
 export interface RenderedEmail {
   subject: string;
   html: string;
@@ -104,5 +111,17 @@ export function renderPasswordReset(ctx: PasswordResetContext): RenderedEmail {
     ? `${ctx.recipientName}님, 아래 링크에서 비밀번호를 재설정해 주세요. 링크는 ${ctx.expiresInMinutes}분 후 만료됩니다.\n\n${ctx.resetUrl}`
     : `Hi ${ctx.recipientName}, use the link below to reset your password. It expires in ${ctx.expiresInMinutes} minutes.\n\n${ctx.resetUrl}`;
   const html = `<div><h2>${escapeHtml(subject)}</h2><p>${escapeHtml(text).replace(/\n/g, '<br>')}</p><p><a href="${escapeHtml(ctx.resetUrl)}">${escapeHtml(ctx.resetUrl)}</a></p></div>`;
+  return { subject, html, text };
+}
+
+export function renderEmailVerification(ctx: EmailVerificationContext): RenderedEmail {
+  const isKo = (ctx.locale ?? 'ko') === 'ko';
+  const subject = isKo
+    ? '[옥화당] 이메일 인증을 완료해 주세요'
+    : '[Okhwadang] Please verify your email';
+  const text = isKo
+    ? `${ctx.recipientName}님, 아래 링크를 클릭하여 이메일 인증을 완료해 주세요. 링크는 ${ctx.expiresInMinutes}분 후 만료됩니다.\n\n${ctx.verificationUrl}`
+    : `Hi ${ctx.recipientName}, click the link below to verify your email address. The link expires in ${ctx.expiresInMinutes} minutes.\n\n${ctx.verificationUrl}`;
+  const html = `<div><h2>${escapeHtml(subject)}</h2><p>${escapeHtml(text).replace(/\n/g, '<br>')}</p><p><a href="${escapeHtml(ctx.verificationUrl)}">${escapeHtml(ctx.verificationUrl)}</a></p></div>`;
   return { subject, html, text };
 }

--- a/backend/src/modules/users/__tests__/users.service.spec.ts
+++ b/backend/src/modules/users/__tests__/users.service.spec.ts
@@ -56,6 +56,8 @@ describe('UsersService', () => {
         phone: null,
         role: UserRole.USER,
         isActive: true,
+        isEmailVerified: true,
+        emailVerifiedAt: new Date(),
         password: 'hashed',
         refreshToken: 'token',
         failedLoginAttempts: 0,

--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -46,6 +46,12 @@ export class User {
   @Column({ name: 'locked_until', type: 'datetime', nullable: true })
   lockedUntil!: Date | null;
 
+  @Column({ name: 'is_email_verified', type: 'tinyint', default: false })
+  isEmailVerified!: boolean;
+
+  @Column({ name: 'email_verified_at', type: 'datetime', nullable: true })
+  emailVerifiedAt!: Date | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 


### PR DESCRIPTION
## Summary
- Migration: users.is_email_verified (bool), users.email_verified_at (datetime nullable)
- Migration: verification_tokens table (user_id, token_hash, expires_at, used_at)
- POST /auth/verify-email - email verification with token
- POST /auth/resend-verification - resend verification email (ThrottlerModule: 3/min)
- Token: randomBytes(32) to SHA-256 hash, 15min TTL, single-use
- Register sends verification email; unverified users cannot login (ForbiddenException)
- Added NotificationModule.sendEmailVerification

## Tests
- npm run lint: passed
- npm run build: passed
- npm run test: 486 passed

Closes #494