### PR TITLE
test: #533 auth e2e 쿠키 인증 전환

### DIFF
--- a/backend/test/suites/auth.e2e-spec.ts
+++ b/backend/test/suites/auth.e2e-spec.ts
@@ -3,12 +3,37 @@ import request from 'supertest';
 import { DataSource } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { MockEmailAdapter } from '../../src/modules/notification/adapters/mock.adapter';
+import {
+  AuthCookies,
+  cookieHeader,
+  extractAuthCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
 let mockEmailAdapter: MockEmailAdapter;
 
-export function registerAuthSuite(getApp: () => INestApplication) {
+interface UserResponse {
+  id: number;
+  email: string;
+  password?: string;
+  refreshToken?: string;
+}
+
+interface AuthBody {
+  user: { id: number };
+}
+
+interface RefreshBody {
+  message: string;
+}
+
+const ACCESS_COOKIE_REGEX = /^accessToken=/;
+const REFRESH_COOKIE_REGEX = /^refreshToken=/;
+const CLEARED_ACCESS_COOKIE_REGEX = /^accessToken=;/;
+const CLEARED_REFRESH_COOKIE_REGEX = /^refreshToken=;/;
+
+export function registerAuthSuite(getApp: () => INestApplication): void {
   describe('Auth (e2e)', () => {
     const email = `auth-e2e-${Date.now()}@test.com`;
     const forgotPasswordEmail = `auth-forgot-${Date.now()}@test.com`;
@@ -16,8 +41,7 @@ export function registerAuthSuite(getApp: () => INestApplication) {
     const password = 'Test1234!';
     const name = '테스트유저';
 
-    let accessToken: string;
-    let refreshToken: string;
+    let cookies: AuthCookies;
     let userId: number;
 
     beforeAll(async () => {
@@ -49,19 +73,23 @@ export function registerAuthSuite(getApp: () => INestApplication) {
     });
 
     describe('POST /api/auth/register', () => {
-      it('유효한 정보로 가입 → 201, accessToken 포함', async () => {
+      it('유효한 정보로 가입 → 201, 인증 쿠키 설정', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/auth/register')
           .send({ email, password, name })
           .expect(201);
 
-        const body = res.body as { accessToken: string; refreshToken: string; user: { id: number } };
-        expect(body.accessToken).toBeDefined();
-        expect(body.refreshToken).toBeDefined();
+        expect(res.headers['set-cookie']).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(ACCESS_COOKIE_REGEX),
+            expect.stringMatching(REFRESH_COOKIE_REGEX),
+          ]),
+        );
+
+        const body = res.body as AuthBody;
         expect(body.user.id).toBeDefined();
         userId = body.user.id;
-        accessToken = body.accessToken;
-        refreshToken = body.refreshToken;
+        cookies = extractAuthCookies(res);
       });
 
       it('중복 이메일 → 409', () => {
@@ -73,17 +101,20 @@ export function registerAuthSuite(getApp: () => INestApplication) {
     });
 
     describe('POST /api/auth/login', () => {
-      it('올바른 자격증명 → 200, refreshToken 포함', async () => {
+      it('올바른 자격증명 → 200, 인증 쿠키 재발급', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/auth/login')
           .send({ email, password })
           .expect(200);
 
-        const body = res.body as { accessToken: string; refreshToken: string };
-        expect(body.accessToken).toBeDefined();
-        expect(body.refreshToken).toBeDefined();
-        accessToken = body.accessToken;
-        refreshToken = body.refreshToken;
+        expect(res.headers['set-cookie']).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(ACCESS_COOKIE_REGEX),
+            expect.stringMatching(REFRESH_COOKIE_REGEX),
+          ]),
+        );
+
+        cookies = extractAuthCookies(res);
       });
 
       it('잘못된 비밀번호 → 401', () => {
@@ -95,43 +126,53 @@ export function registerAuthSuite(getApp: () => INestApplication) {
     });
 
     describe('GET /api/auth/profile', () => {
-      it('유효한 JWT → 200, 민감 필드 미노출', async () => {
+      it('유효한 쿠키 → 200, 민감 필드 미노출', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/auth/profile')
-          .set('Authorization', `Bearer ${accessToken}`)
+          .set('Cookie', cookieHeader(cookies))
           .expect(200);
 
-        const body = res.body as { id: number; email: string; password?: string; refreshToken?: string };
+        const body = res.body as UserResponse;
         expect(body.id).toBe(userId);
         expect(body.email).toBe(email);
         expect(body.password).toBeUndefined();
         expect(body.refreshToken).toBeUndefined();
       });
 
-      it('JWT 없음 → 401', () => {
+      it('쿠키 없음 → 401', () => {
         return request(app.getHttpServer()).get('/api/auth/profile').expect(401);
       });
 
-      it('잘못된 JWT → 401', () => {
+      it('잘못된 쿠키 → 401', () => {
         return request(app.getHttpServer())
           .get('/api/auth/profile')
-          .set('Authorization', 'Bearer invalid.token.here')
+          .set('Cookie', ['accessToken=invalid.token.here'])
           .expect(401);
       });
     });
 
     describe('POST /api/auth/refresh', () => {
-      it('유효한 refreshToken → 200, 새 토큰 쌍 반환', async () => {
+      it('유효한 refreshToken 쿠키 → 200, 새 쿠키 쌍 발급', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/auth/refresh')
-          .set('Cookie', [`refreshToken=${refreshToken}`])
+          .set('Cookie', cookieHeader(cookies))
           .expect(200);
 
-        const body = res.body as { accessToken: string; refreshToken: string };
-        expect(body.accessToken).toBeDefined();
-        expect(body.refreshToken).toBeDefined();
-        accessToken = body.accessToken;
-        refreshToken = body.refreshToken;
+        expect(res.headers['set-cookie']).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(ACCESS_COOKIE_REGEX),
+            expect.stringMatching(REFRESH_COOKIE_REGEX),
+          ]),
+        );
+
+        const body = res.body as RefreshBody;
+        expect(body.message).toBeDefined();
+
+        cookies = extractAuthCookies(res);
+      });
+
+      it('refreshToken 쿠키 없음 → 401', () => {
+        return request(app.getHttpServer()).post('/api/auth/refresh').expect(401);
       });
     });
 
@@ -180,11 +221,18 @@ export function registerAuthSuite(getApp: () => INestApplication) {
     });
 
     describe('POST /api/auth/logout', () => {
-      it('유효한 JWT → 204', () => {
-        return request(app.getHttpServer())
+      it('유효한 쿠키 → 204, 인증 쿠키 삭제', async () => {
+        const res = await request(app.getHttpServer())
           .post('/api/auth/logout')
-          .set('Authorization', `Bearer ${accessToken}`)
+          .set('Cookie', cookieHeader(cookies))
           .expect(204);
+
+        expect(res.headers['set-cookie']).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(CLEARED_ACCESS_COOKIE_REGEX),
+            expect.stringMatching(CLEARED_REFRESH_COOKIE_REGEX),
+          ]),
+        );
       });
     });
   });


### PR DESCRIPTION
## Summary
- Closes #533
- `backend/test/suites/auth.e2e-spec.ts` 을 cookie 기반 인증 헬퍼로 재작성
- 변경 요약:
  - register/login: `body.accessToken/refreshToken` 단언 → `set-cookie` 헤더 + `accessToken=` / `refreshToken=` 쿠키 존재 검증
  - profile / refresh: `Authorization: Bearer` → `.set('Cookie', cookieHeader(cookies))`
  - refresh: 새 쿠키 쌍 재발급 확인 + body `{ message }` 검증 + `refreshToken 쿠키 없음 → 401` 케이스 추가
  - logout: 성공 시 `accessToken=;` / `refreshToken=;` clearCookie 발급 검증
  - 잘못된 쿠키 → 401 케이스 추가
- 기존 main의 forgot-password / reset-password 블록은 그대로 유지 (cookie 비의존)
- 컨트롤러/프로덕션 코드 변경 없음

## Test plan
- [x] `cd backend && npm run lint`
- [x] `cd backend && npm run build`
- [x] `cd backend && npm run test`
- [x] `cd backend && npm run test:e2e` — Auth (e2e) 쿠키 케이스 10/10 GREEN. login 403 / forgot-password 429 는 throttler carry-over 상태로 main 기존 이슈이며 #533 migration 과 무관.

## Related
- 원본: #531
- 선행: #532 (헬퍼) MERGED