### PR TITLE
feat: #496 Scheduler/Cron jobs for orders and coupons

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -31,6 +31,7 @@ import { ArchivesModule } from './modules/archives/archives.module';
 import { JournalModule } from './modules/journal/journal.module';
 import { PointsModule } from './modules/points/points.module';
 import { NotificationModule } from './modules/notification/notification.module';
+import { SchedulerModule } from './modules/scheduler/scheduler.module';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 
@@ -107,6 +108,7 @@ import { RolesGuard } from './common/guards/roles.guard';
     JournalModule,
     PointsModule,
     NotificationModule,
+    SchedulerModule,
   ],
   providers: [
     // Guard execution order: ThrottlerGuard → JwtAuthGuard → RolesGuard

--- a/backend/src/database/migrations/1781000000000-AddPointHistoryExpiresAt.ts
+++ b/backend/src/database/migrations/1781000000000-AddPointHistoryExpiresAt.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPointHistoryExpiresAt1781000000000 implements MigrationInterface {
+  name = 'AddPointHistoryExpiresAt1781000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`point_history\` ADD \`expires_at\` datetime NULL AFTER \`description\``,
+    );
+    await queryRunner.query(
+      `CREATE INDEX \`IDX_point_history_expires_at\` ON \`point_history\` (\`expires_at\`)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX \`IDX_point_history_expires_at\` ON \`point_history\``);
+    await queryRunner.query(`ALTER TABLE \`point_history\` DROP COLUMN \`expires_at\``);
+  }
+}

--- a/backend/src/database/migrations/1781000000001-CreateSchedulerLocksTable.ts
+++ b/backend/src/database/migrations/1781000000001-CreateSchedulerLocksTable.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSchedulerLocksTable1781000000001 implements MigrationInterface {
+  name = 'CreateSchedulerLocksTable1781000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS \`scheduler_locks\` (
+        \`lock_name\` varchar(100) NOT NULL,
+        \`instance_id\` varchar(100) NOT NULL,
+        \`acquired_at\` datetime NOT NULL,
+        \`expires_at\` datetime NOT NULL,
+        PRIMARY KEY (\`lock_name\`)
+      ) ENGINE=InnoDB`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE \`scheduler_locks\``);
+  }
+}

--- a/backend/src/database/migrations/1781000000002-AddSchedulerSiteSettings.ts
+++ b/backend/src/database/migrations/1781000000002-AddSchedulerSiteSettings.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSchedulerSiteSettings1781000000002 implements MigrationInterface {
+  name = 'AddSchedulerSiteSettings1781000000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO \`site_settings\` (\`setting_key\`, \`value\`, \`group\`, \`label\`, \`input_type\`, \`options\`, \`default_value\`, \`sort_order\`)
+      VALUES
+        ('scheduler_pending_cancel_hours', '24', 'scheduler', '미결제 주문 자동 취소 시간', 'number', NULL, '24', 100),
+        ('scheduler_delivered_confirm_days', '7', 'scheduler', '배송 완료 후 구매확정까지 기간', 'number', NULL, '7', 101)
+      ON DUPLICATE KEY UPDATE \`setting_key\` = \`setting_key\`
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM \`site_settings\` WHERE \`setting_key\` IN ('scheduler_pending_cancel_hours', 'scheduler_delivered_confirm_days')`);
+  }
+}

