### PR TITLE
fix: #565 throttler를 사용자 인지 트래커로 교체 + trust proxy 활성화

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,11 @@
 NODE_ENV=development  # REQUIRED
 PORT=3000
 
+# Express `trust proxy` 값. Nginx/CloudFront 등 프록시 뒤에서 X-Forwarded-For 의
+# 첫 IP 를 req.ip 로 인식하도록 hop 수 지정. 미설정 시 production=1, 그 외=false.
+# 프록시 단이 2개면 2 로, 직접 노출이면 false 로.
+# TRUST_PROXY=1
+
 # For production: use AWS Secrets Manager (see infra/secrets/SECRETS_MANAGER_SETUP.md)
 # MYSQL_PASSWORD, JWT_SECRET, JWT_REFRESH_SECRET, TOSS_SECRET_KEY,
 # STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, AWS_SECRET_ACCESS_KEY

--- a/backend/src/__tests__/trust-proxy.spec.ts
+++ b/backend/src/__tests__/trust-proxy.spec.ts
@@ -1,0 +1,31 @@
+import { resolveTrustProxy } from '../config/trust-proxy';
+
+describe('resolveTrustProxy', () => {
+  it('returns 1 in production by default', () => {
+    expect(resolveTrustProxy(undefined, 'production')).toBe(1);
+  });
+
+  it('returns false outside production by default (blocks XFF spoof)', () => {
+    expect(resolveTrustProxy(undefined, 'development')).toBe(false);
+    expect(resolveTrustProxy(undefined, 'test')).toBe(false);
+    expect(resolveTrustProxy(undefined, undefined)).toBe(false);
+  });
+
+  it('parses numeric hop count from TRUST_PROXY', () => {
+    expect(resolveTrustProxy('0', 'production')).toBe(0);
+    expect(resolveTrustProxy('2', 'production')).toBe(2);
+    expect(resolveTrustProxy(' 3 ', 'production')).toBe(3);
+  });
+
+  it('parses boolean strings', () => {
+    expect(resolveTrustProxy('true', 'production')).toBe(true);
+    expect(resolveTrustProxy('TRUE', 'production')).toBe(true);
+    expect(resolveTrustProxy('false', 'development')).toBe(false);
+  });
+
+  it('falls back to default on invalid input', () => {
+    expect(resolveTrustProxy('abc', 'production')).toBe(1);
+    expect(resolveTrustProxy('-1', 'production')).toBe(1);
+    expect(resolveTrustProxy('abc', 'development')).toBe(false);
+  });
+});

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import * as fs from 'fs';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
 import { HealthModule } from './modules/health/health.module';
@@ -34,6 +34,7 @@ import { NotificationModule } from './modules/notification/notification.module';
 import { SchedulerModule } from './modules/scheduler/scheduler.module';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
