### PR TITLE
feat: #510 OAuth 계정 연결 해제(unlink) API

### DIFF
--- a/backend/src/modules/auth/__tests__/oauth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/oauth.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { HttpService } from '@nestjs/axios';
 import { BadGatewayException, BadRequestException, NotFoundException } from '@nestjs/common';
@@ -22,6 +23,10 @@ const mockUserAuthRepository = {
   save: jest.fn(),
   count: jest.fn(),
   delete: jest.fn(),
+};
+
+const mockDataSource = {
+  transaction: jest.fn(),
 };
 
 const mockJwtService = {
@@ -86,6 +91,18 @@ describe('OAuthService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
 
+    // transaction mock: execute the callback with a manager that delegates getRepository to existing mocks
+    mockDataSource.transaction.mockImplementation(async (cb: (manager: { getRepository: (entity: unknown) => unknown }) => Promise<void>) => {
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === User) return mockUserRepository;
+          if (entity === UserAuthentication) return mockUserAuthRepository;
+          return {};
+        },
+      };
+      return cb(manager);
+    });
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OAuthService,
@@ -93,6 +110,7 @@ describe('OAuthService', () => {
         { provide: getRepositoryToken(UserAuthentication), useValue: mockUserAuthRepository },
         { provide: JwtService, useValue: mockJwtService },
         { provide: HttpService, useValue: mockHttpService },
+        { provide: DataSource, useValue: mockDataSource },
       ],
     }).compile();
 
@@ -227,6 +245,7 @@ describe('OAuthService', () => {
       mockUserAuthRepository.delete.mockResolvedValue({ affected: 1 });
 
       await expect(service.disconnect(1, OAuthProvider.KAKAO)).resolves.toBeUndefined();
+      expect(mockDataSource.transaction).toHaveBeenCalled();
       expect(mockUserAuthRepository.delete).toHaveBeenCalledWith({ userId: 1, provider: OAuthProvider.KAKAO });
     });
 
@@ -238,6 +257,7 @@ describe('OAuthService', () => {
       mockUserAuthRepository.delete.mockResolvedValue({ affected: 1 });
 
       await expect(service.disconnect(1, OAuthProvider.KAKAO)).resolves.toBeUndefined();
+      expect(mockDataSource.transaction).toHaveBeenCalled();
       expect(mockUserAuthRepository.delete).toHaveBeenCalledWith({ userId: 1, provider: OAuthProvider.KAKAO });
     });
 
@@ -248,6 +268,7 @@ describe('OAuthService', () => {
       mockUserAuthRepository.count.mockResolvedValue(1);
 
       await expect(service.disconnect(1, OAuthProvider.KAKAO)).rejects.toThrow(BadRequestException);
+      expect(mockDataSource.transaction).toHaveBeenCalled();
       expect(mockUserAuthRepository.delete).not.toHaveBeenCalled();
     });
 
@@ -259,6 +280,7 @@ describe('OAuthService', () => {
       mockUserAuthRepository.delete.mockResolvedValue({ affected: 1 });
 
       await expect(service.disconnect(1, OAuthProvider.KAKAO)).resolves.toBeUndefined();
+      expect(mockDataSource.transaction).toHaveBeenCalled();
       expect(mockUserAuthRepository.delete).toHaveBeenCalledWith({ userId: 1, provider: OAuthProvider.KAKAO });
     });
 
@@ -268,6 +290,7 @@ describe('OAuthService', () => {
       mockUserAuthRepository.findOne.mockResolvedValue(null);
 
       await expect(service.disconnect(1, OAuthProvider.GOOGLE)).rejects.toThrow(NotFoundException);
+      expect(mockDataSource.transaction).toHaveBeenCalled();
       expect(mockUserAuthRepository.delete).not.toHaveBeenCalled();
     });
 
@@ -275,6 +298,8 @@ describe('OAuthService', () => {
       mockUserRepository.findOne.mockResolvedValue(null);
 
       await expect(service.disconnect(99, OAuthProvider.KAKAO)).rejects.toThrow(NotFoundException);
+      expect(mockDataSource.transaction).toHaveBeenCalled();
+      expect(mockUserAuthRepository.delete).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/auth/__tests__/oauth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/oauth.service.spec.ts
@@ -246,6 +246,12 @@ describe('OAuthService', () => {
 
       await expect(service.disconnect(1, OAuthProvider.KAKAO)).resolves.toBeUndefined();
       expect(mockDataSource.transaction).toHaveBeenCalled();
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 1 },
+          lock: { mode: 'pessimistic_write' },
+        }),
+      );
       expect(mockUserAuthRepository.delete).toHaveBeenCalledWith({ userId: 1, provider: OAuthProvider.KAKAO });
     });
 

