### PR TITLE
feat: #503 부분 환불 API + refunds 테이블

### DIFF
--- a/backend/src/database/migrations/1776656402451-AddRefundsTable.ts
+++ b/backend/src/database/migrations/1776656402451-AddRefundsTable.ts
@@ -1,0 +1,85 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRefundsTable1776656402451 implements MigrationInterface {
+  name = 'AddRefundsTable1776656402451';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS \`refunds\` (
+        \`id\` bigint NOT NULL AUTO_INCREMENT,
+        \`payment_id\` bigint NOT NULL,
+        \`order_item_id\` bigint NULL,
+        \`amount\` decimal(12,2) NOT NULL,
+        \`reason\` varchar(500) NOT NULL,
+        \`status\` enum('pending','completed','failed') NOT NULL DEFAULT 'pending',
+        \`gateway_refund_id\` varchar(255) NULL,
+        \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        INDEX \`IDX_refunds_payment_id\` (\`payment_id\`),
+        PRIMARY KEY (\`id\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+    `);
+
+    // FK: refunds.payment_id → payments.id
+    const fkPayment = await queryRunner.query(`
+      SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'refunds'
+        AND CONSTRAINT_NAME = 'FK_refunds_payment_id'
+        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    `);
+    if ((fkPayment as unknown[]).length === 0) {
+      await queryRunner.query(`
+        ALTER TABLE \`refunds\`
+          ADD CONSTRAINT \`FK_refunds_payment_id\`
+          FOREIGN KEY (\`payment_id\`) REFERENCES \`payments\`(\`id\`)
+          ON DELETE NO ACTION ON UPDATE NO ACTION
+      `);
+    }
+
+    // FK: refunds.order_item_id → order_items.id (nullable)
+    const fkOrderItem = await queryRunner.query(`
+      SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'refunds'
+        AND CONSTRAINT_NAME = 'FK_refunds_order_item_id'
+        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    `);
+    if ((fkOrderItem as unknown[]).length === 0) {
+      await queryRunner.query(`
+        ALTER TABLE \`refunds\`
+          ADD CONSTRAINT \`FK_refunds_order_item_id\`
+          FOREIGN KEY (\`order_item_id\`) REFERENCES \`order_items\`(\`id\`)
+          ON DELETE NO ACTION ON UPDATE NO ACTION
+      `);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop FK to order_items if exists
+    const fkOrderItem = await queryRunner.query(`
+      SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'refunds'
+        AND CONSTRAINT_NAME = 'FK_refunds_order_item_id'
+        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    `);
+    if ((fkOrderItem as unknown[]).length > 0) {
+      await queryRunner.query(`ALTER TABLE \`refunds\` DROP FOREIGN KEY \`FK_refunds_order_item_id\``);
+    }
+
+    // Drop FK to payments if exists
+    const fkPayment = await queryRunner.query(`
+      SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'refunds'
+        AND CONSTRAINT_NAME = 'FK_refunds_payment_id'
+        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    `);
+    if ((fkPayment as unknown[]).length > 0) {
+      await queryRunner.query(`ALTER TABLE \`refunds\` DROP FOREIGN KEY \`FK_refunds_payment_id\``);
+    }
+
+    await queryRunner.query(`DROP TABLE IF EXISTS \`refunds\``);
+  }
+}

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -426,6 +426,79 @@ describe('PaymentsService', () => {
       await expect(service.partialRefund(1, { amount: 10000, reason: '환불' })).rejects.toThrow(InternalServerErrorException);
       expect(mockRefundRepo.update).toHaveBeenCalledWith(expect.anything(), { status: RefundStatus.FAILED });
     });
