### PR TITLE
feat: #528 배포 파이프라인 필수 env 검증

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,25 @@ jobs:
           chmod 600 .env keys/jwt-private.pem keys/jwt-public.pem
 
           # ------------------------------------------------------------------
+          # 2-1. 필수 env 키 존재 여부 사전 검증
+          #      .env.example 의 # REQUIRED 태그가 붙은 키를 파싱하여 확인.
+          #      누락 시 배포를 즉시 중단 — PM2 크래시 루프 방지.
+          # ------------------------------------------------------------------
+          REQUIRED_KEYS=$(grep -E '#[[:space:]]*REQUIRED' .env.example | grep -oE '^[A-Z_]+' || true)
+          MISSING_KEYS=""
+          for key in $REQUIRED_KEYS; do
+            if ! grep -qE "^${key}=.+" .env; then
+              MISSING_KEYS="${MISSING_KEYS} ${key}"
+            fi
+          done
+          if [ -n "$MISSING_KEYS" ]; then
+            echo "ERROR: backend/.env 에 다음 필수 키가 없거나 비어 있습니다:${MISSING_KEYS}" >&2
+            echo "       remote-env-sync.sh push 로 EC2 .env 를 업데이트한 후 재배포하세요." >&2
+            exit 1
+          fi
+          echo "필수 env 키 검증 통과"
+
+          # ------------------------------------------------------------------
           # 3. 의존성 설치 및 빌드
           # ------------------------------------------------------------------
           npm ci

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
-NODE_ENV=development
+NODE_ENV=development  # REQUIRED
 PORT=3000
 
 # For production: use AWS Secrets Manager (see infra/secrets/SECRETS_MANAGER_SETUP.md)
@@ -22,22 +22,25 @@ SSH_TUNNEL_REMOTE_PORT=3306
 SSH_KEY_PATH=~/.ssh/your-key.pem
 
 # 원격 DB 직접 접속 (터널 사용 시에는 LOCAL_DATABASE_URL 사용)
-# DATABASE_URL=mysql://user:password@<lightsail-private-ip>:3306/commerce
+# DATABASE_URL=mysql://user:password@<lightsail-private-ip>:3306/commerce  # REQUIRED
+DATABASE_URL=  # REQUIRED — 프로덕션 값은 .env.secrets에서 remote-env-sync.sh push로 주입
 
 # ─────────────────────────────────────────────
 # JWT (REQUIRED in production)
 # ─────────────────────────────────────────────
-JWT_SECRET=  # generate with: openssl rand -hex 32
-JWT_REFRESH_SECRET=  # must differ from JWT_SECRET
+JWT_SECRET=  # REQUIRED — generate with: openssl rand -hex 32
+JWT_REFRESH_SECRET=  # REQUIRED — must differ from JWT_SECRET
+JWT_PRIVATE_KEY_PATH=keys/jwt-private.pem  # REQUIRED
+JWT_PUBLIC_KEY_PATH=keys/jwt-public.pem    # REQUIRED
 JWT_EXPIRES_IN=1h
 JWT_REFRESH_EXPIRES_IN=7d
-FRONTEND_URL=http://localhost:5173
+FRONTEND_URL=http://localhost:5173  # REQUIRED
 
 # ─────────────────────────────────────────────
 # 캐시: 백엔드 프로세스 내 in-memory (CacheService).
 # Redis/ElastiCache 연결 불필요.
 # ─────────────────────────────────────────────
-PAYMENT_GATEWAY=mock  # Required in production. 'mock' is blocked in production. Options: mock, toss, stripe
+PAYMENT_GATEWAY=mock  # REQUIRED — 'mock' is blocked in production. Options: mock, toss, stripe
 TOSS_SECRET_KEY=   # Toss Payments secret key (for ko locale)
 TOSS_CLIENT_KEY=   # Toss Payments client key (for ko locale)
 STRIPE_SECRET_KEY=   # Stripe secret key (for global locale)
