### PR TITLE
test: #534 cart/orders/payments e2e 쿠키 인증 전환

### DIFF
--- a/backend/test/suites/cart.e2e-spec.ts
+++ b/backend/test/suites/cart.e2e-spec.ts
@@ -2,13 +2,20 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+  registerAndGetCookies,
+} from '../helpers/auth-cookie.helper';
+
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerCartSuite(getApp: () => INestApplication) {
   describe('Cart (e2e)', () => {
-    let userAToken: string;
-    let userBToken: string;
+    let userACookies: AuthCookies;
+    let userBCookies: AuthCookies;
     let productId: number;
     let optionId: number;
     let cartItemId: number;
@@ -21,26 +28,26 @@ export function registerCartSuite(getApp: () => INestApplication) {
       dataSource = app.get(DataSource);
 
       // Create user A
-      const regA = await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: userAEmail, password: 'Test1234!', name: '카트유저A' });
-      if (regA.status !== 201) throw new Error(`Register A failed: ${regA.status} ${JSON.stringify(regA.body)}`);
-
-      const loginA = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userAEmail, password: 'Test1234!' });
-      if (loginA.status !== 200) throw new Error(`Login A failed: ${loginA.status} ${JSON.stringify(loginA.body)}`);
-      userAToken = (loginA.body as { accessToken: string }).accessToken;
+      await registerAndGetCookies(app, {
+        email: userAEmail,
+        password: 'Test1234!',
+        name: '카트유저A',
+      });
+      userACookies = await loginAndGetCookies(app, {
+        email: userAEmail,
+        password: 'Test1234!',
+      });
 
       // Create user B
