### PR TITLE
test: #535 admin 및 기타 e2e 쿠키 인증 전환

### DIFF
--- a/backend/test/suites/admin-categories.e2e-spec.ts
+++ b/backend/test/suites/admin-categories.e2e-spec.ts
@@ -2,14 +2,19 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 import * as bcrypt from 'bcrypt';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
   describe('Admin Categories (e2e)', () => {
-    let adminToken: string;
-    let userToken: string;
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
     let adminUserId: number;
     let regularUserId: number;
     let createdCategoryId: number;
@@ -39,16 +44,10 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
       regularUserId = userResult.insertId as number;
 
       // Login as admin
-      const adminLogin = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: adminEmail, password });
-      adminToken = (adminLogin.body as { accessToken: string }).accessToken;
+      adminCookies = await loginAndGetCookies(app, { email: adminEmail, password });
 
       // Login as regular user
-      const userLogin = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userEmail, password });
-      userToken = (userLogin.body as { accessToken: string }).accessToken;
+      userCookies = await loginAndGetCookies(app, { email: userEmail, password });
     });
 
     afterAll(async () => {
@@ -62,7 +61,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
       it('admin → 201, 카테고리 생성 성공', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/categories')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: '테스트루트', slug: 'test-root-admin-e2e', sortOrder: 0 })
           .expect(201);
 
@@ -75,7 +74,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
       it('일반 user → 403', () => {
         return request(app.getHttpServer())
           .post('/api/categories')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ name: '일반유저카테고리', slug: 'user-cat-admin-e2e' })
           .expect(403);
       });
@@ -90,7 +89,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
       it('slug 중복 → 409', () => {
         return request(app.getHttpServer())
           .post('/api/categories')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: '중복슬러그', slug: 'test-root-admin-e2e' })
           .expect(409);
       });
@@ -100,7 +99,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
       it('admin → 200, 이름 업데이트', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/categories/${createdCategoryId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: '업데이트된루트' })
           .expect(200);
 
@@ -114,13 +113,13 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
         // create child
         const childRes = await request(app.getHttpServer())
           .post('/api/categories')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: '하위카테고리', slug: 'child-cat-admin-e2e', parentId: createdCategoryId });
         const childId = (childRes.body as { id: number }).id;
 
         await request(app.getHttpServer())
           .delete(`/api/categories/${createdCategoryId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(400);
 
         // cleanup child
@@ -130,7 +129,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
       it('삭제 성공 → 204', () => {
         return request(app.getHttpServer())
           .delete(`/api/categories/${createdCategoryId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(204);
       });
     });
@@ -139,11 +138,11 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
       it('admin → 204, sort_order 일괄 업데이트', async () => {
         const res1 = await request(app.getHttpServer())
           .post('/api/categories')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: 'reorder1', slug: 'reorder1-admin-e2e', sortOrder: 0 });
         const res2 = await request(app.getHttpServer())
           .post('/api/categories')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: 'reorder2', slug: 'reorder2-admin-e2e', sortOrder: 1 });
 
         const id1 = (res1.body as { id: number }).id;
@@ -151,7 +150,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
 
         await request(app.getHttpServer())
           .patch('/api/categories/reorder')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ orders: [{ id: id1, sortOrder: 10 }, { id: id2, sortOrder: 5 }] })
           .expect(204);
 
