### PR TITLE
fix: #566 refresh 엔드포인트에서 isActive 검증 추가

### DIFF
--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -233,6 +233,28 @@ describe('AuthService', () => {
 
       await expect(service.refresh('invalid.token')).rejects.toThrow(UnauthorizedException);
     });
+
+    it('비활성화된 사용자의 유효한 refresh token → UnauthorizedException', async () => {
+      const rawRefresh = 'mock-token';
+      const hashedRefresh = await bcrypt.hash(rawRefresh, 10);
+      mockJwtService.verify.mockReturnValueOnce({ sub: 1, email: 'test@example.com', role: 'user', tokenType: 'refresh' });
+      mockUserRepository.findOne.mockResolvedValue(makeUser({ isActive: false, refreshToken: hashedRefresh }));
+
+      await expect(service.refresh(rawRefresh)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('활성화된 사용자의 유효한 refresh token → 정상 토큰 발급 (regression)', async () => {
+      const rawRefresh = 'mock-token';
+      const hashedRefresh = await bcrypt.hash(rawRefresh, 10);
+      mockJwtService.verify.mockReturnValueOnce({ sub: 1, email: 'test@example.com', role: 'user', tokenType: 'refresh' });
+      mockUserRepository.findOne.mockResolvedValue(makeUser({ isActive: true, refreshToken: hashedRefresh }));
+      mockUserRepository.update.mockResolvedValue(undefined);
+
+      const result = await service.refresh(rawRefresh);
+
+      expect(result).toHaveProperty('accessToken');
+      expect(result).toHaveProperty('refreshToken');
+    });
   });
 
   describe('forgotPassword', () => {

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -325,7 +325,7 @@ export class AuthService implements OnModuleInit {
     }
 
     const user = await this.userRepository.findOne({ where: { id: payload.sub } });
-    if (!user || !user.refreshToken) {
+    if (!user || !user.isActive || !user.refreshToken) {
       throw new UnauthorizedException('유효하지 않은 리프레시 토큰입니다.');
     }
 


### PR DESCRIPTION
## Summary
- Closes #566
- 관리자가 사용자를 비활성화해도 refresh token을 보유한 사용자가 계속 access token을 발급받을 수 있던 보안 갭 수정
- \`refresh()\`의 user 가드에 \`!user.isActive\` 조건 추가 → 비활성 사용자는 401로 거부

## Test plan
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test
- [x] Unit test: isActive:false 사용자의 refresh 호출 → 401
- [x] Regression: isActive:true 사용자의 정상 refresh는 그대로 동작