### PR TITLE
feat: #506 문의 답변 알림 + 미확인 답변 추적

### DIFF
--- a/backend/src/database/migrations/1782100000000-AddInquiryNotificationColumns.ts
+++ b/backend/src/database/migrations/1782100000000-AddInquiryNotificationColumns.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddInquiryNotificationColumns1782100000000 implements MigrationInterface {
+  name = 'AddInquiryNotificationColumns1782100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [row] = await queryRunner.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'inquiries' AND COLUMN_NAME = 'customer_read_at'`,
+    );
+    if (!row) {
+      await queryRunner.query(
+        `ALTER TABLE \`inquiries\` ADD COLUMN \`customer_read_at\` datetime NULL AFTER \`answered_at\``,
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const [row] = await queryRunner.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'inquiries' AND COLUMN_NAME = 'customer_read_at'`,
+    );
+    if (row) {
+      await queryRunner.query(`ALTER TABLE \`inquiries\` DROP COLUMN \`customer_read_at\``);
+    }
+  }
+}

--- a/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
+++ b/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
@@ -158,6 +158,29 @@ describe('InquiriesService', () => {
 
       expect(mockNotificationService.sendInquiryAnswered).not.toHaveBeenCalled();
     });
+
+    it('재답변 시 customerReadAt을 null로 초기화하여 고객이 다시 읽도록 한다', async () => {
+      const inquiry = {
+        id: 1,
+        userId: 10,
+        title: '문의',
+        status: InquiryStatus.ANSWERED,
+        answer: '이전 답변',
+        answeredAt: new Date('2026-01-01'),
+        customerReadAt: new Date('2026-01-02'),  // 이미 읽음
+      } as Inquiry;
+      repo.findOne.mockResolvedValue(inquiry);
+      repo.save.mockResolvedValue({ ...inquiry, answer: '수정된 답변', customerReadAt: null } as never);
+
+      await service.answerInquiry(1, { answer: '수정된 답변' });
+
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          answer: '수정된 답변',
+          customerReadAt: null,
+        }),
+      );
+    });
   });
 
   describe('findAllForAdmin', () => {

--- a/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
+++ b/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
@@ -12,19 +12,25 @@ const mockRepo = () => ({
   findOne: jest.fn(),
   save: jest.fn(),
   create: jest.fn(),
+  find: jest.fn(),
 });
 
 describe('InquiriesService', () => {
   let service: InquiriesService;
   let repo: jest.Mocked<Repository<Inquiry>>;
+  let mockUserRepo: { findOne: jest.Mock };
+  let mockNotificationService: { sendInquiryAnswered: jest.Mock };
 
   beforeEach(async () => {
+    mockUserRepo = { findOne: jest.fn().mockResolvedValue(null) };
+    mockNotificationService = { sendInquiryAnswered: jest.fn().mockResolvedValue(undefined) };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         InquiriesService,
         { provide: getRepositoryToken(Inquiry), useFactory: mockRepo },
-        { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
-        { provide: NotificationService, useValue: { sendInquiryAnswered: jest.fn() } },
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        { provide: NotificationService, useValue: mockNotificationService },
       ],
     }).compile();
 
@@ -50,7 +56,7 @@ describe('InquiriesService', () => {
 
   describe('findOne', () => {
     it('타인 문의 조회 → ForbiddenException', async () => {
-      const inquiry = { id: 1, userId: 99, title: '타인 문의' };
+      const inquiry = { id: 1, userId: 99, title: '타인 문의', answeredAt: null, customerReadAt: null };
       repo.findOne.mockResolvedValue(inquiry as never);
 
       await expect(service.findOne(1, 10)).rejects.toThrow(ForbiddenException);
@@ -61,17 +67,128 @@ describe('InquiriesService', () => {
 
       await expect(service.findOne(999, 10)).rejects.toThrow(NotFoundException);
     });
+
+    it('답변 있고 customerReadAt 없으면 customerReadAt 갱신', async () => {
+      const inquiry = {
+        id: 1,
+        userId: 10,
+        title: '문의',
+        answeredAt: new Date('2024-01-01'),
+        customerReadAt: null,
+      } as Inquiry;
+      repo.findOne.mockResolvedValue(inquiry);
+      repo.save.mockResolvedValue({ ...inquiry, customerReadAt: new Date() } as never);
+
+      const result = await service.findOne(1, 10);
+      expect(repo.save).toHaveBeenCalled();
+      expect(result.customerReadAt).toBeDefined();
+    });
+
+    it('이미 customerReadAt 있으면 save 호출 안 함', async () => {
+      const inquiry = {
+        id: 1,
+        userId: 10,
+        title: '문의',
+        answeredAt: new Date('2024-01-01'),
+        customerReadAt: new Date('2024-01-02'),
+      } as Inquiry;
+      repo.findOne.mockResolvedValue(inquiry);
+
+      await service.findOne(1, 10);
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('답변 없으면 customerReadAt 갱신 안 함', async () => {
+      const inquiry = {
+        id: 1,
+        userId: 10,
+        title: '문의',
+        answeredAt: null,
+        customerReadAt: null,
+      } as Inquiry;
+      repo.findOne.mockResolvedValue(inquiry);
+
+      await service.findOne(1, 10);
+      expect(repo.save).not.toHaveBeenCalled();
+    });
   });
 
-  describe('answer', () => {
+  describe('answerInquiry', () => {
     it('답변 작성 → status answered 변경', async () => {
-      const inquiry = { id: 1, status: InquiryStatus.PENDING, answer: null } as Inquiry;
+      const inquiry = { id: 1, status: InquiryStatus.PENDING, answer: null, answeredAt: null } as Inquiry;
       repo.findOne.mockResolvedValue(inquiry);
-      repo.save.mockResolvedValue({ ...inquiry, status: InquiryStatus.ANSWERED, answer: '답변 내용' } as never);
+      repo.save.mockResolvedValue({ ...inquiry, status: InquiryStatus.ANSWERED, answer: '답변 내용', answeredAt: new Date() } as never);
 
       const result = await service.answerInquiry(1, { answer: '답변 내용' });
       expect(result.status).toBe(InquiryStatus.ANSWERED);
       expect(result.answer).toBe('답변 내용');
+    });
+
+    it('첫 답변 시 알림 발송 (fire-and-forget)', async () => {
+      const inquiry = { id: 1, userId: 10, title: '문의', status: InquiryStatus.PENDING, answer: null, answeredAt: null } as Inquiry;
+      const savedInquiry = { ...inquiry, status: InquiryStatus.ANSWERED, answer: '답변', answeredAt: new Date() } as Inquiry;
+      repo.findOne.mockResolvedValue(inquiry);
+      repo.save.mockResolvedValue(savedInquiry as never);
+      mockUserRepo.findOne.mockResolvedValue({ id: 10, email: 'user@test.com', name: '홍길동' });
+
+      await service.answerInquiry(1, { answer: '답변' });
+
+      // fire-and-forget이므로 비동기 완료 대기
+      await new Promise<void>(resolve => setTimeout(resolve, 10));
+      expect(mockNotificationService.sendInquiryAnswered).toHaveBeenCalledWith(
+        'user@test.com',
+        expect.objectContaining({ inquiryTitle: '문의', answer: '답변' }),
+      );
+    });
+
+    it('재답변 시 알림 미발송', async () => {
+      const inquiry = {
+        id: 1,
+        userId: 10,
+        title: '문의',
+        status: InquiryStatus.ANSWERED,
+        answer: '이전 답변',
+        answeredAt: new Date('2024-01-01'),
+      } as Inquiry;
+      repo.findOne.mockResolvedValue(inquiry);
+      repo.save.mockResolvedValue({ ...inquiry, answer: '수정 답변' } as never);
+
+      await service.answerInquiry(1, { answer: '수정 답변' });
+      await new Promise<void>(resolve => setTimeout(resolve, 10));
+
+      expect(mockNotificationService.sendInquiryAnswered).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAllForAdmin', () => {
+    const buildMockQb = () => {
+      const qb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+      repo.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      return qb;
+    };
+
+    it('unread=true 필터 → answeredAt IS NOT NULL AND customerReadAt IS NULL', async () => {
+      const mockQb = buildMockQb();
+
+      await service.findAllForAdmin({ unread: true });
+
+      expect(mockQb.andWhere).toHaveBeenCalledWith('inquiry.answeredAt IS NOT NULL');
+      expect(mockQb.andWhere).toHaveBeenCalledWith('inquiry.customerReadAt IS NULL');
+    });
+
+    it('unread 미지정 시 필터 없음', async () => {
+      const mockQb = buildMockQb();
+
+      await service.findAllForAdmin({});
+
+      expect(mockQb.andWhere).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/inquiries/dto/admin-inquiry-query.dto.ts
+++ b/backend/src/modules/inquiries/dto/admin-inquiry-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsInt, IsOptional, Max, Min } from 'class-validator';
 
 export class AdminInquiryQueryDto {
   @ApiPropertyOptional({ description: '페이지 번호', example: 1, default: 1 })
@@ -17,4 +17,10 @@ export class AdminInquiryQueryDto {
   @Min(1, { message: 'limit은 1 이상이어야 합니다.' })
   @Max(100, { message: 'limit은 100 이하여야 합니다.' })
   limit?: number;
+
+  @ApiPropertyOptional({ description: '미확인 답변만 조회 (답변 있음 + 고객 미확인)', example: true })
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => value === 'true' || value === true)
+  @IsBoolean({ message: 'unread는 boolean이어야 합니다.' })
+  unread?: boolean;
 }

--- a/backend/src/modules/inquiries/entities/inquiry.entity.ts
+++ b/backend/src/modules/inquiries/entities/inquiry.entity.ts
@@ -48,6 +48,9 @@ export class Inquiry {
   @Column({ name: 'answered_at', type: 'datetime', nullable: true })
   answeredAt!: Date | null;
 
+  @Column({ name: 'customer_read_at', type: 'datetime', nullable: true })
+  customerReadAt!: Date | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -36,6 +36,12 @@ export class InquiriesService {
   async findOne(id: number, userId: number): Promise<Inquiry> {
     const inquiry = await findOrThrow(this.inquiryRepo, { id }, '문의를 찾을 수 없습니다.');
     assertOwnership(inquiry.userId, userId, '권한이 없습니다.');
+
+    if (inquiry.answeredAt && !inquiry.customerReadAt) {
+      inquiry.customerReadAt = new Date();
+      await this.inquiryRepo.save(inquiry);
+    }
+
     return inquiry;
   }
 
@@ -57,6 +63,11 @@ export class InquiriesService {
       .leftJoinAndSelect('inquiry.user', 'user')
       .orderBy('inquiry.createdAt', 'DESC');
 
+    if (query.unread) {
+      qb.andWhere('inquiry.answeredAt IS NOT NULL')
+        .andWhere('inquiry.customerReadAt IS NULL');
+    }
+
     return paginate(qb, {
       page: query.page ?? 1,
       limit: query.limit ?? 20,
@@ -65,13 +76,17 @@ export class InquiriesService {
 
   async answerInquiry(id: number, dto: AnswerInquiryDto): Promise<Inquiry> {
     const inquiry = await findOrThrow(this.inquiryRepo, { id }, '문의를 찾을 수 없습니다.');
+    const isFirstAnswer = !inquiry.answeredAt;
+
     inquiry.answer = dto.answer;
     inquiry.status = InquiryStatus.ANSWERED;
     inquiry.answeredAt = new Date();
     const saved = await this.inquiryRepo.save(inquiry);
     this.logger.log(`Inquiry answered: id=${id}`);
 
-    void this.notifyInquiryAnswered(saved.userId, saved.title, saved.answer ?? '');
+    if (isFirstAnswer) {
+      void this.notifyInquiryAnswered(saved.userId, saved.title, saved.answer ?? '');
+    }
 
     return saved;
   }

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -81,6 +81,7 @@ export class InquiriesService {
     inquiry.answer = dto.answer;
     inquiry.status = InquiryStatus.ANSWERED;
     inquiry.answeredAt = new Date();
+    inquiry.customerReadAt = null;  // 재답변 시 고객이 다시 읽도록
     const saved = await this.inquiryRepo.save(inquiry);
     this.logger.log(`Inquiry answered: id=${id}`);
 

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -20,6 +20,7 @@ import { registerPagesSuite } from './suites/pages.e2e-spec';
 import { registerNavigationSuite } from './suites/navigation.e2e-spec';
 import { registerReviewsSuite } from './suites/reviews.e2e-spec';
 import { registerAttributesSuite } from './suites/attributes.e2e-spec';
+import { registerInquiriesSuite } from './suites/inquiries.e2e-spec';
 
 describe('App (e2e)', () => {
   let app: INestApplication;
@@ -78,4 +79,5 @@ describe('App (e2e)', () => {
   registerNavigationSuite(() => app);
   registerReviewsSuite(() => app);
   registerAttributesSuite(() => app);
+  registerInquiriesSuite(() => app);
 });

--- a/backend/test/suites/inquiries.e2e-spec.ts
+++ b/backend/test/suites/inquiries.e2e-spec.ts
@@ -27,7 +27,7 @@ export function registerInquiriesSuite(getApp: () => INestApplication) {
       app = getApp();
       dataSource = app.get(DataSource);
 
-      // Insert users directly to avoid hitting auth rate-limit in throttle-active test env
+      // Insert users directly to avoid hitting registration rate-limit in throttle-active test env
       await dataSource.query(
         `INSERT INTO users (email, password, name, role, is_email_verified, email_verified_at, created_at, updated_at) VALUES (?, ?, '문의테스터', 'user', 1, NOW(), NOW(), NOW())`,
         [userEmail, TEST_PASSWORD_HASH],

--- a/backend/test/suites/inquiries.e2e-spec.ts
+++ b/backend/test/suites/inquiries.e2e-spec.ts
@@ -1,0 +1,204 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+} from '../helpers/auth-cookie.helper';
+
+// Pre-hashed 'Test1234!' with bcrypt rounds=10
+const TEST_PASSWORD_HASH = '$2b$10$HdzN6WGZunyatQk56WrsXO.h.9E/gUvsyEF0xFTAM4Cm7cTa3gMbm';
+
+export function registerInquiriesSuite(getApp: () => INestApplication) {
+  describe('Inquiries (e2e)', () => {
+    let app: INestApplication;
+    let dataSource: DataSource;
+    let userCookies: AuthCookies;
+    let adminCookies: AuthCookies;
+    let userId: number;
+    let inquiryId: number;
+
+    const userEmail = `inquiry-user-${Date.now()}@e2e.com`;
+    const adminEmail = `inquiry-admin-${Date.now()}@e2e.com`;
+    const password = 'Test1234!';
+
+    beforeAll(async () => {
+      app = getApp();
+      dataSource = app.get(DataSource);
+
+      // Insert users directly to avoid hitting auth rate-limit in throttle-active test env
+      await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_email_verified, email_verified_at, created_at, updated_at) VALUES (?, ?, '문의테스터', 'user', 1, NOW(), NOW(), NOW())`,
+        [userEmail, TEST_PASSWORD_HASH],
+      );
+      await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_email_verified, email_verified_at, created_at, updated_at) VALUES (?, ?, '관리자', 'admin', 1, NOW(), NOW(), NOW())`,
+        [adminEmail, TEST_PASSWORD_HASH],
+      );
+
+      const [userRow] = await dataSource.query<[{ id: number }]>(
+        `SELECT id FROM users WHERE email = ?`,
+        [userEmail],
+      );
+      userId = userRow.id;
+
+      userCookies = await loginAndGetCookies(app, { email: userEmail, password });
+      adminCookies = await loginAndGetCookies(app, { email: adminEmail, password });
+    });
+
+    afterAll(async () => {
+      await dataSource.query('SET FOREIGN_KEY_CHECKS = 0');
+      await dataSource.query(`DELETE FROM inquiries WHERE user_id = ?`, [userId]);
+      await dataSource.query(`DELETE FROM users WHERE email IN (?, ?)`, [userEmail, adminEmail]);
+      await dataSource.query('SET FOREIGN_KEY_CHECKS = 1');
+    });
+
+    describe('POST /api/inquiries', () => {
+      it('401 - 인증 없이 문의 작성 시도', () => {
+        return request(app.getHttpServer())
+          .post('/api/inquiries')
+          .send({ type: '상품', title: '제목', content: '내용' })
+          .expect(401);
+      });
+
+      it('201 - 문의 작성 성공', async () => {
+        const res = await request(app.getHttpServer())
+          .post('/api/inquiries')
+          .set('Cookie', cookieHeader(userCookies))
+          .send({ type: '상품', title: '테스트 문의', content: '문의 내용입니다.' })
+          .expect(201);
+
+        const body = res.body as { id: number; status: string };
+        expect(body.id).toBeDefined();
+        expect(body.status).toBe('pending');
+        inquiryId = body.id;
+      });
+    });
+
+    describe('GET /api/inquiries', () => {
+      it('200 - 내 문의 목록 조회', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/inquiries')
+          .set('Cookie', cookieHeader(userCookies))
+          .expect(200);
+
+        const body = res.body as Array<{ id: number }>;
+        expect(Array.isArray(body)).toBe(true);
+        expect(body.some((i) => i.id === inquiryId)).toBe(true);
+      });
+    });
+
+    describe('GET /api/inquiries/:id (before answer)', () => {
+      it('200 - 문의 상세 조회, customerReadAt 없음', async () => {
+        const res = await request(app.getHttpServer())
+          .get(`/api/inquiries/${inquiryId}`)
+          .set('Cookie', cookieHeader(userCookies))
+          .expect(200);
+
+        const body = res.body as { id: number; customerReadAt: null };
+        expect(body.id).toBe(inquiryId);
+        expect(body.customerReadAt).toBeNull();
+      });
+
+      it('403 - 타인 문의 조회 금지', async () => {
+        // Admin is a different user trying to access as customer
+        return request(app.getHttpServer())
+          .get(`/api/inquiries/${inquiryId}`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .expect(403);
+      });
+    });
+
+    describe('POST /api/admin/inquiries/:id/answer', () => {
+      it('401 - 인증 없이 답변 시도', () => {
+        return request(app.getHttpServer())
+          .post(`/api/admin/inquiries/${inquiryId}/answer`)
+          .send({ answer: '답변입니다.' })
+          .expect(401);
+      });
+
+      it('201 - 관리자 답변 성공', async () => {
+        const res = await request(app.getHttpServer())
+          .post(`/api/admin/inquiries/${inquiryId}/answer`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ answer: '문의 답변 드립니다.' })
+          .expect(201);
+
+        const body = res.body as { id: number; status: string; answeredAt: string };
+        expect(body.id).toBe(inquiryId);
+        expect(body.status).toBe('answered');
+        expect(body.answeredAt).toBeDefined();
+      });
+    });
+
+    describe('GET /api/inquiries/:id (after answer) → customerReadAt 갱신', () => {
+      it('200 - 조회 후 customerReadAt 자동 설정', async () => {
+        const res = await request(app.getHttpServer())
+          .get(`/api/inquiries/${inquiryId}`)
+          .set('Cookie', cookieHeader(userCookies))
+          .expect(200);
+
+        const body = res.body as { id: number; customerReadAt: string | null };
+        expect(body.id).toBe(inquiryId);
+        expect(body.customerReadAt).not.toBeNull();
+      });
+
+      it('200 - 재조회 시 customerReadAt 유지 (변경 없음)', async () => {
+        const res1 = await request(app.getHttpServer())
+          .get(`/api/inquiries/${inquiryId}`)
+          .set('Cookie', cookieHeader(userCookies))
+          .expect(200);
+
+        const res2 = await request(app.getHttpServer())
+          .get(`/api/inquiries/${inquiryId}`)
+          .set('Cookie', cookieHeader(userCookies))
+          .expect(200);
+
+        const body1 = res1.body as { customerReadAt: string };
+        const body2 = res2.body as { customerReadAt: string };
+        expect(body1.customerReadAt).toBe(body2.customerReadAt);
+      });
+    });
+
+    describe('GET /api/admin/inquiries?unread=true (미확인 답변 필터)', () => {
+      it('200 - 고객 확인 전: 미확인 목록에 포함', async () => {
+        // Create a new inquiry and answer it without customer reading
+        const newInquiry = await request(app.getHttpServer())
+          .post('/api/inquiries')
+          .set('Cookie', cookieHeader(userCookies))
+          .send({ type: '배송', title: '배송 문의', content: '배송 언제 되나요?' })
+          .expect(201);
+        const newInquiryBody = newInquiry.body as { id: number };
+        const newId = newInquiryBody.id;
+
+        await request(app.getHttpServer())
+          .post(`/api/admin/inquiries/${newId}/answer`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ answer: '곧 발송 예정입니다.' })
+          .expect(201);
+
+        const res = await request(app.getHttpServer())
+          .get('/api/admin/inquiries?unread=true')
+          .set('Cookie', cookieHeader(adminCookies))
+          .expect(200);
+
+        const body = res.body as { items: Array<{ id: number }> };
+        expect(Array.isArray(body.items)).toBe(true);
+        expect(body.items.some((i) => i.id === newId)).toBe(true);
+      });
+
+      it('200 - 고객 확인 후: 미확인 목록에서 제외', async () => {
+        // Customer reads the already-answered original inquiry (customerReadAt was set above)
+        const res = await request(app.getHttpServer())
+          .get('/api/admin/inquiries?unread=true')
+          .set('Cookie', cookieHeader(adminCookies))
+          .expect(200);
+
+        const body = res.body as { items: Array<{ id: number }> };
+        // The first inquiry (inquiryId) should NOT be in unread since customer already read it
+        expect(body.items.every((i) => i.id !== inquiryId)).toBe(true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Closes #506
- 1:1 문의 답변 시 고객 이메일 알림 (NotificationService.sendInquiryAnswered, fire-and-forget)
- Inquiry 엔티티에 \`answeredAt\`, \`customerReadAt\` 컬럼 추가 (마이그레이션 포함)
- 고객이 답변 조회 시 \`customerReadAt\` 자동 업데이트
- 관리자 inquiries 목록에 \`?unread=true\` 필터 추가

## 사전 조사 결과
- 알림 메커니즘: **NotificationService** (Global module) — \`sendInquiryAnswered(email, context)\` 호출. fire-and-forget (void, catch → logger.warn)
- \`answeredAt\` 컬럼은 이미 기존 마이그레이션(1775000000000)에 존재. 신규 마이그레이션은 \`customer_read_at\` 컬럼만 추가.

## 수용 조건
- [x] answer() 성공 시 알림 (첫 답변에만)
- [x] answeredAt, customerReadAt 컬럼 추가
- [x] 고객 조회 시 customerReadAt 갱신  
- [x] 미확인 답변 필터 (?unread=true)

## DB Migration
- 신규: \`src/database/migrations/1782100000000-AddInquiryNotificationColumns.ts\`
- ADD COLUMN \`customer_read_at\` datetime NULL (idempotent — INFORMATION_SCHEMA 존재 체크)
- DOWN: \`customer_read_at\` DROP (idempotent)

## Test plan
- [x] cd backend && npm run lint → pass (0 warnings)
- [x] cd backend && npm run build → pass
- [x] cd backend && npm run test → 562 passed, 0 failed
- [x] cd backend && npm run test:e2e → 205 passed (app.e2e), 2 passed (auth-password-reset.e2e), 0 failed