### PR TITLE
feat: #511 최근 본 상품 기록·조회 구현

### DIFF
--- a/backend/src/database/migrations/1782500000000-CreateRecentlyViewedProductsTable.ts
+++ b/backend/src/database/migrations/1782500000000-CreateRecentlyViewedProductsTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateRecentlyViewedProductsTable1782500000000 implements MigrationInterface {
+  name = 'CreateRecentlyViewedProductsTable1782500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS \`recently_viewed_products\` (
+        \`user_id\` bigint NOT NULL,
+        \`product_id\` bigint NOT NULL,
+        \`viewed_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        PRIMARY KEY (\`user_id\`, \`product_id\`),
+        KEY \`IDX_recently_viewed_user\` (\`user_id\`),
+        KEY \`IDX_recently_viewed_product\` (\`product_id\`),
+        CONSTRAINT \`FK_rvp_user\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\` (\`id\`) ON DELETE CASCADE,
+        CONSTRAINT \`FK_rvp_product\` FOREIGN KEY (\`product_id\`) REFERENCES \`products\` (\`id\`) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS \`recently_viewed_products\``);
+  }
+}

--- a/backend/src/modules/products/__tests__/recently-viewed.service.spec.ts
+++ b/backend/src/modules/products/__tests__/recently-viewed.service.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { RecentlyViewedService } from '../recently-viewed.service';
+import { RecentlyViewedProduct } from '../entities/recently-viewed-product.entity';
+
+const mockQueryBuilder = {
+  insert: jest.fn().mockReturnThis(),
+  into: jest.fn().mockReturnThis(),
+  values: jest.fn().mockReturnThis(),
+  orUpdate: jest.fn().mockReturnThis(),
+  delete: jest.fn().mockReturnThis(),
+  from: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  execute: jest.fn().mockResolvedValue({ affected: 0 }),
+};
+
+const mockRepo = {
+  createQueryBuilder: jest.fn(() => mockQueryBuilder),
+  findAndCount: jest.fn(),
+};
+
+describe('RecentlyViewedService', () => {
+  let service: RecentlyViewedService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RecentlyViewedService,
+        { provide: getRepositoryToken(RecentlyViewedProduct), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<RecentlyViewedService>(RecentlyViewedService);
+    jest.clearAllMocks();
+    mockRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.insert.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.into.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.values.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.orUpdate.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.delete.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.from.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.execute.mockResolvedValue({ affected: 0 });
+  });
+
+  describe('upsert', () => {
+    it('should upsert a recently viewed record', async () => {
+      mockQueryBuilder.execute.mockResolvedValue({ raw: [], affected: 1 });
+
+      await expect(service.upsert(10, 5)).resolves.toBeUndefined();
+
+      expect(mockRepo.createQueryBuilder).toHaveBeenCalled();
+      expect(mockQueryBuilder.insert).toHaveBeenCalled();
+      expect(mockQueryBuilder.orUpdate).toHaveBeenCalledWith(['viewed_at'], ['user_id', 'product_id']);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return recently viewed items with total', async () => {
+      const mockItem = {
+        userId: 10,
+        productId: 5,
+        viewedAt: new Date(),
+        product: {
+          id: 5,
+          name: '테스트 상품',
+          slug: 'test-product',
+          price: 10000,
+          salePrice: null,
+          status: 'active',
+          images: [],
+        },
+      } as unknown as RecentlyViewedProduct;
+
+      mockRepo.findAndCount.mockResolvedValue([[mockItem], 1]);
+
+      const result = await service.findAll(10, 20);
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].productId).toBe(5);
+      expect(result.data[0].product?.name).toBe('테스트 상품');
+    });
+
+    it('should cap limit at 100', async () => {
+      mockRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll(10, 200);
+
+      expect(mockRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 }),
+      );
+    });
+
+    it('should use default limit of 20 when not specified', async () => {
+      mockRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll(10);
+
+      expect(mockRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 20 }),
+      );
+    });
+  });
+
+  describe('deleteOlderThan', () => {
+    it('should delete records older than specified days and return count', async () => {
+      mockQueryBuilder.execute.mockResolvedValue({ affected: 5 });
+
+      const deleted = await service.deleteOlderThan(90);
+
+      expect(deleted).toBe(5);
+      expect(mockQueryBuilder.delete).toHaveBeenCalled();
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('viewed_at < :cutoff', expect.any(Object));
+    });
+
+    it('should return 0 when no records deleted', async () => {
+      mockQueryBuilder.execute.mockResolvedValue({ affected: 0 });
+
+      const deleted = await service.deleteOlderThan(90);
+
+      expect(deleted).toBe(0);
+    });
+  });
+});