-      await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: userBEmail, password: 'Test1234!', name: '카트유저B' });
-
-      const loginB = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userBEmail, password: 'Test1234!' });
-      userBToken = (loginB.body as { accessToken: string }).accessToken;
+      await registerAndGetCookies(app, {
+        email: userBEmail,
+        password: 'Test1234!',
+        name: '카트유저B',
+      });
+      userBCookies = await loginAndGetCookies(app, {
+        email: userBEmail,
+        password: 'Test1234!',
+      });
 
       // Seed product and option
       const prodResult = await dataSource.query(`
@@ -85,7 +92,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('user A — empty cart → 200, items=[]', () => {
         return request(app.getHttpServer())
           .get('/api/cart')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .expect(200)
           .expect((res) => {
             expect((res.body as { items: unknown[] }).items).toHaveLength(0);
@@ -98,7 +105,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('adds item for user A → 201', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/cart')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({ productId, productOptionId: null, quantity: 1 })
           .expect(201);
 
@@ -111,7 +118,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('same product again → 201, quantity upserted to 2', () => {
         return request(app.getHttpServer())
           .post('/api/cart')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({ productId, productOptionId: null, quantity: 1 })
           .expect(201)
           .expect((res) => {
@@ -124,7 +131,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('non-existent productId → 404', () => {
         return request(app.getHttpServer())
           .post('/api/cart')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({ productId: 999999, productOptionId: null, quantity: 1 })
           .expect(404);
       });
@@ -132,7 +139,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('quantity=0 → 400 validation error', () => {
         return request(app.getHttpServer())
           .post('/api/cart')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({ productId, productOptionId: null, quantity: 0 })
           .expect(400);
       });
@@ -142,7 +149,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('user A — 1 item quantity=2', () => {
         return request(app.getHttpServer())
           .get('/api/cart')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .expect(200)
           .expect((res) => {
             const items = (res.body as { items: Array<{ quantity: number }> })
@@ -157,7 +164,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('user A updates quantity to 5 → 200', () => {
         return request(app.getHttpServer())
           .patch(`/api/cart/${cartItemId}`)
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({ quantity: 5 })
           .expect(200)
           .expect((res) => {
@@ -168,7 +175,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('user B updates user A item → 403', () => {
         return request(app.getHttpServer())
           .patch(`/api/cart/${cartItemId}`)
-          .set('Authorization', `Bearer ${userBToken}`)
+          .set('Cookie', cookieHeader(userBCookies))
           .send({ quantity: 3 })
           .expect(403);
       });
@@ -178,14 +185,14 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('user B deletes user A item → 403', () => {
         return request(app.getHttpServer())
           .delete(`/api/cart/${cartItemId}`)
-          .set('Authorization', `Bearer ${userBToken}`)
+          .set('Cookie', cookieHeader(userBCookies))
           .expect(403);
       });
 
       it('user A deletes own item → 200', () => {
         return request(app.getHttpServer())
           .delete(`/api/cart/${cartItemId}`)
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .expect(200)
           .expect((res) => {
             expect((res.body as { message: string }).message).toBe(
@@ -197,7 +204,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('GET /api/cart after delete — items=[]', () => {
         return request(app.getHttpServer())
           .get('/api/cart')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .expect(200)
           .expect((res) => {
             expect((res.body as { items: unknown[] }).items).toHaveLength(0);
@@ -209,7 +216,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
       it('adds item with option → 201, totalAmount accounts for priceAdjustment', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/cart')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({ productId, productOptionId: optionId, quantity: 2 })
           .expect(201);
 
@@ -227,7 +234,7 @@ export function registerCartSuite(getApp: () => INestApplication) {
         ).items[0].id;
         await request(app.getHttpServer())
           .delete(`/api/cart/${itemId}`)
-          .set('Authorization', `Bearer ${userAToken}`);
+          .set('Cookie', cookieHeader(userACookies));
       });
     });
   });

--- a/backend/test/suites/orders.e2e-spec.ts
+++ b/backend/test/suites/orders.e2e-spec.ts
@@ -2,13 +2,20 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+  registerAndGetCookies,
+} from '../helpers/auth-cookie.helper';
+
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerOrdersSuite(getApp: () => INestApplication) {
   describe('Orders (e2e)', () => {
-    let userAToken: string;
-    let userBToken: string;
+    let userACookies: AuthCookies;
+    let userBCookies: AuthCookies;
     let productId: number;
     let orderId: number;
 
@@ -20,26 +27,26 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
       dataSource = app.get(DataSource);
 
       // Create user A
-      const regA = await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: userAEmail, password: 'Test1234!', name: '주문유저A' });
-      if (regA.status !== 201) throw new Error(`Register A failed: ${regA.status} ${JSON.stringify(regA.body)}`);
-
-      const loginA = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userAEmail, password: 'Test1234!' });
-      if (loginA.status !== 200) throw new Error(`Login A failed: ${loginA.status} ${JSON.stringify(loginA.body)}`);
-      userAToken = (loginA.body as { accessToken: string }).accessToken;
+      await registerAndGetCookies(app, {
+        email: userAEmail,
+        password: 'Test1234!',
+        name: '주문유저A',
+      });
+      userACookies = await loginAndGetCookies(app, {
+        email: userAEmail,
+        password: 'Test1234!',
+      });
 
       // Create user B
-      await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: userBEmail, password: 'Test1234!', name: '주문유저B' });
-
-      const loginB = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userBEmail, password: 'Test1234!' });
-      userBToken = (loginB.body as { accessToken: string }).accessToken;
+      await registerAndGetCookies(app, {
+        email: userBEmail,
+        password: 'Test1234!',
+        name: '주문유저B',
+      });
+      userBCookies = await loginAndGetCookies(app, {
+        email: userBEmail,
+        password: 'Test1234!',
+      });
 
       // Seed product with stock=5
       const prodResult = await dataSource.query(`
@@ -89,7 +96,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
       it('valid body → 201, orderNumber matches ORD-YYYYMMDD-XXXXX', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/orders')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({
             items: [{ productId, quantity: 1 }],
             recipientName: '홍길동',
@@ -115,7 +122,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
       it('excess quantity → 400', () => {
         return request(app.getHttpServer())
           .post('/api/orders')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({
             items: [{ productId, quantity: 999 }],
             recipientName: '홍길동',
@@ -129,7 +136,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
       it('empty items → 400', () => {
         return request(app.getHttpServer())
           .post('/api/orders')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .send({
             items: [],
             recipientName: '홍길동',
@@ -149,7 +156,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
       it('user A → 200, includes created order', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/orders')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .expect(200);
 
         const body = res.body as { items: Array<{ id: number }>; total: number };
@@ -162,7 +169,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
       it('user A → 200, has items array', async () => {
         const res = await request(app.getHttpServer())
           .get(`/api/orders/${orderId}`)
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .expect(200);
 
         const body = res.body as { id: number; items: unknown[] };
@@ -174,14 +181,14 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
       it('user B for user A order → 403', () => {
         return request(app.getHttpServer())
           .get(`/api/orders/${orderId}`)
-          .set('Authorization', `Bearer ${userBToken}`)
+          .set('Cookie', cookieHeader(userBCookies))
           .expect(403);
       });
 
       it('non-existent id → 404', () => {
         return request(app.getHttpServer())
           .get('/api/orders/999999')
-          .set('Authorization', `Bearer ${userAToken}`)
+          .set('Cookie', cookieHeader(userACookies))
           .expect(404);
       });
     });

--- a/backend/test/suites/payments.e2e-spec.ts
+++ b/backend/test/suites/payments.e2e-spec.ts
@@ -2,12 +2,19 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+  registerAndGetCookies,
+} from '../helpers/auth-cookie.helper';
+
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerPaymentsSuite(getApp: () => INestApplication) {
   describe('Payments (e2e)', () => {
-    let userToken: string;
+    let userCookies: AuthCookies;
     let productId: number;
     let orderId: number;
 
@@ -19,24 +26,27 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       dataSource = app.get(DataSource);
 
       // Create main user
-      const reg = await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: userEmail, password: 'Test1234!', name: '결제유저' });
-      if (reg.status !== 201) throw new Error(`Register failed: ${reg.status} ${JSON.stringify(reg.body)}`);
-
-      const login = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userEmail, password: 'Test1234!' });
-      if (login.status !== 200) throw new Error(`Login failed: ${login.status} ${JSON.stringify(login.body)}`);
-      userToken = (login.body as { accessToken: string }).accessToken;
+      await registerAndGetCookies(app, {
+        email: userEmail,
+        password: 'Test1234!',
+        name: '결제유저',
+      });
+      userCookies = await loginAndGetCookies(app, {
+        email: userEmail,
+        password: 'Test1234!',
+      });
 
       // Create other user
-      await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: otherEmail, password: 'Test1234!', name: '다른유저' });
-      await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: otherEmail, password: 'Test1234!' });
+      await registerAndGetCookies(app, {
+        email: otherEmail,
+        password: 'Test1234!',
+        name: '다른유저',
+      });
+      await loginAndGetCookies(app, {
+        email: otherEmail,
+        password: 'Test1234!',
+      });
+
       // Seed product
       const prodResult = await dataSource.query(`
         INSERT INTO products (name, slug, price, sale_price, stock, status)
@@ -47,7 +57,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       // Create order
       const orderRes = await request(app.getHttpServer())
         .post('/api/orders')
-        .set('Authorization', `Bearer ${userToken}`)
+        .set('Cookie', cookieHeader(userCookies))
         .send({
           items: [{ productId, quantity: 1 }],
           recipientName: '홍길동',
@@ -86,7 +96,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       it('invalid orderId → 404', () => {
         return request(app.getHttpServer())
           .post('/api/payments/prepare')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ orderId: 999999 })
           .expect(404);
       });
@@ -94,7 +104,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       it('valid → 200/201, has clientKey', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/payments/prepare')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ orderId })
           .expect((r) => {
             if (r.status !== 200 && r.status !== 201) throw new Error(`Expected 200/201 got ${r.status}: ${JSON.stringify(r.body)}`);
@@ -111,7 +121,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       it('amount match → 200/201, status=confirmed', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/payments/confirm')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ orderId, paymentKey: 'pay_mock_key', amount: 30000 })
           .expect((r) => {
             if (r.status !== 200 && r.status !== 201) throw new Error(`Expected 200/201 got ${r.status}: ${JSON.stringify(r.body)}`);
@@ -125,7 +135,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       it('after confirm: order.status should be paid', async () => {
         const res = await request(app.getHttpServer())
           .get(`/api/orders/${orderId}`)
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(200);
 
         const body = res.body as { status: string };
@@ -137,7 +147,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
         // The order is already confirmed so we'll get 409; create a separate order for mismatch test
         const orderRes = await request(app.getHttpServer())
           .post('/api/orders')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({
             items: [{ productId, quantity: 1 }],
             recipientName: '홍길동',
@@ -150,12 +160,12 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
         // Prepare it first
         await request(app.getHttpServer())
           .post('/api/payments/prepare')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ orderId: mismatchOrderId });
 
         await request(app.getHttpServer())
           .post('/api/payments/confirm')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ orderId: mismatchOrderId, paymentKey: 'pay_mismatch', amount: 99999 })
           .expect(400);
 
@@ -170,7 +180,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       it('re-confirm (already confirmed) → 409', () => {
         return request(app.getHttpServer())
           .post('/api/payments/confirm')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ orderId, paymentKey: 'pay_mock_key', amount: 30000 })
           .expect(409);
       });
@@ -180,7 +190,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       it('confirmed → 200/201, status=cancelled', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/payments/cancel')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ orderId, reason: '테스트 취소' })
           .expect((r) => {
             if (r.status !== 200 && r.status !== 201) throw new Error(`Expected 200/201 got ${r.status}: ${JSON.stringify(r.body)}`);
@@ -193,7 +203,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       it('after cancel → cancel again → 400', () => {
         return request(app.getHttpServer())
           .post('/api/payments/cancel')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ orderId, reason: '재취소' })
           .expect(400);
       });


### PR DESCRIPTION
## Summary
- Closes #534
- `backend/test/suites/cart.e2e-spec.ts`, `orders.e2e-spec.ts`, `payments.e2e-spec.ts` 3개 suite 를 쿠키 기반 인증 헬퍼로 전환
- 변경:
  - `body.accessToken` 직접 추출 제거 → `registerAndGetCookies` / `loginAndGetCookies` 로 쿠키 획득
  - `.set('Authorization', \`Bearer \${token}\`)` → `.set('Cookie', cookieHeader(cookies))`
  - 401 로 fail 하던 인증 필요 케이스 전부 쿠키 전송 방식으로 교체
- 컨트롤러/프로덕션 코드 변경 없음 (헬퍼는 #532 에서 이미 merge)

## Test plan
- [x] `cd backend && npm run lint`
- [x] `cd backend && npm run build`
- [x] `cd backend && npm run test`
- [ ] CI e2e 로 최종 확인

## Related
- 원본: #531
- 선행: #532 (헬퍼) MERGED