+
+    it('[CRITICAL] 부분 환불 2회 누적 — totalRefunded 이중 계산 없이 정확히 누적', async () => {
+      // 총 10000원 결제, 5000 1차 환불 후 SUM=5000 → PARTIAL_CANCELLED
+      // 5000 2차 환불 후 SUM=10000 → REFUNDED + Order REFUNDED
+      const totalPayment = makePayment({
+        id: 100,
+        orderId: 1,
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: 'pay_abc',
+        amount: 10000,
+        gateway: PaymentGatewayType.MOCK,
+      });
+
+      // Phase 1 manager (create pending refund)
+      const phase1Manager = makeRefundManager({
+        findOne: jest.fn().mockResolvedValue(totalPayment),
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          getRawOne: jest.fn().mockResolvedValue({ total: '5000' }),
+        }),
+      });
+
+      // Phase 3 manager: after updating refund to COMPLETED, SUM returns 10000
+      const phase3Manager = makeTransactionManager({
+        update: jest.fn().mockResolvedValue({}),
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          getRawOne: jest.fn().mockResolvedValue({ total: '10000' }),
+        }),
+      });
+
+      mockDataSource.transaction
+        .mockImplementationOnce(async (fn: (m: typeof phase1Manager) => Promise<unknown>) => fn(phase1Manager))
+        .mockImplementationOnce(async (fn: (m: typeof phase3Manager) => Promise<unknown>) => fn(phase3Manager));
+
+      mockPaymentRepo.findOne.mockResolvedValue(totalPayment);
+      mockRefundRepo.findOne.mockResolvedValue({
+        id: 2, paymentId: 100, amount: 5000, status: RefundStatus.COMPLETED, reason: '2차 환불',
+      });
+      mockDefaultGateway.partialCancel.mockResolvedValue({
+        refundId: 'mock-refund-456',
+        cancelledAt: new Date(),
+        rawResponse: { mock: true },
+      });
+
+      await service.partialRefund(1, { amount: 5000, reason: '2차 환불' });
+
+      // Phase 3 must update Payment to REFUNDED and Order to REFUNDED
+      expect(phase3Manager.update).toHaveBeenCalledWith(Payment, totalPayment.id, { status: PaymentStatus.REFUNDED });
+      expect(phase3Manager.update).toHaveBeenCalledWith(Order, totalPayment.orderId, { status: OrderStatus.REFUNDED });
+    });
+
+    it('[HIGH] Phase 3 DB 실패 — gateway 성공 후 DB 동기화 실패 시 Refund를 FAILED로 마킹하지 않음', async () => {
+      const refundManager = makeRefundManager();
+      mockDataSource.transaction
+        .mockImplementationOnce(async (fn: (m: typeof refundManager) => Promise<unknown>) => fn(refundManager))
+        .mockImplementationOnce(async () => { throw new Error('DB 오류'); });
+
+      mockPaymentRepo.findOne.mockResolvedValue(confirmedPayment);
+      mockDefaultGateway.partialCancel.mockResolvedValue({
+        refundId: 'mock-refund-789',
+        cancelledAt: new Date(),
+        rawResponse: { mock: true },
+      });
+      mockRefundRepo.update.mockResolvedValue({});
+
+      await expect(service.partialRefund(1, { amount: 10000, reason: '환불' })).rejects.toThrow(InternalServerErrorException);
+
+      // Refund must NOT be marked FAILED — gateway already processed the refund
+      expect(mockRefundRepo.update).not.toHaveBeenCalledWith(expect.anything(), { status: RefundStatus.FAILED });
+    });
   });
 
   describe('cancel()', () => {

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -4,6 +4,7 @@ import { DataSource } from 'typeorm';
 import { NotFoundException, BadRequestException, ConflictException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
 import { PaymentsService } from '../payments.service';
 import { Payment, PaymentStatus, PaymentMethod, PaymentGatewayType } from '../entities/payment.entity';
+import { Refund, RefundStatus } from '../entities/refund.entity';
 import { Shipping } from '../entities/shipping.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { User } from '../../users/entities/user.entity';
@@ -93,6 +94,13 @@ describe('PaymentsService', () => {
     update: jest.fn(),
   };
 
+  const mockRefundRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn(),
+  };
+
   const mockOrderRepo = {
     findOne: jest.fn(),
     update: jest.fn(),
@@ -108,6 +116,7 @@ describe('PaymentsService', () => {
     prepare: jest.fn(),
     confirm: jest.fn(),
     cancel: jest.fn(),
+    partialCancel: jest.fn(),
     verifyWebhook: jest.fn(),
   };
 
@@ -115,6 +124,7 @@ describe('PaymentsService', () => {
     prepare: jest.fn(),
     confirm: jest.fn(),
     cancel: jest.fn(),
+    partialCancel: jest.fn(),
     verifyWebhook: jest.fn(),
   };
 
@@ -122,6 +132,7 @@ describe('PaymentsService', () => {
     prepare: jest.fn(),
     confirm: jest.fn(),
     cancel: jest.fn(),
+    partialCancel: jest.fn(),
     verifyWebhook: jest.fn(),
   };
 
@@ -135,6 +146,7 @@ describe('PaymentsService', () => {
       providers: [
         PaymentsService,
         { provide: getRepositoryToken(Payment), useValue: mockPaymentRepo },
+        { provide: getRepositoryToken(Refund), useValue: mockRefundRepo },
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockShippingRepo },
         { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
@@ -313,6 +325,106 @@ describe('PaymentsService', () => {
       expect(confirmResult.status).toBe(PaymentStatus.CONFIRMED);
       expect(mockTossAdapter.confirm).toHaveBeenCalledWith('pay_toss_abc', 30000, 'ORD-20240101-ABCD1');
       expect(mockDefaultGateway.confirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('partialRefund()', () => {
+    const confirmedPayment = makePayment({
+      status: PaymentStatus.CONFIRMED,
+      paymentKey: 'pay_abc',
+      amount: 30000,
+      gateway: PaymentGatewayType.MOCK,
+    });
+
+    const makeRefundManager = (overrides: Record<string, jest.Mock> = {}) => {
+      const pendingRefund = {
+        id: 1,
+        paymentId: 100,
+        orderItemId: null,
+        amount: 10000,
+        reason: '부분 환불',
+        status: RefundStatus.PENDING,
+        gatewayRefundId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      return makeTransactionManager({
+        findOne: jest.fn().mockResolvedValue(confirmedPayment),
+        create: jest.fn().mockImplementation((_entity: unknown, data: unknown) => ({ ...pendingRefund, ...(data as object) })),
+        save: jest.fn().mockImplementation((_entity: unknown, data: unknown) => Promise.resolve({ ...pendingRefund, ...(data as object) })),
+        getRawOne: jest.fn().mockResolvedValue({ total: '0' }),
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          getRawOne: jest.fn().mockResolvedValue({ total: '0' }),
+        }),
+        ...overrides,
+      });
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('결제 CONFIRMED 상태 → 부분 환불 성공 → Refund 반환', async () => {
+      const refundManager = makeRefundManager();
+      mockDataSource.transaction
+        .mockImplementationOnce(async (fn: (m: typeof refundManager) => Promise<unknown>) => fn(refundManager))
+        .mockImplementationOnce(async (fn: (m: typeof refundManager) => Promise<unknown>) => fn(refundManager));
+
+      mockPaymentRepo.findOne.mockResolvedValue(confirmedPayment);
+      mockRefundRepo.findOne.mockResolvedValue({
+        id: 1, paymentId: 100, amount: 10000, status: RefundStatus.COMPLETED, reason: '부분 환불',
+      });
+
+      mockDefaultGateway.partialCancel.mockResolvedValue({
+        refundId: 'mock-refund-123',
+        cancelledAt: new Date(),
+        rawResponse: { mock: true },
+      });
+
+      const result = await service.partialRefund(1, { amount: 10000, reason: '부분 환불' });
+      expect(result.status).toBe(RefundStatus.COMPLETED);
+    });
+
+    it('결제 CONFIRMED 아님 → BadRequestException', async () => {
+      const pendingManager = makeRefundManager({
+        findOne: jest.fn().mockResolvedValue(makePayment({ status: PaymentStatus.PENDING, paymentKey: 'pay_abc' })),
+      });
+      mockDataSource.transaction.mockImplementationOnce(
+        async (fn: (m: typeof pendingManager) => Promise<unknown>) => fn(pendingManager),
+      );
+
+      await expect(service.partialRefund(1, { amount: 10000, reason: '환불' })).rejects.toThrow(BadRequestException);
+    });
+
+    it('금액 초과 → BadRequestException', async () => {
+      const overManager = makeRefundManager({
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          getRawOne: jest.fn().mockResolvedValue({ total: '25000' }),
+        }),
+      });
+      mockDataSource.transaction.mockImplementationOnce(
+        async (fn: (m: typeof overManager) => Promise<unknown>) => fn(overManager),
+      );
+
+      await expect(service.partialRefund(1, { amount: 99999, reason: '초과' })).rejects.toThrow(BadRequestException);
+    });
+
+    it('어댑터 실패 → Refund status=failed + InternalServerErrorException', async () => {
+      const refundManager = makeRefundManager();
+      mockDataSource.transaction.mockImplementationOnce(
+        async (fn: (m: typeof refundManager) => Promise<unknown>) => fn(refundManager),
+      );
+
+      mockPaymentRepo.findOne.mockResolvedValue(confirmedPayment);
+      mockDefaultGateway.partialCancel.mockRejectedValue(new Error('gateway error'));
+      mockRefundRepo.update.mockResolvedValue({});
+
+      await expect(service.partialRefund(1, { amount: 10000, reason: '환불' })).rejects.toThrow(InternalServerErrorException);
+      expect(mockRefundRepo.update).toHaveBeenCalledWith(expect.anything(), { status: RefundStatus.FAILED });
     });
   });
 

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { PaymentsService } from '../payments.service';
 import { Payment } from '../entities/payment.entity';
+import { Refund } from '../entities/refund.entity';
 import { Order } from '../../orders/entities/order.entity';
 import { Shipping } from '../entities/shipping.entity';
 import { TossPaymentAdapter } from '../adapters/toss.adapter';
@@ -31,6 +32,7 @@ describe('PaymentsService — webhook', () => {
       providers: [
         PaymentsService,
         { provide: getRepositoryToken(Payment), useValue: mockRepo },
+        { provide: getRepositoryToken(Refund), useValue: mockRepo },
         { provide: getRepositoryToken(Order), useValue: mockRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockRepo },
         { provide: getRepositoryToken(User), useValue: mockRepo },

--- a/backend/src/modules/payments/__tests__/toss.adapter.spec.ts
+++ b/backend/src/modules/payments/__tests__/toss.adapter.spec.ts
@@ -106,4 +106,79 @@ describe('TossPaymentAdapter', () => {
       expect(result.orderId).toBe('ORDER-123');
     });
   });
+
+  describe('partialCancel', () => {
+    it('Toss 응답의 transactionKey를 refundId로 반환', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          cancels: [
+            {
+              canceledAt: '2026-01-01T00:00:00.000Z',
+              cancelAmount: 5000,
+              transactionKey: 'toss-txn-key-abc123',
+            },
+          ],
+        }),
+      });
+
+      const result = await adapter.partialCancel({
+        paymentKey: 'pk123',
+        cancelAmount: 5000,
+        cancelReason: '부분 환불',
+      });
+
+      expect(result.refundId).toBe('toss-txn-key-abc123');
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('cancels 배열 마지막 항목의 transactionKey 사용', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          cancels: [
+            { canceledAt: '2026-01-01T00:00:00.000Z', cancelAmount: 3000, transactionKey: 'first-key' },
+            { canceledAt: '2026-01-02T00:00:00.000Z', cancelAmount: 5000, transactionKey: 'last-key' },
+          ],
+        }),
+      });
+
+      const result = await adapter.partialCancel({
+        paymentKey: 'pk123',
+        cancelAmount: 5000,
+        cancelReason: '부분 환불',
+      });
+
+      expect(result.refundId).toBe('last-key');
+    });
+
+    it('transactionKey 없으면 toss- 폴백 ID 사용', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          cancels: [{ canceledAt: '2026-01-01T00:00:00.000Z', cancelAmount: 5000 }],
+        }),
+      });
+
+      const result = await adapter.partialCancel({
+        paymentKey: 'pk123',
+        cancelAmount: 5000,
+        cancelReason: '부분 환불',
+      });
+
+      expect(result.refundId).toMatch(/^toss-pk123-\d+$/);
+    });
+
+    it('Toss API 실패 → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ code: 'INVALID_REQUEST' }),
+      });
+
+      await expect(
+        adapter.partialCancel({ paymentKey: 'pk123', cancelAmount: 5000, cancelReason: '환불' }),
+      ).rejects.toThrow(BadGatewayException);
+    });
+  });
 });

