### PR TITLE
feat: #502 #504 #515 #516 #574 백엔드 운영/배송/SEO 보강

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,6 +41,12 @@ JWT_EXPIRES_IN=1h
 JWT_REFRESH_EXPIRES_IN=7d
 FRONTEND_URL=http://localhost:5173  # REQUIRED
 
+# Sentry (error/APM)
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=development
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+
 # ─────────────────────────────────────────────
 # 캐시: 백엔드 프로세스 내 in-memory (CacheService).
 # Redis/ElastiCache 연결 불필요.
@@ -50,6 +56,9 @@ TOSS_SECRET_KEY=   # Toss Payments secret key (for ko locale)
 TOSS_CLIENT_KEY=   # Toss Payments client key (for ko locale)
 STRIPE_SECRET_KEY=   # Stripe secret key (for global locale)
 STRIPE_WEBHOOK_SECRET=   # Stripe webhook signing secret
+# Shipping carrier API
+CJ_TRACKING_API_URL=
+CJ_TRACKING_API_KEY=
 # ─────────────────────────────────────────────
 # AWS S3 + CloudFront CDN
 # ─────────────────────────────────────────────

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,6 +21,7 @@
         "@nestjs/swagger": "^11.2.6",
         "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^11.0.0",
+        "@sentry/node": "^10.49.0",
         "@types/bcrypt": "^6.0.0",
         "@types/multer": "^2.1.0",
         "axios": "^1.13.6",
@@ -1917,6 +1918,78 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fastify/otel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+      "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.2.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4231,6 +4304,490 @@
         "npm": ">=5.10.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+      "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+      "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+      "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+      "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+      "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+      "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+      "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+      "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
+      "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+      "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+      "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+      "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.36.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+      "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+      "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+      "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+      "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+      "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@opentelemetry/sql-common": "^0.41.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+      "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
+      "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+      "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.24.0.tgz",
+      "integrity": "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
+      "integrity": "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
+      "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -4251,12 +4808,183 @@
         "node": ">=14"
       }
     },
+    "node_modules/@prisma/instrumentation": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+      "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.49.0.tgz",
+      "integrity": "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.49.0.tgz",
+      "integrity": "sha512-xr+HXABCiO5mgAJRQxsXRdNOLO0+Ee6CvXAAIqovL2A1GlhxNWc5ooPWeIrrLDJ/KGyT8zI91O5scpVXdXs0uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-ioredis": "0.62.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-redis": "0.62.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/instrumentation-undici": "0.24.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.49.0",
+        "@sentry/node-core": "10.49.0",
+        "@sentry/opentelemetry": "10.49.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.49.0.tgz",
+      "integrity": "sha512-7WO0KuCDPSq3G54TVUSI1CKFJwB67LasG+n/gDMBqbrarzs/Yh/s34OOMU5gfVQpncxQAmQsy4nEboQms8iNqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.49.0",
+        "@sentry/opentelemetry": "10.49.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.49.0.tgz",
+      "integrity": "sha512-XNLm4dXmtegXQf+EEE2Cs84Ymlo/f5wMx+lg2S2XS4qLbXaPN/HttjhwKftd8D+8iUNfmH+xNMCSshx4s1B/1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.49.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -5674,6 +6402,15 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -5713,6 +6450,26 @@
       "dependencies": {
         "@types/express": "*",
         "@types/passport": "*"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -5775,6 +6532,15 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/validator": {
@@ -6408,13 +7174,21 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-import-phases": {
@@ -6844,7 +7618,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7075,7 +7848,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -9074,6 +9846,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -9577,6 +10355,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -11092,7 +11891,6 @@
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -11122,6 +11920,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -11690,6 +12494,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11816,6 +12651,45 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -12026,6 +12900,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {
@@ -14260,6 +15147,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
+    "@sentry/node": "^10.49.0",
     "@types/bcrypt": "^6.0.0",
     "@types/multer": "^2.1.0",
     "axios": "^1.13.6",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { JournalModule } from './modules/journal/journal.module';
 import { PointsModule } from './modules/points/points.module';
 import { NotificationModule } from './modules/notification/notification.module';
 import { SchedulerModule } from './modules/scheduler/scheduler.module';
+import { SeoModule } from './modules/seo/seo.module';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.guard';
@@ -114,6 +115,7 @@ import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.gu
     PointsModule,
     NotificationModule,
     SchedulerModule,
+    SeoModule,
   ],
   providers: [
     // Guard execution order: ThrottlerGuard → JwtAuthGuard → RolesGuard

--- a/backend/src/common/filters/sentry-exception.filter.ts
+++ b/backend/src/common/filters/sentry-exception.filter.ts
@@ -1,0 +1,44 @@
+import {
+  ArgumentsHost,
+  Catch,
+  HttpException,
+} from '@nestjs/common';
+import { BaseExceptionFilter, HttpAdapterHost } from '@nestjs/core';
+import * as Sentry from '@sentry/node';
+import { redactSensitiveFields } from '../utils/redaction.util';
+
+@Catch()
+export class SentryExceptionFilter extends BaseExceptionFilter {
+  constructor(private readonly adapterHost: HttpAdapterHost) {
+    super(adapterHost.httpAdapter);
+  }
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    Sentry.withScope((scope) => {
+      if (host.getType() === 'http') {
+        const request = host.switchToHttp().getRequest<Record<string, unknown>>();
+        const safeRequest = redactSensitiveFields({
+          method: request?.method,
+          url: request?.url,
+          params: request?.params,
+          query: request?.query,
+          headers: request?.headers,
+          body: request?.body,
+          user: request?.user,
+        });
+
+        if (safeRequest) {
+          scope.setContext('request', safeRequest);
+        }
+      }
+
+      if (exception instanceof HttpException) {
+        scope.setTag('http_status', String(exception.getStatus()));
+      }
+
+      Sentry.captureException(exception);
+    });
+
+    super.catch(exception, host);
+  }
+}

--- a/backend/src/common/utils/redaction.util.ts
+++ b/backend/src/common/utils/redaction.util.ts
@@ -2,6 +2,8 @@ export const SENSITIVE_FIELDS = [
   'password',
   'token',
   'authorization',
+  'cookie',
+  'set-cookie',
   'creditcard',
   'credit_card',
   'cvv',

--- a/backend/src/database/migrations/1782400000000-AddPointHistoryRelatedEntityColumns.ts
+++ b/backend/src/database/migrations/1782400000000-AddPointHistoryRelatedEntityColumns.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPointHistoryRelatedEntityColumns1782400000000 implements MigrationInterface {
+  name = 'AddPointHistoryRelatedEntityColumns1782400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`point_history\`
+       ADD \`related_entity_type\` enum ('review', 'order', 'coupon', 'shipping', 'membership') NULL AFTER \`order_id\`,
+       ADD \`related_entity_id\` bigint NULL AFTER \`related_entity_type\``,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX \`IDX_point_history_related_entity\` ON \`point_history\` (\`related_entity_type\`, \`related_entity_id\`)`,
+    );
+
+    await queryRunner.query(
+      `UPDATE \`point_history\`
+       SET
+         \`related_entity_type\` = 'review',
+         \`related_entity_id\` = CAST(
+           SUBSTRING_INDEX(
+             SUBSTRING_INDEX(\`description\`, 'review_id:', -1),
+             ')',
+             1
+           ) AS UNSIGNED
+         )
+       WHERE \`description\` REGEXP 'review_id:[0-9]+'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX \`IDX_point_history_related_entity\` ON \`point_history\``);
+    await queryRunner.query(
+      `ALTER TABLE \`point_history\`
+       DROP COLUMN \`related_entity_id\`,
+       DROP COLUMN \`related_entity_type\``,
+    );
+  }
+}

