### PR TITLE
fix: #492 sitemap.xml/robots.txt locale redirect 차단

### DIFF
--- a/src/__tests__/middleware-config.test.ts
+++ b/src/__tests__/middleware-config.test.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('middleware config matcher', () => {
+  it('excludes sitemap.xml and robots.txt from locale middleware matching', () => {
+    const middlewarePath = path.resolve(process.cwd(), 'src/middleware.ts');
+    const middlewareSource = fs.readFileSync(middlewarePath, 'utf-8');
+
+    expect(middlewareSource).toContain('robots.txt|sitemap.xml');
+  });
+});

--- a/src/__tests__/middleware-seo-routes.test.ts
+++ b/src/__tests__/middleware-seo-routes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('next-intl/middleware', () => ({
+  default: () => (req: { url: string }) => {
+    const requestUrl = new URL(req.url);
+    return new Response(null, {
+      status: 307,
+      headers: { location: `/ko${requestUrl.pathname}` },
+    });
+  },
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  routing: { locales: ['ko', 'en', 'ja', 'zh'], defaultLocale: 'ko' },
+}));
+
+import { middleware } from '@/middleware';
+
+function makeRequest(pathname: string): NextRequest {
+  return new NextRequest(`http://localhost${pathname}`);
+}
+
+describe('middleware seo routes', () => {
+  it('does not redirect /sitemap.xml to locale path', async () => {
+    const res = await middleware(makeRequest('/sitemap.xml'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('does not redirect /robots.txt to locale path', async () => {
+    const res = await middleware(makeRequest('/robots.txt'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('location')).toBeNull();
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -103,6 +103,10 @@ export async function middleware(request: NextRequest) {
   const localePrefix = localeMatch ? `/${localeMatch[1]}` : '';
   const pathnameWithoutLocale = localeMatch ? (localeMatch[2] || '/') : pathname;
 
+  if (pathnameWithoutLocale === '/sitemap.xml' || pathnameWithoutLocale === '/robots.txt') {
+    return NextResponse.next();
+  }
+
   if (pathnameWithoutLocale.startsWith('/admin')) {
     if (!token) {
       const loginUrl = new URL(`${localePrefix}/login`, request.url);
@@ -186,6 +190,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|ttf|woff|woff2|eot|otf)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|ttf|woff|woff2|eot|otf)$).*)',
   ],
 };


### PR DESCRIPTION
## 요약
- `/sitemap.xml`, `/robots.txt`가 locale middleware에 걸려 `/ko/...`로 307 후 404가 나는 문제를 수정했습니다.
- SEO 엔드포인트는 middleware에서 즉시 `NextResponse.next()`로 통과시킵니다.
- matcher에서도 `robots.txt`, `sitemap.xml`를 제외해 회귀 가능성을 낮췄습니다.
- 회귀 방지를 위해 미들웨어 테스트를 추가했습니다.

## 검증
- `npm run build`
- `npm run test:run`
- `cd backend && npm run build && npm run test`

## 참고
- 현재 운영 도메인에서 `/sitemap.xml`, `/robots.txt`가 locale 리다이렉트 후 404여서 Search Console 수동 제출(#492 본문)은 선행 수정 없이는 유효하지 않습니다.

Closes #492