@@ -167,7 +166,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
         ]);
         const res = await request(app.getHttpServer())
           .post('/api/upload/category-image')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .attach('file', fakeImage, {
             filename: 'test.jpg',
             contentType: 'image/jpeg',
@@ -185,7 +184,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
         ]);
         await request(app.getHttpServer())
           .post('/api/upload/category-image')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .attach('file', fakeImage, {
             filename: 'test.jpg',
             contentType: 'image/jpeg',
@@ -211,7 +210,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
       it('admin → 업로드된 이미지 URL을 카테고리에 설정', async () => {
         const catRes = await request(app.getHttpServer())
           .post('/api/categories')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: '이미지카테고리', slug: 'img-cat-admin-e2e', sortOrder: 0 });
         const catId = (catRes.body as { id: number }).id;
 
@@ -220,7 +219,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
         ]);
         const uploadRes = await request(app.getHttpServer())
           .post('/api/upload/category-image')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .attach('file', fakeImage, {
             filename: 'test.jpg',
             contentType: 'image/jpeg',
@@ -229,7 +228,7 @@ export function registerAdminCategoriesSuite(getApp: () => INestApplication) {
 
         const updateRes = await request(app.getHttpServer())
           .patch(`/api/categories/${catId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ imageUrl })
           .expect(200);
 

--- a/backend/test/suites/admin-dashboard.e2e-spec.ts
+++ b/backend/test/suites/admin-dashboard.e2e-spec.ts
@@ -1,6 +1,12 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+  registerAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
@@ -12,34 +18,28 @@ export function registerAdminDashboardSuite(getApp: () => INestApplication) {
     const password = 'Test1234!';
     const name = '대시보드관리자';
 
-    let adminToken: string;
-    let userToken: string;
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
 
     beforeAll(async () => {
       app = getApp();
       dataSource = app.get(DataSource);
 
-      const adminRegRes = await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: adminEmail, password, name });
-      const adminBody = adminRegRes.body as { accessToken?: string };
+      await registerAndGetCookies(app, { email: adminEmail, password, name });
 
       await dataSource.query(
         `UPDATE users SET role = 'admin' WHERE email = ?`,
         [adminEmail],
       );
 
-      const adminLoginRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: adminEmail, password });
-      const adminLoginBody = adminLoginRes.body as { accessToken?: string };
-      adminToken = adminLoginBody.accessToken ?? adminBody.accessToken ?? '';
+      adminCookies = await loginAndGetCookies(app, { email: adminEmail, password });
 
-      const userRegRes = await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: userEmail, password, name: '일반사용자' });
-      const userBody = userRegRes.body as { accessToken?: string };
-      userToken = userBody.accessToken ?? '';
+      const userReg = await registerAndGetCookies(app, {
+        email: userEmail,
+        password,
+        name: '일반사용자',
+      });
+      userCookies = userReg.cookies;
     });
 
     afterAll(async () => {
@@ -59,14 +59,14 @@ export function registerAdminDashboardSuite(getApp: () => INestApplication) {
       it('role=user → 403', () => {
         return request(app.getHttpServer())
           .get('/api/admin/dashboard')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(403);
       });
 
       it('role=admin → 200 with dashboard data', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/dashboard')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as Record<string, unknown>;
@@ -85,7 +85,7 @@ export function registerAdminDashboardSuite(getApp: () => INestApplication) {
       it('기간 필터 적용 (7d)', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/dashboard?period=7d')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as { revenue_chart: Array<{ date: string }> };
@@ -95,7 +95,7 @@ export function registerAdminDashboardSuite(getApp: () => INestApplication) {
       it('커스텀 날짜 범위', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/dashboard?startDate=2026-03-01&endDate=2026-03-10')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as { revenue_chart: Array<{ date: string }> };
@@ -105,14 +105,14 @@ export function registerAdminDashboardSuite(getApp: () => INestApplication) {
       it('365일 초과 범위 → 400', () => {
         return request(app.getHttpServer())
           .get('/api/admin/dashboard?startDate=2024-01-01&endDate=2026-03-01')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(400);
       });
 
       it('order_status_summary 구조 검증', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/dashboard')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as { order_status_summary: Record<string, number> };

--- a/backend/test/suites/admin-members.e2e-spec.ts
+++ b/backend/test/suites/admin-members.e2e-spec.ts
@@ -1,15 +1,20 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerAdminMembersSuite(getApp: () => INestApplication) {
   describe('Admin Members (e2e)', () => {
-    let superAdminToken: string;
-    let adminToken: string;
-    let userToken: string;
+    let superAdminCookies: AuthCookies;
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
     let userId: number;
     let adminId: number;
     let superAdminId: number;
@@ -27,13 +32,13 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
         .post('/api/auth/register')
         .send({ email: superAdminEmail, password: 'Test1234!', name: '슈퍼관리자' });
       await dataSource.query(`UPDATE users SET role = 'super_admin' WHERE email = ?`, [superAdminEmail]);
-      const superRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: superAdminEmail, password: 'Test1234!' });
-      superAdminToken = (superRes.body as { accessToken: string }).accessToken;
+      superAdminCookies = await loginAndGetCookies(app, {
+        email: superAdminEmail,
+        password: 'Test1234!',
+      });
       const superProfile = await request(app.getHttpServer())
         .get('/api/auth/profile')
-        .set('Authorization', `Bearer ${superAdminToken}`);
+        .set('Cookie', cookieHeader(superAdminCookies));
       superAdminId = (superProfile.body as { id: number }).id;
 
       // Register admin
@@ -41,26 +46,26 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
         .post('/api/auth/register')
         .send({ email: adminEmail, password: 'Test1234!', name: '회원관리자' });
       await dataSource.query(`UPDATE users SET role = 'admin' WHERE email = ?`, [adminEmail]);
-      const adminRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: adminEmail, password: 'Test1234!' });
-      adminToken = (adminRes.body as { accessToken: string }).accessToken;
+      adminCookies = await loginAndGetCookies(app, {
+        email: adminEmail,
+        password: 'Test1234!',
+      });
       const adminProfile = await request(app.getHttpServer())
         .get('/api/auth/profile')
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Cookie', cookieHeader(adminCookies));
       adminId = (adminProfile.body as { id: number }).id;
 
       // Register user
       await request(app.getHttpServer())
         .post('/api/auth/register')
         .send({ email: userEmail, password: 'Test1234!', name: '일반회원' });
-      const userRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userEmail, password: 'Test1234!' });
-      userToken = (userRes.body as { accessToken: string }).accessToken;
+      userCookies = await loginAndGetCookies(app, {
+        email: userEmail,
+        password: 'Test1234!',
+      });
       const userProfile = await request(app.getHttpServer())
         .get('/api/auth/profile')
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Cookie', cookieHeader(userCookies));
       userId = (userProfile.body as { id: number }).id;
     });
 
@@ -68,7 +73,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('admin → 200 회원 목록 조회', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/members')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as { items: Record<string, unknown>[]; total: number; page: number; limit: number };
@@ -86,7 +91,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('일반 user → 403 거부', async () => {
         await request(app.getHttpServer())
           .get('/api/admin/members')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(403);
       });
 
@@ -99,7 +104,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('q 검색 필터 → 200', async () => {
         const res = await request(app.getHttpServer())
           .get(`/api/admin/members?q=${encodeURIComponent('일반회원')}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as { items: { name: string }[] };
@@ -109,7 +114,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('role 필터 → 200', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/members?role=admin')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as { items: { role: string }[] };
@@ -123,7 +128,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('admin: user→admin 허용', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/members/${userId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ role: 'admin' })
           .expect(200);
 
@@ -134,7 +139,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('admin: admin→user 허용', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/members/${userId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ role: 'user' })
           .expect(200);
 
@@ -145,7 +150,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('admin: super_admin 부여 → 403', async () => {
         await request(app.getHttpServer())
           .patch(`/api/admin/members/${userId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ role: 'super_admin' })
           .expect(403);
       });
@@ -153,7 +158,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('admin: super_admin 강등 → 403', async () => {
         await request(app.getHttpServer())
           .patch(`/api/admin/members/${superAdminId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ role: 'user' })
           .expect(403);
       });
@@ -161,7 +166,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('자기 자신 역할 변경 → 400', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/members/${adminId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ role: 'user' })
           .expect(400);
 
@@ -172,7 +177,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('super_admin: user→super_admin 허용', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/members/${userId}`)
-          .set('Authorization', `Bearer ${superAdminToken}`)
+          .set('Cookie', cookieHeader(superAdminCookies))
           .send({ role: 'super_admin' })
           .expect(200);
 
@@ -184,7 +189,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
         // userId is now super_admin, superAdminId is also super_admin → count=2
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/members/${userId}`)
-          .set('Authorization', `Bearer ${superAdminToken}`)
+          .set('Cookie', cookieHeader(superAdminCookies))
           .send({ role: 'user' })
           .expect(200);
 
@@ -198,7 +203,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
 
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/members/${userId}`)
-          .set('Authorization', `Bearer ${superAdminToken}`)
+          .set('Cookie', cookieHeader(superAdminCookies))
           .send({ role: 'admin' })
           .expect(400);
 
@@ -212,7 +217,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('일반 user → 403', async () => {
         await request(app.getHttpServer())
           .patch(`/api/admin/members/${userId}`)
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ role: 'admin' })
           .expect(403);
       });
@@ -220,7 +225,7 @@ export function registerAdminMembersSuite(getApp: () => INestApplication) {
       it('응답에 password, refreshToken 미포함', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/members/${userId}`)
-          .set('Authorization', `Bearer ${superAdminToken}`)
+          .set('Cookie', cookieHeader(superAdminCookies))
           .send({ role: 'admin' })
           .expect(200);
 

--- a/backend/test/suites/admin-orders.e2e-spec.ts
+++ b/backend/test/suites/admin-orders.e2e-spec.ts
@@ -1,14 +1,19 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerAdminOrdersSuite(getApp: () => INestApplication) {
   describe('Admin Orders (e2e)', () => {
-    let adminToken: string;
-    let userToken: string;
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
     let orderId: number;
     let refundOrderId: number;
     let productId: number;
@@ -19,7 +24,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
     async function createOrder(): Promise<number> {
       const orderRes = await request(app.getHttpServer())
         .post('/api/orders')
-        .set('Authorization', `Bearer ${userToken}`)
+        .set('Cookie', cookieHeader(userCookies))
         .send({
           items: [{ productId, quantity: 1 }],
           recipientName: '테스트',
@@ -39,24 +44,25 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
         .post('/api/auth/register')
         .send({ email: adminEmail, password: 'Test1234!', name: '주문관리자' });
       await dataSource.query(`UPDATE users SET role = 'admin' WHERE email = ?`, [adminEmail]);
-      const adminRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: adminEmail, password: 'Test1234!' });
-      adminToken = (adminRes.body as { accessToken: string }).accessToken;
+      adminCookies = await loginAndGetCookies(app, {
+        email: adminEmail,
+        password: 'Test1234!',
+      });
 
       // Register user
       await request(app.getHttpServer())
         .post('/api/auth/register')
         .send({ email: userEmail, password: 'Test1234!', name: '일반유저' });
-      const userRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userEmail, password: 'Test1234!' });
-      userToken = (userRes.body as { accessToken: string }).accessToken;
+      userCookies = await loginAndGetCookies(app, {
+        email: userEmail,
+        password: 'Test1234!',
+      });
+
       // Create product for order
       const slug = `admin-orders-test-product-${Date.now()}`;
       const productRes = await request(app.getHttpServer())
         .post('/api/products')
-        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Cookie', cookieHeader(adminCookies))
         .send({ name: '주문테스트상품', slug, price: 10000, stock: 100, status: 'active' });
       productId = (productRes.body as { id: number }).id;
 
@@ -68,7 +74,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('admin → 200 주문 목록 조회', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/orders')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as { items: unknown[]; total: number; page: number; limit: number };
@@ -80,7 +86,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('일반 user → 403 거부', async () => {
         await request(app.getHttpServer())
           .get('/api/admin/orders')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(403);
       });
 
@@ -93,7 +99,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('상태 필터 → 200', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/orders?status=pending')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as { items: { status: string }[] };
@@ -107,7 +113,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('pending → paid 상태 변경', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'paid' })
           .expect(200);
 
@@ -118,7 +124,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('paid → preparing 상태 변경', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'preparing' })
           .expect(200);
 
@@ -129,7 +135,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('preparing → shipped: 운송장 없으면 400', async () => {
         await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'shipped' })
           .expect(400);
       });
@@ -138,7 +144,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
         // preparing → pending is not allowed
         await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'pending' })
           .expect(400);
       });