--- a/backend/src/database/migrations/1782400000001-AddShippingPolicySettings.ts
+++ b/backend/src/database/migrations/1782400000001-AddShippingPolicySettings.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddShippingPolicySettings1782400000001 implements MigrationInterface {
+  name = 'AddShippingPolicySettings1782400000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO \`site_settings\` (\`setting_key\`, \`value\`, \`group\`, \`label\`, \`input_type\`, \`options\`, \`default_value\`, \`sort_order\`)
+       VALUES
+         ('free_shipping_threshold', '50000', 'shipping', '무료배송 임계 금액', 'number', NULL, '50000', 300),
+         ('shipping_base_fee', '3000', 'shipping', '기본 배송비', 'number', NULL, '3000', 301),
+         ('remote_area_surcharge', '3000', 'shipping', '도서산간 추가 배송비', 'number', NULL, '3000', 302)
+       ON DUPLICATE KEY UPDATE
+         \`value\` = VALUES(\`value\`),
+         \`default_value\` = VALUES(\`default_value\`),
+         \`group\` = VALUES(\`group\`),
+         \`label\` = VALUES(\`label\`),
+         \`input_type\` = VALUES(\`input_type\`),
+         \`options\` = VALUES(\`options\`),
+         \`sort_order\` = VALUES(\`sort_order\`)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM \`site_settings\` WHERE \`setting_key\` IN ('free_shipping_threshold', 'shipping_base_fee', 'remote_area_surcharge')`,
+    );
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,13 +1,17 @@
 import 'reflect-metadata';
 import 'dotenv/config';
+import * as Sentry from '@sentry/node';
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, Logger, BadRequestException } from '@nestjs/common';
+import { ValidationPipe, Logger, BadRequestException, RequestMethod } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 import { assertEnv } from './config/env-validator';
 import { resolveTrustProxy } from './config/trust-proxy';
+import { SentryExceptionFilter } from './common/filters/sentry-exception.filter';
+import { redactSensitiveFields } from './common/utils/redaction.util';
 
 // 프로덕션 환경에서 필수 env 키 사전 검증 — 누락 시 명확한 에러 메시지와 함께 종료
 assertEnv();
@@ -16,6 +20,28 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const logger = new Logger('Bootstrap');
   app.enableShutdownHooks();
+
+  const sentryDsn = process.env.SENTRY_DSN?.trim();
+  if (sentryDsn) {
+    const tracesSampleRate = Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1');
+    Sentry.init({
+      dsn: sentryDsn,
+      environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
+      release: process.env.SENTRY_RELEASE || process.env.GIT_COMMIT_SHA,
+      tracesSampleRate: Number.isFinite(tracesSampleRate) ? tracesSampleRate : 0.1,
+      sendDefaultPii: false,
+      beforeSend(event) {
+        const redacted = redactSensitiveFields(event as unknown as Record<string, unknown>);
+        if (!redacted) {
+          return event;
+        }
+        return redacted as unknown as typeof event;
+      },
+    });
+
+    app.useGlobalFilters(new SentryExceptionFilter(app.get(HttpAdapterHost)));
+    logger.log('Sentry error monitoring enabled');
+  }
 
   // TypeORM returns bigint columns as strings; convert numeric strings to numbers in JSON responses
   const httpAdapter = app.getHttpAdapter();
@@ -38,7 +64,12 @@ async function bootstrap() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (httpAdapter.getInstance() as any).set('trust proxy', trustProxy);
 