--- a/backend/src/modules/payments/adapters/mock.adapter.ts
+++ b/backend/src/modules/payments/adapters/mock.adapter.ts
@@ -1,5 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { PaymentGateway, PrepareResult, ConfirmResult, CancelResult } from '../interfaces/payment-gateway.interface';
+import {
+  PaymentGateway, PrepareResult, ConfirmResult, CancelResult,
+  PartialCancelParams, PartialCancelResult,
+} from '../interfaces/payment-gateway.interface';
 
 export const MOCK_TEST_SIGNATURE = 'mock-test-signature';
 
@@ -28,6 +31,14 @@ export class MockPaymentAdapter implements PaymentGateway {
 
   async cancel(paymentKey: string, reason: string): Promise<CancelResult> {
     return { cancelledAt: new Date(), rawResponse: { mock: true, reason, paymentKey } as object };
+  }
+
+  async partialCancel(params: PartialCancelParams): Promise<PartialCancelResult> {
+    return {
+      refundId: `mock-refund-${Date.now()}`,
+      cancelledAt: new Date(),
+      rawResponse: { mock: true, ...params } as object,
+    };
   }
 
   verifyWebhook(_payload: unknown, signature: string): boolean {

--- a/backend/src/modules/payments/adapters/stripe.adapter.ts
+++ b/backend/src/modules/payments/adapters/stripe.adapter.ts
@@ -7,6 +7,8 @@ import {
   PrepareResult,
   ConfirmResult,
   CancelResult,
+  PartialCancelParams,
+  PartialCancelResult,
 } from '../interfaces/payment-gateway.interface';
 
 @Injectable()
@@ -108,6 +110,28 @@ export class StripePaymentAdapter implements PaymentGateway {
         `Stripe cancel failed: paymentKey=${paymentKey}, error=${String(err)}`,
       );
       throw new BadGatewayException('Stripe API 취소 오류');
+    }
+  }
+
+  async partialCancel(params: PartialCancelParams): Promise<PartialCancelResult> {
+    try {
+      const refund = await this.ensureStripe().refunds.create({
+        payment_intent: params.paymentKey,
+        amount: params.cancelAmount,
+        reason: 'requested_by_customer',
+        metadata: { reason: params.cancelReason },
+      });
+
+      return {
+        refundId: refund.id,
+        cancelledAt: new Date((refund.created ?? Date.now() / 1000) * 1000),
+        rawResponse: refund as unknown as object,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Stripe partialCancel failed: paymentKey=${params.paymentKey}, error=${String(err)}`,
+      );
+      throw new BadGatewayException('Stripe API 부분 취소 오류');
     }
   }
 

--- a/backend/src/modules/payments/adapters/toss.adapter.ts
+++ b/backend/src/modules/payments/adapters/toss.adapter.ts
@@ -117,11 +117,15 @@ export class TossPaymentAdapter implements PaymentGateway {
     }
 
     const body = (await response.json()) as Record<string, unknown>;
-    const cancels = body.cancels as Array<{ canceledAt?: string }> | undefined;
+    const cancels = body.cancels as Array<{ canceledAt?: string; transactionKey?: string }> | undefined;
+    const lastCancel = Array.isArray(cancels) ? cancels[cancels.length - 1] : null;
+    const refundId = typeof lastCancel?.transactionKey === 'string'
+      ? lastCancel.transactionKey
+      : `toss-${params.paymentKey}-${Date.now()}`;
 
     return {
-      refundId: `toss-${params.paymentKey}-${Date.now()}`,
-      cancelledAt: new Date(cancels?.[0]?.canceledAt ?? Date.now()),
+      refundId,
+      cancelledAt: new Date(lastCancel?.canceledAt ?? Date.now()),
       rawResponse: body as object,
     };
   }

--- a/backend/src/modules/payments/adapters/toss.adapter.ts
+++ b/backend/src/modules/payments/adapters/toss.adapter.ts
@@ -6,6 +6,8 @@ import {
   PrepareResult,
   ConfirmResult,
   CancelResult,
+  PartialCancelParams,
+  PartialCancelResult,
 } from '../interfaces/payment-gateway.interface';
 
 @Injectable()
@@ -85,6 +87,40 @@ export class TossPaymentAdapter implements PaymentGateway {
     const cancels = body.cancels as Array<{ canceledAt?: string }> | undefined;
 
     return {
+      cancelledAt: new Date(cancels?.[0]?.canceledAt ?? Date.now()),
+      rawResponse: body as object,
+    };
+  }
+
+  async partialCancel(params: PartialCancelParams): Promise<PartialCancelResult> {
+    const response = await fetch(
+      `https://api.tosspayments.com/v1/payments/${params.paymentKey}/cancel`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: this.authHeader,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          cancelReason: params.cancelReason,
+          cancelAmount: params.cancelAmount,
+        }),
+        signal: AbortSignal.timeout(8000),
+      },
+    );
+
+    if (!response.ok) {
+      this.logger.error(
+        `Toss partialCancel failed: status=${response.status}, paymentKey=${params.paymentKey}`,
+      );
+      throw new BadGatewayException('토스 API 부분 취소 오류');
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+    const cancels = body.cancels as Array<{ canceledAt?: string }> | undefined;
+
+    return {
+      refundId: `toss-${params.paymentKey}-${Date.now()}`,
       cancelledAt: new Date(cancels?.[0]?.canceledAt ?? Date.now()),
       rawResponse: body as object,
     };

--- a/backend/src/modules/payments/admin-order-refunds.controller.ts
+++ b/backend/src/modules/payments/admin-order-refunds.controller.ts
@@ -1,0 +1,33 @@
+import {
+  Controller, Post, Param, Body, ParseIntPipe,
+} from '@nestjs/common';
+import {
+  ApiTags, ApiOperation, ApiResponse, ApiParam, ApiCookieAuth,
+} from '@nestjs/swagger';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { PaymentsService } from './payments.service';
+import { CreateRefundDto } from './dto/create-refund.dto';
+import { Refund } from './entities/refund.entity';
+
+@ApiTags('관리자 - 환불')
+@ApiCookieAuth()
+@Roles('admin', 'super_admin')
+@Controller('admin/orders')
+export class AdminOrderRefundsController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  @Post(':id/refunds')
+  @ApiOperation({ summary: '부분 환불 처리', description: '주문에 대해 부분 환불을 처리합니다.' })
+  @ApiParam({ name: 'id', type: Number, description: '주문 ID' })
+  @ApiResponse({ status: 201, description: '환불 처리 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청 (환불 불가 상태 또는 금액 초과)' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 404, description: '주문을 찾을 수 없음' })
+  async create(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: CreateRefundDto,
+  ): Promise<Refund> {
+    return this.paymentsService.partialRefund(id, dto);
+  }
+}