@@ -45,7 +48,7 @@ STRIPE_WEBHOOK_SECRET=   # Stripe webhook signing secret
 # ─────────────────────────────────────────────
 # AWS S3 + CloudFront CDN
 # ─────────────────────────────────────────────
-STORAGE_PROVIDER=local  # s3 or local
+STORAGE_PROVIDER=local  # REQUIRED — s3 or local
 AWS_REGION=ap-northeast-2
 AWS_S3_BUCKET=okhwadang-assets
 AWS_CLOUDFRONT_DOMAIN=dt24i8idwxww1.cloudfront.net
@@ -63,8 +66,8 @@ GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
 
 # ─────────────────────────────────────────────
 # Notification / Email
-# 'mock' is blocked in production. Options: mock, resend, ses
+# REQUIRED — 'mock' is blocked in production. Options: mock, resend, ses
 # ─────────────────────────────────────────────
-NOTIFICATION_PROVIDER=mock
-RESEND_API_KEY=
+NOTIFICATION_PROVIDER=mock  # REQUIRED
+RESEND_API_KEY=  # REQUIRED (when NOTIFICATION_PROVIDER=resend)
 EMAIL_FROM=no-reply@okhwadang.com

--- a/backend/src/config/__tests__/env-validator.spec.ts
+++ b/backend/src/config/__tests__/env-validator.spec.ts
@@ -1,0 +1,113 @@
+import { validateEnv, assertEnv, REQUIRED_PROD_ENV_KEYS } from '../env-validator';
+
+const makeFullEnv = (): NodeJS.ProcessEnv => ({
+  NODE_ENV: 'production',
+  DATABASE_URL: 'mysql://user:pass@host:3306/db',
+  JWT_SECRET: 'secret',
+  JWT_REFRESH_SECRET: 'refresh-secret',
+  JWT_PRIVATE_KEY_PATH: '/app/keys/jwt-private.pem',
+  JWT_PUBLIC_KEY_PATH: '/app/keys/jwt-public.pem',
+  FRONTEND_URL: 'https://ockhwadang.com',
+  NOTIFICATION_PROVIDER: 'resend',
+  RESEND_API_KEY: 're_abc123',
+  PAYMENT_GATEWAY: 'toss',
+  STORAGE_PROVIDER: 's3',
+});
+
+describe('validateEnv', () => {
+  it('프로덕션이 아니면 항상 빈 배열 반환', () => {
+    expect(validateEnv({ NODE_ENV: 'development' })).toEqual([]);
+    expect(validateEnv({ NODE_ENV: 'test' })).toEqual([]);
+    expect(validateEnv({})).toEqual([]);
+  });
+
+  it('필수 키가 모두 있으면 빈 배열 반환', () => {
+    expect(validateEnv(makeFullEnv())).toEqual([]);
+  });
+
+  it('누락된 키가 있으면 해당 키 에러 반환', () => {
+    const env = makeFullEnv();
+    delete env.NOTIFICATION_PROVIDER;
+    delete env.RESEND_API_KEY;
+
+    const errors = validateEnv(env);
+    expect(errors).toHaveLength(2);
+    expect(errors.map((e) => e.key)).toContain('NOTIFICATION_PROVIDER');
+    expect(errors.map((e) => e.key)).toContain('RESEND_API_KEY');
+  });
+
+  it('값이 빈 문자열이면 에러 반환', () => {
+    const env = makeFullEnv();
+    env.RESEND_API_KEY = '';
+    env.JWT_SECRET = '   ';
+
+    const errors = validateEnv(env);
+    const errorKeys = errors.map((e) => e.key);
+    expect(errorKeys).toContain('RESEND_API_KEY');
+    expect(errorKeys).toContain('JWT_SECRET');
+  });
+
+  it('REQUIRED_PROD_ENV_KEYS에 있는 모든 키를 검증', () => {
+    const env: NodeJS.ProcessEnv = { NODE_ENV: 'production' };
+    const errors = validateEnv(env);
+    // NODE_ENV는 있으므로 나머지 키들이 모두 에러로 나와야 함
+    const missing = REQUIRED_PROD_ENV_KEYS.filter((k) => k !== 'NODE_ENV');
+    const errorKeys = errors.map((e) => e.key);
+    for (const key of missing) {
+      expect(errorKeys).toContain(key);
+    }
+  });
+});
+
+describe('assertEnv', () => {
+  let exitSpy: jest.SpyInstance;
+  let stderrSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((_code?: number | string | null) => {
+        throw new Error(`process.exit(${_code})`);
+      });
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('프로덕션이 아니면 exit 호출 안 함', () => {
+    expect(() => assertEnv({ NODE_ENV: 'development' })).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('모든 키가 있으면 exit 호출 안 함', () => {
+    expect(() => assertEnv(makeFullEnv())).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('누락 키가 있으면 exit(1) 호출', () => {
+    const env = makeFullEnv();
+    delete env.RESEND_API_KEY;
+
+    expect(() => assertEnv(env)).toThrow('process.exit(1)');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('에러 메시지에 누락 키 이름이 포함됨', () => {
+    const env = makeFullEnv();
+    delete env.RESEND_API_KEY;
+    delete env.NOTIFICATION_PROVIDER;
+
+    try {
+      assertEnv(env);
+    } catch {
+      // process.exit mock
+    }
+
+    const allOutput = stderrSpy.mock.calls.flat().join('\n');
+    expect(allOutput).toContain('RESEND_API_KEY');
+    expect(allOutput).toContain('NOTIFICATION_PROVIDER');
+  });
+});

--- a/backend/src/config/env-validator.ts
+++ b/backend/src/config/env-validator.ts
@@ -1,0 +1,83 @@
+/**
+ * 프로덕션 환경에서 NestJS bootstrap 전 필수 env 키 검증.
+ *
+ * backend/.env.example에 # REQUIRED 주석이 붙은 키 목록과 동기화할 것.
+ * 누락 시 명확한 에러 메시지 출력 후 프로세스 종료.
+ */
+
+export const REQUIRED_PROD_ENV_KEYS = [
+  'NODE_ENV',
+  'DATABASE_URL',
+  'JWT_SECRET',
+  'JWT_REFRESH_SECRET',
+  'JWT_PRIVATE_KEY_PATH',
+  'JWT_PUBLIC_KEY_PATH',
+  'FRONTEND_URL',
+  'NOTIFICATION_PROVIDER',
+  'RESEND_API_KEY',
+  'PAYMENT_GATEWAY',
+  'STORAGE_PROVIDER',
+] as const;
+
+export type RequiredEnvKey = (typeof REQUIRED_PROD_ENV_KEYS)[number];
+
+export interface EnvValidationError {
+  key: string;
+  reason: string;
+}
+
+/**
+ * 주어진 env 객체(기본값: process.env)에서 필수 키를 검증한다.
+ * 프로덕션 환경(NODE_ENV=production)에서만 실행.
+ *
+ * @returns 누락/빈 키 목록 (빈 배열이면 정상)
+ */
+export function validateEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): EnvValidationError[] {
+  if (env.NODE_ENV !== 'production') {
+    return [];
+  }
+
+  const errors: EnvValidationError[] = [];
+
+  for (const key of REQUIRED_PROD_ENV_KEYS) {
+    const value = env[key];
+    if (value === undefined || value === null || value.trim() === '') {
+      errors.push({ key, reason: '값이 없거나 비어 있습니다' });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * 검증 실패 시 에러 로그를 출력하고 프로세스를 종료한다.
+ * main.ts에서 NestFactory.create() 전에 호출한다.
+ */
+export function assertEnv(env: NodeJS.ProcessEnv = process.env): void {
+  const errors = validateEnv(env);
+  if (errors.length === 0) {
+    return;
+  }
+
+  const line = '════════════════════════════════════════════════════════════════\n';
+  const write = (msg: string) => process.stderr.write(msg + '\n');
+
+  write('');
+  write(line.trimEnd());
+  write('  [ENV 검증 실패] 프로덕션 필수 환경변수가 누락되었습니다.');
+  write(line.trimEnd());
+  for (const { key, reason } of errors) {
+    write(`  ✗ ${key}: ${reason}`);
+  }
+  write('');
+  write('  해결 방법:');
+  write('    1. EC2에서 backend/.env 확인: cat /app/shop-okhwadang/shop-okhwadang/backend/.env');
+  write('    2. 로컬에서 원격 동기화: bash scripts/remote-env-sync.sh push');
+  write('    3. 키 목록 검증: bash scripts/remote-env-sync.sh verify');
+  write(line.trimEnd());
+  write('');
+
+  process.exit(1);
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,6 +6,10 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
+import { assertEnv } from './config/env-validator';
+
+// 프로덕션 환경에서 필수 env 키 사전 검증 — 누락 시 명확한 에러 메시지와 함께 종료
+assertEnv();
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/docs/infrastructure/DEPLOYMENT.md
+++ b/docs/infrastructure/DEPLOYMENT.md
@@ -153,6 +153,24 @@ sudo systemctl enable --now nginx
 
 ---
 
+## 환경변수 추가 시 작업 순서
+
+> 2026-04-18 장애 재발 방지용. 새 env 키를 추가할 때 반드시 이 순서를 따를 것.
+
+1. **`backend/.env.example` 수정** — 새 키 추가, 프로덕션 필수 키면 끝에 `# REQUIRED` 주석 추가
+2. **로컬 `backend/.env` 업데이트** — 개발 값 설정
+3. **`backend/.env.production` 업데이트** — 운영 값 설정 (민감값은 `.env.secrets` 오버라이드 활용)
+4. **원격 동기화**: `bash scripts/remote-env-sync.sh push`
+5. **검증**: `bash scripts/remote-env-sync.sh verify` — 원격 `.env`에 REQUIRED 키가 모두 있는지 확인
+6. **배포** — deploy.yml이 Step 2-1에서 REQUIRED 키를 재검증. 누락 시 배포 중단.
+
+> **`# REQUIRED` 규칙**: `.env.example` 의 키 라인 끝에 `# REQUIRED` 주석을 붙이면
+> `deploy.yml`(Step 2-1)과 `remote-env-sync.sh verify`가 자동으로 해당 키를 필수 항목으로 인식한다.
+> NestJS bootstrap 전 `src/config/env-validator.ts`도 동일 목록을 검증하므로,
+> 새 필수 키 추가 시 `REQUIRED_PROD_ENV_KEYS` 배열도 함께 업데이트한다.
+
+---
+
 ## 트러블슈팅
 
 ### EC2 — PM2 프로세스 비정상 종료

--- a/scripts/remote-env-sync.sh
+++ b/scripts/remote-env-sync.sh
@@ -7,13 +7,15 @@
 # .env.secrets의 DATABASE_URL을 덮어쓰기 옵션으로 적용.
 #
 # 사용법:
-#   bash scripts/remote-env-sync.sh [push|diff|pull|rollback|set-secret] [--verbose]
+#   bash scripts/remote-env-sync.sh [push|diff|pull|rollback|set-secret|verify] [--verbose]
 #     push          (기본) 로컬 → 원격 업로드 + pm2 restart
 #     diff                  로컬 vs 원격 차이 (기본은 키 이름만, --verbose 시 값 노출)
 #     pull                  원격 → /tmp/remote.env 로 백업 (mode 600)
 #     rollback              원격의 .env.prev 를 .env 로 되돌리고 pm2 restart
 #     set-secret            GitHub Secret BACKEND_ENV_PRODUCTION 도 같이 업데이트
 #                           (deploy.yml 이 매 배포마다 Secret → .env 로 복원하므로 필수)
+#     verify                로컬 .env.example 의 # REQUIRED 키가 원격 .env 에 모두 있는지 확인
+#                           누락 키 발견 시 목록 출력 후 exit 1
 #
 # 보호 장치:
 #   - 업로드 전 값에 localhost/127.0.0.1 포함 시 경고 후 중단
@@ -159,8 +161,38 @@ case "$SUBCMD" in
     chmod 600 "$OUT"
     echo "✓ 백업: $OUT (mode 600)"
     ;;
+  verify)
+    # .env.example 의 # REQUIRED 태그 키를 파싱하여 원격 .env 에 존재하는지 확인
+    REQUIRED_KEYS=$(grep -E '#[[:space:]]*REQUIRED' backend/.env.example | grep -oE '^[A-Z_]+' || true)
+    if [ -z "$REQUIRED_KEYS" ]; then
+      echo "WARNING: backend/.env.example 에서 # REQUIRED 태그를 찾지 못했습니다." >&2
+      exit 0
+    fi
+
+    REMOTE_ENV_CONTENT=$(ssh -i "$BASTION_KEY_EXPANDED" $SSH_OPTS \
+        "$BASTION_USER@$BASTION_HOST" "cat $REMOTE_PATH")
+
+    MISSING_KEYS=""
+    for key in $REQUIRED_KEYS; do
+      if ! echo "$REMOTE_ENV_CONTENT" | grep -qE "^${key}=.+"; then
+        MISSING_KEYS="${MISSING_KEYS} ${key}"
+      fi
+    done
+
+    if [ -n "$MISSING_KEYS" ]; then
+      echo "ERROR: 원격 .env 에 다음 필수 키가 없거나 비어 있습니다:" >&2
+      for key in $MISSING_KEYS; do
+        echo "  ✗ ${key}" >&2
+      done
+      echo "" >&2
+      echo "  해결: bash scripts/remote-env-sync.sh push" >&2
+      exit 1
+    fi
+
+    echo "✓ 원격 .env 필수 키 검증 통과 ($(echo "$REQUIRED_KEYS" | wc -w | tr -d ' ')개 확인)"
+    ;;
   *)
-    echo "Usage: $0 [push|diff|pull|rollback|set-secret] [--verbose]" >&2
+    echo "Usage: $0 [push|diff|pull|rollback|set-secret|verify] [--verbose]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## 개요

2026-04-18 운영 장애(NOTIFICATION_PROVIDER, RESEND_API_KEY 누락 → PM2 크래시 루프) 재발 방지.

## 변경 사항

### 1. NestJS bootstrap 전 env 사전 검증 `backend/src/config/env-validator.ts`
- 프로덕션 환경에서 필수 키(DATABASE_URL, JWT_SECRET, NOTIFICATION_PROVIDER, RESEND_API_KEY 등 11개) 누락 시 명확한 에러 메시지 출력 후 `process.exit(1)`
- `main.ts`에서 `NestFactory.create()` 전에 `assertEnv()` 호출

### 2. 단위 테스트 `backend/src/config/__tests__/env-validator.spec.ts`
- 9개 테스트: 비프로덕션 패스스루, 전체 키 통과, 누락/빈값 감지, exit(1) 호출, 에러 메시지 검증

### 3. `.github/workflows/deploy.yml` — Step 2-1 추가
- 배포 전 EC2 `.env`에서 `.env.example`의 `# REQUIRED` 태그 키 파싱 → 존재 여부 검증
- 누락 시 배포 즉시 중단 (PM2 크래시 루프 진입 전 차단)

### 4. `scripts/remote-env-sync.sh` — `verify` 서브커맨드 추가
- `bash scripts/remote-env-sync.sh verify`: 로컬 `.env.example`의 REQUIRED 키가 원격 `.env`에 모두 존재하는지 확인

### 5. `backend/.env.example` — `# REQUIRED` 태그 표기
- 프로덕션 필수 키 11개에 `# REQUIRED` 주석 추가 (deploy.yml과 remote-env-sync.sh가 파싱)

### 6. `docs/infrastructure/DEPLOYMENT.md` — env 추가 시 작업 순서 문서화
- .env.example 수정 → 로컬 .env 업데이트 → remote-env-sync.sh push → verify → 배포 순서 명시

## 검증

- lint: 통과
- build: 통과
- test: 521/521 통과

Closes #528