### PR TITLE
fix: #홈 상품 블록 평점 노출 및 홈 페이지 시드 공개 상태 수정

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -64,6 +64,10 @@ import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.gu
         name: 'forgotPassword',
         ttl: Number(process.env.THROTTLE_FORGOT_PASSWORD_TTL ?? 60000),
         limit: Number(process.env.THROTTLE_FORGOT_PASSWORD_LIMIT ?? 1),
+        skipIf: (context) => {
+          const req = context.switchToHttp().getRequest<{ method?: string; originalUrl?: string }>();
+          return !(req.method === 'POST' && String(req.originalUrl ?? '').startsWith('/api/auth/forgot-password'));
+        },
         getTracker: (req) => {
           const rawEmail =
             typeof req.body === 'object' && req.body !== null && 'email' in req.body

--- a/backend/src/database/seeds/seeders/page.seeder.ts
+++ b/backend/src/database/seeds/seeders/page.seeder.ts
@@ -12,6 +12,20 @@ export class PageSeeder extends Seeder {
   async run(): Promise<void> {
     const repo = this.dataSource.getRepository(Page);
     const inserted = await this.upsert(repo, pages as unknown as Partial<Page>[], (p) => p.slug);
-    console.log(`✓ Pages: ${inserted} inserted, ${pages.length - inserted} existing`);
+
+    let updated = 0;
+    for (const page of pages) {
+      const result = await repo.update(
+        { slug: page.slug },
+        {
+          title: page.title,
+          template: page.template,
+          is_published: page.isPublished,
+        },
+      );
+      updated += result.affected ?? 0;
+    }
+
+    console.log(`✓ Pages: ${inserted} inserted, ${updated - inserted} updated, ${pages.length - updated} unchanged`);
   }
 }

--- a/scripts/run-seed.sh
+++ b/scripts/run-seed.sh
@@ -7,7 +7,7 @@ BACKEND_DIR="$SCRIPT_DIR/../backend"
 DB_HOST="${DB_HOST:-127.0.0.1}"
 DB_PORT="${DB_PORT:-3307}"
 DB_USER="${DB_USER:-root}"
-DB_PASS="${DB_PASS:-changeme_root_password}"
+DB_PASS="${DB_PASS:-okhwadang_local_root_2024}"
 DB_NAME="${DB_NAME:-commerce}"
 
 # typeorm.config.ts는 DATABASE_URL을 LOCAL_DATABASE_URL보다 우선 사용하고,

--- a/src/components/shared/blocks/ProductCarouselBlock.tsx
+++ b/src/components/shared/blocks/ProductCarouselBlock.tsx
@@ -149,6 +149,8 @@ export default function ProductCarouselBlock({ content }: Props) {
                 name={product.name}
                 price={product.price}
                 salePrice={product.salePrice}
+                rating={product.rating}
+                reviewCount={product.reviewCount}
                 categoryName={product.category?.name}
                 status={product.status}
                 images={product.images}

--- a/src/components/shared/blocks/ProductGridBlock.tsx
+++ b/src/components/shared/blocks/ProductGridBlock.tsx
@@ -113,6 +113,8 @@ export default function ProductGridBlock({ content }: Props) {
               name={product.name}
               price={product.price}
               salePrice={product.salePrice}
+              rating={product.rating}
+              reviewCount={product.reviewCount}
               categoryName={product.category?.name}
               status={product.status}
               images={product.images}


### PR DESCRIPTION
## 변경 사항
- 홈 CMS 상품 캐러셀/그리드 블록에서 ProductCard에 rating, reviewCount 전달
- run-seed 기본 DB 비밀번호를 로컬 환경과 일치하도록 수정
- forgotPassword throttling이 공개 GET API에 새지 않도록 제한
- PageSeeder가 기존 pages 레코드에도 시드의 isPublished 값을 반영하도록 수정

## 검증
- bash scripts/run-seed.sh
- bash scripts/start-local.sh
- 홈 페이지 브라우저 확인: 상품 블록 별점 노출 확인

Closes #0