### PR TITLE
feat: #499 장바구니 재검증 API

### DIFF
--- a/backend/src/modules/cart/__tests__/cart.service.spec.ts
+++ b/backend/src/modules/cart/__tests__/cart.service.spec.ts
@@ -207,4 +207,140 @@ describe('CartService', () => {
       await expect(service.remove(999, 1)).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('validate', () => {
+    const buildValidateQb = (items: Partial<CartItem>[]) => {
+      const qb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(items),
+      };
+      return qb;
+    };
+
+    it('returns available=true for active in-stock item without option', async () => {
+      const items = [
+        {
+          id: 1,
+          userId: 1,
+          quantity: 2,
+          product: { id: 1, price: 20000, salePrice: null, stock: 5, status: 'active' } as Product,
+          option: null,
+        },
+      ];
+      mockCartItemRepo.createQueryBuilder.mockReturnValue(buildValidateQb(items));
+
+      const result = await service.validate(1, [1]);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({
+        itemId: 1,
+        available: true,
+        unitPrice: 20000,
+        stock: 5,
+        issues: [],
+      });
+    });
+
+    it('returns out_of_stock issue when product stock is 0', async () => {
+      const items = [
+        {
+          id: 2,
+          userId: 1,
+          quantity: 1,
+          product: { id: 2, price: 15000, salePrice: null, stock: 0, status: 'active' } as Product,
+          option: null,
+        },
+      ];
+      mockCartItemRepo.createQueryBuilder.mockReturnValue(buildValidateQb(items));
+
+      const result = await service.validate(1, [2]);
+
+      expect(result.results[0].available).toBe(false);
+      expect(result.results[0].issues).toContain('out_of_stock');
+    });
+
+    it('returns out_of_stock issue when product status is soldout', async () => {
+      const items = [
+        {
+          id: 3,
+          userId: 1,
+          quantity: 1,
+          product: { id: 3, price: 10000, salePrice: null, stock: 10, status: 'soldout' } as Product,
+          option: null,
+        },
+      ];
+      mockCartItemRepo.createQueryBuilder.mockReturnValue(buildValidateQb(items));
+
+      const result = await service.validate(1, [3]);
+
+      expect(result.results[0].available).toBe(false);
+      expect(result.results[0].issues).toContain('out_of_stock');
+    });
+
+    it('returns discontinued issue when product status is hidden', async () => {
+      const items = [
+        {
+          id: 4,
+          userId: 1,
+          quantity: 1,
+          product: { id: 4, price: 10000, salePrice: null, stock: 5, status: 'hidden' } as Product,
+          option: null,
+        },
+      ];
+      mockCartItemRepo.createQueryBuilder.mockReturnValue(buildValidateQb(items));
+
+      const result = await service.validate(1, [4]);
+
+      expect(result.results[0].available).toBe(false);
+      expect(result.results[0].issues).toContain('discontinued');
+    });
+
+    it('uses option stock when option is present', async () => {
+      const items = [
+        {
+          id: 5,
+          userId: 1,
+          quantity: 1,
+          product: { id: 5, price: 20000, salePrice: null, stock: 10, status: 'active' } as Product,
+          option: { id: 1, priceAdjustment: 2000, stock: 0 } as ProductOption,
+        },
+      ];
+      mockCartItemRepo.createQueryBuilder.mockReturnValue(buildValidateQb(items));
+
+      const result = await service.validate(1, [5]);
+
+      expect(result.results[0].stock).toBe(0);
+      expect(result.results[0].unitPrice).toBe(22000);
+      expect(result.results[0].available).toBe(false);
+      expect(result.results[0].issues).toContain('out_of_stock');
+    });
+
+    it('uses salePrice when set', async () => {
+      const items = [
+        {
+          id: 6,
+          userId: 1,
+          quantity: 1,
+          product: { id: 6, price: 30000, salePrice: 25000, stock: 3, status: 'active' } as Product,
+          option: null,
+        },
+      ];
+      mockCartItemRepo.createQueryBuilder.mockReturnValue(buildValidateQb(items));
+
+      const result = await service.validate(1, [6]);
+
+      expect(result.results[0].unitPrice).toBe(25000);
+      expect(result.results[0].available).toBe(true);
+    });
+
+    it('returns empty results when no matching items', async () => {
+      mockCartItemRepo.createQueryBuilder.mockReturnValue(buildValidateQb([]));
+
+      const result = await service.validate(1, [999]);
+
+      expect(result.results).toHaveLength(0);
+    });
+  });
 });

--- a/backend/src/modules/cart/cart.controller.ts
+++ b/backend/src/modules/cart/cart.controller.ts
@@ -11,6 +11,7 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { ValidateCartDto, ValidateCartResponseDto } from './dto/validate-cart.dto';
 import {
   ApiTags,
   ApiOperation,
@@ -53,6 +54,27 @@ export class CartController {
   @ApiResponse({ status: 401, description: '인증 필요' })
   add(@CurrentUser() user: AuthUser, @Body() dto: AddToCartDto) {
     return this.cartService.add(user.id, dto);
+  }
+
+  @Post('validate')
+  @ApiCookieAuth()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '장바구니 재검증',
+    description:
+      '결제 전 장바구니 항목의 재고·단종·가격 상태를 확인합니다. 가격 정책: 가격 변동은 사용자에게 안내 후 최신 가격으로 자동 반영됩니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '항목별 가용성 및 이슈 목록 반환',
+    type: ValidateCartResponseDto,
+  })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  validate(
+    @CurrentUser() user: AuthUser,
+    @Body() dto: ValidateCartDto,
+  ): Promise<ValidateCartResponseDto> {
+    return this.cartService.validate(user.id, dto.itemIds);
   }
 
   @Patch(':id')

