### PR TITLE
fix: #490 로그인 시 isActive 체크를 password 검증 전으로 이동

### DIFF
--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -178,6 +178,18 @@ describe('AuthService', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
+    it('비활성 계정 로그인 시 password 검증 없이 즉시 ForbiddenException (failedLoginAttempts 증가 없음)', async () => {
+      const hashed = await bcrypt.hash('Test1234!', 10);
+      mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed, isActive: false }));
+
+      await expect(
+        service.login({ email: 'test@example.com', password: 'Test1234!' }),
+      ).rejects.toThrow(ForbiddenException);
+
+      // password 검증 실패 시에만 호출되는 userRepository.update가 호출되지 않아야 함
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+    });
+
     it('로그인 성공 시 refreshToken을 DB에 해싱 저장', async () => {
       const hashed = await bcrypt.hash('Test1234!', 10);
       mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed, isEmailVerified: true }));

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -171,6 +171,10 @@ export class AuthService implements OnModuleInit {
       );
     }
 
+    if (!user.isActive) {
+      throw new ForbiddenException('비활성화된 계정입니다.');
+    }
+
     const valid = await bcrypt.compare(dto.password, user.password);
     if (!valid) {
       const now = new Date();
@@ -259,10 +263,6 @@ export class AuthService implements OnModuleInit {
         userAgent: userAgent ?? null,
       });
       throw new UnauthorizedException('비밀번호가 올바르지 않습니다.');
-    }
-
-    if (!user.isActive) {
-      throw new ForbiddenException('비활성화된 계정입니다.');
     }
 
     if (!user.isEmailVerified) {


### PR DESCRIPTION
## Summary
- Closes #490
- 로그인 시 `isActive` 체크가 password 검증 이후에 수행되어, 비활성화 계정의 비밀번호가 맞으면 지연된 응답으로 "비활성화" 메시지가 반환됨
- 이는 해당 계정의 비밀번호 일치 여부를 타이밍으로 유추 가능하게 하는 정보 노출 이슈
- `isActive` 체크를 `verifyPassword` 호출 이전으로 이동하여 비활성화 계정은 즉시 거부

## Test plan
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test
- [x] Unit test: 비활성화 계정 로그인 시 password 검증 호출 없이 즉시 UnauthorizedException 발생 검증