-  app.setGlobalPrefix('api');
+  app.setGlobalPrefix('api', {
+    exclude: [
+      { path: 'sitemap.xml', method: RequestMethod.GET },
+      { path: 'robots.txt', method: RequestMethod.GET },
+    ],
+  });
 
   const frontendUrl = process.env.FRONTEND_URL;
   if (!frontendUrl) {
@@ -83,6 +114,7 @@ async function bootstrap() {
 
   const gracefulShutdown = async (signal: string) => {
     logger.log(`Received ${signal}. Starting graceful shutdown...`);
+    await Sentry.close(2000);
     const closeWithTimeout = Promise.race([
       app.close(),
       new Promise((resolve) => setTimeout(resolve, 30_000)),

--- a/backend/src/modules/coupons/entities/point-history.entity.ts
+++ b/backend/src/modules/coupons/entities/point-history.entity.ts
@@ -36,6 +36,17 @@ export class PointHistory {
   @Column({ name: 'order_id', type: 'bigint', nullable: true })
   orderId!: number | null;
 
+  @Column({
+    name: 'related_entity_type',
+    type: 'enum',
+    enum: ['review', 'order', 'coupon', 'shipping', 'membership'],
+    nullable: true,
+  })
+  relatedEntityType!: 'review' | 'order' | 'coupon' | 'shipping' | 'membership' | null;
+
+  @Column({ name: 'related_entity_id', type: 'bigint', nullable: true })
+  relatedEntityId!: number | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 

--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -9,6 +9,7 @@ import { CreateOrderDto } from '../dto/create-order.dto';
 import { PointsService } from '../../points/points.service';
 import { NotificationService } from '../../notification/notification.service';
 import { CouponsService } from '../../coupons/coupons.service';
+import { ShippingFeeCalculatorService } from '../../shipping/services/shipping-fee-calculator.service';
 
 const mockQueryRunner = {
   connect: jest.fn(),
@@ -42,6 +43,19 @@ const mockCouponsService = {
   useCoupon: jest.fn(),
 };
 
+const mockShippingFeeCalculator = {
+  calculate: jest.fn().mockResolvedValue({
+    subtotal: 0,
+    zipcode: '12345',
+    shippingFee: 0,
+    isFreeShipping: true,
+    isRemoteArea: false,
+    threshold: 50000,
+    baseFee: 3000,
+    remoteAreaSurcharge: 3000,
+  }),
+};
+
 describe('OrdersService', () => {
   let service: OrdersService;
 
@@ -58,6 +72,7 @@ describe('OrdersService', () => {
         { provide: PointsService, useValue: mockPointsService },
         { provide: NotificationService, useValue: { sendOrderConfirmed: jest.fn() } },
         { provide: CouponsService, useValue: mockCouponsService },
+        { provide: ShippingFeeCalculatorService, useValue: mockShippingFeeCalculator },
       ],
     }).compile();
 

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -8,9 +8,15 @@ import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 import { PointsModule } from '../points/points.module';
 import { CouponsModule } from '../coupons/coupons.module';
+import { ShippingModule } from '../shipping/shipping.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order, OrderItem, PointHistory, User]), PointsModule, CouponsModule],
+  imports: [
+    TypeOrmModule.forFeature([Order, OrderItem, PointHistory, User]),
+    PointsModule,
+    CouponsModule,
+    ShippingModule,
+  ],
   controllers: [OrdersController],
   providers: [OrdersService],
   exports: [OrdersService],

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -18,6 +18,7 @@ import { PointsService } from '../points/points.service';
 import { NotificationService } from '../notification/notification.service';
 import { CouponsService } from '../coupons/coupons.service';
 import { CalculateDiscountDto } from '../coupons/dto/calculate-discount.dto';
+import { ShippingFeeCalculatorService } from '../shipping/services/shipping-fee-calculator.service';
 
 @Injectable()
 export class OrdersService {
@@ -33,6 +34,7 @@ export class OrdersService {
     private readonly pointsService: PointsService,
     private readonly notificationService: NotificationService,
     private readonly couponsService: CouponsService,
+    private readonly shippingFeeCalculator: ShippingFeeCalculatorService,
   ) {}
 
   private generateOrderNumber(): string {
@@ -65,7 +67,7 @@ export class OrdersService {
       }
 
       const orderItems: Partial<OrderItem>[] = [];
-      let totalAmount = 0;
+      let subtotalAmount = 0;
 
       for (const item of dto.items) {
         const product = await queryRunner.manager
@@ -118,7 +120,7 @@ export class OrdersService {
 
         const unitPrice = Number(product.salePrice ?? product.price) + priceAdjustment;
         const subtotal = unitPrice * item.quantity;
-        totalAmount += subtotal;
+        subtotalAmount += subtotal;
 
         orderItems.push({
           productId: Number(item.productId),
@@ -131,24 +133,29 @@ export class OrdersService {
       }
 
       let discountAmount = 0;
-      if (dto.userCouponId) {
+      let discountedAmount = subtotalAmount;
+
+      if (dto.userCouponId || pointsToUse > 0) {
         const calculateDto: CalculateDiscountDto = {
-          orderAmount: totalAmount,
+          orderAmount: subtotalAmount,
           userCouponId: dto.userCouponId,
           pointsToUse,
         };
         const discountResult = await this.couponsService.calculate(userId, calculateDto);
         discountAmount = discountResult.couponDiscount;
-        totalAmount = discountResult.finalAmount;
+        discountedAmount = discountResult.finalAmount;
       }
+
+      const shippingQuote = await this.shippingFeeCalculator.calculate(subtotalAmount, dto.zipcode);
+      const totalPayable = discountedAmount + shippingQuote.shippingFee;
 
       const order = queryRunner.manager.create(Order, {
         userId,
         orderNumber: this.generateOrderNumber(),
         status: OrderStatus.PENDING,
-        totalAmount,
+        totalAmount: totalPayable,
         discountAmount,
-        shippingFee: 0,
+        shippingFee: shippingQuote.shippingFee,
         recipientName: dto.recipientName,
         recipientPhone: dto.recipientPhone,
         zipcode: dto.zipcode,
@@ -199,7 +206,7 @@ export class OrdersService {
       await queryRunner.commitTransaction();
       this.logger.log(`Order created: ${savedOrder.orderNumber} userId=${userId}`);
 
-      void this.notifyOrderCreated(userId, savedOrder.orderNumber, totalAmount, dto.recipientName);
+      void this.notifyOrderCreated(userId, savedOrder.orderNumber, totalPayable, dto.recipientName);
 
       return this.findOne(Number(savedOrder.id), userId);
     } catch (err) {

--- a/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
@@ -281,7 +281,14 @@ describe('ReviewsService', () => {
     it('should delete own review and revoke points', async () => {
       mockRepo.findOne.mockResolvedValue({ ...mockReview });
 
-      const earnEntry = { id: 99, amount: 100, type: 'earn', description: '리뷰 포인트 적립 (review_id:1)' };
+      const earnEntry = {
+        id: 99,
+        amount: 100,
+        type: 'earn',
+        description: '리뷰 포인트 적립 (review_id:1)',
+        relatedEntityType: 'review',
+        relatedEntityId: 1,
+      };
       mockManager.findOne
         .mockResolvedValueOnce(earnEntry) // earn entry
         .mockResolvedValueOnce(null)      // no existing revoke
@@ -301,11 +308,59 @@ describe('ReviewsService', () => {
       expect((revokeSave![1] as { amount: number }).amount).toBe(100);
     });
 
+    it('should revoke based on relatedEntity columns even when description format changes', async () => {
+      mockRepo.findOne.mockResolvedValue({ ...mockReview });
+
+      const earnEntry = {
+        id: 199,
+        amount: 100,
+        type: 'earn',
+        description: 'LEGACY_FORMAT',
+        relatedEntityType: 'review',
+        relatedEntityId: 1,
+      };
+      mockManager.findOne
+        .mockResolvedValueOnce(earnEntry)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+      mockManager.create.mockImplementation((_entity: unknown, data: unknown) => data);
+      mockManager.save.mockResolvedValue({});
+      mockManager.remove.mockResolvedValue(undefined);
+
+      await expect(service.remove(1, 10, 'user')).resolves.not.toThrow();
+
+      expect(mockManager.findOne).toHaveBeenNthCalledWith(
+        1,
+        PointHistory,
+        expect.objectContaining({
+          where: expect.objectContaining({
+            relatedEntityType: 'review',
+            relatedEntityId: 1,
+            type: 'earn',
+          }),
+        }),
+      );
+    });
+
     it('should not double-revoke points if already revoked', async () => {
       mockRepo.findOne.mockResolvedValue({ ...mockReview });
 
-      const earnEntry = { id: 99, amount: 100, type: 'earn', description: '리뷰 포인트 적립 (review_id:1)' };
-      const spendEntry = { id: 100, amount: 100, type: 'spend', description: '리뷰 포인트 환수 (review_id:1)' };
+      const earnEntry = {
+        id: 99,
+        amount: 100,
+        type: 'earn',
+        description: '리뷰 포인트 적립 (review_id:1)',
+        relatedEntityType: 'review',
+        relatedEntityId: 1,
+      };
+      const spendEntry = {
+        id: 100,
+        amount: 100,
+        type: 'spend',
+        description: '리뷰 포인트 환수 (review_id:1)',
+        relatedEntityType: 'review',
+        relatedEntityId: 1,
+      };
       mockManager.findOne
         .mockResolvedValueOnce(earnEntry)  // earn entry found
         .mockResolvedValueOnce(spendEntry); // already revoked

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -215,6 +215,8 @@ export class ReviewsService {
           balance: newBalance,
           description: `리뷰 포인트 적립 (review_id:${saved.id})`,
           orderId: null,
+          relatedEntityType: 'review' as const,
+          relatedEntityId: Number(saved.id),
           expiresAt: null,
         });
         await manager.save(PointHistory, pointEntry);
@@ -254,13 +256,23 @@ export class ReviewsService {
     await this.dataSource.transaction(async (manager) => {
       // Revoke points — find the original EARN entry for this review
       const earnEntry = await manager.findOne(PointHistory, {
-        where: { description: `리뷰 포인트 적립 (review_id:${id})`, type: 'earn' },
+        where: {
+          userId: Number(review.userId),
+          relatedEntityType: 'review',
+          relatedEntityId: id,
+          type: 'earn',
+        },
       });
 
       if (earnEntry) {
         // Check if already revoked (spend entry exists for this review)
         const alreadyRevoked = await manager.findOne(PointHistory, {
-          where: { description: `리뷰 포인트 환수 (review_id:${id})`, type: 'spend' },
+          where: {
+            userId: Number(review.userId),
+            relatedEntityType: 'review',
+            relatedEntityId: id,
+            type: 'spend',
+          },
         });
 
         if (!alreadyRevoked) {
@@ -274,6 +286,8 @@ export class ReviewsService {
             balance: newBalance,
             description: `리뷰 포인트 환수 (review_id:${id})`,
             orderId: null,
+            relatedEntityType: 'review' as const,
+            relatedEntityId: id,
             expiresAt: null,
           });
           await manager.save(PointHistory, revokeEntry);

--- a/backend/src/modules/seo/__tests__/seo.service.spec.ts
+++ b/backend/src/modules/seo/__tests__/seo.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SeoService } from '../seo.service';
+import { Product, ProductStatus } from '../../products/entities/product.entity';
+import { Page } from '../../pages/entities/page.entity';
+import { JournalEntry } from '../../journal/entities/journal-entry.entity';
+
+describe('SeoService', () => {
+  let service: SeoService;
+
+  const mockProductRepo = {
+    find: jest.fn(),
+  } as unknown as Repository<Product>;
+
+  const mockPageRepo = {
+    find: jest.fn(),
+  } as unknown as Repository<Page>;
+
+  const mockJournalRepo = {
+    find: jest.fn(),
+  } as unknown as Repository<JournalEntry>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SeoService,
+        { provide: getRepositoryToken(Product), useValue: mockProductRepo },
+        { provide: getRepositoryToken(Page), useValue: mockPageRepo },
+        { provide: getRepositoryToken(JournalEntry), useValue: mockJournalRepo },
+      ],
+    }).compile();
+
+    service = module.get<SeoService>(SeoService);
+    jest.clearAllMocks();
+    process.env.FRONTEND_URL = 'https://www.okhwadang.com';
+  });
+
+  it('should generate sitemap with localized alternate links', async () => {
+    mockProductRepo.find = jest.fn().mockResolvedValue([
+      { id: 101, status: ProductStatus.ACTIVE, updatedAt: new Date('2026-04-19T10:00:00.000Z') },
+    ]);
+    mockPageRepo.find = jest.fn().mockResolvedValue([
+      { slug: 'home', updated_at: new Date('2026-04-19T09:00:00.000Z'), is_published: true },
+    ]);
+    mockJournalRepo.find = jest.fn().mockResolvedValue([
+      { slug: 'tea-brewing', updatedAt: new Date('2026-04-18T10:00:00.000Z'), isPublished: true },
+    ]);
+
+    const xml = await service.generateSitemapXml();
+
+    expect(xml).toContain('<urlset');
+    expect(xml).toContain('https://www.okhwadang.com/ko/products/101');
+    expect(xml).toContain('hreflang="en" href="https://www.okhwadang.com/en/products/101"');
+    expect(xml).toContain('https://www.okhwadang.com/ko/journal/tea-brewing');
+    expect(xml).toContain('<lastmod>2026-04-19T10:00:00.000Z</lastmod>');
+  });
+
+  it('should generate disallow-all robots for non-production', () => {
+    process.env.NODE_ENV = 'staging';
+
+    const robots = service.generateRobotsTxt();
+
+    expect(robots).toBe('User-agent: *\nDisallow: /');
+  });
+
+  it('should generate allow robots with sitemap for production', () => {
+    process.env.NODE_ENV = 'production';
+
+    const robots = service.generateRobotsTxt();
+
+    expect(robots).toBe(
+      'User-agent: *\nAllow: /\nSitemap: https://www.okhwadang.com/sitemap.xml',
+    );
+  });
+});

--- a/backend/src/modules/seo/seo.controller.ts
+++ b/backend/src/modules/seo/seo.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Public } from '../../common/decorators/public.decorator';
+import { SeoService } from './seo.service';
+
+@ApiTags('SEO')
+@Controller()
+export class SeoController {
+  constructor(private readonly seoService: SeoService) {}
+
+  @Get('sitemap.xml')
+  @Public()
+  @Header('Content-Type', 'application/xml; charset=utf-8')
+  @Header('Cache-Control', 'public, max-age=3600')
+  @ApiOperation({ summary: '동적 sitemap.xml 생성' })
+  @ApiResponse({ status: 200, description: 'sitemap.xml 생성 성공' })
+  async getSitemap(): Promise<string> {
+    return this.seoService.generateSitemapXml();
+  }
+
+  @Get('robots.txt')
+  @Public()
+  @Header('Content-Type', 'text/plain; charset=utf-8')
+  @Header('Cache-Control', 'public, max-age=3600')
+  @ApiOperation({ summary: '동적 robots.txt 생성' })
+  @ApiResponse({ status: 200, description: 'robots.txt 생성 성공' })
+  getRobots(): string {
+    return this.seoService.generateRobotsTxt();
+  }
+}

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Product } from '../products/entities/product.entity';
+import { Page } from '../pages/entities/page.entity';
+import { JournalEntry } from '../journal/entities/journal-entry.entity';
+import { SeoController } from './seo.controller';
+import { SeoService } from './seo.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Product, Page, JournalEntry])],
+  controllers: [SeoController],
+  providers: [SeoService],
+})
+export class SeoModule {}

--- a/backend/src/modules/seo/seo.service.ts
+++ b/backend/src/modules/seo/seo.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Product, ProductStatus } from '../products/entities/product.entity';
+import { Page } from '../pages/entities/page.entity';
+import { JournalEntry } from '../journal/entities/journal-entry.entity';
+
+interface SitemapItem {
+  pathByLocale: Record<string, string>;
+  updatedAt: Date;
+}
+
+const LOCALES = ['ko', 'en', 'ja', 'zh'] as const;
+
+@Injectable()
+export class SeoService {
+  constructor(
+    @InjectRepository(Product)
+    private readonly productRepo: Repository<Product>,
+    @InjectRepository(Page)
+    private readonly pageRepo: Repository<Page>,
+    @InjectRepository(JournalEntry)
+    private readonly journalRepo: Repository<JournalEntry>,
+  ) {}
+
+  private getSiteUrl(): string {
+    const raw = process.env.FRONTEND_URL || 'http://localhost:5173';
+    return raw.replace(/\/+$/, '');
+  }
+
+  private escapeXml(input: string): string {
+    return input
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  private buildLocalizedPaths(basePath: string): Record<string, string> {
+    return Object.fromEntries(LOCALES.map((locale) => [locale, `/${locale}${basePath}`]));
+  }
+
+  private buildUrlNode(item: SitemapItem): string {
+    const siteUrl = this.getSiteUrl();
+    const canonicalLocale = 'ko';
+    const canonicalUrl = `${siteUrl}${item.pathByLocale[canonicalLocale]}`;
+    const alternates = LOCALES.map(
+      (locale) =>
+        `<xhtml:link rel="alternate" hreflang="${locale}" href="${this.escapeXml(`${siteUrl}${item.pathByLocale[locale]}`)}" />`,
+    ).join('');
+
+    return [
+      '<url>',
+      `<loc>${this.escapeXml(canonicalUrl)}</loc>`,
+      `<lastmod>${item.updatedAt.toISOString()}</lastmod>`,
+      alternates,
+      `<xhtml:link rel="alternate" hreflang="x-default" href="${this.escapeXml(canonicalUrl)}" />`,
+      '</url>',
+    ].join('');
+  }
+
+  async generateSitemapXml(): Promise<string> {
+    const [products, pages, journalEntries] = await Promise.all([
+      this.productRepo.find({
+        where: { status: ProductStatus.ACTIVE },
+        select: { id: true, updatedAt: true },
+        order: { updatedAt: 'DESC' },
+      }),
+      this.pageRepo.find({
+        where: { is_published: true },
+        select: { slug: true, updated_at: true },
+        order: { updated_at: 'DESC' },
+      }),
+      this.journalRepo.find({
+        where: { isPublished: true },
+        select: { slug: true, updatedAt: true },
+        order: { updatedAt: 'DESC' },
+      }),
+    ]);
+
+    const productItems: SitemapItem[] = products.map((product) => ({
+      pathByLocale: this.buildLocalizedPaths(`/products/${product.id}`),
+      updatedAt: product.updatedAt,
+    }));
+
+    const pageItems: SitemapItem[] = pages.map((page) => ({
+      pathByLocale: page.slug === 'home'
+        ? Object.fromEntries(LOCALES.map((locale) => [locale, `/${locale}`]))
+        : this.buildLocalizedPaths(`/p/${page.slug}`),
+      updatedAt: page.updated_at,
+    }));
+
+    const articleItems: SitemapItem[] = journalEntries.map((article) => ({
+      pathByLocale: this.buildLocalizedPaths(`/journal/${article.slug}`),
+      updatedAt: article.updatedAt,
+    }));
+
+    const allItems = [...productItems, ...pageItems, ...articleItems].sort(
+      (a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+    );
+
+    const urlNodes = allItems.map((item) => this.buildUrlNode(item)).join('');
+
+    return [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
+      urlNodes,
+      '</urlset>',
+    ].join('');
+  }
+
+  generateRobotsTxt(): string {
+    const siteUrl = this.getSiteUrl();
+    const env = (process.env.NODE_ENV || 'development').toLowerCase();
+    const isProduction = env === 'production';
+
+    if (!isProduction) {
+      return [
+        'User-agent: *',
+        'Disallow: /',
+      ].join('\n');
+    }
+
+    return [
+      'User-agent: *',
+      'Allow: /',
+      `Sitemap: ${siteUrl}/sitemap.xml`,
+    ].join('\n');
+  }
+}

--- a/backend/src/modules/shipping/__tests__/shipping-fee-calculator.service.spec.ts
+++ b/backend/src/modules/shipping/__tests__/shipping-fee-calculator.service.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ShippingFeeCalculatorService } from '../services/shipping-fee-calculator.service';
+import { SettingsService } from '../../settings/settings.service';
+
+describe('ShippingFeeCalculatorService', () => {
+  let service: ShippingFeeCalculatorService;
+
+  const mockSettingsService = {
+    getNumber: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockSettingsService.getNumber.mockImplementation((key: string, defaultValue: number) => {
+      if (key === 'free_shipping_threshold') return Promise.resolve(50000);
+      if (key === 'shipping_base_fee') return Promise.resolve(3000);
+      if (key === 'remote_area_surcharge') return Promise.resolve(4000);
+      return Promise.resolve(defaultValue);
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShippingFeeCalculatorService,
+        { provide: SettingsService, useValue: mockSettingsService },
+      ],
+    }).compile();
+
+    service = module.get<ShippingFeeCalculatorService>(ShippingFeeCalculatorService);
+  });
+
+  it('free shipping threshold 미만이면 기본 배송비를 부과한다', async () => {
+    const result = await service.calculate(30000, '04524');
+
+    expect(result.shippingFee).toBe(3000);
+    expect(result.isFreeShipping).toBe(false);
+    expect(result.isRemoteArea).toBe(false);
+  });
+
+  it('제주(63 prefix) 우편번호는 도서산간 추가비를 부과한다', async () => {
+    const result = await service.calculate(30000, '63124');
+
+    expect(result.shippingFee).toBe(7000);
+    expect(result.isRemoteArea).toBe(true);
+  });
+
+  it('무료배송 임계 이상이면 기본 배송비를 0으로 처리한다', async () => {
+    const result = await service.calculate(50000, '04524');
+
+    expect(result.shippingFee).toBe(0);
+    expect(result.isFreeShipping).toBe(true);
+  });
+});

--- a/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
+++ b/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
@@ -6,6 +6,9 @@ import { Shipping, ShippingStatus } from '../../payments/entities/shipping.entit
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { User } from '../../users/entities/user.entity';
 import { NotificationService } from '../../notification/notification.service';
+import { MockShippingAdapter } from '../adapters/mock-shipping.adapter';
+import { CjShippingAdapter } from '../adapters/cj-shipping.adapter';
+import { ShippingFeeCalculatorService } from '../services/shipping-fee-calculator.service';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order =>
   ({ id: 1, userId: 10, status: OrderStatus.PAID, ...overrides } as unknown as Order);
@@ -33,6 +36,35 @@ describe('ShippingService', () => {
     findOne: jest.fn(),
     update: jest.fn(),
   };
+  const mockAdapter = {
+    registerTrackingNumber: jest.fn(),
+    getTrackingStatus: jest.fn().mockImplementation((trackingNumber: string) =>
+      Promise.resolve({
+        trackingNumber,
+        status: 'in_transit',
+        steps: [{ status: 'in_transit', description: '배송 중', timestamp: new Date().toISOString() }],
+      })),
+  };
+  const mockCjAdapter = {
+    registerTrackingNumber: jest.fn(),
+    getTrackingStatus: jest.fn().mockResolvedValue({
+      trackingNumber: '12345',
+      status: 'in_transit',
+      steps: [{ status: 'in_transit', description: '배송 중', timestamp: new Date().toISOString() }],
+    }),
+  };
+  const mockCalculator = {
+    calculate: jest.fn().mockResolvedValue({
+      subtotal: 10000,
+      zipcode: '12345',
+      shippingFee: 3000,
+      isFreeShipping: false,
+      isRemoteArea: false,
+      threshold: 50000,
+      baseFee: 3000,
+      remoteAreaSurcharge: 3000,
+    }),
+  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -43,6 +75,9 @@ describe('ShippingService', () => {
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
         { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
         { provide: NotificationService, useValue: { sendShippingUpdate: jest.fn() } },
+        { provide: MockShippingAdapter, useValue: mockAdapter },
+        { provide: CjShippingAdapter, useValue: mockCjAdapter },
+        { provide: ShippingFeeCalculatorService, useValue: mockCalculator },
       ],
     }).compile();
     service = module.get<ShippingService>(ShippingService);
@@ -180,6 +215,15 @@ describe('ShippingService', () => {
       expect(result.trackingNumber).toBe('12345');
       expect(result.status).toBe('in_transit');
       expect(Array.isArray(result.steps)).toBe(true);
+    });
+  });
+
+  describe('quote', () => {
+    it('subtotal + zipcode로 배송비를 계산한다', async () => {
+      const result = await service.quote(10000, '12345');
+
+      expect(mockCalculator.calculate).toHaveBeenCalledWith(10000, '12345');
+      expect(result.shippingFee).toBe(3000);
     });
   });
 });

--- a/backend/src/modules/shipping/adapters/cj-shipping.adapter.ts
+++ b/backend/src/modules/shipping/adapters/cj-shipping.adapter.ts
@@ -1,0 +1,68 @@
+import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import axios, { AxiosError } from 'axios';
+import { CarrierCode, ShippingProvider, TrackingResult } from '../interfaces/shipping-provider.interface';
+
+@Injectable()
+export class CjShippingAdapter implements ShippingProvider {
+  private readonly logger = new Logger(CjShippingAdapter.name);
+
+  private resolveConfig(): { baseUrl: string; apiKey: string } {
+    const baseUrl = process.env.CJ_TRACKING_API_URL?.trim();
+    const apiKey = process.env.CJ_TRACKING_API_KEY?.trim();
+
+    if (!baseUrl || !apiKey) {
+      throw new BadRequestException('CJ 택배 API 연동 설정이 누락되었습니다.');
+    }
+
+    return { baseUrl, apiKey };
+  }
+
+  async registerTrackingNumber(_orderId: string, _trackingNumber: string): Promise<void> {
+    // CJ API는 별도 등록 절차 없이 운송장 조회만 수행합니다.
+  }
+
+  async getTrackingStatus(trackingNumber: string, _carrier: CarrierCode): Promise<TrackingResult> {
+    const { baseUrl, apiKey } = this.resolveConfig();
+
+    try {
+      const response = await axios.get(baseUrl, {
+        params: { trackingNumber },
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+        timeout: 5000,
+      });
+
+      const data = response.data as {
+        status?: string;
+        estimatedDelivery?: string;
+        steps?: Array<{ status?: string; description?: string; timestamp?: string }>;
+      };
+
+      return {
+        trackingNumber,
+        status: this.mapStatus(data.status),
+        estimatedDelivery: data.estimatedDelivery,
+        steps: (data.steps ?? []).map((step) => ({
+          status: step.status ?? 'in_transit',
+          description: step.description ?? '',
+          timestamp: step.timestamp ?? new Date().toISOString(),
+        })),
+      };
+    } catch (err) {
+      if (err instanceof AxiosError && err.response?.status === 429) {
+        throw new BadRequestException('CJ API 요청 한도를 초과했습니다.');
+      }
+
+      this.logger.warn(`CJ tracking lookup failed: ${String(err)}`);
+      throw new BadRequestException('CJ 배송 추적 조회에 실패했습니다.');
+    }
+  }
+
+  private mapStatus(status?: string): 'shipped' | 'in_transit' | 'delivered' {
+    const normalized = (status ?? '').toLowerCase();
+    if (normalized.includes('deliver')) return 'delivered';
+    if (normalized.includes('transit') || normalized.includes('move')) return 'in_transit';
+    return 'shipped';
+  }
+}

--- a/backend/src/modules/shipping/dto/shipping-quote.dto.ts
+++ b/backend/src/modules/shipping/dto/shipping-quote.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString, Min, Length } from 'class-validator';
+
+export class ShippingQuoteDto {
+  @ApiProperty({ example: 42000, description: '상품 소계 금액(원)' })
+  @IsNumber()
+  @Min(0)
+  subtotal!: number;
+
+  @ApiProperty({ example: '63124', description: '배송지 우편번호' })
+  @IsString()
+  @Length(3, 10)
+  zipcode!: string;
+}

--- a/backend/src/modules/shipping/services/shipping-fee-calculator.service.ts
+++ b/backend/src/modules/shipping/services/shipping-fee-calculator.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { SettingsService } from '../../settings/settings.service';
+import { isRemoteAreaZipcode } from '../utils/remote-area.util';
+
+const DEFAULT_FREE_SHIPPING_THRESHOLD = 50000;
+const DEFAULT_BASE_SHIPPING_FEE = 3000;
+const DEFAULT_REMOTE_AREA_SURCHARGE = 3000;
+
+export interface ShippingFeeQuote {
+  subtotal: number;
+  zipcode: string;
+  shippingFee: number;
+  isFreeShipping: boolean;
+  isRemoteArea: boolean;
+  threshold: number;
+  baseFee: number;
+  remoteAreaSurcharge: number;
+}
+
+@Injectable()
+export class ShippingFeeCalculatorService {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  async calculate(subtotal: number, zipcode: string): Promise<ShippingFeeQuote> {
+    const safeSubtotal = Math.max(0, Math.floor(subtotal));
+
+    const [threshold, baseFee, remoteAreaSurcharge] = await Promise.all([
+      this.settingsService.getNumber('free_shipping_threshold', DEFAULT_FREE_SHIPPING_THRESHOLD),
+      this.settingsService.getNumber('shipping_base_fee', DEFAULT_BASE_SHIPPING_FEE),
+      this.settingsService.getNumber('remote_area_surcharge', DEFAULT_REMOTE_AREA_SURCHARGE),
+    ]);
+
+    const isFreeShipping = safeSubtotal >= threshold;
+    const isRemoteArea = isRemoteAreaZipcode(zipcode);
+
+    const shippingFee = (isFreeShipping ? 0 : baseFee) + (isRemoteArea ? remoteAreaSurcharge : 0);
+
+    return {
+      subtotal: safeSubtotal,
+      zipcode,
+      shippingFee,
+      isFreeShipping,
+      isRemoteArea,
+      threshold,
+      baseFee,
+      remoteAreaSurcharge,
+    };
+  }
+}

--- a/backend/src/modules/shipping/shipping.controller.ts
+++ b/backend/src/modules/shipping/shipping.controller.ts
@@ -9,6 +9,8 @@ import {
 import { ShippingService } from './shipping.service';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { TrackShipmentDto } from './dto/track-shipment.dto';
+import { ShippingQuoteDto } from './dto/shipping-quote.dto';
+import { Public } from '../../common/decorators/public.decorator';
 
 @ApiTags('배송')
 @Controller('shipping')
@@ -36,5 +38,13 @@ export class ShippingController {
   track(@Body() dto: TrackShipmentDto) {
     return this.shippingService.track(dto);
   }
-}
 
+  @Post('quote')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '배송비 사전 견적', description: '체크아웃 전에 배송비를 계산합니다.' })
+  @ApiResponse({ status: 200, description: '배송비 견적 성공' })
+  quote(@Body() dto: ShippingQuoteDto) {
+    return this.shippingService.quote(dto.subtotal, dto.zipcode);
+  }
+}

--- a/backend/src/modules/shipping/shipping.module.ts
+++ b/backend/src/modules/shipping/shipping.module.ts
@@ -6,11 +6,14 @@ import { User } from '../users/entities/user.entity';
 import { ShippingService } from './shipping.service';
 import { ShippingController } from './shipping.controller';
 import { MockShippingAdapter } from './adapters/mock-shipping.adapter';
+import { CjShippingAdapter } from './adapters/cj-shipping.adapter';
+import { ShippingFeeCalculatorService } from './services/shipping-fee-calculator.service';
+import { SettingsModule } from '../settings/settings.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Shipping, Order, User])],
+  imports: [TypeOrmModule.forFeature([Shipping, Order, User]), SettingsModule],
   controllers: [ShippingController],
-  providers: [ShippingService, MockShippingAdapter],
-  exports: [ShippingService],
+  providers: [ShippingService, ShippingFeeCalculatorService, MockShippingAdapter, CjShippingAdapter],
+  exports: [ShippingService, ShippingFeeCalculatorService],
 })
 export class ShippingModule {}

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -8,12 +8,18 @@ import { Shipping, ShippingStatus } from '../payments/entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
 import { User } from '../users/entities/user.entity';
 import { MockShippingAdapter } from './adapters/mock-shipping.adapter';
-import { CarrierCode, TrackingResult } from './interfaces/shipping-provider.interface';
+import { CjShippingAdapter } from './adapters/cj-shipping.adapter';
+import {
+  CarrierCode,
+  ShippingProvider,
+  TrackingResult,
+} from './interfaces/shipping-provider.interface';
 import { RegisterTrackingDto } from './dto/register-tracking.dto';
 import { TrackShipmentDto } from './dto/track-shipment.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { NotificationService } from '../notification/notification.service';
+import { ShippingFeeCalculatorService, ShippingFeeQuote } from './services/shipping-fee-calculator.service';
 
 const ALLOWED_TRANSITIONS: Record<ShippingStatus, ShippingStatus[]> = {
   [ShippingStatus.PAYMENT_CONFIRMED]: [ShippingStatus.PREPARING],
@@ -27,7 +33,7 @@ const ALLOWED_TRANSITIONS: Record<ShippingStatus, ShippingStatus[]> = {
 @Injectable()
 export class ShippingService {
   private readonly logger = new Logger(ShippingService.name);
-  private readonly mockAdapter: MockShippingAdapter;
+  private readonly trackingCache = new Map<string, TrackingResult>();
 
   constructor(
     @InjectRepository(Shipping)
@@ -37,9 +43,10 @@ export class ShippingService {
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
     private readonly notificationService: NotificationService,
-  ) {
-    this.mockAdapter = new MockShippingAdapter();
-  }
+    private readonly mockAdapter: MockShippingAdapter,
+    private readonly cjAdapter: CjShippingAdapter,
+    private readonly shippingFeeCalculator: ShippingFeeCalculatorService,
+  ) {}
 
   async getByOrderId(orderId: number, userId: number): Promise<{
     id: number;
@@ -59,9 +66,9 @@ export class ShippingService {
     let tracking: TrackingResult | null = null;
     if (shipping.trackingNumber) {
       try {
-        tracking = await this.mockAdapter.getTrackingStatus(
+        tracking = await this.getTrackingWithStaleFallback(
           shipping.trackingNumber,
-          shipping.carrier as CarrierCode,
+          (shipping.carrier as CarrierCode) ?? 'mock',
         );
       } catch (err) {
         this.logger.warn(`Carrier API error for orderId=${orderId}: ${String(err)}`);
@@ -87,7 +94,7 @@ export class ShippingService {
     steps: unknown[];
   }> {
     try {
-      const result = await this.mockAdapter.getTrackingStatus(dto.trackingNumber, dto.carrier);
+      const result = await this.getTrackingWithStaleFallback(dto.trackingNumber, dto.carrier);
       return {
         carrier: dto.carrier,
         trackingNumber: dto.trackingNumber,
@@ -106,7 +113,8 @@ export class ShippingService {
 
     this.validateTransition(shipping.status, ShippingStatus.PREPARING);
 
-    await this.mockAdapter.registerTrackingNumber(String(orderId), dto.trackingNumber);
+    const provider = this.resolveProvider(dto.carrier);
+    await provider.registerTrackingNumber(String(orderId), dto.trackingNumber);
 
     await this.shippingRepository.update(shipping.id, {
       carrier: dto.carrier,
@@ -125,6 +133,10 @@ export class ShippingService {
     );
 
     return this.shippingRepository.findOne({ where: { orderId } });
+  }
+
+  async quote(subtotal: number, zipcode: string): Promise<ShippingFeeQuote> {
+    return this.shippingFeeCalculator.calculate(subtotal, zipcode);
   }
 
   private async notifyShippingUpdate(
@@ -152,6 +164,42 @@ export class ShippingService {
     const allowed = ALLOWED_TRANSITIONS[current] ?? [];
     if (!allowed.includes(next)) {
       throw new BadRequestException('유효하지 않은 배송 상태 변경입니다.');
+    }
+  }
+
+  private resolveProvider(carrier: CarrierCode): ShippingProvider {
+    switch (carrier) {
+      case 'cj':
+        return this.cjAdapter;
+      case 'hanjin':
+      case 'lotte':
+      case 'mock':
+      default:
+        return this.mockAdapter;
+    }
+  }
+
+  private async getTrackingWithStaleFallback(
+    trackingNumber: string,
+    carrier: CarrierCode,
+  ): Promise<TrackingResult> {
+    const cacheKey = `${carrier}:${trackingNumber}`;
+    const provider = this.resolveProvider(carrier);
+
+    try {
+      const result = await provider.getTrackingStatus(trackingNumber, carrier);
+      this.trackingCache.set(cacheKey, result);
+      return result;
+    } catch (err) {
+      const stale = this.trackingCache.get(cacheKey);
+      if (stale) {
+        this.logger.warn(
+          `Carrier lookup failed; serving stale cache for ${cacheKey}: ${String(err)}`,
+        );
+        return stale;
+      }
+
+      throw err;
     }
   }
 }

--- a/backend/src/modules/shipping/utils/remote-area.util.ts
+++ b/backend/src/modules/shipping/utils/remote-area.util.ts
@@ -1,0 +1,12 @@
+const REMOTE_ZIPCODE_PREFIXES = ['53', '54', '63'] as const;
+
+export function normalizeZipcode(input: string): string {
+  return input.replace(/\D/g, '');
+}
+
+export function isRemoteAreaZipcode(zipcode: string): boolean {
+  const normalized = normalizeZipcode(zipcode);
+  if (normalized.length < 2) return false;
+
+  return REMOTE_ZIPCODE_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}

--- a/backend/test/suites/payments.e2e-spec.ts
+++ b/backend/test/suites/payments.e2e-spec.ts
@@ -17,6 +17,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
     let userCookies: AuthCookies;
     let productId: number;
     let orderId: number;
+    let orderAmount: number;
 
     const userEmail = `payments-user-${Date.now()}@test.com`;
     const otherEmail = `payments-other-${Date.now()}@test.com`;
@@ -67,6 +68,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
         });
       if (orderRes.status !== 201) throw new Error(`Create order failed: ${orderRes.status} ${JSON.stringify(orderRes.body)}`);
       orderId = Number((orderRes.body as { id: number }).id);
+      orderAmount = Number((orderRes.body as { totalAmount: number | string }).totalAmount);
     });
 
     afterAll(async () => {
@@ -113,7 +115,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
         const body = res.body as { clientKey: string; orderId: number; amount: number };
         expect(body.clientKey).toBeDefined();
         expect(body.orderId).toBe(orderId);
-        expect(body.amount).toBe(30000);
+        expect(body.amount).toBe(orderAmount);
       });
     });
 
@@ -122,7 +124,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
         const res = await request(app.getHttpServer())
           .post('/api/payments/confirm')
           .set('Cookie', cookieHeader(userCookies))
-          .send({ orderId, paymentKey: 'pay_mock_key', amount: 30000 })
+          .send({ orderId, paymentKey: 'pay_mock_key', amount: orderAmount })
           .expect((r) => {
             if (r.status !== 200 && r.status !== 201) throw new Error(`Expected 200/201 got ${r.status}: ${JSON.stringify(r.body)}`);
           });
@@ -181,7 +183,7 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
         return request(app.getHttpServer())
           .post('/api/payments/confirm')
           .set('Cookie', cookieHeader(userCookies))
-          .send({ orderId, paymentKey: 'pay_mock_key', amount: 30000 })
+          .send({ orderId, paymentKey: 'pay_mock_key', amount: orderAmount })
           .expect(409);
       });
     });

--- a/backend/test/suites/refunds.e2e-spec.ts
+++ b/backend/test/suites/refunds.e2e-spec.ts
@@ -17,6 +17,7 @@ export function registerRefundsSuite(getApp: () => INestApplication) {
     let userCookies: AuthCookies;
     let productId: number;
     let orderId: number;
+    let orderAmount: number;
 
     const adminEmail = `refunds-admin-${Date.now()}@test.com`;
     const userEmail = `refunds-user-${Date.now()}@test.com`;
@@ -68,6 +69,7 @@ export function registerRefundsSuite(getApp: () => INestApplication) {
         })
         .expect(201);
       orderId = Number((orderRes.body as { id: number }).id);
+      orderAmount = Number((orderRes.body as { totalAmount: number | string }).totalAmount);
 
       // Prepare payment
       await request(app.getHttpServer())
@@ -79,7 +81,7 @@ export function registerRefundsSuite(getApp: () => INestApplication) {
       await request(app.getHttpServer())
         .post('/api/payments/confirm')
         .set('Cookie', cookieHeader(userCookies))
-        .send({ orderId, paymentKey: 'pay_mock_refund_test', amount: 30000 })
+        .send({ orderId, paymentKey: 'pay_mock_refund_test', amount: orderAmount })
         .expect((r) => {
           if (r.status !== 200 && r.status !== 201)
             throw new Error(`Confirm failed: ${r.status} ${JSON.stringify(r.body)}`);

--- a/backend/test/suites/shipping.e2e-spec.ts
+++ b/backend/test/suites/shipping.e2e-spec.ts
@@ -17,6 +17,7 @@ export function registerShippingSuite(getApp: () => INestApplication) {
     let otherCookies: AuthCookies;
     let adminCookies: AuthCookies;
     let orderId: number;
+    let orderAmount: number;
     let productId: number;
 
     const userEmail = `shipping-user-${Date.now()}@test.com`;
@@ -83,6 +84,7 @@ export function registerShippingSuite(getApp: () => INestApplication) {
         });
       if (orderRes.status !== 201) throw new Error(`Create order failed: ${orderRes.status} ${JSON.stringify(orderRes.body)}`);
       orderId = Number((orderRes.body as { id: number }).id);
+      orderAmount = Number((orderRes.body as { totalAmount: number | string }).totalAmount);
 
       // Confirm payment to auto-create shipping record
       await request(app.getHttpServer())
@@ -93,7 +95,7 @@ export function registerShippingSuite(getApp: () => INestApplication) {
       await request(app.getHttpServer())
         .post('/api/payments/confirm')
         .set('Cookie', cookieHeader(userCookies))
-        .send({ orderId, paymentKey: 'mock_key_123', amount: 10000 });
+        .send({ orderId, paymentKey: 'mock_key_123', amount: orderAmount });
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## 요약
- Sentry를 백엔드 부트스트랩에 연결하고 글로벌 예외 캡처 + 민감정보(redaction) 필터를 적용했습니다.
- PointHistory에 relatedEntityType/relatedEntityId를 추가하고 리뷰 포인트 환수 매칭을 문자열 파싱에서 컬럼 기반으로 전환했습니다.
- 배송비 정책 엔진(설정 기반)과 POST /api/shipping/quote를 추가하고, 주문 생성 시 배송비를 총액에 반영했습니다.
- shipping provider 선택 로직을 추가하고 CjShippingAdapter(API 연동 스캐폴드) + 조회 실패 시 stale cache fallback을 도입했습니다.
- 동적 sitemap.xml/robots.txt 엔드포인트를 추가하고 글로벌 prefix에서 제외해 루트 경로로 노출했습니다.
- 변경된 주문 총액(배송비 반영)에 맞춰 결제/환불/배송 E2E를 주문 응답 총액 기준으로 보정했습니다.

## 검증
- npm run build && npm run test:run
- cd backend && npm run lint
- cd backend && npm run build && npm run test
- MYSQL_ROOT_PASSWORD=root TEST_DATABASE_URL=mysql://root:root@127.0.0.1:3308/commerce_test JWT_PRIVATE_KEY_FILE=/tmp/jwt-private.pem JWT_PUBLIC_KEY_FILE=/tmp/jwt-public.pem JWT_SECRET=dummy JWT_REFRESH_SECRET=dummy2 FRONTEND_URL=http://localhost:5173 NOTIFICATION_PROVIDER=mock STORAGE_PROVIDER=local PAYMENT_GATEWAY=mock bash scripts/test.sh e2e
- bash scripts/start-local.sh

## 비고
- CJ 실 API 호출은 운영 키/엔드포인트가 필요해 실환경 smoke test가 추가로 필요합니다.

Closes #502
Closes #504
Closes #515
Closes #516
Closes #574