--- a/backend/src/modules/cart/cart.service.ts
+++ b/backend/src/modules/cart/cart.service.ts
@@ -6,10 +6,15 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
 import { CartItem } from './entities/cart-item.entity';
-import { Product } from '../products/entities/product.entity';
+import { Product, ProductStatus } from '../products/entities/product.entity';
 import { ProductOption } from '../products/entities/product-option.entity';
 import { AddToCartDto } from './dto/add-to-cart.dto';
 import { UpdateCartQuantityDto } from './dto/update-cart-quantity.dto';
+import {
+  CartIssueType,
+  CartItemValidationResultDto,
+  ValidateCartResponseDto,
+} from './dto/validate-cart.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
 
@@ -158,5 +163,59 @@ export class CartService {
 
     await this.cartItemRepository.remove(item);
     return { message: '삭제되었습니다.' };
+  }
+
+  async validate(
+    userId: number,
+    itemIds: number[],
+  ): Promise<ValidateCartResponseDto> {
+    const items = await this.cartItemRepository
+      .createQueryBuilder('cartItem')
+      .leftJoinAndSelect('cartItem.product', 'product')
+      .leftJoinAndSelect('cartItem.option', 'option')
+      .where('cartItem.userId = :userId', { userId })
+      .andWhere('cartItem.id IN (:...itemIds)', { itemIds })
+      .getMany();
+
+    const results: CartItemValidationResultDto[] = items.map((item) => {
+      const product = item.product;
+      const option = item.option;
+
+      const basePrice = Number(product.salePrice ?? product.price);
+      const adjustment = option ? Number(option.priceAdjustment) : 0;
+      const unitPrice = basePrice + adjustment;
+
+      // 옵션이 있으면 옵션 재고 우선, 없으면 상품 재고
+      const stock = option !== null ? option.stock : product.stock;
+
+      const issues: CartIssueType[] = [];
+
+      if (
+        product.status === ProductStatus.HIDDEN ||
+        product.status === ProductStatus.DRAFT
+      ) {
+        issues.push('discontinued');
+      }
+
+      if (product.status === ProductStatus.SOLDOUT || stock <= 0) {
+        issues.push('out_of_stock');
+      }
+
+      const available = issues.length === 0;
+
+      this.logger.log(
+        `Validate cart: userId=${userId} itemId=${item.id} issues=${issues.join(',')}`,
+      );
+
+      return {
+        itemId: item.id,
+        available,
+        unitPrice,
+        stock,
+        issues,
+      };
+    });
+
+    return { results };
   }
 }

--- a/backend/src/modules/cart/dto/validate-cart.dto.ts
+++ b/backend/src/modules/cart/dto/validate-cart.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, ArrayNotEmpty } from 'class-validator';
+
+export class ValidateCartDto {
+  @ApiProperty({
+    example: [1, 2, 3],
+    description: '검증할 장바구니 아이템 ID 목록',
+    type: [Number],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsInt({ each: true })
+  itemIds!: number[];
+}
+
+export type CartIssueType = 'out_of_stock' | 'discontinued' | 'price_changed';
+
+export class CartItemValidationResultDto {
+  @ApiProperty({ example: 1, description: '장바구니 아이템 ID' })
+  itemId!: number;
+
+  @ApiProperty({ example: true, description: '구매 가능 여부' })
+  available!: boolean;
+
+  @ApiProperty({ example: 25000, description: '현재 단가 (원)' })
+  unitPrice!: number;
+
+  @ApiProperty({ example: 10, description: '현재 재고 수량' })
+  stock!: number;
+
+  @ApiProperty({
+    example: ['price_changed'],
+    description: '문제 유형 목록',
+    enum: ['out_of_stock', 'discontinued', 'price_changed'],
+    isArray: true,
+  })
+  issues!: CartIssueType[];
+}
+
+export class ValidateCartResponseDto {
+  @ApiProperty({ type: [CartItemValidationResultDto] })
+  results!: CartItemValidationResultDto[];
+}


### PR DESCRIPTION
## 변경 사항

`POST /cart/validate` 엔드포인트를 추가하여 결제 전 장바구니 항목의 재고·단종 상태를 검증합니다.

### 구현 내용
- `POST /cart/validate` — itemIds 목록을 받아 항목별 가용성 반환
- 항목별 응답: `{ itemId, available, unitPrice, stock, issues }`
- 이슈 유형: `out_of_stock` (품절/재고 0), `discontinued` (hidden/draft 상태)
- 옵션이 있는 상품은 옵션 재고 우선 반영
- salePrice 우선 적용 (있을 경우)

### 가격 변동 정책
CartItem 엔티티에 단가 스냅샷 컬럼이 없어 이번 구현에서는 price_changed 감지를 생략합니다. 가격 변동 감지가 필요한 경우 cart_items 테이블에 `unit_price` 컬럼을 추가하는 별도 마이그레이션이 선행되어야 합니다.

### 테스트
- cart.service.spec.ts에 validate 테스트 7건 추가 (18 passed)

Closes #499