### PR TITLE
fix: #498 audit_logs 테이블 누락 마이그레이션 추가

### DIFF
--- a/backend/src/database/migrations/1781500000000-CreateAuditLogsTable.ts
+++ b/backend/src/database/migrations/1781500000000-CreateAuditLogsTable.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAuditLogsTable1781500000000 implements MigrationInterface {
+  name = 'CreateAuditLogsTable1781500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [existing] = (await queryRunner.query(
+      `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'audit_logs'`,
+    )) as Array<{ TABLE_NAME: string }>;
+    if (existing) {
+      return;
+    }
+
+    await queryRunner.query(`
+      CREATE TABLE \`audit_logs\` (
+        \`id\` INT NOT NULL AUTO_INCREMENT,
+        \`actorId\` INT NOT NULL,
+        \`actorRole\` VARCHAR(50) NOT NULL,
+        \`action\` VARCHAR(100) NOT NULL,
+        \`resourceType\` VARCHAR(100) NOT NULL,
+        \`resourceId\` INT NULL,
+        \`beforeJson\` JSON NULL,
+        \`afterJson\` JSON NULL,
+        \`ip\` VARCHAR(45) NULL,
+        \`userAgent\` VARCHAR(500) NULL,
+        \`createdAt\` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        PRIMARY KEY (\`id\`),
+        INDEX \`IDX_audit_logs_actorId_createdAt\` (\`actorId\`, \`createdAt\`),
+        INDEX \`IDX_audit_logs_resourceType_resourceId\` (\`resourceType\`, \`resourceId\`),
+        INDEX \`IDX_audit_logs_action_createdAt\` (\`action\`, \`createdAt\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS \`audit_logs\``);
+  }
+}


### PR DESCRIPTION
## 개요
#498 에서 AuditLog entity 가 도입되었지만 대응 마이그레이션이 포함되지 않아 CI e2e 에서 모든 PR 이 다음 에러로 실패 중:

\`\`\`
QueryFailedError: Table 'commerce_test.audit_logs' doesn't exist
\`\`\`

main 은 실제로는 CI fail 상태로 merge 되고 있었음. 이 PR 이후 정상 흐름 복구.

## 변경
- \`1781500000000-CreateAuditLogsTable.ts\` 추가
- AuditLog entity (\`src/modules/audit-logs/entities/audit-log.entity.ts\`) 에 맞춘 컬럼/인덱스 정의
- 기존 테이블 존재 시 no-op 으로 멱등 처리 (부분 적용된 환경 대응)

## Test plan
- [x] local 에서 \`migration:run\` 후 \`DESCRIBE audit_logs\` 로 컬럼 확인 완료
- [x] 기존 스키마 충돌 없음
- [ ] CI Backend e2e 복구 확인

## Related
- #498 (audit log 기능 도입)
- 이 PR 블락된 #550, #551, #552 CI 복구