@@ -146,7 +152,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('일반 user → 403', async () => {
         await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ status: 'paid' })
           .expect(403);
       });
@@ -156,7 +162,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('운송장 등록 → 201', async () => {
         const res = await request(app.getHttpServer())
           .post(`/api/admin/shipping/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ carrier: 'cj', trackingNumber: `TRK-${Date.now()}` })
           .expect(201);
 
@@ -168,7 +174,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('운송장 중복 등록 → 409', async () => {
         await request(app.getHttpServer())
           .post(`/api/admin/shipping/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ carrier: 'cj', trackingNumber: `TRK-DUP-${Date.now()}` })
           .expect(409);
       });
@@ -176,7 +182,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('일반 user → 403', async () => {
         await request(app.getHttpServer())
           .post(`/api/admin/shipping/${orderId}`)
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ carrier: 'cj', trackingNumber: 'TRK-USER' })
           .expect(403);
       });
@@ -186,7 +192,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('preparing → shipped (운송장 등록 후)', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'shipped' })
           .expect(200);
 
@@ -197,7 +203,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('shipped → delivered', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'delivered' })
           .expect(200);
 
@@ -208,7 +214,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('delivered → completed', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'completed' })
           .expect(200);
 
@@ -219,7 +225,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('completed → paid: 전이 불가', async () => {
         await request(app.getHttpServer())
           .patch(`/api/admin/orders/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'paid' })
           .expect(400);
       });
@@ -229,7 +235,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('refund order 운송장 등록 → 201', async () => {
         const res = await request(app.getHttpServer())
           .post(`/api/admin/shipping/${refundOrderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ carrier: 'cj', trackingNumber: `TRK-REFUND-${Date.now()}` })
           .expect(201);
 
@@ -241,7 +247,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('refund order pending → paid', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${refundOrderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'paid' })
           .expect(200);
 
@@ -252,7 +258,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('refund order paid → preparing', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${refundOrderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'preparing' })
           .expect(200);
 
@@ -263,7 +269,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('refund order preparing → shipped', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${refundOrderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'shipped' })
           .expect(200);
 
@@ -274,7 +280,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('refund order shipped → delivered', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${refundOrderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'delivered' })
           .expect(200);
 
@@ -285,7 +291,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('refund order delivered → refund_requested', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${refundOrderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'refund_requested' })
           .expect(200);
 
@@ -296,7 +302,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       it('refund_requested → refunded', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${refundOrderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ status: 'refunded' })
           .expect(200);
 

--- a/backend/test/suites/admin-products.e2e-spec.ts
+++ b/backend/test/suites/admin-products.e2e-spec.ts
@@ -1,14 +1,19 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerAdminProductsSuite(getApp: () => INestApplication) {
   describe('Admin Products (e2e)', () => {
-    let adminToken: string;
-    let userToken: string;
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
     let createdProductId: number;
 
     const adminEmail = `admin-products-admin-${Date.now()}@test.com`;
@@ -23,19 +28,19 @@ export function registerAdminProductsSuite(getApp: () => INestApplication) {
         .post('/api/auth/register')
         .send({ email: adminEmail, password: 'Test1234!', name: '관리자' });
       await dataSource.query(`UPDATE users SET role = 'admin' WHERE email = ?`, [adminEmail]);
-      const adminRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: adminEmail, password: 'Test1234!' });
-      adminToken = (adminRes.body as { accessToken: string }).accessToken;
+      adminCookies = await loginAndGetCookies(app, {
+        email: adminEmail,
+        password: 'Test1234!',
+      });
 
       // Register regular user
       await request(app.getHttpServer())
         .post('/api/auth/register')
         .send({ email: userEmail, password: 'Test1234!', name: '일반유저' });
-      const userRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userEmail, password: 'Test1234!' });
-      userToken = (userRes.body as { accessToken: string }).accessToken;
+      userCookies = await loginAndGetCookies(app, {
+        email: userEmail,
+        password: 'Test1234!',
+      });
     });
 
     describe('POST /api/products (admin)', () => {
@@ -43,7 +48,7 @@ export function registerAdminProductsSuite(getApp: () => INestApplication) {
         const slug = `test-product-admin-e2e-${Date.now()}`;
         const res = await request(app.getHttpServer())
           .post('/api/products')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({
             name: '어드민 테스트 상품',
             slug,
@@ -62,7 +67,7 @@ export function registerAdminProductsSuite(getApp: () => INestApplication) {
       it('일반 user → 403 거부', async () => {
         await request(app.getHttpServer())
           .post('/api/products')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({
             name: '일반유저상품',
             slug: `user-product-${Date.now()}`,
@@ -87,7 +92,7 @@ export function registerAdminProductsSuite(getApp: () => INestApplication) {
       it('admin → 200 상품 수정', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/products/${createdProductId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: '수정된 상품명', price: 20000 })
           .expect(200);
 
@@ -101,13 +106,13 @@ export function registerAdminProductsSuite(getApp: () => INestApplication) {
         const slug = `delete-test-${Date.now()}`;
         const createRes = await request(app.getHttpServer())
           .post('/api/products')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ name: '삭제테스트', slug, price: 1000 });
         const deleteId = (createRes.body as { id: number }).id;
 
         await request(app.getHttpServer())
           .delete(`/api/products/${deleteId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
       });
     });
@@ -117,7 +122,7 @@ export function registerAdminProductsSuite(getApp: () => INestApplication) {
         const gifBuffer = Buffer.from('GIF89a', 'ascii');
         await request(app.getHttpServer())
           .post('/api/upload/image')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .attach('file', gifBuffer, {
             filename: 'test.gif',
             contentType: 'image/gif',
@@ -129,7 +134,7 @@ export function registerAdminProductsSuite(getApp: () => INestApplication) {
         const buf = Buffer.from('fake');
         await request(app.getHttpServer())
           .post('/api/upload/image')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .attach('file', buf, {
             filename: 'test.jpg',
             contentType: 'image/jpeg',

--- a/backend/test/suites/admin.e2e-spec.ts
+++ b/backend/test/suites/admin.e2e-spec.ts
@@ -1,6 +1,12 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+  registerAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
@@ -12,8 +18,8 @@ export function registerAdminSuite(getApp: () => INestApplication) {
     const password = 'Test1234!';
     const name = '테스트관리자';
 
-    let adminToken: string;
-    let userToken: string;
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
 
     beforeAll(async () => {
       app = getApp();
@@ -31,29 +37,25 @@ export function registerAdminSuite(getApp: () => INestApplication) {
         [userEmail, name],
       );
 
-      // Login as admin
-      const adminRegRes = await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: `new-${adminEmail}`, password, name });
-      const adminBody = adminRegRes.body as { accessToken?: string };
-      if (adminBody.accessToken) {
-        // Update role to admin
-        await dataSource.query(
-          `UPDATE users SET role = 'admin' WHERE email = ?`,
-          [`new-${adminEmail}`],
-        );
-        // Re-login to get fresh token with admin role - using direct token
-        adminToken = adminBody.accessToken;
-      }
+      // Register a new admin user via API and promote to admin
+      const adminReg = await registerAndGetCookies(app, {
+        email: `new-${adminEmail}`,
+        password,
+        name,
+      });
+      adminCookies = adminReg.cookies;
+      await dataSource.query(
+        `UPDATE users SET role = 'admin' WHERE email = ?`,
+        [`new-${adminEmail}`],
+      );
 
-      // Login as regular user
-      const userRegRes = await request(app.getHttpServer())
-        .post('/api/auth/register')
-        .send({ email: `new-${userEmail}`, password, name });
-      const userBody = userRegRes.body as { accessToken?: string };
-      if (userBody.accessToken) {
-        userToken = userBody.accessToken;
-      }
+      // Register regular user via API
+      const userReg = await registerAndGetCookies(app, {
+        email: `new-${userEmail}`,
+        password,
+        name,
+      });
+      userCookies = userReg.cookies;
     });
 
     afterAll(async () => {
@@ -73,31 +75,20 @@ export function registerAdminSuite(getApp: () => INestApplication) {
       it('role=user → 403', () => {
         return request(app.getHttpServer())
           .get('/api/admin/dashboard')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(403);
       });
 
       it('role=admin → 200', async () => {
-        // Update the newly created user to admin role and get a valid token
-        await dataSource.query(
-          `UPDATE users SET role = 'admin' WHERE email = ?`,
-          [`new-${adminEmail}`],
-        );
-
-        // Login again to get token with admin role reflected via JWT
-        // Note: JWT role is embedded at sign time, so we need a fresh login
-        const loginRes = await request(app.getHttpServer())
-          .post('/api/auth/login')
-          .send({ email: `new-${adminEmail}`, password });
-
-        const loginBody = loginRes.body as { accessToken?: string };
-        if (loginBody.accessToken) {
-          adminToken = loginBody.accessToken;
-        }
+        // Re-login to get fresh cookies with admin role in JWT
+        adminCookies = await loginAndGetCookies(app, {
+          email: `new-${adminEmail}`,
+          password,
+        });
 
         return request(app.getHttpServer())
           .get('/api/admin/dashboard')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
       });
     });

--- a/backend/test/suites/navigation.e2e-spec.ts
+++ b/backend/test/suites/navigation.e2e-spec.ts
@@ -2,13 +2,18 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 import * as bcrypt from 'bcrypt';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 export function registerNavigationSuite(getApp: () => INestApplication) {
   describe('Navigation (e2e)', () => {
     let app: INestApplication;
     let dataSource: DataSource;
-    let adminToken: string;
-    let userToken: string;
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
     let adminUserId: number;
     let regularUserId: number;
     let createdItemId: number;
@@ -36,15 +41,8 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       );
       regularUserId = userResult.insertId as number;
 
-      const adminLogin = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: adminEmail, password });
-      adminToken = (adminLogin.body as { accessToken: string }).accessToken;
-
-      const userLogin = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userEmail, password });
-      userToken = (userLogin.body as { accessToken: string }).accessToken;
+      adminCookies = await loginAndGetCookies(app, { email: adminEmail, password });
+      userCookies = await loginAndGetCookies(app, { email: userEmail, password });
     });
 
     afterAll(async () => {
@@ -58,7 +56,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('admin -> 201, 네비게이션 생성', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/navigation')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ group: 'gnb', label: '상품', url: '/products', sort_order: 0 })
           .expect(201);
 
@@ -72,7 +70,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('admin -> 201, 자식 항목 생성', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/navigation')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ group: 'gnb', label: '신상품', url: '/products?sort=newest', sort_order: 0, parent_id: createdItemId })
           .expect(201);
 
@@ -84,7 +82,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('일반 user -> 403', () => {
         return request(app.getHttpServer())
           .post('/api/navigation')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ group: 'gnb', label: '테스트', url: '/test' })
           .expect(403);
       });
@@ -115,7 +113,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('admin -> 200, 전체 목록 (비활성 포함)', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/navigation?group=gnb')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as Array<{ label: string }>;
@@ -125,7 +123,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('일반 user -> 403', () => {
         return request(app.getHttpServer())
           .get('/api/admin/navigation?group=gnb')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(403);
       });
     });
@@ -134,7 +132,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('admin -> 200, 항목 수정', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/navigation/${createdItemId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ label: '수정된 상품' })
           .expect(200);
 
@@ -145,7 +143,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('존재하지 않는 항목 -> 404', () => {
         return request(app.getHttpServer())
           .patch('/api/navigation/999999')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ label: '없음' })
           .expect(404);
       });
@@ -155,7 +153,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('admin -> 204, 순서 변경', async () => {
         await request(app.getHttpServer())
           .patch('/api/navigation/reorder')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({
             orders: [
               { id: createdItemId, sort_order: 1 },
@@ -169,7 +167,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('admin -> 204, 자식 항목 삭제', async () => {
         await request(app.getHttpServer())
           .delete(`/api/navigation/${childItemId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(204);
 
         childItemId = 0;
@@ -178,7 +176,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('admin -> 204, 부모 항목 삭제', async () => {
         await request(app.getHttpServer())
           .delete(`/api/navigation/${createdItemId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(204);
 
         createdItemId = 0;
@@ -187,7 +185,7 @@ export function registerNavigationSuite(getApp: () => INestApplication) {
       it('존재하지 않는 항목 -> 404', () => {
         return request(app.getHttpServer())
           .delete('/api/navigation/999999')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(404);
       });
     });

--- a/backend/test/suites/pages.e2e-spec.ts
+++ b/backend/test/suites/pages.e2e-spec.ts
@@ -2,13 +2,18 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 import * as bcrypt from 'bcrypt';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 export function registerPagesSuite(getApp: () => INestApplication) {
   describe('Pages (e2e)', () => {
     let app: INestApplication;
     let dataSource: DataSource;
-    let adminToken: string;
-    let userToken: string;
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
     let adminUserId: number;
     let regularUserId: number;
     let createdPageId: number;
@@ -36,15 +41,8 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       );
       regularUserId = userResult.insertId as number;
 
-      const adminLogin = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: adminEmail, password });
-      adminToken = (adminLogin.body as { accessToken: string }).accessToken;
-
-      const userLogin = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userEmail, password });
-      userToken = (userLogin.body as { accessToken: string }).accessToken;
+      adminCookies = await loginAndGetCookies(app, { email: adminEmail, password });
+      userCookies = await loginAndGetCookies(app, { email: userEmail, password });
     });
 
     afterAll(async () => {
@@ -59,7 +57,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('admin -> 201, 페이지 생성 성공', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/pages')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ slug: 'test-home-pages-e2e', title: '테스트 홈페이지' })
           .expect(201);
 
@@ -73,7 +71,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('일반 user -> 403', () => {
         return request(app.getHttpServer())
           .post('/api/pages')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ slug: 'user-page-pages-e2e', title: '유저페이지' })
           .expect(403);
       });
@@ -88,7 +86,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('slug 중복 -> 409', () => {
         return request(app.getHttpServer())
           .post('/api/pages')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ slug: 'test-home-pages-e2e', title: '중복' })
           .expect(409);
       });
@@ -99,7 +97,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
         // publish the page first
         await request(app.getHttpServer())
           .patch(`/api/pages/${createdPageId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ is_published: true });
 
         const res = await request(app.getHttpServer())
@@ -117,7 +115,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('admin -> 200, 페이지 수정', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/pages/${createdPageId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ title: '수정된 홈페이지' })
           .expect(200);
 
@@ -130,7 +128,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('공개 중인 페이지 삭제 -> 400', () => {
         return request(app.getHttpServer())
           .delete(`/api/pages/${createdPageId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(400);
       });
     });
@@ -157,12 +155,12 @@ export function registerPagesSuite(getApp: () => INestApplication) {
         // create unpublished page
         await request(app.getHttpServer())
           .post('/api/pages')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ slug: 'unpublished-pages-e2e', title: '비공개 페이지' });
 
         const res = await request(app.getHttpServer())
           .get('/api/admin/pages')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(200);
 
         const body = res.body as Array<{ slug: string }>;
@@ -172,7 +170,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('일반 user -> 403', () => {
         return request(app.getHttpServer())
           .get('/api/admin/pages')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(403);
       });
     });
@@ -181,7 +179,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('admin -> 201, 블록 추가', async () => {
         const res = await request(app.getHttpServer())
           .post(`/api/pages/${createdPageId}/blocks`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({
             type: 'hero_banner',
             content: { title: '메인 배너', imageUrl: '/banner.jpg' },
@@ -197,7 +195,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('존재하지 않는 페이지 -> 404', () => {
         return request(app.getHttpServer())
           .post('/api/pages/999999/blocks')
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ type: 'hero_banner', content: {} })
           .expect(404);
       });
@@ -205,7 +203,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('지원하지 않는 블록 타입 -> 400', () => {
         return request(app.getHttpServer())
           .post(`/api/pages/${createdPageId}/blocks`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ type: 'invalid_type', content: {} })
           .expect(400);
       });
@@ -215,7 +213,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('admin -> 200, 블록 수정', async () => {
         const res = await request(app.getHttpServer())
           .patch(`/api/pages/${createdPageId}/blocks/${createdBlockId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ content: { title: '수정된 배너' } })
           .expect(200);
 
@@ -229,13 +227,13 @@ export function registerPagesSuite(getApp: () => INestApplication) {
         // add another block
         const res = await request(app.getHttpServer())
           .post(`/api/pages/${createdPageId}/blocks`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ type: 'text_content', content: { text: '본문' }, sort_order: 1 });
         const secondBlockId = (res.body as { id: number }).id;
 
         await request(app.getHttpServer())
           .patch(`/api/pages/${createdPageId}/blocks/reorder`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({
             orders: [
               { id: createdBlockId, sort_order: 1 },
@@ -250,7 +248,7 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('admin -> 204, 블록 삭제', () => {
         return request(app.getHttpServer())
           .delete(`/api/pages/${createdPageId}/blocks/${createdBlockId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(204);
       });
     });
@@ -259,12 +257,12 @@ export function registerPagesSuite(getApp: () => INestApplication) {
       it('비공개 처리 후 삭제 -> 204', async () => {
         await request(app.getHttpServer())
           .patch(`/api/pages/${createdPageId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ is_published: false });
 
         await request(app.getHttpServer())
           .delete(`/api/pages/${createdPageId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .expect(204);
       });
     });

--- a/backend/test/suites/reviews.e2e-spec.ts
+++ b/backend/test/suites/reviews.e2e-spec.ts
@@ -1,13 +1,19 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+  registerAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerReviewsSuite(getApp: () => INestApplication) {
   describe('Reviews (e2e)', () => {
-    let accessToken: string;
+    let authCookies: AuthCookies;
     let userId: number;
     let productId: number;
     let orderItemId: number;
@@ -23,22 +29,27 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
       );
       userId = userResult.insertId as number;
 
-      // Login to get token
+      // Try login first
       const loginRes = await request(app.getHttpServer())
         .post('/api/auth/login')
         .send({ email: 'review-test@e2e.com', password: 'Password1!' });
 
-      // If login fails due to password hash, create token directly via register
+      // If login fails due to password hash, create via register
       if (loginRes.status !== 200 && loginRes.status !== 201) {
         // Clean up and re-register
         await dataSource.query(`DELETE FROM users WHERE email = 'review-test@e2e.com'`);
-        const regRes = await request(app.getHttpServer())
-          .post('/api/auth/register')
-          .send({ email: 'review-test@e2e.com', password: 'Password1!', name: '리뷰테스터' });
-        accessToken = (regRes.body as { accessToken: string }).accessToken;
-        userId = (regRes.body as { user: { id: number } }).user.id;
+        const reg = await registerAndGetCookies(app, {
+          email: 'review-test@e2e.com',
+          password: 'Password1!',
+          name: '리뷰테스터',
+        });
+        authCookies = reg.cookies;
+        userId = reg.body.user.id;
       } else {
-        accessToken = (loginRes.body as { accessToken: string }).accessToken;
+        authCookies = await loginAndGetCookies(app, {
+          email: 'review-test@e2e.com',
+          password: 'Password1!',
+        });
       }
 
       // Create test product
@@ -99,7 +110,7 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
       it('201 - 리뷰 작성 성공', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/reviews')
-          .set('Authorization', `Bearer ${accessToken}`)
+          .set('Cookie', cookieHeader(authCookies))
           .send({ productId, orderItemId, rating: 5, content: '정말 좋은 상품입니다!' })
           .expect(201);
 
@@ -113,7 +124,7 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
       it('409 - 중복 리뷰 작성', () => {
         return request(app.getHttpServer())
           .post('/api/reviews')
-          .set('Authorization', `Bearer ${accessToken}`)
+          .set('Cookie', cookieHeader(authCookies))
           .send({ productId, orderItemId, rating: 4, content: '또 써볼까' })
           .expect(409);
       });
@@ -137,7 +148,7 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
       it('200 - 리뷰 수정 성공', () => {
         return request(app.getHttpServer())
           .patch(`/api/reviews/${reviewId}`)
-          .set('Authorization', `Bearer ${accessToken}`)
+          .set('Cookie', cookieHeader(authCookies))
           .send({ rating: 4, content: '수정된 리뷰' })
           .expect(200)
           .expect((res) => {
@@ -152,14 +163,14 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
       it('200 - 리뷰 삭제 성공', () => {
         return request(app.getHttpServer())
           .delete(`/api/reviews/${reviewId}`)
-          .set('Authorization', `Bearer ${accessToken}`)
+          .set('Cookie', cookieHeader(authCookies))
           .expect(200);
       });
 
       it('404 - 이미 삭제된 리뷰', () => {
         return request(app.getHttpServer())
           .delete(`/api/reviews/${reviewId}`)
-          .set('Authorization', `Bearer ${accessToken}`)
+          .set('Cookie', cookieHeader(authCookies))
           .expect(404);
       });
     });

--- a/backend/test/suites/shipping.e2e-spec.ts
+++ b/backend/test/suites/shipping.e2e-spec.ts
@@ -1,15 +1,20 @@
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+} from '../helpers/auth-cookie.helper';
 
 let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerShippingSuite(getApp: () => INestApplication) {
   describe('Shipping (e2e)', () => {
-    let userToken: string;
-    let otherToken: string;
-    let adminToken: string;
+    let userCookies: AuthCookies;
+    let otherCookies: AuthCookies;
+    let adminCookies: AuthCookies;
     let orderId: number;
     let productId: number;
 
@@ -26,18 +31,18 @@ export function registerShippingSuite(getApp: () => INestApplication) {
         .post('/api/auth/register')
         .send({ email: userEmail, password: 'Test1234!', name: '배송유저' });
 
-      const loginRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: userEmail, password: 'Test1234!' });
-      userToken = (loginRes.body as { accessToken: string }).accessToken;
+      userCookies = await loginAndGetCookies(app, {
+        email: userEmail,
+        password: 'Test1234!',
+      });
 
       await request(app.getHttpServer())
         .post('/api/auth/register')
         .send({ email: otherEmail, password: 'Test1234!', name: '다른유저' });
-      const otherRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: otherEmail, password: 'Test1234!' });
-      otherToken = (otherRes.body as { accessToken: string }).accessToken;
+      otherCookies = await loginAndGetCookies(app, {
+        email: otherEmail,
+        password: 'Test1234!',
+      });
 
       // Create admin user
       await request(app.getHttpServer())
@@ -47,10 +52,10 @@ export function registerShippingSuite(getApp: () => INestApplication) {
         `UPDATE users SET role = 'admin' WHERE email = ?`,
         [adminEmail],
       );
-      const adminRes = await request(app.getHttpServer())
-        .post('/api/auth/login')
-        .send({ email: adminEmail, password: 'Test1234!' });
-      adminToken = (adminRes.body as { accessToken: string }).accessToken;
+      adminCookies = await loginAndGetCookies(app, {
+        email: adminEmail,
+        password: 'Test1234!',
+      });
 
       // Seed product
       const prodResult = await dataSource.query(`
@@ -62,7 +67,7 @@ export function registerShippingSuite(getApp: () => INestApplication) {
       // Create order
       const orderRes = await request(app.getHttpServer())
         .post('/api/orders')
-        .set('Authorization', `Bearer ${userToken}`)
+        .set('Cookie', cookieHeader(userCookies))
         .send({
           items: [{ productId, quantity: 1 }],
           recipientName: '홍길동',
@@ -76,12 +81,12 @@ export function registerShippingSuite(getApp: () => INestApplication) {
       // Confirm payment to auto-create shipping record
       await request(app.getHttpServer())
         .post('/api/payments/prepare')
-        .set('Authorization', `Bearer ${userToken}`)
+        .set('Cookie', cookieHeader(userCookies))
         .send({ orderId });
 
       await request(app.getHttpServer())
         .post('/api/payments/confirm')
-        .set('Authorization', `Bearer ${userToken}`)
+        .set('Cookie', cookieHeader(userCookies))
         .send({ orderId, paymentKey: 'mock_key_123', amount: 10000 });
     });
 
@@ -109,21 +114,21 @@ export function registerShippingSuite(getApp: () => INestApplication) {
       it('타인의 orderId → 403 FORBIDDEN', () => {
         return request(app.getHttpServer())
           .get(`/api/shipping/${orderId}`)
-          .set('Authorization', `Bearer ${otherToken}`)
+          .set('Cookie', cookieHeader(otherCookies))
           .expect(403);
       });
 
       it('존재하지 않는 orderId → 404', () => {
         return request(app.getHttpServer())
           .get('/api/shipping/99999999')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(404);
       });
 
       it('valid JWT + 본인 orderId → 200, shipping 정보 반환', async () => {
         const res = await request(app.getHttpServer())
           .get(`/api/shipping/${orderId}`)
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .expect(200);
 
         const body = res.body as {
@@ -150,7 +155,7 @@ export function registerShippingSuite(getApp: () => INestApplication) {
       it('유효한 carrier + trackingNumber → 200, steps 배열', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/shipping/track')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ carrier: 'mock', trackingNumber: '1234567890123' })
           .expect(201);
 
@@ -163,7 +168,7 @@ export function registerShippingSuite(getApp: () => INestApplication) {
       it('지원하지 않는 carrier → 400', () => {
         return request(app.getHttpServer())
           .post('/api/shipping/track')
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ carrier: 'unknown_carrier', trackingNumber: '123' })
           .expect(400);
       });
@@ -173,7 +178,7 @@ export function registerShippingSuite(getApp: () => INestApplication) {
       it('일반 사용자 → 403', () => {
         return request(app.getHttpServer())
           .post(`/api/admin/shipping/${orderId}`)
-          .set('Authorization', `Bearer ${userToken}`)
+          .set('Cookie', cookieHeader(userCookies))
           .send({ carrier: 'mock', trackingNumber: 'TRACK001' })
           .expect(403);
       });
@@ -181,7 +186,7 @@ export function registerShippingSuite(getApp: () => INestApplication) {
       it('admin → 200, tracking_number 업데이트', async () => {
         const res = await request(app.getHttpServer())
           .post(`/api/admin/shipping/${orderId}`)
-          .set('Authorization', `Bearer ${adminToken}`)
+          .set('Cookie', cookieHeader(adminCookies))
           .send({ carrier: 'mock', trackingNumber: 'TRACK001' })
           .expect(201);
 


### PR DESCRIPTION
## Summary
- Closes #535
- admin (categories/dashboard/members/orders/products), reviews, pages, navigation, shipping 등 10개 e2e suite 를 쿠키 기반 인증 헬퍼로 전환
- 변경:
  - `body.accessToken` 추출 전면 제거 → `loginAndGetCookies` 로 쿠키 획득
  - `Authorization: Bearer` → `Cookie: accessToken=...; refreshToken=...` (`cookieHeader(cookies)`)
  - super_admin / admin / 일반 user 권한 케이스 모두 쿠키 방식으로 통일
- #533 / #534 scope (auth, cart, orders, payments) 파일은 건드리지 않음
- 컨트롤러/프로덕션 코드 변경 없음

## Test plan
- [x] `cd backend && npm run lint`
- [x] `cd backend && npm run build`
- [x] `cd backend && npm run test`
- [ ] CI e2e 로 최종 확인

## Related
- 원본: #531
- 선행: #532 (헬퍼) MERGED