### PR TITLE
fix: #487 Product findBulk이 caller의 ids 배열을 수정하지 않도록 복사본 정렬

### DIFF
--- a/backend/src/modules/products/__tests__/products.service.spec.ts
+++ b/backend/src/modules/products/__tests__/products.service.spec.ts
@@ -22,6 +22,8 @@ const mockGetManyAndCount = jest.fn();
 const mockGetOne = jest.fn();
 const mockWhere = jest.fn().mockReturnThis();
 
+const mockGetMany = jest.fn();
+
 const mockQueryBuilder = {
   leftJoinAndSelect: mockLeftJoinAndSelect,
   andWhere: mockAndWhere,
@@ -31,6 +33,7 @@ const mockQueryBuilder = {
   take: mockTake,
   getManyAndCount: mockGetManyAndCount,
   getOne: mockGetOne,
+  getMany: mockGetMany,
 } as unknown as SelectQueryBuilder<Product>;
 
 const mockRepository = {
@@ -341,6 +344,19 @@ describe('ProductsService', () => {
       const result = await service.update(1, { nameEn: 'Updated English Name' });
 
       expect(result).toMatchObject({ nameEn: 'Updated English Name' });
+    });
+  });
+
+  describe('findBulk', () => {
+    it('원본 ids 배열을 변경하지 않는다', async () => {
+      mockGetMany.mockResolvedValue([]);
+
+      const ids = [3, 1, 2];
+      const originalOrder = [...ids];
+
+      await service.findBulk(ids);
+
+      expect(ids).toEqual(originalOrder);
     });
   });
 });

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -496,7 +496,7 @@ export class ProductsService {
   ): Promise<(Product & { rating: number; reviewCount: number })[]> {
     if (!ids || ids.length === 0) return [];
 
-    const cacheKey = `products:bulk:${ids.sort().join(',')}`;
+    const cacheKey = `products:bulk:${[...ids].sort().join(',')}`;
     const cached = await this.cacheService.get<
       (Product & { rating: number; reviewCount: number })[]
     >(cacheKey);


### PR DESCRIPTION
## Summary
- Closes #487
- `findBulk(ids)` 메서드에서 `ids.sort()` 직접 호출로 인해 caller의 배열이 의도치 않게 변경되는 이슈 수정
- `[...ids].sort()`로 복사본 정렬하도록 변경

## Test plan
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test
- [x] Unit test: `findBulk([3, 1, 2])` 후 원본 배열 불변 검증