--- a/backend/src/modules/products/entities/recently-viewed-product.entity.ts
+++ b/backend/src/modules/products/entities/recently-viewed-product.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Product } from './product.entity';
+
+@Entity('recently_viewed_products')
+@Index('IDX_recently_viewed_user', ['userId'])
+@Index('IDX_recently_viewed_product', ['productId'])
+export class RecentlyViewedProduct {
+  @PrimaryColumn({ name: 'user_id', type: 'bigint' })
+  userId!: number;
+
+  @PrimaryColumn({ name: 'product_id', type: 'bigint' })
+  productId!: number;
+
+  @UpdateDateColumn({ name: 'viewed_at' })
+  viewedAt!: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user!: User;
+
+  @ManyToOne(() => Product, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'product_id' })
+  product!: Product;
+}

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -30,6 +30,7 @@ import { Roles } from '../../common/decorators/roles.decorator';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
 import { CreateRestockAlertDto } from '../restock-alerts/dto/create-restock-alert.dto';
+import { RecentlyViewedService } from './recently-viewed.service';
 
 interface RequestWithUser {
   user?: { id: number; email: string; role: string };
@@ -41,6 +42,7 @@ export class ProductsController {
   constructor(
     private readonly productsService: ProductsService,
     private readonly restockAlertsService: RestockAlertsService,
+    private readonly recentlyViewedService: RecentlyViewedService,
   ) {}
 
   @Get()
@@ -83,13 +85,21 @@ export class ProductsController {
   @ApiResponse({ status: 404, description: '상품을 찾을 수 없음' })
   @ApiParam({ name: 'id', type: Number, description: '상품 ID' })
   @ApiQuery({ name: 'locale', required: false, type: String, description: ' locale (ko/en)' })
-  findOne(
+  async findOne(
     @Param('id', ParseIntPipe) id: number,
     @Query('locale') locale: string | undefined,
     @Request() req: RequestWithUser,
   ) {
     const isAdmin = req.user?.role === 'admin';
-    return this.productsService.findOne(id, isAdmin, locale);
+    const result = await this.productsService.findOne(id, isAdmin, locale);
+
+    if (req.user?.id) {
+      this.recentlyViewedService
+        .upsert(req.user.id, id)
+        .catch(() => undefined);
+    }
+
+    return result;
   }
 
   @Post()

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -11,11 +11,13 @@ import { ProductAttribute } from './entities/product-attribute.entity';
 import { ProductsService } from './products.service';
 import { CategoriesService } from './categories.service';
 import { AttributesService } from './attributes.service';
+import { RecentlyViewedService } from './recently-viewed.service';
 import { ProductsController } from './products.controller';
 import { CategoriesController } from './categories.controller';
 import { AttributesController } from './attributes.controller';
 import { CacheModule } from '../cache/cache.module';
 import { RestockAlertsModule } from '../restock-alerts/restock-alerts.module';
+import { RecentlyViewedProduct } from './entities/recently-viewed-product.entity';
 
 @Module({
   imports: [
@@ -28,12 +30,13 @@ import { RestockAlertsModule } from '../restock-alerts/restock-alerts.module';
       Review,
       AttributeType,
       ProductAttribute,
+      RecentlyViewedProduct,
     ]),
     CacheModule,
     RestockAlertsModule,
   ],
-  providers: [ProductsService, CategoriesService, AttributesService],
+  providers: [ProductsService, CategoriesService, AttributesService, RecentlyViewedService],
   controllers: [ProductsController, CategoriesController, AttributesController],
-  exports: [ProductsService, CategoriesService, AttributesService],
+  exports: [ProductsService, CategoriesService, AttributesService, RecentlyViewedService],
 })
 export class ProductsModule {}

--- a/backend/src/modules/products/recently-viewed.service.ts
+++ b/backend/src/modules/products/recently-viewed.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RecentlyViewedProduct } from './entities/recently-viewed-product.entity';
+
+export interface RecentlyViewedItem {
+  productId: number;
+  viewedAt: Date;
+  product?: {
+    id: number;
+    name: string;
+    slug: string;
+    price: number;
+    salePrice: number | null;
+    status: string;
+    images: { url: string; alt: string | null; isThumbnail: boolean }[];
+  };
+}
+
+export interface RecentlyViewedListResult {
+  data: RecentlyViewedItem[];
+  total: number;
+}
+
+@Injectable()
+export class RecentlyViewedService {
+  private readonly logger = new Logger(RecentlyViewedService.name);
+
+  constructor(
+    @InjectRepository(RecentlyViewedProduct)
+    private readonly recentlyViewedRepo: Repository<RecentlyViewedProduct>,
+  ) {}
+
+  async upsert(userId: number, productId: number): Promise<void> {
+    await this.recentlyViewedRepo
+      .createQueryBuilder()
+      .insert()
+      .into(RecentlyViewedProduct)
+      .values({ userId, productId, viewedAt: new Date() })
+      .orUpdate(['viewed_at'], ['user_id', 'product_id'])
+      .execute();
+
+    this.logger.debug(`Recently viewed upsert: userId=${userId}, productId=${productId}`);
+  }
+
+  async findAll(userId: number, limit = 20): Promise<RecentlyViewedListResult> {
+    const safeLimit = Math.min(Math.max(1, limit), 100);
+
+    const [items, total] = await this.recentlyViewedRepo.findAndCount({
+      where: { userId },
+      relations: ['product', 'product.images'],
+      order: { viewedAt: 'DESC' },
+      take: safeLimit,
+    });
+
+    return {
+      data: items.map((item) => this.toResponse(item)),
+      total,
+    };
+  }
+
+  async deleteOlderThan(days: number): Promise<number> {
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    const result = await this.recentlyViewedRepo
+      .createQueryBuilder()
+      .delete()
+      .from(RecentlyViewedProduct)
+      .where('viewed_at < :cutoff', { cutoff })
+      .execute();
+
+    return result.affected ?? 0;
+  }
+
+  private toResponse(item: RecentlyViewedProduct): RecentlyViewedItem {
+    const base: RecentlyViewedItem = {
+      productId: Number(item.productId),
+      viewedAt: item.viewedAt,
+    };
+
+    if (item.product) {
+      base.product = {
+        id: Number(item.product.id),
+        name: item.product.name,
+        slug: item.product.slug,
+        price: Number(item.product.price),
+        salePrice: item.product.salePrice != null ? Number(item.product.salePrice) : null,
+        status: item.product.status,
+        images: (item.product.images ?? []).map((img) => ({
+          url: img.url,
+          alt: img.alt,
+          isThumbnail: img.isThumbnail,
+        })),
+      };
+    }
+
+    return base;
+  }
+}

--- a/backend/src/modules/scheduler/__tests__/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/__tests__/scheduler.service.spec.ts
@@ -9,6 +9,7 @@ import { ProductOption } from '../../products/entities/product-option.entity';
 import { Coupon } from '../../coupons/entities/coupon.entity';
 import { PointHistory } from '../../coupons/entities/point-history.entity';
 import { User } from '../../users/entities/user.entity';
+import { RecentlyViewedProduct } from '../../products/entities/recently-viewed-product.entity';
 import { NotificationService } from '../../notification/notification.service';
 import { SettingsService } from '../../settings/settings.service';
 
@@ -72,6 +73,10 @@ const mockUserRepo = {
   findOne: jest.fn(),
 };
 
+const mockRecentlyViewedRepo = {
+  createQueryBuilder: jest.fn(),
+};
+
 const mockNotificationService = {
   sendEmail: jest.fn(),
   sendOrderConfirmed: jest.fn(),
@@ -99,6 +104,7 @@ describe('SchedulerService', () => {
         { provide: getRepositoryToken(Coupon), useValue: mockCouponRepo },
         { provide: getRepositoryToken(PointHistory), useValue: mockPointHistoryRepo },
         { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        { provide: getRepositoryToken(RecentlyViewedProduct), useValue: mockRecentlyViewedRepo },
         { provide: DataSource, useValue: mockDataSource },
         { provide: NotificationService, useValue: mockNotificationService },
         { provide: SettingsService, useValue: mockSettingsService },

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -8,13 +8,14 @@ import { Coupon } from '../coupons/entities/coupon.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { User } from '../users/entities/user.entity';
 import { UserAddress } from '../users/entities/user-address.entity';
+import { RecentlyViewedProduct } from '../products/entities/recently-viewed-product.entity';
 import { SchedulerService } from './scheduler.service';
 import { SettingsModule } from '../settings/settings.module';
 import { NotificationModule } from '../notification/notification.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Order, OrderItem, Product, ProductOption, Coupon, PointHistory, User, UserAddress]),
+    TypeOrmModule.forFeature([Order, OrderItem, Product, ProductOption, Coupon, PointHistory, User, UserAddress, RecentlyViewedProduct]),
     SettingsModule,
     NotificationModule,
   ],

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -11,6 +11,7 @@ import { Coupon } from '../coupons/entities/coupon.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { User } from '../users/entities/user.entity';
 import { UserAddress } from '../users/entities/user-address.entity';
+import { RecentlyViewedProduct } from '../products/entities/recently-viewed-product.entity';
 import { NotificationService } from '../notification/notification.service';
 import { SettingsService } from '../settings/settings.service';
 import { InjectDataSource } from '@nestjs/typeorm';
@@ -34,6 +35,8 @@ export class SchedulerService {
     private readonly pointHistoryRepo: Repository<PointHistory>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
+    @InjectRepository(RecentlyViewedProduct)
+    private readonly recentlyViewedRepo: Repository<RecentlyViewedProduct>,
     @InjectDataSource()
     private readonly dataSource: DataSource,
     private readonly notificationService: NotificationService,
@@ -398,6 +401,37 @@ export class SchedulerService {
         text: '요청하신 회원 탈퇴가 완료되었습니다. 개인정보는 익명화되어 보관됩니다.',
         html: '<p>요청하신 회원 탈퇴가 완료되었습니다.</p><p>개인정보는 익명화되어 보관됩니다.</p>',
       });
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async handleRecentlyViewedCleanup(): Promise<void> {
+    const lockName = 'cron:recently-viewed-cleanup';
+    if (!(await this.acquireLock(lockName, 55))) {
+      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
+      return;
+    }
+
+    try {
+      const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+
+      const result = await this.recentlyViewedRepo
+        .createQueryBuilder()
+        .delete()
+        .from(RecentlyViewedProduct)
+        .where('viewed_at < :cutoff', { cutoff })
+        .execute();
+
+      const deleted = result.affected ?? 0;
+      if (deleted > 0) {
+        this.logger.log(`[cron:recently-viewed-cleanup] Deleted ${deleted} records older than 90 days`);
+      } else {
+        this.logger.debug('[cron:recently-viewed-cleanup] No old records to delete');
+      }
+    } catch (err) {
+      this.logger.error(`[cron:recently-viewed-cleanup] Error: ${String(err)}`);
+    } finally {
+      await this.releaseLock(lockName);
     }
   }
 

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -1,5 +1,5 @@
 import {
-  Controller, Get, Post, Patch, Delete, Body, Param, ParseIntPipe,
+  Controller, Get, Post, Patch, Delete, Body, Param, ParseIntPipe, Query,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -7,6 +7,7 @@ import {
   ApiResponse,
   ApiParam,
   ApiCookieAuth,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { UpdateProfileDto } from './dto/update-profile.dto';
@@ -15,6 +16,7 @@ import { UpdateAddressDto } from './dto/update-address.dto';
 import { RequestAccountDeletionDto } from './dto/request-account-deletion.dto';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
+import { RecentlyViewedService } from '../products/recently-viewed.service';
 
 interface AuthUser {
   id: number;
@@ -28,6 +30,7 @@ export class UsersController {
   constructor(
     private readonly usersService: UsersService,
     private readonly restockAlertsService: RestockAlertsService,
+    private readonly recentlyViewedService: RecentlyViewedService,
   ) {}
 
   @Patch('me')
@@ -55,6 +58,20 @@ export class UsersController {
   @ApiResponse({ status: 401, description: '인증 필요' })
   getRestockAlerts(@CurrentUser() user: AuthUser) {
     return this.restockAlertsService.findUserAlerts(user.id);
+  }
+
+  @Get('me/recently-viewed')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '최근 본 상품 목록 조회', description: '현재 사용자가 최근 열람한 상품 목록을 조회합니다.' })
+  @ApiResponse({ status: 200, description: '최근 본 상품 목록 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: '조회 개수 (기본값: 20, 최대: 100)' })
+  getRecentlyViewed(
+    @CurrentUser() user: AuthUser,
+    @Query('limit') limit?: string,
+  ) {
+    const parsedLimit = limit ? parseInt(limit, 10) : 20;
+    return this.recentlyViewedService.findAll(user.id, parsedLimit);
   }
 
   @Post('me/addresses')

--- a/backend/src/modules/users/users.module.ts
+++ b/backend/src/modules/users/users.module.ts
@@ -5,9 +5,10 @@ import { UserAddress } from './entities/user-address.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { RestockAlertsModule } from '../restock-alerts/restock-alerts.module';
+import { ProductsModule } from '../products/products.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, UserAddress]), RestockAlertsModule],
+  imports: [TypeOrmModule.forFeature([User, UserAddress]), RestockAlertsModule, ProductsModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],


### PR DESCRIPTION
## Summary
- Closes #511
- recently_viewed_products 마이그레이션 추가
- 상품 상세 조회 시 upsert 기록
- GET /users/me/recently-viewed 엔드포인트
- 90일 이상 오래된 레코드 자동 정리 Cron

## Test plan
- [ ] npm run build
- [ ] npm run test