--- a/backend/src/modules/payments/dto/create-refund.dto.ts
+++ b/backend/src/modules/payments/dto/create-refund.dto.ts
@@ -1,6 +1,6 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsInt, IsString, MaxLength, Min, IsArray, IsOptional,
+  IsInt, IsString, MaxLength, Min,
 } from 'class-validator';
 
 export class CreateRefundDto {
@@ -13,14 +13,4 @@ export class CreateRefundDto {
   @IsString()
   @MaxLength(500)
   reason!: string;
-
-  @ApiPropertyOptional({
-    example: [1, 2],
-    description: '환불 대상 주문 항목 ID 목록 (null이면 전체)',
-    type: [Number],
-  })
-  @IsArray()
-  @IsOptional()
-  @IsInt({ each: true })
-  orderItemIds?: number[];
 }

--- a/backend/src/modules/payments/dto/create-refund.dto.ts
+++ b/backend/src/modules/payments/dto/create-refund.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsInt, IsString, MaxLength, Min, IsArray, IsOptional,
+} from 'class-validator';
+
+export class CreateRefundDto {
+  @ApiProperty({ example: 15000, description: '환불 금액 (원)' })
+  @IsInt()
+  @Min(1)
+  amount!: number;
+
+  @ApiProperty({ example: '고객 변심', description: '환불 사유 (최대 500자)' })
+  @IsString()
+  @MaxLength(500)
+  reason!: string;
+
+  @ApiPropertyOptional({
+    example: [1, 2],
+    description: '환불 대상 주문 항목 ID 목록 (null이면 전체)',
+    type: [Number],
+  })
+  @IsArray()
+  @IsOptional()
+  @IsInt({ each: true })
+  orderItemIds?: number[];
+}

