### PR TITLE
fix: #488 상품 검색 LIKE fallback에서 검색어 조건 재적용

### DIFF
--- a/backend/src/modules/products/__tests__/products.search.spec.ts
+++ b/backend/src/modules/products/__tests__/products.search.spec.ts
@@ -260,5 +260,27 @@ describe('ProductsService — Search', () => {
 
       expect(mockOrderBy).toHaveBeenCalledWith('product.price', 'DESC');
     });
+
+    it('FULLTEXT 실패(errno 1191) 후 LIKE 폴백에서도 검색어 조건이 유지됨', async () => {
+      mockGetManyAndCount
+        .mockRejectedValueOnce(makeFulltextError())
+        .mockResolvedValue([[], 0]);
+
+      await service.findAll({ q: '보이차' });
+
+      // LIKE 폴백 경로의 andWhere 호출에 검색어 LIKE 조건이 포함되어야 함
+      expect(mockAndWhere).toHaveBeenCalledWith('product.name LIKE :q', { q: '%보이차%' });
+    });
+
+    it('q 없이 LIKE 폴백 경로 진입 시 LIKE 조건 추가 안 함 (q 길이 1인 경우)', async () => {
+      // q가 1글자면 FULLTEXT가 아닌 LIKE 경로가 바로 사용되고, 폴백이 아니라 정상 경로로 처리
+      // 이 케이스는 findAll에서 직접 LIKE 경로를 탄다 (q.length < 2)
+      mockGetManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ q: '차' });
+
+      // 단글자 q → 직접 LIKE 조건 (FULLTEXT 아님)
+      expect(mockAndWhere).toHaveBeenCalledWith('product.name LIKE :q', { q: '%차%' });
+    });
   });
 });

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -306,9 +306,14 @@ export class ProductsService {
     locale?: string,
     cacheKey?: string,
   ) {
-    const { status } = query;
+    const { status, q } = query;
 
     const likeQb = this.buildBaseQueryBuilder(isAdmin, status as ProductStatus | undefined);
+
+    if (q) {
+      likeQb.andWhere('product.name LIKE :q', { q: `%${q}%` });
+    }
+
     this.applyFiltersAndSort(likeQb, query, categoryIds, attrTypeIdMap);
 
     return this.executeFindAll(likeQb, page, limit, sort, locale, cacheKey);


### PR DESCRIPTION
## Summary
- Closes #488
- FULLTEXT 검색 실패(errno 1191) 시 LIKE fallback으로 넘어갈 때 검색어(`q`) 조건이 누락되어 검색어와 무관한 모든 상품이 반환되던 버그 수정
- `executeFindAllWithLikeFallback`에서 `q`가 있을 때 `product.name LIKE :q` 조건을 재적용 (FULLTEXT 원본과 동일한 name 필드)

## Changes
- `backend/src/modules/products/products.service.ts`: `executeFindAllWithLikeFallback`에 `q` LIKE 조건 추가 (파라미터 바인딩, SQL 인젝션 안전)
- `backend/src/modules/products/__tests__/products.search.spec.ts`: LIKE fallback 검색어 조건 유지 검증 테스트 2건 추가

## Test plan
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test (533 passed, 50 suites)
- [x] Unit test: FULLTEXT 실패 강제(errno 1191) → LIKE fallback → `product.name LIKE :q` 조건 유지 검증
- [x] Unit test: q 1글자 → 직접 LIKE 경로 검증