### PR TITLE
fix: #485 상품 생성/수정 트랜잭션 처리

### DIFF
--- a/backend/src/modules/products/__tests__/products.service.spec.ts
+++ b/backend/src/modules/products/__tests__/products.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { NotFoundException, ConflictException } from '@nestjs/common';
 import { SelectQueryBuilder } from 'typeorm';
 import { ProductsService } from '../products.service';
@@ -40,6 +40,16 @@ const mockRepository = {
   save: jest.fn(),
   remove: jest.fn(),
   increment: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockManager = {
+  create: jest.fn(),
+  save: jest.fn(),
+  delete: jest.fn(),
+};
+
+const mockDataSource = {
+  transaction: jest.fn().mockImplementation(async (cb: (manager: typeof mockManager) => Promise<unknown>) => cb(mockManager)),
 };
 
 describe('ProductsService', () => {
@@ -90,6 +100,10 @@ describe('ProductsService', () => {
           provide: CacheService,
           useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn().mockResolvedValue(undefined), del: jest.fn().mockResolvedValue(undefined), delByPattern: jest.fn().mockResolvedValue(undefined), delPattern: jest.fn().mockResolvedValue(undefined) },
         },
+        {
+          provide: getDataSourceToken(),
+          useValue: mockDataSource,
+        },
       ],
     }).compile();
 