--- a/backend/src/modules/payments/entities/refund.entity.ts
+++ b/backend/src/modules/payments/entities/refund.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn,
+  ManyToOne, JoinColumn, Index,
+} from 'typeorm';
+import { Payment } from './payment.entity';
+import { OrderItem } from '../../orders/entities/order-item.entity';
+
+export enum RefundStatus {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+@Entity('refunds')
+@Index(['paymentId'])
+export class Refund {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({ name: 'payment_id', type: 'bigint' })
+  paymentId!: number;
+
+  @Column({ name: 'order_item_id', type: 'bigint', nullable: true })
+  orderItemId!: number | null;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  amount!: number;
+
+  @Column({ type: 'varchar', length: 500 })
+  reason!: string;
+
+  @Column({ type: 'enum', enum: RefundStatus, default: RefundStatus.PENDING })
+  status!: RefundStatus;
+
+  @Column({ name: 'gateway_refund_id', type: 'varchar', length: 255, nullable: true })
+  gatewayRefundId!: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+
+  @ManyToOne(() => Payment)
+  @JoinColumn({ name: 'payment_id' })
+  payment!: Payment;
+
+  @ManyToOne(() => OrderItem, { nullable: true })
+  @JoinColumn({ name: 'order_item_id' })
+  orderItem!: OrderItem | null;
+}

--- a/backend/src/modules/payments/interfaces/payment-gateway.interface.ts
+++ b/backend/src/modules/payments/interfaces/payment-gateway.interface.ts
@@ -16,9 +16,22 @@ export interface CancelResult {
   rawResponse: object;
 }
 
+export interface PartialCancelParams {
+  paymentKey: string;
+  cancelAmount: number;
+  cancelReason: string;
+}
+
+export interface PartialCancelResult {
+  refundId: string;
+  cancelledAt: Date;
+  rawResponse: object;
+}
+
 export interface PaymentGateway {
   prepare(orderId: string, amount: number): Promise<PrepareResult>;
   confirm(paymentKey: string, amount: number, orderId: string): Promise<ConfirmResult>;
   cancel(paymentKey: string, reason: string): Promise<CancelResult>;
+  partialCancel(params: PartialCancelParams): Promise<PartialCancelResult>;
   verifyWebhook(payload: unknown, signature: string): boolean;
 }

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from './entities/payment.entity';
+import { Refund } from './entities/refund.entity';
 import { Shipping } from './entities/shipping.entity';
 import { Order } from '../orders/entities/order.entity';
 import { User } from '../users/entities/user.entity';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
+import { AdminOrderRefundsController } from './admin-order-refunds.controller';
 import { MockPaymentAdapter } from './adapters/mock.adapter';
 import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
@@ -55,8 +57,8 @@ const gatewayProviders = [
 ];
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment, Shipping, Order, User])],
-  controllers: [PaymentsController],
+  imports: [TypeOrmModule.forFeature([Payment, Refund, Shipping, Order, User])],
+  controllers: [PaymentsController, AdminOrderRefundsController],
   providers: [...gatewayProviders, PaymentsService],
   exports: [PaymentsService],
 })

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -320,20 +320,29 @@ export class PaymentsService {
     const payment = await findOrThrow(this.paymentRepository, { orderId }, '결제 정보를 찾을 수 없습니다.');
     const cancelGateway = this.resolveGatewayByType(payment.gateway);
 
+    let gatewayResult: { refundId: string };
     try {
-      const result = await cancelGateway.partialCancel({
+      gatewayResult = await cancelGateway.partialCancel({
         paymentKey: payment.paymentKey!,
         cancelAmount: dto.amount,
         cancelReason: dto.reason,
       });
+    } catch (err) {
+      await this.refundRepository.update(refund.id, { status: RefundStatus.FAILED });
+      this.logger.error(`partialRefund gateway failed: orderId=${orderId}, refundId=${refund.id}, error=${String(err)}`);
+      if (err instanceof BadRequestException) throw err;
+      throw new InternalServerErrorException('환불 처리에 실패했습니다.');
+    }
 
-      // Phase 3: update Refund + Payment status
+    // Phase 3: DB sync of gateway success
+    try {
       await this.dataSource.transaction(async (manager) => {
         await manager.update(Refund, refund.id, {
           status: RefundStatus.COMPLETED,
-          gatewayRefundId: result.refundId,
+          gatewayRefundId: gatewayResult.refundId,
         });
 
+        // SUM already includes current refund (updated to COMPLETED above)
         const completedRefundsResult = await manager
           .createQueryBuilder(Refund, 'r')
           .select('COALESCE(SUM(r.amount), 0)', 'total')
@@ -342,25 +351,30 @@ export class PaymentsService {
             status: RefundStatus.COMPLETED,
           })
           .getRawOne<{ total: string }>();
-        const totalRefunded = Number(completedRefundsResult?.total ?? 0) + dto.amount;
+        const totalRefunded = Number(completedRefundsResult?.total ?? 0);
 
-        const newPaymentStatus =
-          totalRefunded >= Number(payment.amount)
-            ? PaymentStatus.REFUNDED
-            : PaymentStatus.PARTIAL_CANCELLED;
-
-        await manager.update(Payment, payment.id, { status: newPaymentStatus });
+        if (totalRefunded >= Number(payment.amount)) {
+          await manager.update(Payment, payment.id, { status: PaymentStatus.REFUNDED });
+          await manager.update(Order, payment.orderId, { status: OrderStatus.REFUNDED });
+        } else {
+          await manager.update(Payment, payment.id, { status: PaymentStatus.PARTIAL_CANCELLED });
+        }
       });
-
-      refund = await findOrThrow(this.refundRepository, { id: refund.id }, '환불 정보를 찾을 수 없습니다.');
-
-      // TODO(#481, #483): 재고 복구/포인트 환수 연계
     } catch (err) {
-      if (err instanceof BadRequestException) throw err;
-      await this.refundRepository.update(refund.id, { status: RefundStatus.FAILED });
-      this.logger.error(`partialRefund failed: orderId=${orderId}, refundId=${refund.id}, error=${String(err)}`);
-      throw new InternalServerErrorException('부분 환불 처리에 실패했습니다.');
+      this.logger.error({
+        event: 'refund_db_sync_failed',
+        orderId,
+        refundId: refund.id,
+        gatewayRefundId: gatewayResult.refundId,
+        amount: dto.amount,
+        error: err instanceof Error ? err.message : String(err),
+      }, 'Gateway refund succeeded but DB sync failed - manual reconciliation required');
+      throw new InternalServerErrorException('환불이 처리됐으나 시스템 반영에 실패했습니다. 운영팀에 문의하세요.');
     }
+
+    refund = await findOrThrow(this.refundRepository, { id: refund.id }, '환불 정보를 찾을 수 없습니다.');
+
+    // TODO(#481, #483): 재고 복구/포인트 환수 연계
 
     return refund;
   }

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -6,6 +6,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { Payment, PaymentStatus, PaymentGatewayType, PaymentMethod } from './entities/payment.entity';
+import { Refund, RefundStatus } from './entities/refund.entity';
 import { Shipping, ShippingStatus } from './entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
 import { User } from '../users/entities/user.entity';
@@ -13,6 +14,7 @@ import { PaymentGateway } from './interfaces/payment-gateway.interface';
 import { PreparePaymentDto } from './dto/prepare-payment.dto';
 import { ConfirmPaymentDto } from './dto/confirm-payment.dto';
 import { CancelPaymentDto } from './dto/cancel-payment.dto';
+import { CreateRefundDto } from './dto/create-refund.dto';
 import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
 import { resolveGatewayByLocale } from './payments.module';
@@ -29,6 +31,8 @@ export class PaymentsService {
   constructor(
     @InjectRepository(Payment)
     private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(Refund)
+    private readonly refundRepository: Repository<Refund>,
     @InjectRepository(Order)
     private readonly orderRepository: Repository<Order>,
     @InjectRepository(Shipping)
@@ -265,6 +269,100 @@ export class PaymentsService {
       cancelledAt: result.cancelledAt,
       cancelReason: reason,
     };
+  }
+
+  async partialRefund(orderId: number, dto: CreateRefundDto): Promise<Refund> {
+    // Phase 1: lock payment + validate + create pending Refund
+    let refund = await this.dataSource.transaction(async (manager) => {
+      const payment = await manager.findOne(Payment, {
+        where: { orderId },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!payment) {
+        throw new BadRequestException('결제 정보를 찾을 수 없습니다.');
+      }
+      if (payment.status !== PaymentStatus.CONFIRMED && payment.status !== PaymentStatus.PARTIAL_CANCELLED) {
+        throw new BadRequestException('환불 가능한 상태가 아닙니다.');
+      }
+      if (!payment.paymentKey) {
+        throw new BadRequestException('결제 키가 없습니다.');
+      }
+
+      // Validate remaining refundable amount
+      const completedRefundsResult = await manager
+        .createQueryBuilder(Refund, 'r')
+        .select('COALESCE(SUM(r.amount), 0)', 'total')
+        .where('r.paymentId = :paymentId AND r.status = :status', {
+          paymentId: payment.id,
+          status: RefundStatus.COMPLETED,
+        })
+        .getRawOne<{ total: string }>();
+      const alreadyRefunded = Number(completedRefundsResult?.total ?? 0);
+      const remaining = Number(payment.amount) - alreadyRefunded;
+      if (dto.amount > remaining) {
+        throw new BadRequestException(
+          `환불 가능 금액(${remaining}원)을 초과했습니다.`,
+        );
+      }
+
+      const pendingRefund = manager.create(Refund, {
+        paymentId: Number(payment.id),
+        orderItemId: null,
+        amount: dto.amount,
+        reason: dto.reason,
+        status: RefundStatus.PENDING,
+        gatewayRefundId: null,
+      });
+      return manager.save(Refund, pendingRefund);
+    });
+
+    // Phase 2: call gateway outside transaction
+    const payment = await findOrThrow(this.paymentRepository, { orderId }, '결제 정보를 찾을 수 없습니다.');
+    const cancelGateway = this.resolveGatewayByType(payment.gateway);
+
+    try {
+      const result = await cancelGateway.partialCancel({
+        paymentKey: payment.paymentKey!,
+        cancelAmount: dto.amount,
+        cancelReason: dto.reason,
+      });
+
+      // Phase 3: update Refund + Payment status
+      await this.dataSource.transaction(async (manager) => {
+        await manager.update(Refund, refund.id, {
+          status: RefundStatus.COMPLETED,
+          gatewayRefundId: result.refundId,
+        });
+
+        const completedRefundsResult = await manager
+          .createQueryBuilder(Refund, 'r')
+          .select('COALESCE(SUM(r.amount), 0)', 'total')
+          .where('r.paymentId = :paymentId AND r.status = :status', {
+            paymentId: payment.id,
+            status: RefundStatus.COMPLETED,
+          })
+          .getRawOne<{ total: string }>();
+        const totalRefunded = Number(completedRefundsResult?.total ?? 0) + dto.amount;
+
+        const newPaymentStatus =
+          totalRefunded >= Number(payment.amount)
+            ? PaymentStatus.REFUNDED
+            : PaymentStatus.PARTIAL_CANCELLED;
+
+        await manager.update(Payment, payment.id, { status: newPaymentStatus });
+      });
+
+      refund = await findOrThrow(this.refundRepository, { id: refund.id }, '환불 정보를 찾을 수 없습니다.');
+
+      // TODO(#481, #483): 재고 복구/포인트 환수 연계
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      await this.refundRepository.update(refund.id, { status: RefundStatus.FAILED });
+      this.logger.error(`partialRefund failed: orderId=${orderId}, refundId=${refund.id}, error=${String(err)}`);
+      throw new InternalServerErrorException('부분 환불 처리에 실패했습니다.');
+    }
+
+    return refund;
   }
 
   private async notifyPaymentConfirmed(

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,9 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerGuard, ThrottlerStorage } from '@nestjs/throttler';
 import request from 'supertest';
 import cookieParser from 'cookie-parser';
 import { AppModule } from '../src/app.module';
+import { UserAwareThrottlerGuard } from '../src/common/guards/user-aware-throttler.guard';
 import { registerAuthSuite } from './suites/auth.e2e-spec';
 import { registerCartSuite } from './suites/cart.e2e-spec';
 import { registerOrdersSuite } from './suites/orders.e2e-spec';
@@ -21,6 +22,7 @@ import { registerNavigationSuite } from './suites/navigation.e2e-spec';
 import { registerReviewsSuite } from './suites/reviews.e2e-spec';
 import { registerAttributesSuite } from './suites/attributes.e2e-spec';
 import { registerInquiriesSuite } from './suites/inquiries.e2e-spec';
+import { registerRefundsSuite } from './suites/refunds.e2e-spec';
 
 describe('App (e2e)', () => {
   let app: INestApplication;
@@ -31,6 +33,10 @@ describe('App (e2e)', () => {
     })
       .overrideGuard(ThrottlerGuard)
       .useValue({ canActivate: () => true })
+      .overrideGuard(UserAwareThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .overrideProvider(ThrottlerStorage)
+      .useValue({ increment: async () => ({ totalHits: 1, timeToExpire: 0, isBlocked: false, timeToBlockExpire: 0 }), getRecord: async () => [] })
       .compile();
 
     app = moduleFixture.createNestApplication();
@@ -80,4 +86,5 @@ describe('App (e2e)', () => {
   registerReviewsSuite(() => app);
   registerAttributesSuite(() => app);
   registerInquiriesSuite(() => app);
+  registerRefundsSuite(() => app);
 });

--- a/backend/test/suites/refunds.e2e-spec.ts
+++ b/backend/test/suites/refunds.e2e-spec.ts
@@ -1,0 +1,156 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import {
+  AuthCookies,
+  cookieHeader,
+  loginAndGetCookies,
+  registerAndGetCookies,
+} from '../helpers/auth-cookie.helper';
+
+let app: INestApplication;
+let dataSource: DataSource;
+
+export function registerRefundsSuite(getApp: () => INestApplication) {
+  describe('Refunds (e2e)', () => {
+    let adminCookies: AuthCookies;
+    let userCookies: AuthCookies;
+    let productId: number;
+    let orderId: number;
+
+    const adminEmail = `refunds-admin-${Date.now()}@test.com`;
+    const userEmail = `refunds-user-${Date.now()}@test.com`;
+
+    beforeAll(async () => {
+      app = getApp();
+      dataSource = app.get(DataSource);
+
+      // Register & promote admin
+      await registerAndGetCookies(app, {
+        email: adminEmail,
+        password: 'Test1234!',
+        name: '환불관리자',
+      });
+      await dataSource.query(`UPDATE users SET role = 'admin' WHERE email = ?`, [adminEmail]);
+      adminCookies = await loginAndGetCookies(app, {
+        email: adminEmail,
+        password: 'Test1234!',
+      });
+
+      // Register user
+      await registerAndGetCookies(app, {
+        email: userEmail,
+        password: 'Test1234!',
+        name: '결제유저',
+      });
+      userCookies = await loginAndGetCookies(app, {
+        email: userEmail,
+        password: 'Test1234!',
+      });
+
+      // Seed product
+      const prodResult = await dataSource.query(`
+        INSERT INTO products (name, slug, price, sale_price, stock, status)
+        VALUES ('환불테스트상품', 'refunds-test-product-e2e', 30000, 30000, 10, 'active')
+      `);
+      productId = (prodResult as { insertId: number }).insertId;
+
+      // Create order
+      const orderRes = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Cookie', cookieHeader(userCookies))
+        .send({
+          items: [{ productId, quantity: 1 }],
+          recipientName: '홍길동',
+          recipientPhone: '010-1234-5678',
+          zipcode: '12345',
+          address: '서울시 강남구',
+        })
+        .expect(201);
+      orderId = Number((orderRes.body as { id: number }).id);
+
+      // Prepare payment
+      await request(app.getHttpServer())
+        .post('/api/payments/prepare')
+        .set('Cookie', cookieHeader(userCookies))
+        .send({ orderId });
+
+      // Confirm payment (mock)
+      await request(app.getHttpServer())
+        .post('/api/payments/confirm')
+        .set('Cookie', cookieHeader(userCookies))
+        .send({ orderId, paymentKey: 'pay_mock_refund_test', amount: 30000 })
+        .expect((r) => {
+          if (r.status !== 200 && r.status !== 201)
+            throw new Error(`Confirm failed: ${r.status} ${JSON.stringify(r.body)}`);
+        });
+    });
+
+    afterAll(async () => {
+      await dataSource.query('SET FOREIGN_KEY_CHECKS = 0');
+      await dataSource.query(`DELETE FROM refunds WHERE payment_id IN (SELECT id FROM payments WHERE order_id = ?)`, [orderId]);
+      await dataSource.query(`DELETE FROM shipping WHERE order_id = ?`, [orderId]);
+      await dataSource.query(`DELETE FROM payments WHERE order_id = ?`, [orderId]);
+      await dataSource.query(`DELETE FROM order_items WHERE order_id = ?`, [orderId]);
+      await dataSource.query(`DELETE FROM orders WHERE id = ?`, [orderId]);
+      await dataSource.query(`DELETE FROM products WHERE id = ?`, [productId]);
+      await dataSource.query(`DELETE FROM users WHERE email IN (?, ?)`, [adminEmail, userEmail]);
+      await dataSource.query('SET FOREIGN_KEY_CHECKS = 1');
+    });
+
+    describe('POST /api/admin/orders/:id/refunds', () => {
+      it('일반 사용자 → 403', async () => {
+        return request(app.getHttpServer())
+          .post(`/api/admin/orders/${orderId}/refunds`)
+          .set('Cookie', cookieHeader(userCookies))
+          .send({ amount: 10000, reason: '테스트 환불' })
+          .expect(403);
+      });
+
+      it('인증 없음 → 401', async () => {
+        return request(app.getHttpServer())
+          .post(`/api/admin/orders/${orderId}/refunds`)
+          .send({ amount: 10000, reason: '테스트 환불' })
+          .expect(401);
+      });
+
+      it('관리자 → 부분 환불 → 201, Refund 반환', async () => {
+        const res = await request(app.getHttpServer())
+          .post(`/api/admin/orders/${orderId}/refunds`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ amount: 10000, reason: '부분 환불 테스트' })
+          .expect((r) => {
+            if (r.status !== 200 && r.status !== 201)
+              throw new Error(`Expected 201 got ${r.status}: ${JSON.stringify(r.body)}`);
+          });
+
+        const body = res.body as {
+          id: number;
+          amount: number;
+          status: string;
+          reason: string;
+        };
+        expect(body.id).toBeDefined();
+        expect(Number(body.amount)).toBe(10000);
+        expect(body.status).toBe('completed');
+        expect(body.reason).toBe('부분 환불 테스트');
+      });
+
+      it('환불 금액 초과 → 400', async () => {
+        return request(app.getHttpServer())
+          .post(`/api/admin/orders/${orderId}/refunds`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ amount: 99999, reason: '초과 환불' })
+          .expect(400);
+      });
+
+      it('존재하지 않는 주문 → 400', async () => {
+        return request(app.getHttpServer())
+          .post(`/api/admin/orders/999999999/refunds`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ amount: 1000, reason: '없는 주문' })
+          .expect(400);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Closes #503
- POST /admin/orders/:id/refunds (관리자 전용)
- Refund 엔티티 + refunds 테이블 (신규 마이그레이션)
- Toss/Stripe/Mock 어댑터 partialCancel 경로
- Payment 상태 자동 전이: PARTIAL_CANCELLED → CANCELLED/REFUNDED
- 2-phase 트랜잭션 (lock → adapter 호출 → 결과 반영)

## 범위 제외 (별도 이슈)
- 재고 복구 + 포인트 환수는 #481 / #483 연계 (hook 주석만)

## DB Migration
- `refunds` 테이블 (payment_id FK, order_item_id FK nullable, amount decimal, reason varchar, status enum, gateway_refund_id varchar, timestamps)

## Test plan
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test
- [x] cd backend && npm run test:e2e