--- a/backend/src/modules/coupons/entities/point-history.entity.ts
+++ b/backend/src/modules/coupons/entities/point-history.entity.ts
@@ -30,6 +30,9 @@ export class PointHistory {
   @Column({ type: 'varchar', length: 255, nullable: true })
   description!: string | null;
 
+  @Column({ name: 'expires_at', type: 'datetime', nullable: true })
+  expiresAt!: Date | null;
+
   @Column({ name: 'order_id', type: 'bigint', nullable: true })
   orderId!: number | null;
 

--- a/backend/src/modules/scheduler/__tests__/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/__tests__/scheduler.service.spec.ts
@@ -1,0 +1,317 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { SchedulerService } from '../scheduler.service';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { OrderItem } from '../../orders/entities/order-item.entity';
+import { Product } from '../../products/entities/product.entity';
+import { ProductOption } from '../../products/entities/product-option.entity';
+import { Coupon } from '../../coupons/entities/coupon.entity';
+import { PointHistory } from '../../coupons/entities/point-history.entity';
+import { User } from '../../users/entities/user.entity';
+import { NotificationService } from '../../notification/notification.service';
+import { SettingsService } from '../../settings/settings.service';
+
+const mockQueryRunner = {
+  connect: jest.fn(),
+  startTransaction: jest.fn(),
+  commitTransaction: jest.fn(),
+  rollbackTransaction: jest.fn(),
+  release: jest.fn(),
+  manager: {
+    createQueryBuilder: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn(),
+    findOne: jest.fn(),
+    increment: jest.fn(),
+    getRepository: jest.fn(),
+  },
+};
+
+const mockDataSource = {
+  createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+  query: jest.fn(),
+};
+
+const mockOrderRepo = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+const mockOrderItemRepo = {
+  find: jest.fn(),
+};
+
+const mockProductRepo = {
+  findOne: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockProductOptionRepo = {
+  findOne: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockCouponRepo = {
+  find: jest.fn(),
+  update: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+const mockPointHistoryRepo = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockUserRepo = {
+  findOne: jest.fn(),
+};
+
+const mockNotificationService = {
+  sendEmail: jest.fn(),
+  sendOrderConfirmed: jest.fn(),
+};
+
+const mockSettingsService = {
+  getMap: jest.fn(),
+};
+
+describe('SchedulerService', () => {
+  let service: SchedulerService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockDataSource.createQueryRunner.mockReturnValue(mockQueryRunner);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SchedulerService,
+        { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
+        { provide: getRepositoryToken(OrderItem), useValue: mockOrderItemRepo },
+        { provide: getRepositoryToken(Product), useValue: mockProductRepo },
+        { provide: getRepositoryToken(ProductOption), useValue: mockProductOptionRepo },
+        { provide: getRepositoryToken(Coupon), useValue: mockCouponRepo },
+        { provide: getRepositoryToken(PointHistory), useValue: mockPointHistoryRepo },
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        { provide: DataSource, useValue: mockDataSource },
+        { provide: NotificationService, useValue: mockNotificationService },
+        { provide: SettingsService, useValue: mockSettingsService },
+      ],
+    }).compile();
+
+    service = module.get<SchedulerService>(SchedulerService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('handlePendingOrderCancellation', () => {
+    it('should skip when another instance holds lock', async () => {
+      mockDataSource.query.mockResolvedValue([{ instance_id: 'other-instance' }]);
+
+      await service.handlePendingOrderCancellation();
+
+      expect(mockOrderRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('should cancel pending orders older than configured interval', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ instance_id: 'default' }]);
+      mockSettingsService.getMap.mockResolvedValue({ scheduler_pending_cancel_hours: '24' });
+
+      const oldPendingOrder = {
+        id: 1,
+        orderNumber: 'ORD-20240101-ABC123',
+        userId: 1,
+        status: OrderStatus.PENDING,
+        createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+        items: [
+          { id: 1, productId: 1, productOptionId: null, quantity: 2 },
+        ],
+      };
+
+      mockOrderRepo.find.mockResolvedValue([oldPendingOrder]);
+      mockUserRepo.findOne.mockResolvedValue({ id: 1, email: 'test@example.com' });
+      mockQueryRunner.manager.findOne.mockResolvedValue(null);
+
+      await service.handlePendingOrderCancellation();
+
+      expect(mockOrderRepo.find).toHaveBeenCalled();
+      expect(mockDataSource.query).toHaveBeenCalled();
+    });
+
+    it('should do nothing when no pending orders found', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ instance_id: 'default' }]);
+      mockSettingsService.getMap.mockResolvedValue({ scheduler_pending_cancel_hours: '24' });
+      mockOrderRepo.find.mockResolvedValue([]);
+
+      await service.handlePendingOrderCancellation();
+
+      expect(mockOrderRepo.find).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleDeliveredOrderAutoConfirm', () => {
+    it('should skip when another instance holds lock', async () => {
+      mockDataSource.query.mockResolvedValue([{ instance_id: 'other-instance' }]);
+
+      await service.handleDeliveredOrderAutoConfirm();
+
+      expect(mockOrderRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('should confirm delivered orders older than configured interval', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ instance_id: 'default' }]);
+      mockSettingsService.getMap.mockResolvedValue({ scheduler_delivered_confirm_days: '7' });
+
+      const oldDeliveredOrder = {
+        id: 1,
+        orderNumber: 'ORD-20240101-ABC123',
+        userId: 1,
+        status: OrderStatus.DELIVERED,
+        createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+        updatedAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+        totalAmount: 50000,
+        recipientName: '홍길동',
+        user: { id: 1, email: 'test@example.com' },
+        items: [{ productName: '테스트상품', quantity: 1, price: 50000 }],
+      };
+
+      mockOrderRepo.find.mockResolvedValue([oldDeliveredOrder]);
+      mockOrderRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.handleDeliveredOrderAutoConfirm();
+
+      expect(mockOrderRepo.find).toHaveBeenCalled();
+      expect(mockOrderRepo.update).toHaveBeenCalledWith(1, { status: OrderStatus.COMPLETED });
+    });
+
+    it('should do nothing when no delivered orders found', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ instance_id: 'default' }]);
+      mockSettingsService.getMap.mockResolvedValue({ scheduler_delivered_confirm_days: '7' });
+      mockOrderRepo.find.mockResolvedValue([]);
+
+      await service.handleDeliveredOrderAutoConfirm();
+
+      expect(mockOrderRepo.find).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCouponExpiry', () => {
+    it('should skip when another instance holds lock', async () => {
+      mockDataSource.query.mockResolvedValue([{ instance_id: 'other-instance' }]);
+
+      await service.handleCouponExpiry();
+
+      expect(mockCouponRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should deactivate expired coupons', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ instance_id: 'default' }]);
+
+      const mockQueryBuilder = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 3 }),
+      };
+      mockCouponRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+      await service.handleCouponExpiry();
+
+      expect(mockCouponRepo.createQueryBuilder).toHaveBeenCalled();
+      expect(mockQueryBuilder.execute).toHaveBeenCalled();
+    });
+  });
+
+  describe('handlePointExpiry', () => {
+    it('should skip when another instance holds lock', async () => {
+      mockDataSource.query.mockResolvedValue([{ instance_id: 'other-instance' }]);
+
+      await service.handlePointExpiry();
+
+      expect(mockPointHistoryRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('should process expired points', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ instance_id: 'default' }]);
+
+      const expiredPoints = [
+        {
+          id: 1,
+          userId: 1,
+          type: 'earn' as const,
+          amount: 1000,
+          balance: 5000,
+          expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          user: { id: 1, email: 'test@example.com' },
+        },
+      ];
+
+      mockPointHistoryRepo.find.mockResolvedValue(expiredPoints);
+      mockQueryRunner.manager.findOne.mockResolvedValue({ balance: 5000 });
+      mockQueryRunner.manager.save.mockResolvedValue({});
+      mockUserRepo.findOne.mockResolvedValue({ id: 1, email: 'test@example.com' });
+
+      await service.handlePointExpiry();
+
+      expect(mockPointHistoryRepo.find).toHaveBeenCalled();
+    });
+
+    it('should do nothing when no expired points found', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ instance_id: 'default' }]);
+      mockPointHistoryRepo.find.mockResolvedValue([]);
+
+      await service.handlePointExpiry();
+
+      expect(mockPointHistoryRepo.find).toHaveBeenCalled();
+    });
+  });
+
+  describe('getSettingNumber', () => {
+    it('should return setting value when exists', async () => {
+      mockSettingsService.getMap.mockResolvedValue({ scheduler_pending_cancel_hours: '48' });
+
+      const result = await service['getSettingNumber']('scheduler_pending_cancel_hours', 24);
+
+      expect(result).toBe(48);
+    });
+
+    it('should return default value when setting not found', async () => {
+      mockSettingsService.getMap.mockResolvedValue({});
+
+      const result = await service['getSettingNumber']('nonexistent_key', 24);
+
+      expect(result).toBe(24);
+    });
+
+    it('should return default value when settings service throws', async () => {
+      mockSettingsService.getMap.mockRejectedValue(new Error('DB error'));
+
+      const result = await service['getSettingNumber']('scheduler_pending_cancel_hours', 24);
+
+      expect(result).toBe(24);
+    });
+  });
+});

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Order } from '../orders/entities/order.entity';
+import { OrderItem } from '../orders/entities/order-item.entity';
+import { Product } from '../products/entities/product.entity';
+import { ProductOption } from '../products/entities/product-option.entity';
+import { Coupon } from '../coupons/entities/coupon.entity';
+import { PointHistory } from '../coupons/entities/point-history.entity';
+import { User } from '../users/entities/user.entity';
+import { SchedulerService } from './scheduler.service';
+import { SettingsModule } from '../settings/settings.module';
+import { NotificationModule } from '../notification/notification.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Order, OrderItem, Product, ProductOption, Coupon, PointHistory, User]),
+    SettingsModule,
+    NotificationModule,
+  ],
+  providers: [SchedulerService],
+  exports: [SchedulerService],
+})
+export class SchedulerModule {}

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -1,0 +1,338 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource, LessThan } from 'typeorm';
+import { Order, OrderStatus } from '../orders/entities/order.entity';
+import { OrderItem } from '../orders/entities/order-item.entity';
+import { Product } from '../products/entities/product.entity';
+import { ProductOption } from '../products/entities/product-option.entity';
+import { Coupon } from '../coupons/entities/coupon.entity';
+import { PointHistory } from '../coupons/entities/point-history.entity';
+import { User } from '../users/entities/user.entity';
+import { NotificationService } from '../notification/notification.service';
+import { SettingsService } from '../settings/settings.service';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+@Injectable()
+export class SchedulerService {
+  private readonly logger = new Logger(SchedulerService.name);
+
+  constructor(
+    @InjectRepository(Order)
+    private readonly orderRepo: Repository<Order>,
+    @InjectRepository(OrderItem)
+    private readonly orderItemRepo: Repository<OrderItem>,
+    @InjectRepository(Product)
+    private readonly productRepo: Repository<Product>,
+    @InjectRepository(ProductOption)
+    private readonly productOptionRepo: Repository<ProductOption>,
+    @InjectRepository(Coupon)
+    private readonly couponRepo: Repository<Coupon>,
+    @InjectRepository(PointHistory)
+    private readonly pointHistoryRepo: Repository<PointHistory>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly notificationService: NotificationService,
+    private readonly settingsService: SettingsService,
+  ) {}
+
+  private async acquireLock(lockName: string, ttlMinutes: number): Promise<boolean> {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + ttlMinutes * 60 * 1000);
+
+    try {
+      await this.dataSource.query(
+        `INSERT INTO scheduler_locks (lock_name, instance_id, acquired_at, expires_at)
+         VALUES (?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+           acquired_at = IF(expires_at <= NOW(), VALUES(acquired_at), acquired_at),
+           expires_at = IF(expires_at <= NOW(), VALUES(expires_at), expires_at),
+           instance_id = IF(expires_at <= NOW(), VALUES(instance_id), instance_id)`,
+        [lockName, process.env.INSTANCE_ID || 'default', now, expiresAt],
+      );
+
+      const lock = await this.dataSource.query(
+        `SELECT instance_id FROM scheduler_locks WHERE lock_name = ? AND expires_at > NOW()`,
+        [lockName],
+      );
+
+      return lock.length > 0 && lock[0].instance_id === (process.env.INSTANCE_ID || 'default');
+    } catch (err) {
+      this.logger.error(`Failed to acquire lock ${lockName}: ${String(err)}`);
+      return false;
+    }
+  }
+
+  private async releaseLock(lockName: string): Promise<void> {
+    try {
+      await this.dataSource.query(
+        `DELETE FROM scheduler_locks WHERE lock_name = ? AND instance_id = ?`,
+        [lockName, process.env.INSTANCE_ID || 'default'],
+      );
+    } catch (err) {
+      this.logger.error(`Failed to release lock ${lockName}: ${String(err)}`);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async handlePendingOrderCancellation(): Promise<void> {
+    const lockName = 'cron:pending-order-cancel';
+    if (!(await this.acquireLock(lockName, 55))) {
+      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
+      return;
+    }
+
+    try {
+      const intervalHours = await this.getSettingNumber('scheduler_pending_cancel_hours', 24);
+      const cutoff = new Date(Date.now() - intervalHours * 60 * 60 * 1000);
+
+      const pendingOrders = await this.orderRepo.find({
+        where: { status: OrderStatus.PENDING, createdAt: LessThan(cutoff) },
+        relations: { items: true },
+      });
+
+      if (pendingOrders.length === 0) {
+        this.logger.debug('[cron:pending-order-cancel] No pending orders to cancel');
+        return;
+      }
+
+      this.logger.log(`[cron:pending-order-cancel] Cancelling ${pendingOrders.length} pending orders`);
+
+      for (const order of pendingOrders) {
+        await this.cancelOrderAndRestoreStock(order);
+      }
+
+      this.logger.log(`[cron:pending-order-cancel] Completed cancelling ${pendingOrders.length} orders`);
+    } catch (err) {
+      this.logger.error(`[cron:pending-order-cancel] Error: ${String(err)}`);
+    } finally {
+      await this.releaseLock(lockName);
+    }
+  }
+
+  private async cancelOrderAndRestoreStock(order: Order): Promise<void> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      for (const item of order.items) {
+        if (item.productOptionId) {
+          await queryRunner.manager.increment(
+            ProductOption,
+            { id: item.productOptionId },
+            'stock',
+            item.quantity,
+          );
+        } else {
+          await queryRunner.manager.increment(
+            Product,
+            { id: item.productId },
+            'stock',
+            item.quantity,
+          );
+        }
+      }
+
+      await queryRunner.manager.update(Order, order.id, { status: OrderStatus.CANCELLED });
+
+      await queryRunner.commitTransaction();
+
+      const user = await this.userRepo.findOne({ where: { id: order.userId } });
+      if (user?.email) {
+        this.notificationService
+          .sendEmail({
+            to: user.email,
+            subject: `[옥화당] 주문 자동 취소 안내`,
+            text: `안녕하세요. 고객님의 주문(${order.orderNumber})이 결제 미완료로 자동 취소되었습니다.`,
+            html: `<p>안녕하세요.</p><p>고객님의 주문(<strong>${order.orderNumber}</strong>)이 결제 미완료로 자동 취소되었습니다.</p>`,
+          })
+          .catch((err) => this.logger.warn(`Failed to send cancellation email: ${String(err)}`));
+      }
+
+      this.logger.log(`[cron:pending-order-cancel] Cancelled order ${order.orderNumber}`);
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error(`[cron:pending-order-cancel] Failed to cancel order ${order.orderNumber}: ${String(err)}`);
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleDeliveredOrderAutoConfirm(): Promise<void> {
+    const lockName = 'cron:delivered-order-confirm';
+    if (!(await this.acquireLock(lockName, 55))) {
+      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
+      return;
+    }
+
+    try {
+      const intervalDays = await this.getSettingNumber('scheduler_delivered_confirm_days', 7);
+      const cutoff = new Date(Date.now() - intervalDays * 24 * 60 * 60 * 1000);
+
+      const deliveredOrders = await this.orderRepo.find({
+        where: { status: OrderStatus.DELIVERED, updatedAt: LessThan(cutoff) },
+        relations: { user: true },
+      });
+
+      if (deliveredOrders.length === 0) {
+        this.logger.debug('[cron:delivered-order-confirm] No delivered orders to confirm');
+        return;
+      }
+
+      this.logger.log(`[cron:delivered-order-confirm] Confirming ${deliveredOrders.length} delivered orders`);
+
+      for (const order of deliveredOrders) {
+        await this.orderRepo.update(order.id, { status: OrderStatus.COMPLETED });
+
+        if (order.user?.email) {
+          this.notificationService
+            .sendOrderConfirmed(order.user.email, {
+              orderNumber: order.orderNumber,
+              totalAmount: order.totalAmount,
+              recipientName: order.recipientName,
+            })
+            .catch((err) => this.logger.warn(`Failed to send confirmation email: ${String(err)}`));
+        }
+      }
+
+      this.logger.log(`[cron:delivered-order-confirm] Completed confirming ${deliveredOrders.length} orders`);
+    } catch (err) {
+      this.logger.error(`[cron:delivered-order-confirm] Error: ${String(err)}`);
+    } finally {
+      await this.releaseLock(lockName);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleCouponExpiry(): Promise<void> {
+    const lockName = 'cron:coupon-expiry';
+    if (!(await this.acquireLock(lockName, 55))) {
+      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
+      return;
+    }
+
+    try {
+      const now = new Date();
+
+      const result = await this.couponRepo
+        .createQueryBuilder()
+        .update(Coupon)
+        .set({ isActive: false })
+        .where('is_active = :isActive', { isActive: true })
+        .andWhere('expires_at < :now', { now })
+        .execute();
+
+      if (result.affected && result.affected > 0) {
+        this.logger.log(`[cron:coupon-expiry] Deactivated ${result.affected} expired coupons`);
+      } else {
+        this.logger.debug('[cron:coupon-expiry] No expired coupons to deactivate');
+      }
+    } catch (err) {
+      this.logger.error(`[cron:coupon-expiry] Error: ${String(err)}`);
+    } finally {
+      await this.releaseLock(lockName);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
+  async handlePointExpiry(): Promise<void> {
+    const lockName = 'cron:point-expiry';
+    if (!(await this.acquireLock(lockName, 55))) {
+      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
+      return;
+    }
+
+    try {
+      const now = new Date();
+
+      const expiredPoints = await this.pointHistoryRepo.find({
+        where: {
+          expiresAt: LessThan(now),
+          type: 'earn',
+        },
+        relations: { user: true },
+      });
+
+      if (expiredPoints.length === 0) {
+        this.logger.debug('[cron:point-expiry] No expired points to process');
+        return;
+      }
+
+      this.logger.log(`[cron:point-expiry] Processing ${expiredPoints.length} expired point records`);
+
+      const userExpiredMap = new Map<number, number>();
+      for (const ph of expiredPoints) {
+        const current = userExpiredMap.get(ph.userId) || 0;
+        userExpiredMap.set(ph.userId, current + ph.amount);
+      }
+
+      for (const [userId, totalExpired] of userExpiredMap) {
+        const queryRunner = this.dataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
+
+        try {
+          const latestBalance = await queryRunner.manager.findOne(PointHistory, {
+            where: { userId },
+            order: { createdAt: 'DESC', id: 'DESC' },
+          });
+
+          const currentBalance = latestBalance?.balance ?? 0;
+          const expireAmount = Math.min(totalExpired, currentBalance);
+
+          if (expireAmount > 0 && currentBalance > 0) {
+            await queryRunner.manager.save(PointHistory, {
+              userId,
+              type: 'expire',
+              amount: -expireAmount,
+              balance: currentBalance - expireAmount,
+              description: '포인트 만료',
+              expiresAt: null,
+            });
+
+            const user = await queryRunner.manager.findOne(User, { where: { id: userId } });
+            if (user?.email) {
+              this.notificationService
+                .sendEmail({
+                  to: user.email,
+                  subject: '[옥화당] 포인트 만료 안내',
+                  text: `안녕하세요. 고객님의 포인트 ${expireAmount.toLocaleString()}원이 만료되었습니다.`,
+                  html: `<p>안녕하세요.</p><p>고객님의 포인트 <strong>${expireAmount.toLocaleString()}원</strong>이 만료되었습니다.</p>`,
+                })
+                .catch((err) => this.logger.warn(`Failed to send point expiry email: ${String(err)}`));
+            }
+          }
+
+          await queryRunner.commitTransaction();
+          this.logger.log(`[cron:point-expiry] Expired ${expireAmount} points for user ${userId}`);
+        } catch (err) {
+          await queryRunner.rollbackTransaction();
+          this.logger.error(`[cron:point-expiry] Failed to expire points for user ${userId}: ${String(err)}`);
+        } finally {
+          await queryRunner.release();
+        }
+      }
+
+      this.logger.log(`[cron:point-expiry] Completed processing ${expiredPoints.length} expired point records`);
+    } catch (err) {
+      this.logger.error(`[cron:point-expiry] Error: ${String(err)}`);
+    } finally {
+      await this.releaseLock(lockName);
+    }
+  }
+
+  private async getSettingNumber(key: string, defaultValue: number): Promise<number> {
+    try {
+      const settings = await this.settingsService.getMap();
+      const value = settings[key];
+      return value ? parseInt(value, 10) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implements `@Cron` decorators via `@nestjs/schedule` for automated order/coupon/point management
- PENDING order auto-cancellation (configurable via `scheduler_pending_cancel_hours` setting, default 24h)
- DELIVERED order auto-confirmation (configurable via `scheduler_delivered_confirm_days` setting, default 7 days)
- Daily coupon expiry deactivation at midnight
- Daily point expiry processing at 2AM (requires `PointHistory.expires_at` column)
- Leader election via `scheduler_locks` DB table to prevent duplicate cron execution in multi-instance

## Changes

### New Files
- `backend/src/modules/scheduler/scheduler.service.ts` — Cron job implementations
- `backend/src/modules/scheduler/scheduler.module.ts` — Scheduler module
- `backend/src/modules/scheduler/__tests__/scheduler.service.spec.ts` — Unit tests
- `backend/src/database/migrations/1781000000000-AddPointHistoryExpiresAt.ts` — Add `expires_at` column
- `backend/src/database/migrations/1781000000001-CreateSchedulerLocksTable.ts` — Leader election lock table
- `backend/src/database/migrations/1781000000002-AddSchedulerSiteSettings.ts` — Scheduler settings seed

### Modified Files
- `backend/src/app.module.ts` — Added `SchedulerModule` import
- `backend/src/modules/coupons/entities/point-history.entity.ts` — Added `expiresAt` column

## Acceptance Criteria
- [x] `@nestjs/schedule` with `ScheduleModule.forRoot()` (already present)
- [x] Cron: PENDING 주문 24시간 후 자동 취소 + 재고 복구 + 알림
- [x] Cron: DELIVERED 주문 7일 후 자동 구매확정 (setting 테이블로 조정 가능)
- [x] Cron: 만료 쿠폰 `is_active=false` 전환 (매일 00:00)
- [x] Cron: 포인트 만료 처리 (PointHistory.expiresAt 컬럼)
- [x] Leader election 또는 단일 워커 전제 문서화 (scheduler_locks table)
- [x] E2E 또는 스케줄러 단위 테스트

Closes #496