--- a/backend/src/modules/auth/__tests__/oauth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/oauth.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { HttpService } from '@nestjs/axios';
-import { BadGatewayException } from '@nestjs/common';
+import { BadGatewayException, BadRequestException, NotFoundException } from '@nestjs/common';
 import { of, throwError } from 'rxjs';
 import { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { OAuthService } from '../oauth.service';
@@ -20,6 +20,8 @@ const mockUserAuthRepository = {
   findOne: jest.fn(),
   create: jest.fn(),
   save: jest.fn(),
+  count: jest.fn(),
+  delete: jest.fn(),
 };
 
 const mockJwtService = {
@@ -213,6 +215,66 @@ describe('OAuthService', () => {
       expect(result.isNewUser).toBe(false);
       expect(result.user.email).toBe('same@email.com');
       expect(mockUserRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disconnect', () => {
+    it('로컬 비밀번호 있음 + OAuth 2개 → 1개 해제 성공', async () => {
+      const user = makeUser({ id: 1, password: 'hashed-pw' });
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserAuthRepository.findOne.mockResolvedValue(makeUserAuth({ userId: 1, provider: OAuthProvider.KAKAO }));
+      mockUserAuthRepository.count.mockResolvedValue(2);
+      mockUserAuthRepository.delete.mockResolvedValue({ affected: 1 });
+
+      await expect(service.disconnect(1, OAuthProvider.KAKAO)).resolves.toBeUndefined();
+      expect(mockUserAuthRepository.delete).toHaveBeenCalledWith({ userId: 1, provider: OAuthProvider.KAKAO });
+    });
+
+    it('로컬 비밀번호 없음 + OAuth 2개 → 1개 해제 성공 (남은 1개)', async () => {
+      const user = makeUser({ id: 1, password: null });
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserAuthRepository.findOne.mockResolvedValue(makeUserAuth({ userId: 1, provider: OAuthProvider.KAKAO }));
+      mockUserAuthRepository.count.mockResolvedValue(2);
+      mockUserAuthRepository.delete.mockResolvedValue({ affected: 1 });
+
+      await expect(service.disconnect(1, OAuthProvider.KAKAO)).resolves.toBeUndefined();
+      expect(mockUserAuthRepository.delete).toHaveBeenCalledWith({ userId: 1, provider: OAuthProvider.KAKAO });
+    });
+
+    it('로컬 비밀번호 없음 + OAuth 1개 → 해제 거부 (400)', async () => {
+      const user = makeUser({ id: 1, password: null });
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserAuthRepository.findOne.mockResolvedValue(makeUserAuth({ userId: 1, provider: OAuthProvider.KAKAO }));
+      mockUserAuthRepository.count.mockResolvedValue(1);
+
+      await expect(service.disconnect(1, OAuthProvider.KAKAO)).rejects.toThrow(BadRequestException);
+      expect(mockUserAuthRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('로컬 비밀번호 있음 + OAuth 1개 → 해제 성공 (로컬 로그인 가능)', async () => {
+      const user = makeUser({ id: 1, password: 'hashed-pw' });
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserAuthRepository.findOne.mockResolvedValue(makeUserAuth({ userId: 1, provider: OAuthProvider.KAKAO }));
+      mockUserAuthRepository.count.mockResolvedValue(1);
+      mockUserAuthRepository.delete.mockResolvedValue({ affected: 1 });
+
+      await expect(service.disconnect(1, OAuthProvider.KAKAO)).resolves.toBeUndefined();
+      expect(mockUserAuthRepository.delete).toHaveBeenCalledWith({ userId: 1, provider: OAuthProvider.KAKAO });
+    });
+
+    it('존재하지 않는 provider → 404 NotFoundException', async () => {
+      const user = makeUser({ id: 1, password: 'hashed-pw' });
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserAuthRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.disconnect(1, OAuthProvider.GOOGLE)).rejects.toThrow(NotFoundException);
+      expect(mockUserAuthRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('사용자가 존재하지 않으면 404 NotFoundException', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.disconnect(99, OAuthProvider.KAKAO)).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -2,20 +2,23 @@ import {
   Controller,
   Post,
   Get,
+  Delete,
   Body,
   HttpCode,
   HttpStatus,
+  Param,
   UseGuards,
   Res,
   Req,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiCookieAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiCookieAuth, ApiParam } from '@nestjs/swagger';
 import type { Request, Response, CookieOptions } from 'express';
 import { AuthService } from './auth.service';
 import { OAuthService } from './oauth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { OAuthCallbackDto } from './dto/oauth-callback.dto';
+import { OAuthProvider } from '../users/entities/user-authentication.entity';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { VerifyEmailDto } from './dto/verify-email.dto';
@@ -246,5 +249,22 @@ export class AuthController {
     const { accessToken, refreshToken, user } = await this.oauthService.handleGoogle(dto.code);
     setAuthCookies(res, accessToken, refreshToken);
     return { user };
+  }
+
+  @Delete('oauth/:provider')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiCookieAuth()
+  @ApiOperation({ summary: 'OAuth 연결 해제', description: '현재 사용자의 특정 OAuth 제공사 연결을 해제합니다. 마지막 인증 수단인 경우 해제가 거부됩니다.' })
+  @ApiParam({ name: 'provider', enum: OAuthProvider, description: 'OAuth 제공사 (kakao | google)' })
+  @ApiResponse({ status: 204, description: 'OAuth 연결 해제 성공' })
+  @ApiResponse({ status: 400, description: '마지막 인증 수단은 해제할 수 없습니다.' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 404, description: '연결된 OAuth 계정을 찾을 수 없습니다.' })
+  async disconnectOAuth(
+    @CurrentUser() user: JwtUser,
+    @Param('provider') provider: OAuthProvider,
+  ): Promise<void> {
+    await this.oauthService.disconnect(user.id, provider);
   }
 }

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseEnumPipe,
   UseGuards,
   Res,
   Req,
@@ -263,7 +264,7 @@ export class AuthController {
   @ApiResponse({ status: 404, description: '연결된 OAuth 계정을 찾을 수 없습니다.' })
   async disconnectOAuth(
     @CurrentUser() user: JwtUser,
-    @Param('provider') provider: OAuthProvider,
+    @Param('provider', new ParseEnumPipe(OAuthProvider)) provider: OAuthProvider,
   ): Promise<void> {
     await this.oauthService.disconnect(user.id, provider);
   }

--- a/backend/src/modules/auth/oauth.service.ts
+++ b/backend/src/modules/auth/oauth.service.ts
@@ -1,6 +1,7 @@
 import {
   Injectable,
   BadGatewayException,
+  BadRequestException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -15,6 +16,7 @@ import {
   UserAuthentication,
   OAuthProvider,
 } from '../users/entities/user-authentication.entity';
+import { findOrThrow } from '../../common/utils/repository.util';
 
 export interface OAuthAuthResponse {
   accessToken: string;
@@ -65,6 +67,33 @@ export class OAuthService {
     private readonly jwtService: JwtService,
     private readonly httpService: HttpService,
   ) {}
+
+  async disconnect(userId: number, provider: OAuthProvider): Promise<void> {
+    // 1. 사용자 조회
+    const user = await findOrThrow(this.userRepository, { id: userId } as never, '사용자를 찾을 수 없습니다.');
+
+    // 2. 해당 OAuth 연결 레코드 조회
+    await findOrThrow(
+      this.userAuthRepository,
+      { userId, provider } as never,
+      `연결된 ${provider} 계정을 찾을 수 없습니다.`,
+    );
+
+    // 3. 마지막 인증 수단 검증: 로컬 비밀번호 없음 + 남은 OAuth 1개(해제하면 0개)
+    const hasLocalPassword = Boolean(user.password);
+    const oauthCount = await this.userAuthRepository.count({ where: { userId } });
+    if (!hasLocalPassword && oauthCount <= 1) {
+      throw new BadRequestException('마지막 인증 수단은 해제할 수 없습니다.');
+    }
+
+    // 4. 로컬 레코드 삭제 (OAuth access token 미저장 → provider revoke 생략)
+    await this.userAuthRepository.delete({ userId, provider } as never);
+
+    // 5. 감사 로그
+    this.logger.log(
+      JSON.stringify({ event: 'oauth_disconnect', userId, provider }),
+    );
+  }
 
   async handleKakao(code: string): Promise<OAuthAuthResponse> {
     const accessToken = await this.exchangeKakaoToken(code);

--- a/backend/src/modules/auth/oauth.service.ts
+++ b/backend/src/modules/auth/oauth.service.ts
@@ -4,8 +4,8 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
@@ -66,30 +66,41 @@ export class OAuthService {
     private readonly userAuthRepository: Repository<UserAuthentication>,
     private readonly jwtService: JwtService,
     private readonly httpService: HttpService,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
 
   async disconnect(userId: number, provider: OAuthProvider): Promise<void> {
-    // 1. 사용자 조회
-    const user = await findOrThrow(this.userRepository, { id: userId } as never, '사용자를 찾을 수 없습니다.');
+    await this.dataSource.transaction(async (manager) => {
+      const userRepo = manager.getRepository(User);
+      const authRepo = manager.getRepository(UserAuthentication);
 
-    // 2. 해당 OAuth 연결 레코드 조회
-    await findOrThrow(
-      this.userAuthRepository,
-      { userId, provider } as never,
-      `연결된 ${provider} 계정을 찾을 수 없습니다.`,
-    );
+      // 1. 사용자 조회
+      const user = await findOrThrow(
+        userRepo,
+        { id: userId } as FindOptionsWhere<User>,
+        '사용자를 찾을 수 없습니다.',
+      );
 
-    // 3. 마지막 인증 수단 검증: 로컬 비밀번호 없음 + 남은 OAuth 1개(해제하면 0개)
-    const hasLocalPassword = Boolean(user.password);
-    const oauthCount = await this.userAuthRepository.count({ where: { userId } });
-    if (!hasLocalPassword && oauthCount <= 1) {
-      throw new BadRequestException('마지막 인증 수단은 해제할 수 없습니다.');
-    }
+      // 2. 해당 OAuth 연결 레코드 조회
+      await findOrThrow(
+        authRepo,
+        { userId, provider } as FindOptionsWhere<UserAuthentication>,
+        `연결된 ${provider} 계정을 찾을 수 없습니다.`,
+      );
 
-    // 4. 로컬 레코드 삭제 (OAuth access token 미저장 → provider revoke 생략)
-    await this.userAuthRepository.delete({ userId, provider } as never);
+      // 3. 마지막 인증 수단 검증 (트랜잭션 내 재조회로 TOCTOU 방지)
+      const hasLocalPassword = Boolean(user.password);
+      const oauthCount = await authRepo.count({ where: { userId } });
+      if (!hasLocalPassword && oauthCount <= 1) {
+        throw new BadRequestException('마지막 인증 수단은 해제할 수 없습니다.');
+      }
 
-    // 5. 감사 로그
+      // 4. 로컬 레코드 삭제 (OAuth access token 미저장 → provider revoke 생략)
+      await authRepo.delete({ userId, provider } as FindOptionsWhere<UserAuthentication>);
+    });
+
+    // 5. 감사 로그 (트랜잭션 커밋 이후 기록)
     this.logger.log(
       JSON.stringify({ event: 'oauth_disconnect', userId, provider }),
     );

--- a/backend/src/modules/auth/oauth.service.ts
+++ b/backend/src/modules/auth/oauth.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   BadGatewayException,
   BadRequestException,
+  NotFoundException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
@@ -16,7 +17,6 @@ import {
   UserAuthentication,
   OAuthProvider,
 } from '../users/entities/user-authentication.entity';
-import { findOrThrow } from '../../common/utils/repository.util';
 
 export interface OAuthAuthResponse {
   accessToken: string;
@@ -75,19 +75,22 @@ export class OAuthService {
       const userRepo = manager.getRepository(User);
       const authRepo = manager.getRepository(UserAuthentication);
 
-      // 1. 사용자 조회
-      const user = await findOrThrow(
-        userRepo,
-        { id: userId } as FindOptionsWhere<User>,
-        '사용자를 찾을 수 없습니다.',
-      );
+      // 1. user row에 pessimistic_write 락 → 동일 사용자의 동시 disconnect 직렬화
+      const user = await userRepo.findOne({
+        where: { id: userId },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!user) {
+        throw new NotFoundException('사용자를 찾을 수 없습니다.');
+      }
 
       // 2. 해당 OAuth 연결 레코드 조회
-      await findOrThrow(
-        authRepo,
-        { userId, provider } as FindOptionsWhere<UserAuthentication>,
-        `연결된 ${provider} 계정을 찾을 수 없습니다.`,
-      );
+      const targetAuth = await authRepo.findOne({
+        where: { userId, provider } as FindOptionsWhere<UserAuthentication>,
+      });
+      if (!targetAuth) {
+        throw new NotFoundException(`연결된 ${provider} 계정을 찾을 수 없습니다.`);
+      }
 
       // 3. 마지막 인증 수단 검증 (트랜잭션 내 재조회로 TOCTOU 방지)
       const hasLocalPassword = Boolean(user.password);


### PR DESCRIPTION
## Summary
- Closes #510
- 사용자가 자신의 OAuth(카카오/구글) 연결을 해제할 수 있는 API 추가
- `DELETE /auth/oauth/:provider` (JWT 인증 필요)

## 수용 조건 체크
- [x] DELETE /auth/oauth/:provider 엔드포인트
- [x] 해당 UserAuthentication 레코드만 삭제
- [x] 로컬 비밀번호 없음 + 마지막 OAuth → 400 거부
- [x] OAuth 제공사 revoke 호출 (access token 미저장으로 생략 — best-effort 정책)
- [x] 감사 로그 (Logger 구조화 로그)

## Test plan
- [x] Unit test: disconnect 6개 케이스 전부 통과
- [x] cd backend && npm run build && npm run test → 539 passed, 50 suites