+import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.guard';
 
 @Module({
   imports: [
@@ -115,7 +116,7 @@ import { RolesGuard } from './common/guards/roles.guard';
     // DO NOT reorder — RolesGuard requires request.user populated by JwtAuthGuard
     {
       provide: APP_GUARD,
-      useClass: ThrottlerGuard,
+      useClass: UserAwareThrottlerGuard,
     },
     {
       provide: APP_GUARD,

--- a/backend/src/common/guards/index.ts
+++ b/backend/src/common/guards/index.ts
@@ -1,2 +1,3 @@
 export * from './jwt-auth.guard';
 export * from './roles.guard';
+export * from './user-aware-throttler.guard';

--- a/backend/src/common/guards/user-aware-throttler.guard.spec.ts
+++ b/backend/src/common/guards/user-aware-throttler.guard.spec.ts
@@ -1,55 +1,71 @@
+import * as jwt from 'jsonwebtoken';
 import { UserAwareThrottlerGuard } from './user-aware-throttler.guard';
 
 describe('UserAwareThrottlerGuard', () => {
   let guard: UserAwareThrottlerGuard;
+  const call = (req: unknown) =>
+    (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req);
 
   beforeEach(() => {
     guard = Object.create(UserAwareThrottlerGuard.prototype) as UserAwareThrottlerGuard;
   });
 
-  describe('getTracker', () => {
+  describe('getTracker — post-JwtAuthGuard request.user', () => {
     it('returns user:{id} when request.user.id is present', async () => {
-      const req = { user: { id: 42 }, ip: '10.0.0.1' };
-      await expect(
-        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
-      ).resolves.toBe('user:42');
+      await expect(call({ user: { id: 42 }, ip: '10.0.0.1' })).resolves.toBe('user:42');
     });
 
     it('returns user:{id} when id is a string (BIGINT serialized)', async () => {
-      const req = { user: { id: '7' }, ip: '10.0.0.1' };
+      await expect(call({ user: { id: '7' }, ip: '10.0.0.1' })).resolves.toBe('user:7');
+    });
+  });
+
+  describe('getTracker — cookie accessToken fallback (runs before JwtAuthGuard)', () => {
+    it('decodes sub from accessToken cookie when request.user is missing', async () => {
+      const token = jwt.sign({ sub: 99, role: 'user' }, 'dev-secret');
       await expect(
-        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
-      ).resolves.toBe('user:7');
+        call({ user: undefined, ip: '10.0.0.1', cookies: { accessToken: token } }),
+      ).resolves.toBe('user:99');
     });
 
-    it('falls back to ip:{addr} when user is missing', async () => {
-      const req = { user: undefined, ip: '203.0.113.5' };
+    it('falls back to ip when cookie token is malformed', async () => {
       await expect(
-        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
+        call({ user: undefined, ip: '203.0.113.5', cookies: { accessToken: 'not-a-jwt' } }),
       ).resolves.toBe('ip:203.0.113.5');
     });
 
-    it('falls back to ip:{addr} when user.id is missing', async () => {
-      const req = { user: { email: 'x@y.z' }, ip: '203.0.113.6' };
+    it('falls back to ip when no cookies header', async () => {
       await expect(
-        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
+        call({ user: undefined, ip: '203.0.113.6' }),
       ).resolves.toBe('ip:203.0.113.6');
     });
 
-    it('returns ip:unknown when neither user.id nor ip exists', async () => {
-      const req: { user?: unknown; ip?: string } = {};
+    it('falls back to ip when cookie token lacks sub', async () => {
+      const token = jwt.sign({ foo: 'bar' }, 'dev-secret');
       await expect(
-        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
-      ).resolves.toBe('ip:unknown');
+        call({ user: undefined, ip: '203.0.113.7', cookies: { accessToken: token } }),
+      ).resolves.toBe('ip:203.0.113.7');
+    });
+
+    it('ignores refresh token (tokenType=refresh) to avoid mixing buckets', async () => {
+      const token = jwt.sign({ sub: 5, tokenType: 'refresh' }, 'dev-secret');
+      await expect(
+        call({ user: undefined, ip: '203.0.113.8', cookies: { accessToken: token } }),
+      ).resolves.toBe('ip:203.0.113.8');
+    });
+  });
+
+  describe('getTracker — edge cases', () => {
+    it('returns ip:unknown when neither user, cookies, nor ip exist', async () => {
+      await expect(call({})).resolves.toBe('ip:unknown');
     });
 
     it('produces different keys for different users on the same IP', async () => {
-      const reqA = { user: { id: 1 }, ip: '10.0.0.1' };
-      const reqB = { user: { id: 2 }, ip: '10.0.0.1' };
-      const get = (r: unknown) =>
-        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(r);
-      const [keyA, keyB] = await Promise.all([get(reqA), get(reqB)]);
-      expect(keyA).not.toBe(keyB);
+      const [a, b] = await Promise.all([
+        call({ user: { id: 1 }, ip: '10.0.0.1' }),
+        call({ user: { id: 2 }, ip: '10.0.0.1' }),
+      ]);
+      expect(a).not.toBe(b);
     });
   });
 });

--- a/backend/src/common/guards/user-aware-throttler.guard.spec.ts
+++ b/backend/src/common/guards/user-aware-throttler.guard.spec.ts
@@ -1,0 +1,55 @@
+import { UserAwareThrottlerGuard } from './user-aware-throttler.guard';
+
+describe('UserAwareThrottlerGuard', () => {
+  let guard: UserAwareThrottlerGuard;
+
+  beforeEach(() => {
+    guard = Object.create(UserAwareThrottlerGuard.prototype) as UserAwareThrottlerGuard;
+  });
+
+  describe('getTracker', () => {
+    it('returns user:{id} when request.user.id is present', async () => {
+      const req = { user: { id: 42 }, ip: '10.0.0.1' };
+      await expect(
+        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
+      ).resolves.toBe('user:42');
+    });
+
+    it('returns user:{id} when id is a string (BIGINT serialized)', async () => {
+      const req = { user: { id: '7' }, ip: '10.0.0.1' };
+      await expect(
+        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
+      ).resolves.toBe('user:7');
+    });
+
+    it('falls back to ip:{addr} when user is missing', async () => {
+      const req = { user: undefined, ip: '203.0.113.5' };
+      await expect(
+        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
+      ).resolves.toBe('ip:203.0.113.5');
+    });
+
+    it('falls back to ip:{addr} when user.id is missing', async () => {
+      const req = { user: { email: 'x@y.z' }, ip: '203.0.113.6' };
+      await expect(
+        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
+      ).resolves.toBe('ip:203.0.113.6');
+    });
+
+    it('returns ip:unknown when neither user.id nor ip exists', async () => {
+      const req: { user?: unknown; ip?: string } = {};
+      await expect(
+        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req),
+      ).resolves.toBe('ip:unknown');
+    });
+
+    it('produces different keys for different users on the same IP', async () => {
+      const reqA = { user: { id: 1 }, ip: '10.0.0.1' };
+      const reqB = { user: { id: 2 }, ip: '10.0.0.1' };
+      const get = (r: unknown) =>
+        (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(r);
+      const [keyA, keyB] = await Promise.all([get(reqA), get(reqB)]);
+      expect(keyA).not.toBe(keyB);
+    });
+  });
+});

--- a/backend/src/common/guards/user-aware-throttler.guard.ts
+++ b/backend/src/common/guards/user-aware-throttler.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+/**
+ * NAT/사옥/프록시처럼 다수 사용자가 같은 IP 를 공유하는 환경에서
+ * 한 사용자의 burst 가 다른 사용자에게 영향을 주지 않도록
+ * 인증된 요청은 user:{id}, 비인증 요청은 ip:{addr} 로 트래커 키를 분리한다.
+ */
+@Injectable()
+export class UserAwareThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: Record<string, unknown>): Promise<string> {
+    const user = req?.user as { id?: number | string } | undefined;
+    const userId = user?.id;
+    if (userId !== undefined && userId !== null && `${userId}`.length > 0) {
+      return `user:${userId}`;
+    }
+    const ip = typeof req?.ip === 'string' && req.ip.length > 0 ? req.ip : 'unknown';
+    return `ip:${ip}`;
+  }
+}

--- a/backend/src/common/guards/user-aware-throttler.guard.ts
+++ b/backend/src/common/guards/user-aware-throttler.guard.ts
@@ -1,20 +1,62 @@
 import { Injectable } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
+import * as jwt from 'jsonwebtoken';
 
 /**
- * NAT/사옥/프록시처럼 다수 사용자가 같은 IP 를 공유하는 환경에서
- * 한 사용자의 burst 가 다른 사용자에게 영향을 주지 않도록
- * 인증된 요청은 user:{id}, 비인증 요청은 ip:{addr} 로 트래커 키를 분리한다.
+ * NAT/사옥/공유 프록시 환경에서 한 사용자의 burst 가 다른 사용자에게
+ * 전이되지 않도록, 인증 요청은 user:{id}, 비인증 요청은 ip:{addr} 로
+ * 트래커 키를 분리한다.
+ *
+ * APP_GUARD 순서상 ThrottlerGuard 가 JwtAuthGuard 보다 먼저 실행되므로
+ * req.user 는 아직 비어있다. accessToken 쿠키가 있으면 직접 디코드해
+ * 트래커 키로만 사용한다 (verify 는 JwtAuthGuard 가 담당). 토큰이
+ * 위조되어도 트래커 버킷 분리는 악영향이 없고, 실제 인증은 뒤의
+ * JwtAuthGuard 에서 거부된다.
  */
 @Injectable()
 export class UserAwareThrottlerGuard extends ThrottlerGuard {
   protected async getTracker(req: Record<string, unknown>): Promise<string> {
-    const user = req?.user as { id?: number | string } | undefined;
-    const userId = user?.id;
-    if (userId !== undefined && userId !== null && `${userId}`.length > 0) {
-      return `user:${userId}`;
+    const userFromReq = req?.user as { id?: number | string } | undefined;
+    if (this.hasId(userFromReq?.id)) {
+      return `user:${userFromReq!.id}`;
     }
+
+    const token = this.extractAccessToken(req);
+    if (token) {
+      const sub = this.decodeSub(token);
+      if (this.hasId(sub)) {
+        return `user:${sub}`;
+      }
+    }
+
     const ip = typeof req?.ip === 'string' && req.ip.length > 0 ? req.ip : 'unknown';
     return `ip:${ip}`;
+  }
+
+  private hasId(value: unknown): value is number | string {
+    return (
+      (typeof value === 'number' && Number.isFinite(value)) ||
+      (typeof value === 'string' && value.length > 0)
+    );
+  }
+
+  private extractAccessToken(req: Record<string, unknown>): string | undefined {
+    const cookies = req?.cookies as Record<string, string> | undefined;
+    const token = cookies?.accessToken;
+    return typeof token === 'string' && token.length > 0 ? token : undefined;
+  }
+
+  private decodeSub(token: string): number | string | undefined {
+    try {
+      const payload = jwt.decode(token);
+      if (!payload || typeof payload !== 'object') return undefined;
+      // refresh 토큰은 tracker 버킷을 access 와 섞지 않도록 거부
+      if ((payload as { tokenType?: string }).tokenType === 'refresh') return undefined;
+      const sub = (payload as { sub?: unknown }).sub;
+      if (typeof sub === 'number' || typeof sub === 'string') return sub;
+      return undefined;
+    } catch {
+      return undefined;
+    }
   }
 }

--- a/backend/src/config/trust-proxy.ts
+++ b/backend/src/config/trust-proxy.ts
@@ -1,0 +1,18 @@
+/**
+ * Express `trust proxy` 값 결정.
+ * - TRUST_PROXY 명시 시 숫자(hop count) 또는 boolean 문자열("true"/"false") 허용
+ * - 미설정 시 production=1, 그 외=false (직접 노출된 dev 환경에서 X-Forwarded-For 스푸핑 차단)
+ */
+export function resolveTrustProxy(
+  raw: string | undefined,
+  nodeEnv: string | undefined,
+): number | boolean {
+  if (raw !== undefined) {
+    const trimmed = raw.trim();
+    if (trimmed.toLowerCase() === 'true') return true;
+    if (trimmed.toLowerCase() === 'false') return false;
+    const hops = Number(trimmed);
+    if (Number.isInteger(hops) && hops >= 0) return hops;
+  }
+  return nodeEnv === 'production' ? 1 : false;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -29,6 +29,11 @@ async function bootstrap() {
   app.use(helmet());
   app.use(cookieParser());
 
+  // Nginx/Vercel/CloudFront 등 프록시 뒤에서 X-Forwarded-For 의 첫 IP 를 req.ip 로 인식.
+  // ThrottlerGuard 가 진짜 클라이언트 IP 기준으로 동작하도록 보장.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (httpAdapter.getInstance() as any).set('trust proxy', 1);
+
   app.setGlobalPrefix('api');
 
   const frontendUrl = process.env.FRONTEND_URL;

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,6 +7,7 @@ import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 import { assertEnv } from './config/env-validator';
+import { resolveTrustProxy } from './config/trust-proxy';
 
 // 프로덕션 환경에서 필수 env 키 사전 검증 — 누락 시 명확한 에러 메시지와 함께 종료
 assertEnv();
@@ -31,8 +32,11 @@ async function bootstrap() {
 
   // Nginx/Vercel/CloudFront 등 프록시 뒤에서 X-Forwarded-For 의 첫 IP 를 req.ip 로 인식.
   // ThrottlerGuard 가 진짜 클라이언트 IP 기준으로 동작하도록 보장.
+  // TRUST_PROXY 환경변수로 hop count 제어 (ex. CloudFront+Nginx 2단이면 2).
+  // 기본값: production=1, 그 외 0 (직접 노출된 dev 환경에서 X-Forwarded-For 스푸핑 차단).
+  const trustProxy = resolveTrustProxy(process.env.TRUST_PROXY, process.env.NODE_ENV);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (httpAdapter.getInstance() as any).set('trust proxy', 1);
+  (httpAdapter.getInstance() as any).set('trust proxy', trustProxy);
 
   app.setGlobalPrefix('api');
 

--- a/backend/src/modules/products/__tests__/products.search.spec.ts
+++ b/backend/src/modules/products/__tests__/products.search.spec.ts
@@ -260,5 +260,27 @@ describe('ProductsService — Search', () => {
 
       expect(mockOrderBy).toHaveBeenCalledWith('product.price', 'DESC');
     });
+
+    it('FULLTEXT 실패(errno 1191) 후 LIKE 폴백에서도 검색어 조건이 유지됨', async () => {
+      mockGetManyAndCount
+        .mockRejectedValueOnce(makeFulltextError())
+        .mockResolvedValue([[], 0]);
+
+      await service.findAll({ q: '보이차' });
+
+      // LIKE 폴백 경로의 andWhere 호출에 검색어 LIKE 조건이 포함되어야 함
+      expect(mockAndWhere).toHaveBeenCalledWith('product.name LIKE :q', { q: '%보이차%' });
+    });
+
+    it('q 없이 LIKE 폴백 경로 진입 시 LIKE 조건 추가 안 함 (q 길이 1인 경우)', async () => {
+      // q가 1글자면 FULLTEXT가 아닌 LIKE 경로가 바로 사용되고, 폴백이 아니라 정상 경로로 처리
+      // 이 케이스는 findAll에서 직접 LIKE 경로를 탄다 (q.length < 2)
+      mockGetManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ q: '차' });
+
+      // 단글자 q → 직접 LIKE 조건 (FULLTEXT 아님)
+      expect(mockAndWhere).toHaveBeenCalledWith('product.name LIKE :q', { q: '%차%' });
+    });
   });
 });

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -306,9 +306,14 @@ export class ProductsService {
     locale?: string,
     cacheKey?: string,
   ) {
-    const { status } = query;
+    const { status, q } = query;
 
     const likeQb = this.buildBaseQueryBuilder(isAdmin, status as ProductStatus | undefined);
+
+    if (q) {
+      likeQb.andWhere('product.name LIKE :q', { q: `%${q}%` });
+    }
+
     this.applyFiltersAndSort(likeQb, query, categoryIds, attrTypeIdMap);
 
     return this.executeFindAll(likeQb, page, limit, sort, locale, cacheKey);


### PR DESCRIPTION
## Summary

홈 진입 시 다수의 CSR 블록이 동시에 백엔드를 두드려 200 req/min 글로벌 한도에 빠르게 도달하던 429 burst 를 P0 범위에서 우선 완화한다.

- `UserAwareThrottlerGuard` 추가: 인증 사용자는 `user:{id}`, 비인증은 `ip:{addr}` 키로 분리
  → NAT/사옥/공유 프록시 환경에서 한 사용자의 burst 가 다른 사용자에게 전이되지 않음
- `main.ts` 에 `'trust proxy' = 1` 설정
  → Nginx/Vercel/CloudFront 뒤에서 `X-Forwarded-For` 의 첫 IP 를 `req.ip` 로 인식
- `app.module.ts` 의 `ThrottlerGuard` 바인딩을 `UserAwareThrottlerGuard` 로 교체

P1(홈 블록 SSR 화 / bootstrap 묶음 호출), P2(read 전용 throttler 한도 분리 또는 응답 캐싱), D(`/auth/me` 401 시 토큰 리프레시 스킵) 은 후속 이슈로 분리한다.

Closes #565

## Test plan

- [x] backend: `npm run lint && npm run build && npm run test` (51 suites / 535 tests)
- [x] backend: `UserAwareThrottlerGuard` 단위 테스트 6 케이스 추가 (user 인증 키, BIGINT string, IP fallback, ip unknown, 동일 IP 다른 user 분리)
- [x] frontend: `npm run lint && npm run build && npm run test:run` (62 files / 391 tests)