@@ -102,6 +116,10 @@ describe('ProductsService', () => {
     mockOrderBy.mockReturnThis();
     mockSkip.mockReturnThis();
     mockTake.mockReturnThis();
+    mockDataSource.transaction.mockImplementation(async (cb: (manager: typeof mockManager) => Promise<unknown>) => cb(mockManager));
+    mockManager.create.mockReturnValue({});
+    mockManager.save.mockResolvedValue({});
+    mockManager.delete.mockResolvedValue(undefined);
   });
 
   describe('findAll', () => {
@@ -222,8 +240,8 @@ describe('ProductsService', () => {
         name: 'QueryFailedError',
         code: 'ER_DUP_ENTRY',
       });
-      mockRepository.create.mockReturnValue({});
-      mockRepository.save.mockRejectedValue(dupError);
+      mockManager.create.mockReturnValue({});
+      mockManager.save.mockRejectedValue(dupError);
 
       await expect(
         service.create({ name: 'test', slug: 'duplicate', price: 1000 }),
@@ -232,8 +250,8 @@ describe('ProductsService', () => {
 
     it('정상 생성', async () => {
       const created = { id: 1 } as Product;
-      mockRepository.create.mockReturnValue(created);
-      mockRepository.save.mockResolvedValue(created);
+      mockManager.create.mockReturnValue(created);
+      mockManager.save.mockResolvedValue(created);
 
       const result = await service.create({
         name: '신상품',
@@ -246,8 +264,8 @@ describe('ProductsService', () => {
 
     it('다국어 필드 포함 생성 시 entity에 전달됨', async () => {
       const created = { id: 2 } as Product;
-      mockRepository.create.mockReturnValue(created);
-      mockRepository.save.mockResolvedValue(created);
+      mockManager.create.mockReturnValue(created);
+      mockManager.save.mockResolvedValue(created);
 
       await service.create({
         name: '보이차',
@@ -264,7 +282,8 @@ describe('ProductsService', () => {
         shortDescriptionZh: '口感顺滑',
       });
 
-      expect(mockRepository.create).toHaveBeenCalledWith(
+      expect(mockManager.create).toHaveBeenCalledWith(
+        expect.any(Function),
         expect.objectContaining({
           nameEn: 'Pu-erh Tea',
           nameJa: '普洱茶',
@@ -277,6 +296,26 @@ describe('ProductsService', () => {
           shortDescriptionZh: '口感顺滑',
         }),
       );
+    });
+
+    it('이미지 저장 실패 시 상품도 롤백됨', async () => {
+      const created = { id: 10 } as Product;
+      mockManager.create.mockReturnValue(created);
+      // 첫 번째 save(Product) 성공, 두 번째 save(ProductImage) 실패
+      mockManager.save
+        .mockResolvedValueOnce(created)
+        .mockRejectedValueOnce(new Error('이미지 저장 실패'));
+      // transaction 자체가 reject되도록 실제 콜백 실행
+      mockDataSource.transaction.mockImplementation(async (cb: (manager: typeof mockManager) => Promise<unknown>) => cb(mockManager));
+
+      await expect(
+        service.create({
+          name: '롤백테스트',
+          slug: 'rollback-test',
+          price: 5000,
+          images: [{ url: 'https://example.com/img.jpg' }],
+        }),
+      ).rejects.toThrow('이미지 저장 실패');
     });
   });
 
@@ -296,7 +335,8 @@ describe('ProductsService', () => {
         shortDescriptionZh: null,
       } as unknown as Product;
       mockRepository.findOne.mockResolvedValue(existing);
-      mockRepository.save.mockResolvedValue({ ...existing, nameEn: 'Updated English Name' });
+      const updated = { ...existing, nameEn: 'Updated English Name' };
+      mockManager.save.mockResolvedValue(updated);
 
       const result = await service.update(1, { nameEn: 'Updated English Name' });
 

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -6,7 +6,8 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, QueryFailedError, SelectQueryBuilder } from 'typeorm';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource, EntityManager, Repository, QueryFailedError, SelectQueryBuilder } from 'typeorm';
 import { Product, ProductStatus } from './entities/product.entity';
 import { Category } from './entities/category.entity';
 import { ProductImage } from './entities/product-image.entity';
@@ -45,6 +46,8 @@ export class ProductsService {
     @InjectRepository(ProductAttribute)
     private readonly productAttributeRepository: Repository<ProductAttribute>,
     private readonly cacheService: CacheService,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
 
   private async getReviewStats(
@@ -365,43 +368,44 @@ export class ProductsService {
 
   async create(dto: CreateProductDto): Promise<Product> {
     const { images, detailImages, ...productData } = dto;
-    const product = this.productRepository.create({
-      ...productData,
-      categoryId: dto.categoryId ?? null,
-      salePrice: dto.salePrice ?? null,
-      sku: dto.sku ?? null,
-    });
-
     try {
-      const saved = await this.productRepository.save(product);
+      return await this.dataSource.transaction(async (manager: EntityManager) => {
+        const product = manager.create(Product, {
+          ...productData,
+          categoryId: dto.categoryId ?? null,
+          salePrice: dto.salePrice ?? null,
+          sku: dto.sku ?? null,
+        });
+        const saved = await manager.save(product);
 
-      if (images && images.length > 0) {
-        const imageEntities = images.map((img, index) =>
-          this.productImageRepository.create({
-            productId: saved.id,
-            url: img.url,
-            alt: img.alt ?? null,
-            sortOrder: img.sortOrder ?? index,
-            isThumbnail: img.isThumbnail ?? index === 0,
-          }),
-        );
-        await this.productImageRepository.save(imageEntities);
-      }
+        if (images && images.length > 0) {
+          const imageEntities = images.map((img, index) =>
+            manager.create(ProductImage, {
+              productId: saved.id,
+              url: img.url,
+              alt: img.alt ?? null,
+              sortOrder: img.sortOrder ?? index,
+              isThumbnail: img.isThumbnail ?? index === 0,
+            }),
+          );
+          await manager.save(ProductImage, imageEntities);
+        }
 
-      if (detailImages && detailImages.length > 0) {
-        const detailEntities = detailImages.map((img, index) =>
-          this.productDetailImageRepository.create({
-            productId: saved.id,
-            url: img.url,
-            alt: img.alt ?? null,
-            sortOrder: img.sortOrder ?? index,
-            isActive: true,
-          }),
-        );
-        await this.productDetailImageRepository.save(detailEntities);
-      }
+        if (detailImages && detailImages.length > 0) {
+          const detailEntities = detailImages.map((img, index) =>
+            manager.create(ProductDetailImage, {
+              productId: saved.id,
+              url: img.url,
+              alt: img.alt ?? null,
+              sortOrder: img.sortOrder ?? index,
+              isActive: true,
+            }),
+          );
+          await manager.save(ProductDetailImage, detailEntities);
+        }
 
-      return saved;
+        return saved;
+      });
     } catch (err) {
       if (
         err instanceof Error &&
@@ -420,39 +424,43 @@ export class ProductsService {
     Object.assign(product, productData);
 
     try {
-      const saved = await this.productRepository.save(product);
+      const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+        const updatedProduct = await manager.save(product);
 
-      if (images !== undefined) {
-        await this.productImageRepository.delete({ productId: id });
-        if (images && images.length > 0) {
-          const imageEntities = images.map((img, index) =>
-            this.productImageRepository.create({
-              productId: id,
-              url: img.url,
-              alt: img.alt ?? null,
-              sortOrder: img.sortOrder ?? index,
-              isThumbnail: img.isThumbnail ?? index === 0,
-            }),
-          );
-          await this.productImageRepository.save(imageEntities);
+        if (images !== undefined) {
+          await manager.delete(ProductImage, { productId: id });
+          if (images && images.length > 0) {
+            const imageEntities = images.map((img, index) =>
+              manager.create(ProductImage, {
+                productId: id,
+                url: img.url,
+                alt: img.alt ?? null,
+                sortOrder: img.sortOrder ?? index,
+                isThumbnail: img.isThumbnail ?? index === 0,
+              }),
+            );
+            await manager.save(ProductImage, imageEntities);
+          }
         }
-      }
 
-      if (detailImages !== undefined) {
-        await this.productDetailImageRepository.delete({ productId: id });
-        if (detailImages && detailImages.length > 0) {
-          const detailEntities = detailImages.map((img, index) =>
-            this.productDetailImageRepository.create({
-              productId: id,
-              url: img.url,
-              alt: img.alt ?? null,
-              sortOrder: img.sortOrder ?? index,
-              isActive: true,
-            }),
-          );
-          await this.productDetailImageRepository.save(detailEntities);
+        if (detailImages !== undefined) {
+          await manager.delete(ProductDetailImage, { productId: id });
+          if (detailImages && detailImages.length > 0) {
+            const detailEntities = detailImages.map((img, index) =>
+              manager.create(ProductDetailImage, {
+                productId: id,
+                url: img.url,
+                alt: img.alt ?? null,
+                sortOrder: img.sortOrder ?? index,
+                isActive: true,
+              }),
+            );
+            await manager.save(ProductDetailImage, detailEntities);
+          }
         }
-      }
+
+        return updatedProduct;
+      });
 
       await Promise.all([
         this.cacheService.del(`products:detail:${id}`),


### PR DESCRIPTION
## 변경 사항

상품 생성/수정 시 이미지 저장이 실패할 경우 상품 데이터가 불완전한 상태로 남는 문제를 트랜잭션으로 해결합니다.

### 핵심 변경

- `ProductsService.create()`: `dataSource.transaction()`으로 감싸 상품 저장 + 이미지 저장 + 상세 이미지 저장을 atomic하게 처리
- `ProductsService.update()`: 동일하게 트랜잭션 적용 — 기존 이미지 삭제 후 새 이미지 저장까지 원자적으로 처리
- 이미지 orphan 방지: 이미지 저장 실패 시 트랜잭션 전체 rollback

### 테스트

- 이미지 저장 실패 시 상품도 롤백됨 (mock reject으로 검증)
- 기존 테스트 17개 전부 통과

Closes #485