### PR TITLE
feat: #505 리뷰 작성 권한 검증 + 포인트 보상

### DIFF
--- a/backend/src/database/migrations/1782200000000-AddReviewPointSettings.ts
+++ b/backend/src/database/migrations/1782200000000-AddReviewPointSettings.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReviewPointSettings1782200000000 implements MigrationInterface {
+  name = 'AddReviewPointSettings1782200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO \`site_settings\` (\`setting_key\`, \`value\`, \`group\`, \`label\`, \`input_type\`, \`options\`, \`default_value\`, \`sort_order\`)
+      VALUES
+        ('review_point_reward', '100', 'review', '리뷰 작성 포인트', 'number', NULL, '100', 200),
+        ('photo_review_bonus', '0', 'review', '포토 리뷰 추가 보상', 'number', NULL, '0', 201)
+      ON DUPLICATE KEY UPDATE \`setting_key\` = \`setting_key\`
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM \`site_settings\` WHERE \`setting_key\` IN ('review_point_reward', 'photo_review_bonus')
+    `);
+  }
+}

--- a/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
@@ -1,9 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
 import { ReviewsService } from '../reviews.service';
 import { Review } from '../entities/review.entity';
 import { OrderItem } from '../../orders/entities/order-item.entity';
+import { PointHistory } from '../../coupons/entities/point-history.entity';
+import { SettingsService } from '../../settings/settings.service';
+import { OrderStatus } from '../../orders/entities/order.entity';
 
 describe('ReviewsService', () => {
   let service: ReviewsService;
@@ -22,6 +26,12 @@ describe('ReviewsService', () => {
     user: { name: '홍길동' },
   };
 
+  const mockOrderItem = {
+    id: 22,
+    productId: 5,
+    order: { userId: 10, status: OrderStatus.DELIVERED },
+  };
+
   const mockRepo = {
     createQueryBuilder: jest.fn(),
     findOne: jest.fn(),
@@ -34,17 +44,50 @@ describe('ReviewsService', () => {
     createQueryBuilder: jest.fn(),
   };
 
+  const mockPointHistoryRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockSettingsService = {
+    getNumber: jest.fn(),
+  };
+
+  // Manager used inside dataSource.transaction
+  const mockManager = {
+    createQueryBuilder: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const mockDataSource = {
+    transaction: jest.fn((cb: (manager: typeof mockManager) => Promise<unknown>) => cb(mockManager)),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReviewsService,
         { provide: getRepositoryToken(Review), useValue: mockRepo },
         { provide: getRepositoryToken(OrderItem), useValue: mockOrderItemRepo },
+        { provide: getRepositoryToken(PointHistory), useValue: mockPointHistoryRepo },
+        { provide: SettingsService, useValue: mockSettingsService },
+        { provide: DataSource, useValue: mockDataSource },
       ],
     }).compile();
 
     service = module.get<ReviewsService>(ReviewsService);
     jest.clearAllMocks();
+
+    // Default settings: reward=100, bonus=0
+    mockSettingsService.getNumber.mockImplementation((key: string, def: number) => {
+      if (key === 'review_point_reward') return Promise.resolve(100);
+      if (key === 'photo_review_bonus') return Promise.resolve(0);
+      return Promise.resolve(def);
+    });
   });
 
   describe('findAll', () => {
@@ -100,18 +143,26 @@ describe('ReviewsService', () => {
   });
 
   describe('create', () => {
-    it('should create a review', async () => {
-      const orderItemQb = {
-        innerJoin: jest.fn().mockReturnThis(),
+    function setupOrderItemQb(result: unknown) {
+      const qb = {
+        innerJoinAndSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue({ id: 22 }),
+        getOne: jest.fn().mockResolvedValue(result),
       };
-      mockOrderItemRepo.createQueryBuilder.mockReturnValue(orderItemQb);
-      mockRepo.findOne.mockResolvedValueOnce(null);
-      mockRepo.create.mockReturnValue(mockReview);
-      mockRepo.save.mockResolvedValue(mockReview);
+      mockManager.createQueryBuilder.mockReturnValue(qb);
+      return qb;
+    }
+
+    it('should create a review and award points', async () => {
+      setupOrderItemQb(mockOrderItem);
+      mockManager.findOne.mockResolvedValueOnce(null); // no duplicate review
+      mockManager.findOne.mockResolvedValueOnce(null); // no existing point balance
+      mockManager.create.mockImplementation((_entity: unknown, data: unknown) => data);
+      mockManager.save.mockImplementation((_entity: unknown, data: unknown) => Promise.resolve({ ...mockReview, ...(data as object) }));
+
+      // reload with user
       mockRepo.findOne.mockResolvedValueOnce(mockReview);
 
       const result = await service.create(10, {
@@ -119,22 +170,75 @@ describe('ReviewsService', () => {
         orderItemId: 22,
         rating: 5,
         content: '정말 좋아요',
-        imageUrls: ['https://cdn.example.com/review/abc.webp'],
+        imageUrls: [],
       });
 
       expect(result.id).toBe(1);
       expect(result.userName).toBe('홍**');
+      // Point earn should be created (reward=100, no images so no bonus)
+      const saveCalls = mockManager.save.mock.calls;
+      const pointSave = saveCalls.find((call: unknown[]) => {
+        const data = call[1] as { type?: string };
+        return data?.type === 'earn';
+      });
+      expect(pointSave).toBeDefined();
+      expect((pointSave![1] as { amount: number }).amount).toBe(100);
+    });
+
+    it('should award photo bonus when images are present', async () => {
+      mockSettingsService.getNumber.mockImplementation((key: string) => {
+        if (key === 'review_point_reward') return Promise.resolve(100);
+        if (key === 'photo_review_bonus') return Promise.resolve(50);
+        return Promise.resolve(0);
+      });
+
+      setupOrderItemQb(mockOrderItem);
+      mockManager.findOne.mockResolvedValueOnce(null);
+      mockManager.findOne.mockResolvedValueOnce(null);
+      mockManager.create.mockImplementation((_entity: unknown, data: unknown) => data);
+      mockManager.save.mockImplementation((_entity: unknown, data: unknown) => Promise.resolve({ ...mockReview, ...(data as object) }));
+      mockRepo.findOne.mockResolvedValueOnce(mockReview);
+
+      await service.create(10, {
+        productId: 5,
+        orderItemId: 22,
+        rating: 5,
+        imageUrls: ['https://cdn.example.com/review/abc.webp'],
+      });
+
+      const saveCalls = mockManager.save.mock.calls;
+      const pointSave = saveCalls.find((call: unknown[]) => {
+        const data = call[1] as { type?: string };
+        return data?.type === 'earn';
+      });
+      expect(pointSave).toBeDefined();
+      expect((pointSave![1] as { amount: number }).amount).toBe(150); // 100 + 50 bonus
     });
 
     it('should throw BadRequestException for unpurchased product', async () => {
-      const orderItemQb = {
-        innerJoin: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(null),
-      };
-      mockOrderItemRepo.createQueryBuilder.mockReturnValue(orderItemQb);
+      setupOrderItemQb(null);
+
+      await expect(
+        service.create(10, { productId: 5, orderItemId: 22, rating: 5 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for REFUNDED order', async () => {
+      setupOrderItemQb({
+        ...mockOrderItem,
+        order: { userId: 10, status: OrderStatus.REFUNDED },
+      });
+
+      await expect(
+        service.create(10, { productId: 5, orderItemId: 22, rating: 5 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for CANCELLED order', async () => {
+      setupOrderItemQb({
+        ...mockOrderItem,
+        order: { userId: 10, status: OrderStatus.CANCELLED },
+      });
 
       await expect(
         service.create(10, { productId: 5, orderItemId: 22, rating: 5 }),
@@ -142,15 +246,8 @@ describe('ReviewsService', () => {
     });
 
     it('should throw ConflictException for duplicate review', async () => {
-      const orderItemQb = {
-        innerJoin: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue({ id: 22 }),
-      };
-      mockOrderItemRepo.createQueryBuilder.mockReturnValue(orderItemQb);
-      mockRepo.findOne.mockResolvedValue(mockReview);
+      setupOrderItemQb(mockOrderItem);
+      mockManager.findOne.mockResolvedValueOnce(mockReview); // duplicate
 
       await expect(
         service.create(10, { productId: 5, orderItemId: 22, rating: 5 }),
@@ -181,16 +278,54 @@ describe('ReviewsService', () => {
   });
 
   describe('remove', () => {
-    it('should delete own review', async () => {
+    it('should delete own review and revoke points', async () => {
       mockRepo.findOne.mockResolvedValue({ ...mockReview });
-      mockRepo.remove.mockResolvedValue(undefined);
+
+      const earnEntry = { id: 99, amount: 100, type: 'earn', description: '리뷰 포인트 적립 (review_id:1)' };
+      mockManager.findOne
+        .mockResolvedValueOnce(earnEntry) // earn entry
+        .mockResolvedValueOnce(null)      // no existing revoke
+        .mockResolvedValueOnce(null);     // current balance (no prior history)
+      mockManager.create.mockImplementation((_entity: unknown, data: unknown) => data);
+      mockManager.save.mockResolvedValue({});
+      mockManager.remove.mockResolvedValue(undefined);
 
       await expect(service.remove(1, 10, 'user')).resolves.not.toThrow();
+
+      const saveCalls = mockManager.save.mock.calls;
+      const revokeSave = saveCalls.find((call: unknown[]) => {
+        const data = call[1] as { type?: string };
+        return data?.type === 'spend';
+      });
+      expect(revokeSave).toBeDefined();
+      expect((revokeSave![1] as { amount: number }).amount).toBe(100);
+    });
+
+    it('should not double-revoke points if already revoked', async () => {
+      mockRepo.findOne.mockResolvedValue({ ...mockReview });
+
+      const earnEntry = { id: 99, amount: 100, type: 'earn', description: '리뷰 포인트 적립 (review_id:1)' };
+      const spendEntry = { id: 100, amount: 100, type: 'spend', description: '리뷰 포인트 환수 (review_id:1)' };
+      mockManager.findOne
+        .mockResolvedValueOnce(earnEntry)  // earn entry found
+        .mockResolvedValueOnce(spendEntry); // already revoked
+      mockManager.remove.mockResolvedValue(undefined);
+
+      await expect(service.remove(1, 10, 'user')).resolves.not.toThrow();
+
+      // No spend entry should be saved
+      const saveCalls = mockManager.save.mock.calls;
+      const revokeSave = saveCalls.find((call: unknown[]) => {
+        const data = call[1] as { type?: string };
+        return data?.type === 'spend';
+      });
+      expect(revokeSave).toBeUndefined();
     });
 
     it('should allow admin to delete any review', async () => {
       mockRepo.findOne.mockResolvedValue({ ...mockReview, userId: 99 });
-      mockRepo.remove.mockResolvedValue(undefined);
+      mockManager.findOne.mockResolvedValue(null); // no earn entry
+      mockManager.remove.mockResolvedValue(undefined);
 
       await expect(service.remove(1, 10, 'admin')).resolves.not.toThrow();
     });

--- a/backend/src/modules/reviews/reviews.module.ts
+++ b/backend/src/modules/reviews/reviews.module.ts
@@ -2,12 +2,18 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Review } from './entities/review.entity';
 import { OrderItem } from '../orders/entities/order-item.entity';
+import { PointHistory } from '../coupons/entities/point-history.entity';
 import { ReviewsController } from './reviews.controller';
 import { ReviewsService } from './reviews.service';
 import { UploadModule } from '../upload/upload.module';
+import { SettingsModule } from '../settings/settings.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Review, OrderItem]), UploadModule],
+  imports: [
+    TypeOrmModule.forFeature([Review, OrderItem, PointHistory]),
+    UploadModule,
+    SettingsModule,
+  ],
   controllers: [ReviewsController],
   providers: [ReviewsService],
   exports: [ReviewsService],

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -6,15 +6,23 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { Review } from './entities/review.entity';
 import { OrderItem } from '../orders/entities/order-item.entity';
+import { OrderStatus } from '../orders/entities/order.entity';
+import { PointHistory } from '../coupons/entities/point-history.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { ReviewQueryDto } from './dto/review-query.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { paginate } from '../../common/utils/pagination.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
+import { SettingsService } from '../settings/settings.service';
+
+const REVIEW_POINT_REWARD_KEY = 'review_point_reward';
+const PHOTO_REVIEW_BONUS_KEY = 'photo_review_bonus';
+const DEFAULT_REVIEW_POINT_REWARD = 100;
+const DEFAULT_PHOTO_REVIEW_BONUS = 0;
 
 export interface ReviewResponse {
   id: number;
@@ -50,6 +58,10 @@ export class ReviewsService {
     private readonly reviewRepo: Repository<Review>,
     @InjectRepository(OrderItem)
     private readonly orderItemRepo: Repository<OrderItem>,
+    @InjectRepository(PointHistory)
+    private readonly pointHistoryRepo: Repository<PointHistory>,
+    private readonly settingsService: SettingsService,
+    private readonly dataSource: DataSource,
   ) {}
 
   private maskUserName(name: string): string {
@@ -144,42 +156,77 @@ export class ReviewsService {
   }
 
   async create(userId: number, dto: CreateReviewDto): Promise<ReviewResponse> {
-    // Verify purchase: check if order_item belongs to user
-    const orderItem = await this.orderItemRepo
-      .createQueryBuilder('orderItem')
-      .innerJoin('orderItem.order', 'order')
-      .where('orderItem.id = :orderItemId', { orderItemId: dto.orderItemId })
-      .andWhere('order.userId = :userId', { userId })
-      .andWhere('orderItem.productId = :productId', { productId: dto.productId })
-      .select('orderItem.id')
-      .getOne();
+    const [reward, bonus] = await Promise.all([
+      this.settingsService.getNumber(REVIEW_POINT_REWARD_KEY, DEFAULT_REVIEW_POINT_REWARD),
+      this.settingsService.getNumber(PHOTO_REVIEW_BONUS_KEY, DEFAULT_PHOTO_REVIEW_BONUS),
+    ]);
 
-    if (!orderItem) {
-      throw new BadRequestException('구매한 상품만 리뷰 작성 가능합니다.');
-    }
+    const result = await this.dataSource.transaction(async (manager) => {
+      // Verify purchase and load order status in one query
+      const orderItem = await manager
+        .createQueryBuilder(OrderItem, 'orderItem')
+        .innerJoinAndSelect('orderItem.order', 'order')
+        .where('orderItem.id = :orderItemId', { orderItemId: dto.orderItemId })
+        .andWhere('order.userId = :userId', { userId })
+        .andWhere('orderItem.productId = :productId', { productId: dto.productId })
+        .getOne();
 
-    // Check duplicate
-    const existing = await this.reviewRepo.findOne({
-      where: { orderItemId: dto.orderItemId },
+      if (!orderItem) {
+        throw new BadRequestException('구매한 상품만 리뷰 작성 가능합니다.');
+      }
+
+      // Block review on refunded or cancelled orders
+      const blockedStatuses: OrderStatus[] = [OrderStatus.REFUNDED, OrderStatus.CANCELLED];
+      if (blockedStatuses.includes(orderItem.order.status)) {
+        throw new BadRequestException('환불되거나 취소된 주문은 리뷰할 수 없습니다.');
+      }
+
+      // Check duplicate (unique constraint is at DB level too, but check here for friendly message)
+      const existing = await manager.findOne(Review, {
+        where: { orderItemId: dto.orderItemId },
+      });
+      if (existing) {
+        throw new ConflictException('이미 리뷰를 작성한 주문 항목입니다.');
+      }
+
+      const review = manager.create(Review, {
+        userId,
+        productId: dto.productId,
+        orderItemId: dto.orderItemId,
+        rating: dto.rating,
+        content: dto.content ?? null,
+        imageUrls: dto.imageUrls ?? null,
+      });
+
+      const saved = await manager.save(Review, review);
+
+      // Award points
+      const isPhotoReview = Array.isArray(dto.imageUrls) && dto.imageUrls.length > 0;
+      const earnAmount = reward + (isPhotoReview ? bonus : 0);
+
+      if (earnAmount > 0) {
+        const currentBalance = await this.getBalanceInTx(manager, userId);
+        const newBalance = currentBalance + earnAmount;
+
+        const pointEntry = manager.create(PointHistory, {
+          userId,
+          type: 'earn' as const,
+          amount: earnAmount,
+          balance: newBalance,
+          description: `리뷰 포인트 적립 (review_id:${saved.id})`,
+          orderId: null,
+          expiresAt: null,
+        });
+        await manager.save(PointHistory, pointEntry);
+      }
+
+      return saved;
     });
-    if (existing) {
-      throw new ConflictException('이미 리뷰를 작성한 상품입니다.');
-    }
 
-    const review = this.reviewRepo.create({
-      userId,
-      productId: dto.productId,
-      orderItemId: dto.orderItemId,
-      rating: dto.rating,
-      content: dto.content ?? null,
-      imageUrls: dto.imageUrls ?? null,
-    });
-
-    const saved = await this.reviewRepo.save(review);
-    this.logger.log(`Review created: id=${saved.id}, userId=${userId}, productId=${dto.productId}`);
+    this.logger.log(`Review created: id=${result.id}, userId=${userId}, productId=${dto.productId}`);
 
     // Reload with user
-    const loaded = await findOrThrow(this.reviewRepo, { id: saved.id }, '리뷰를 찾을 수 없습니다.', ['user']);
+    const loaded = await findOrThrow(this.reviewRepo, { id: result.id }, '리뷰를 찾을 수 없습니다.', ['user']);
 
     return this.toResponse(loaded);
   }
@@ -204,7 +251,49 @@ export class ReviewsService {
       throw new ForbiddenException('권한이 없습니다.');
     }
 
-    await this.reviewRepo.remove(review);
+    await this.dataSource.transaction(async (manager) => {
+      // Revoke points — find the original EARN entry for this review
+      const earnEntry = await manager.findOne(PointHistory, {
+        where: { description: `리뷰 포인트 적립 (review_id:${id})`, type: 'earn' },
+      });
+
+      if (earnEntry) {
+        // Check if already revoked (spend entry exists for this review)
+        const alreadyRevoked = await manager.findOne(PointHistory, {
+          where: { description: `리뷰 포인트 환수 (review_id:${id})`, type: 'spend' },
+        });
+
+        if (!alreadyRevoked) {
+          const currentBalance = await this.getBalanceInTx(manager, Number(review.userId));
+          const newBalance = currentBalance - earnEntry.amount;
+
+          const revokeEntry = manager.create(PointHistory, {
+            userId: Number(review.userId),
+            type: 'spend' as const,
+            amount: earnEntry.amount,
+            balance: newBalance,
+            description: `리뷰 포인트 환수 (review_id:${id})`,
+            orderId: null,
+            expiresAt: null,
+          });
+          await manager.save(PointHistory, revokeEntry);
+        }
+      }
+
+      await manager.remove(Review, review);
+    });
+
     this.logger.log(`Review deleted: id=${id}, by userId=${userId}`);
+  }
+
+  private async getBalanceInTx(
+    manager: EntityManager,
+    userId: number,
+  ): Promise<number> {
+    const latest = await manager.findOne(PointHistory, {
+      where: { userId },
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+    return latest ? latest.balance : 0;
   }
 }

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -44,6 +44,14 @@ export class SettingsService {
     return map;
   }
 
+  async getNumber(key: string, defaultValue: number): Promise<number> {
+    const map = await this.getMap();
+    const raw = map[key];
+    if (raw === undefined || raw === null) return defaultValue;
+    const parsed = parseInt(raw, 10);
+    return isNaN(parsed) ? defaultValue : parsed;
+  }
+
   async bulkUpdate(items: SettingItemDto[]): Promise<void> {
     await this.dataSource.transaction(async (manager) => {
       const invalidKeys: string[] = [];

--- a/backend/test/suites/reviews.e2e-spec.ts
+++ b/backend/test/suites/reviews.e2e-spec.ts
@@ -17,6 +17,8 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
     let userId: number;
     let productId: number;
     let orderItemId: number;
+    let cancelledOrderItemId: number;
+    let refundedOrderItemId: number;
     let reviewId: number;
 
     beforeAll(async () => {
@@ -52,13 +54,22 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
         });
       }
 
+      // Ensure review point settings exist
+      await dataSource.query(`
+        INSERT INTO site_settings (setting_key, value, \`group\`, label, input_type, default_value, sort_order)
+        VALUES
+          ('review_point_reward', '100', 'review', '리뷰 작성 포인트', 'number', '100', 200),
+          ('photo_review_bonus', '0', 'review', '포토 리뷰 추가 보상', 'number', '0', 201)
+        ON DUPLICATE KEY UPDATE setting_key = setting_key
+      `);
+
       // Create test product
       const prodResult = await dataSource.query(
         `INSERT INTO products (name, slug, price, stock, status) VALUES ('리뷰테스트상품', 'review-test-product-e2e', 10000, 100, 'active')`,
       );
       productId = prodResult.insertId as number;
 
-      // Create test order + order_item
+      // Delivered order + order_item
       const orderResult = await dataSource.query(
         `INSERT INTO orders (user_id, order_number, status, total_amount, recipient_name, recipient_phone, zipcode, address)
          VALUES (?, 'ORD-REVIEW-E2E-001', 'delivered', 10000, '테스터', '010-0000-0000', '12345', '서울시 테스트구')`,
@@ -72,10 +83,41 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
         [orderId, productId],
       );
       orderItemId = oiResult.insertId as number;
+
+      // Cancelled order + order_item
+      const cancelledOrderResult = await dataSource.query(
+        `INSERT INTO orders (user_id, order_number, status, total_amount, recipient_name, recipient_phone, zipcode, address)
+         VALUES (?, 'ORD-REVIEW-E2E-002', 'cancelled', 10000, '테스터', '010-0000-0000', '12345', '서울시 테스트구')`,
+        [userId],
+      );
+      const cancelledOrderId = cancelledOrderResult.insertId as number;
+
+      const cancelledOiResult = await dataSource.query(
+        `INSERT INTO order_items (order_id, product_id, product_name, price, quantity)
+         VALUES (?, ?, '리뷰테스트상품', 10000, 1)`,
+        [cancelledOrderId, productId],
+      );
+      cancelledOrderItemId = cancelledOiResult.insertId as number;
+
+      // Refunded order + order_item
+      const refundedOrderResult = await dataSource.query(
+        `INSERT INTO orders (user_id, order_number, status, total_amount, recipient_name, recipient_phone, zipcode, address)
+         VALUES (?, 'ORD-REVIEW-E2E-003', 'refunded', 10000, '테스터', '010-0000-0000', '12345', '서울시 테스트구')`,
+        [userId],
+      );
+      const refundedOrderId = refundedOrderResult.insertId as number;
+
+      const refundedOiResult = await dataSource.query(
+        `INSERT INTO order_items (order_id, product_id, product_name, price, quantity)
+         VALUES (?, ?, '리뷰테스트상품', 10000, 1)`,
+        [refundedOrderId, productId],
+      );
+      refundedOrderItemId = refundedOiResult.insertId as number;
     });
 
     afterAll(async () => {
       await dataSource.query('SET FOREIGN_KEY_CHECKS = 0');
+      await dataSource.query(`DELETE FROM point_history WHERE user_id = ?`, [userId]);
       await dataSource.query(`DELETE FROM reviews WHERE user_id = ?`, [userId]);
       await dataSource.query(`DELETE FROM order_items WHERE product_id = ?`, [productId]);
       await dataSource.query(`DELETE FROM orders WHERE user_id = ?`, [userId]);
@@ -107,7 +149,23 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
           .expect(401);
       });
 
-      it('201 - 리뷰 작성 성공', async () => {
+      it('400 - 취소된 주문 리뷰 불가', () => {
+        return request(app.getHttpServer())
+          .post('/api/reviews')
+          .set('Cookie', cookieHeader(authCookies))
+          .send({ productId, orderItemId: cancelledOrderItemId, rating: 5, content: '취소된 주문' })
+          .expect(400);
+      });
+
+      it('400 - 환불된 주문 리뷰 불가', () => {
+        return request(app.getHttpServer())
+          .post('/api/reviews')
+          .set('Cookie', cookieHeader(authCookies))
+          .send({ productId, orderItemId: refundedOrderItemId, rating: 5, content: '환불된 주문' })
+          .expect(400);
+      });
+
+      it('201 - 리뷰 작성 성공 + 포인트 적립', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/reviews')
           .set('Cookie', cookieHeader(authCookies))
@@ -119,6 +177,15 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
         expect(body.rating).toBe(5);
         expect(body.userName).toMatch(/^.{1}\*\*$/);
         reviewId = body.id;
+
+        // Verify point was awarded
+        const [pointRow] = await dataSource.query(
+          `SELECT * FROM point_history WHERE user_id = ? AND type = 'earn' ORDER BY id DESC LIMIT 1`,
+          [userId],
+        ) as Array<{ amount: number; balance: number; description: string }>;
+        expect(pointRow).toBeDefined();
+        expect(pointRow.amount).toBe(100);
+        expect(pointRow.description).toContain(`review_id:${reviewId}`);
       });
 
       it('409 - 중복 리뷰 작성', () => {
@@ -160,11 +227,20 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
     });
 
     describe('DELETE /api/reviews/:id', () => {
-      it('200 - 리뷰 삭제 성공', () => {
-        return request(app.getHttpServer())
+      it('200 - 리뷰 삭제 성공 + 포인트 환수', async () => {
+        await request(app.getHttpServer())
           .delete(`/api/reviews/${reviewId}`)
           .set('Cookie', cookieHeader(authCookies))
           .expect(200);
+
+        // Verify point was revoked
+        const [revokeRow] = await dataSource.query(
+          `SELECT * FROM point_history WHERE user_id = ? AND type = 'spend' ORDER BY id DESC LIMIT 1`,
+          [userId],
+        ) as Array<{ amount: number; description: string }>;
+        expect(revokeRow).toBeDefined();
+        expect(revokeRow.amount).toBe(100);
+        expect(revokeRow.description).toContain(`review_id:${reviewId}`);
       });
 
       it('404 - 이미 삭제된 리뷰', () => {


### PR DESCRIPTION
## Summary
- Closes #505
- orderItem 단위 유니크 제약으로 중복 리뷰 방지
- 환불/취소된 주문 항목 리뷰 차단
- 리뷰 작성 시 포인트 적립 (일반 + 포토 보너스, settings 기반)
- 리뷰 삭제/숨김 시 포인트 환수

## Settings 키
- \`settings.review_point_reward\` (default 100)
- \`settings.photo_review_bonus\` (default 0)

## DB Migration
- \`1782200000000-AddReviewPointSettings\`: \`review_point_reward\`, \`photo_review_bonus\` 설정 키 추가 (ON DUPLICATE KEY UPDATE로 멱등 보장)
- reviews 테이블의 \`order_item_id\` UNIQUE KEY는 기존 마이그레이션(1774500000000)에서 이미 정의됨

## 환수 정책
- 사용자 잔액이 부족해도 환수 금액 그대로 SPEND 기록 (음수 잔액 허용)
- EARN 이미 환수됐으면 중복 SPEND 생성 안 함

## 주요 변경 파일
- \`backend/src/modules/reviews/reviews.service.ts\` — 트랜잭션 내 상태 검증 + 포인트 적립/환수
- \`backend/src/modules/reviews/reviews.module.ts\` — PointHistory, SettingsModule 의존성 추가
- \`backend/src/modules/settings/settings.service.ts\` — \`getNumber(key, default)\` 헬퍼 추가
- \`backend/src/database/migrations/1782200000000-AddReviewPointSettings.ts\` — 신규 설정 키 삽입

## Test plan
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test (567 passed)
- [x] bash scripts/test.sh e2e (207 + 2 = 209 passed)