### PR TITLE
feat: #514 쿠폰 자동 발급 규칙 엔진 구현

### DIFF
--- a/backend/src/database/migrations/1782600000000-CreateCouponRulesTable.ts
+++ b/backend/src/database/migrations/1782600000000-CreateCouponRulesTable.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCouponRulesTable1782600000000 implements MigrationInterface {
+  name = 'CreateCouponRulesTable1782600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE \`coupon_rules\` (
+        \`id\` bigint NOT NULL AUTO_INCREMENT,
+        \`trigger\` enum('signup','first_purchase','birthday','tier_up') NOT NULL,
+        \`coupon_template_id\` bigint NOT NULL,
+        \`conditions_json\` json NULL,
+        \`active\` tinyint(1) NOT NULL DEFAULT 1,
+        \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        INDEX \`IDX_coupon_rules_trigger\` (\`trigger\`),
+        INDEX \`IDX_coupon_rules_active\` (\`active\`),
+        CONSTRAINT \`FK_coupon_rules_coupon_template\` FOREIGN KEY (\`coupon_template_id\`) REFERENCES \`coupons\` (\`id\`) ON DELETE CASCADE,
+        PRIMARY KEY (\`id\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE \`coupon_rules\``);
+  }
+}

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -10,6 +10,7 @@ import { VerificationToken } from '../entities/verification-token.entity';
 import { NotificationService } from '../../notification/notification.service';
 import { AuditLogService } from '../../audit-logs/audit-log.service';
 import { TokenBlacklistService } from '../token-blacklist.service';
+import { AuthEventEmitter } from '../auth-event.emitter';
 
 const mockUserRepository = {
   findOne: jest.fn(),
@@ -104,6 +105,7 @@ describe('AuthService', () => {
         { provide: NotificationService, useValue: mockNotificationService },
         { provide: AuditLogService, useValue: mockAuditLogService },
         { provide: TokenBlacklistService, useValue: mockTokenBlacklistService },
+        { provide: AuthEventEmitter, useValue: { emitUserRegistered: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/modules/auth/auth-event.emitter.ts
+++ b/backend/src/modules/auth/auth-event.emitter.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter } from 'events';
+import { UserRegisteredEvent, USER_REGISTERED_EVENT } from './events/user-registered.event';
+
+@Injectable()
+export class AuthEventEmitter {
+  private readonly emitter = new EventEmitter();
+
+  emitUserRegistered(event: UserRegisteredEvent): void {
+    this.emitter.emit(USER_REGISTERED_EVENT, event);
+  }
+
+  onUserRegistered(handler: (event: UserRegisteredEvent) => void): void {
+    this.emitter.on(USER_REGISTERED_EVENT, handler);
+  }
+}

--- a/backend/src/modules/auth/auth-events.module.ts
+++ b/backend/src/modules/auth/auth-events.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AuthEventEmitter } from './auth-event.emitter';
+
+@Module({
+  providers: [AuthEventEmitter],
+  exports: [AuthEventEmitter],
+})
+export class AuthEventsModule {}

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -17,6 +17,7 @@ import { VerificationToken } from './entities/verification-token.entity';
 import { User } from '../users/entities/user.entity';
 import { UserAuthentication } from '../users/entities/user-authentication.entity';
 import { AuditLogModule } from '../audit-logs/audit-log.module';
+import { AuthEventsModule } from './auth-events.module';
 
 function getJwtPrivateKey(): string {
   if (process.env.JWT_PRIVATE_KEY) {
@@ -52,9 +53,10 @@ function getJwtPrivateKey(): string {
     }),
     HttpModule,
     AuditLogModule,
+    AuthEventsModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, OAuthService, JwtStrategy, TokenBlacklistService],
-  exports: [PassportModule, JwtModule, AuditLogModule],
+  exports: [PassportModule, JwtModule, AuditLogModule, AuthEventsModule],
 })
 export class AuthModule {}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -26,6 +26,8 @@ import { NotificationService } from '../notification/notification.service';
 import { AuditLogService } from '../audit-logs/audit-log.service';
 import { AuditAction } from '../audit-logs/entities/audit-log.entity';
 import { TokenBlacklistService } from './token-blacklist.service';
+import { AuthEventEmitter } from './auth-event.emitter';
+import { UserRegisteredEvent } from './events/user-registered.event';
 
 const LOCK_LEVEL_1_ATTEMPTS = 5;
 const LOCK_LEVEL_2_ATTEMPTS = 10;
@@ -83,6 +85,7 @@ export class AuthService implements OnModuleInit {
     private readonly notificationService: NotificationService,
     private readonly auditLogService: AuditLogService,
     private readonly tokenBlacklistService: TokenBlacklistService,
+    private readonly authEventEmitter: AuthEventEmitter,
   ) {}
 
   onModuleInit() {
@@ -116,6 +119,8 @@ export class AuthService implements OnModuleInit {
       isEmailVerified: false,
     });
     await this.userRepository.save(user);
+
+    this.authEventEmitter.emitUserRegistered(new UserRegisteredEvent(Number(user.id), user.email));
 
     await this.createVerificationTokenAndSendEmail(user);
 

--- a/backend/src/modules/auth/events/user-registered.event.ts
+++ b/backend/src/modules/auth/events/user-registered.event.ts
@@ -1,0 +1,8 @@
+export class UserRegisteredEvent {
+  constructor(
+    public readonly userId: number,
+    public readonly email: string,
+  ) {}
+}
+
+export const USER_REGISTERED_EVENT = 'auth.user_registered';

--- a/backend/src/modules/coupons/__tests__/coupon-rules.service.spec.ts
+++ b/backend/src/modules/coupons/__tests__/coupon-rules.service.spec.ts
@@ -1,0 +1,240 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { CouponRulesService } from '../coupon-rules.service';
+import { CouponRule, CouponRuleTrigger } from '../entities/coupon-rule.entity';
+import { CouponsService } from '../coupons.service';
+import { MembershipEventEmitter } from '../../membership/membership-event.emitter';
+import { AuthEventEmitter } from '../../auth/auth-event.emitter';
+import { OrderEventEmitter } from '../../orders/order-event.emitter';
+import { User } from '../../users/entities/user.entity';
+
+const makeCouponRule = (overrides: Partial<CouponRule> = {}): CouponRule =>
+  Object.assign(new CouponRule(), {
+    id: 1,
+    trigger: CouponRuleTrigger.SIGNUP,
+    couponTemplateId: 10,
+    conditionsJson: null,
+    active: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  });
+
+describe('CouponRulesService', () => {
+  let service: CouponRulesService;
+
+  const mockCouponRuleRepo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const mockUserRepo = {
+    findOne: jest.fn(),
+  };
+
+  const mockCouponsService = {
+    issueCoupon: jest.fn(),
+  };
+
+  const mockMembershipEvents = {
+    onTierUpgraded: jest.fn(),
+  };
+
+  const mockAuthEvents = {
+    onUserRegistered: jest.fn(),
+  };
+
+  const mockOrderEvents = {
+    onOrderCompleted: jest.fn(),
+  };
+
+  const mockDataSource = {
+    query: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CouponRulesService,
+        { provide: getRepositoryToken(CouponRule), useValue: mockCouponRuleRepo },
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        { provide: CouponsService, useValue: mockCouponsService },
+        { provide: MembershipEventEmitter, useValue: mockMembershipEvents },
+        { provide: AuthEventEmitter, useValue: mockAuthEvents },
+        { provide: OrderEventEmitter, useValue: mockOrderEvents },
+        { provide: DataSource, useValue: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<CouponRulesService>(CouponRulesService);
+  });
+
+  describe('onModuleInit', () => {
+    it('registers handlers for all 3 event emitters', () => {
+      service.onModuleInit();
+      expect(mockAuthEvents.onUserRegistered).toHaveBeenCalledTimes(1);
+      expect(mockOrderEvents.onOrderCompleted).toHaveBeenCalledTimes(1);
+      expect(mockMembershipEvents.onTierUpgraded).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findAll', () => {
+    it('returns all rules ordered by createdAt DESC', async () => {
+      const rules = [makeCouponRule()];
+      mockCouponRuleRepo.find.mockResolvedValue(rules);
+
+      const result = await service.findAll();
+      expect(result).toEqual(rules);
+      expect(mockCouponRuleRepo.find).toHaveBeenCalledWith({ order: { createdAt: 'DESC' } });
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns rule if found', async () => {
+      const rule = makeCouponRule();
+      mockCouponRuleRepo.findOne.mockResolvedValue(rule);
+
+      const result = await service.findOne(1);
+      expect(result).toEqual(rule);
+    });
+
+    it('throws NotFoundException if not found', async () => {
+      mockCouponRuleRepo.findOne.mockResolvedValue(null);
+      await expect(service.findOne(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('creates and saves a coupon rule', async () => {
+      const rule = makeCouponRule();
+      mockCouponRuleRepo.create.mockReturnValue(rule);
+      mockCouponRuleRepo.save.mockResolvedValue(rule);
+
+      const result = await service.create({
+        trigger: CouponRuleTrigger.SIGNUP,
+        couponTemplateId: 10,
+      });
+      expect(result).toEqual(rule);
+      expect(mockCouponRuleRepo.create).toHaveBeenCalled();
+      expect(mockCouponRuleRepo.save).toHaveBeenCalledWith(rule);
+    });
+
+    it('defaults active to true when not provided', async () => {
+      const rule = makeCouponRule({ active: true });
+      mockCouponRuleRepo.create.mockReturnValue(rule);
+      mockCouponRuleRepo.save.mockResolvedValue(rule);
+
+      await service.create({ trigger: CouponRuleTrigger.FIRST_PURCHASE, couponTemplateId: 5 });
+
+      expect(mockCouponRuleRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ active: true }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('updates rule fields', async () => {
+      const rule = makeCouponRule();
+      mockCouponRuleRepo.findOne.mockResolvedValue(rule);
+      mockCouponRuleRepo.save.mockResolvedValue({ ...rule, active: false });
+
+      const result = await service.update(1, { active: false });
+      expect(result.active).toBe(false);
+      expect(mockCouponRuleRepo.save).toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when rule does not exist', async () => {
+      mockCouponRuleRepo.findOne.mockResolvedValue(null);
+      await expect(service.update(999, { active: false })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes rule and returns success message', async () => {
+      const rule = makeCouponRule();
+      mockCouponRuleRepo.findOne.mockResolvedValue(rule);
+      mockCouponRuleRepo.remove.mockResolvedValue(undefined);
+
+      const result = await service.remove(1);
+      expect(result).toEqual({ message: '삭제되었습니다.' });
+      expect(mockCouponRuleRepo.remove).toHaveBeenCalledWith(rule);
+    });
+
+    it('throws NotFoundException when rule does not exist', async () => {
+      mockCouponRuleRepo.findOne.mockResolvedValue(null);
+      await expect(service.remove(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('applyRulesForUser', () => {
+    it('issues coupons for all matching active rules', async () => {
+      const rules = [makeCouponRule({ couponTemplateId: 10 }), makeCouponRule({ id: 2, couponTemplateId: 20 })];
+      mockCouponRuleRepo.find.mockResolvedValue(rules);
+      mockCouponsService.issueCoupon.mockResolvedValue({});
+
+      await service.applyRulesForUser(CouponRuleTrigger.SIGNUP, 42);
+
+      expect(mockCouponsService.issueCoupon).toHaveBeenCalledTimes(2);
+      expect(mockCouponsService.issueCoupon).toHaveBeenCalledWith({ userId: 42, couponId: 10 });
+      expect(mockCouponsService.issueCoupon).toHaveBeenCalledWith({ userId: 42, couponId: 20 });
+    });
+
+    it('skips duplicate coupon issue errors silently', async () => {
+      const rules = [makeCouponRule()];
+      mockCouponRuleRepo.find.mockResolvedValue(rules);
+      mockCouponsService.issueCoupon.mockRejectedValue(new Error('이미 발급된 쿠폰입니다.'));
+
+      await expect(service.applyRulesForUser(CouponRuleTrigger.SIGNUP, 42)).resolves.not.toThrow();
+    });
+
+    it('does nothing if no active rules', async () => {
+      mockCouponRuleRepo.find.mockResolvedValue([]);
+      await service.applyRulesForUser(CouponRuleTrigger.SIGNUP, 42);
+      expect(mockCouponsService.issueCoupon).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('matchesConditions (via applyRulesForUser)', () => {
+    it('tier_up rule with minTier condition matches when newTier >= minTier', async () => {
+      const rule = makeCouponRule({
+        trigger: CouponRuleTrigger.TIER_UP,
+        conditionsJson: { minTier: 'Silver' },
+      });
+      mockCouponRuleRepo.find.mockResolvedValue([rule]);
+      mockCouponsService.issueCoupon.mockResolvedValue({});
+
+      await service.applyRulesForUser(CouponRuleTrigger.TIER_UP, 1, { newTier: 'Gold' });
+
+      expect(mockCouponsService.issueCoupon).toHaveBeenCalled();
+    });
+
+    it('tier_up rule with minTier condition skips when newTier < minTier', async () => {
+      const rule = makeCouponRule({
+        trigger: CouponRuleTrigger.TIER_UP,
+        conditionsJson: { minTier: 'Gold' },
+      });
+      mockCouponRuleRepo.find.mockResolvedValue([rule]);
+
+      await service.applyRulesForUser(CouponRuleTrigger.TIER_UP, 1, { newTier: 'Silver' });
+
+      expect(mockCouponsService.issueCoupon).not.toHaveBeenCalled();
+    });
+
+    it('rule with null conditionsJson always matches', async () => {
+      const rule = makeCouponRule({ conditionsJson: null });
+      mockCouponRuleRepo.find.mockResolvedValue([rule]);
+      mockCouponsService.issueCoupon.mockResolvedValue({});
+
+      await service.applyRulesForUser(CouponRuleTrigger.SIGNUP, 1);
+
+      expect(mockCouponsService.issueCoupon).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/coupons/coupon-rules.controller.ts
+++ b/backend/src/modules/coupons/coupon-rules.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiCookieAuth,
+} from '@nestjs/swagger';
+import { CouponRulesService } from './coupon-rules.service';
+import { CreateCouponRuleDto } from './dto/create-coupon-rule.dto';
+import { UpdateCouponRuleDto } from './dto/update-coupon-rule.dto';
+import { Roles } from '../../common/decorators/roles.decorator';
+
+@ApiTags('관리자 - 쿠폰 규칙')
+@Controller('admin/coupon-rules')
+@Roles('admin', 'super_admin')
+export class AdminCouponRulesController {
+  constructor(private readonly couponRulesService: CouponRulesService) {}
+
+  @Get()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '쿠폰 규칙 목록 조회' })
+  @ApiResponse({ status: 200, description: '목록 조회 성공' })
+  findAll() {
+    return this.couponRulesService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '쿠폰 규칙 단건 조회' })
+  @ApiResponse({ status: 200, description: '조회 성공' })
+  @ApiResponse({ status: 404, description: '규칙 없음' })
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.couponRulesService.findOne(id);
+  }
+
+  @Post()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '쿠폰 규칙 생성' })
+  @ApiResponse({ status: 201, description: '생성 성공' })
+  create(@Body() dto: CreateCouponRuleDto) {
+    return this.couponRulesService.create(dto);
+  }
+
+  @Patch(':id')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '쿠폰 규칙 수정' })
+  @ApiResponse({ status: 200, description: '수정 성공' })
+  @ApiResponse({ status: 404, description: '규칙 없음' })
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateCouponRuleDto) {
+    return this.couponRulesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '쿠폰 규칙 삭제' })
+  @ApiResponse({ status: 200, description: '삭제 성공' })
+  @ApiResponse({ status: 404, description: '규칙 없음' })
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.couponRulesService.remove(id);
+  }
+}

--- a/backend/src/modules/coupons/coupon-rules.service.ts
+++ b/backend/src/modules/coupons/coupon-rules.service.ts
@@ -1,0 +1,249 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { CouponRule, CouponRuleTrigger } from './entities/coupon-rule.entity';
+import { CouponsService } from './coupons.service';
+import { CreateCouponRuleDto } from './dto/create-coupon-rule.dto';
+import { UpdateCouponRuleDto } from './dto/update-coupon-rule.dto';
+import { MembershipEventEmitter } from '../membership/membership-event.emitter';
+import { AuthEventEmitter } from '../auth/auth-event.emitter';
+import { OrderEventEmitter } from '../orders/order-event.emitter';
+import { User } from '../users/entities/user.entity';
+
+@Injectable()
+export class CouponRulesService implements OnModuleInit {
+  private readonly logger = new Logger(CouponRulesService.name);
+
+  constructor(
+    @InjectRepository(CouponRule)
+    private readonly couponRuleRepo: Repository<CouponRule>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    private readonly couponsService: CouponsService,
+    private readonly membershipEvents: MembershipEventEmitter,
+    private readonly authEvents: AuthEventEmitter,
+    private readonly orderEvents: OrderEventEmitter,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  onModuleInit(): void {
+    this.authEvents.onUserRegistered(async (event) => {
+      try {
+        await this.applyRulesForUser(CouponRuleTrigger.SIGNUP, event.userId);
+      } catch (err) {
+        this.logger.warn(`[signup] Failed to issue coupon for userId=${event.userId}: ${String(err)}`);
+      }
+    });
+
+    this.orderEvents.onOrderCompleted(async (event) => {
+      if (event.isFirstPurchase) {
+        try {
+          await this.applyRulesForUser(CouponRuleTrigger.FIRST_PURCHASE, event.userId);
+        } catch (err) {
+          this.logger.warn(`[first_purchase] Failed to issue coupon for userId=${event.userId}: ${String(err)}`);
+        }
+      }
+    });
+
+    this.membershipEvents.onTierUpgraded(async (event) => {
+      try {
+        await this.applyRulesForUser(CouponRuleTrigger.TIER_UP, event.userId, { newTier: event.newTier });
+      } catch (err) {
+        this.logger.warn(`[tier_up] Failed to issue coupon for userId=${event.userId}: ${String(err)}`);
+      }
+    });
+  }
+
+  async applyRulesForUser(
+    trigger: CouponRuleTrigger,
+    userId: number,
+    context: Record<string, unknown> = {},
+  ): Promise<void> {
+    const rules = await this.couponRuleRepo.find({
+      where: { trigger, active: true },
+    });
+
+    for (const rule of rules) {
+      if (!this.matchesConditions(rule, context)) {
+        continue;
+      }
+
+      try {
+        await this.couponsService.issueCoupon({ userId, couponId: Number(rule.couponTemplateId) });
+        this.logger.log(
+          `[${trigger}] Issued couponTemplateId=${rule.couponTemplateId} to userId=${userId}`,
+        );
+      } catch (err) {
+        // BadRequestException for duplicate issues is expected — skip silently
+        this.logger.debug(
+          `[${trigger}] Skipped couponTemplateId=${rule.couponTemplateId} for userId=${userId}: ${String(err)}`,
+        );
+      }
+    }
+  }
+
+  private matchesConditions(rule: CouponRule, context: Record<string, unknown>): boolean {
+    const cond = rule.conditionsJson;
+    if (!cond) return true;
+
+    if (rule.trigger === CouponRuleTrigger.TIER_UP && cond['minTier']) {
+      const tierOrder = ['Bronze', 'Silver', 'Gold', 'VIP'];
+      const minIdx = tierOrder.indexOf(String(cond['minTier']));
+      const newIdx = tierOrder.indexOf(String(context['newTier'] ?? ''));
+      if (minIdx < 0 || newIdx < minIdx) return false;
+    }
+
+    return true;
+  }
+
+  // Birthday coupon batch — runs daily at midnight
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleBirthdayCoupons(): Promise<void> {
+    const lockName = 'cron:birthday-coupons';
+    const acquired = await this.acquireLock(lockName, 55);
+    if (!acquired) {
+      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
+      return;
+    }
+
+    try {
+      const rules = await this.couponRuleRepo.find({
+        where: { trigger: CouponRuleTrigger.BIRTHDAY, active: true },
+      });
+
+      if (rules.length === 0) {
+        this.logger.debug('[cron:birthday-coupons] No active birthday rules');
+        return;
+      }
+
+      const today = new Date();
+      const month = today.getMonth() + 1;
+      const day = today.getDate();
+
+      const birthdayUsers = await this.dataSource.query<Array<{ id: number }>>(
+        `SELECT id FROM users
+         WHERE MONTH(birth_date) = ? AND DAY(birth_date) = ?
+           AND is_active = 1 AND deleted_at IS NULL`,
+        [month, day],
+      );
+
+      if (birthdayUsers.length === 0) {
+        this.logger.debug(`[cron:birthday-coupons] No users with birthday today (${month}/${day})`);
+        return;
+      }
+
+      this.logger.log(
+        `[cron:birthday-coupons] Processing ${birthdayUsers.length} users with birthday on ${month}/${day}`,
+      );
+
+      for (const { id: userId } of birthdayUsers) {
+        for (const rule of rules) {
+          try {
+            await this.couponsService.issueCoupon({ userId, couponId: Number(rule.couponTemplateId) });
+            this.logger.log(`[cron:birthday-coupons] Issued couponTemplateId=${rule.couponTemplateId} to userId=${userId}`);
+          } catch (err) {
+            this.logger.debug(
+              `[cron:birthday-coupons] Skipped couponTemplateId=${rule.couponTemplateId} for userId=${userId}: ${String(err)}`,
+            );
+          }
+        }
+      }
+
+      this.logger.log(`[cron:birthday-coupons] Completed for ${birthdayUsers.length} users`);
+    } catch (err) {
+      this.logger.error(`[cron:birthday-coupons] Error: ${String(err)}`);
+    } finally {
+      await this.releaseLock(lockName);
+    }
+  }
+
+  // Admin CRUD
+
+  async findAll(): Promise<CouponRule[]> {
+    return this.couponRuleRepo.find({ order: { createdAt: 'DESC' } });
+  }
+
+  async findOne(id: number): Promise<CouponRule> {
+    const rule = await this.couponRuleRepo.findOne({ where: { id } });
+    if (!rule) {
+      throw new NotFoundException('쿠폰 규칙을 찾을 수 없습니다.');
+    }
+    return rule;
+  }
+
+  async create(dto: CreateCouponRuleDto): Promise<CouponRule> {
+    const rule = this.couponRuleRepo.create({
+      trigger: dto.trigger,
+      couponTemplateId: dto.couponTemplateId,
+      conditionsJson: dto.conditionsJson ?? null,
+      active: dto.active ?? true,
+    });
+    const saved = await this.couponRuleRepo.save(rule);
+    this.logger.log(`CouponRule created: id=${saved.id} trigger=${saved.trigger}`);
+    return saved;
+  }
+
+  async update(id: number, dto: UpdateCouponRuleDto): Promise<CouponRule> {
+    const rule = await this.findOne(id);
+
+    if (dto.trigger !== undefined) rule.trigger = dto.trigger;
+    if (dto.couponTemplateId !== undefined) rule.couponTemplateId = dto.couponTemplateId;
+    if (dto.conditionsJson !== undefined) rule.conditionsJson = dto.conditionsJson ?? null;
+    if (dto.active !== undefined) rule.active = dto.active;
+
+    const saved = await this.couponRuleRepo.save(rule);
+    this.logger.log(`CouponRule updated: id=${saved.id}`);
+    return saved;
+  }
+
+  async remove(id: number): Promise<{ message: string }> {
+    const rule = await this.findOne(id);
+    await this.couponRuleRepo.remove(rule);
+    this.logger.log(`CouponRule deleted: id=${id}`);
+    return { message: '삭제되었습니다.' };
+  }
+
+  private async acquireLock(lockName: string, ttlMinutes: number): Promise<boolean> {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + ttlMinutes * 60 * 1000);
+
+    try {
+      await this.dataSource.query(
+        `INSERT INTO scheduler_locks (lock_name, instance_id, acquired_at, expires_at)
+         VALUES (?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+           acquired_at = IF(expires_at <= NOW(), VALUES(acquired_at), acquired_at),
+           expires_at = IF(expires_at <= NOW(), VALUES(expires_at), expires_at),
+           instance_id = IF(expires_at <= NOW(), VALUES(instance_id), instance_id)`,
+        [lockName, process.env.INSTANCE_ID || 'default', now, expiresAt],
+      );
+
+      const lock = await this.dataSource.query(
+        `SELECT instance_id FROM scheduler_locks WHERE lock_name = ? AND expires_at > NOW()`,
+        [lockName],
+      );
+
+      return lock.length > 0 && lock[0].instance_id === (process.env.INSTANCE_ID || 'default');
+    } catch (err) {
+      this.logger.error(`Failed to acquire lock ${lockName}: ${String(err)}`);
+      return false;
+    }
+  }
+
+  private async releaseLock(lockName: string): Promise<void> {
+    try {
+      await this.dataSource.query(
+        `DELETE FROM scheduler_locks WHERE lock_name = ? AND instance_id = ?`,
+        [lockName, process.env.INSTANCE_ID || 'default'],
+      );
+    } catch (err) {
+      this.logger.error(`Failed to release lock ${lockName}: ${String(err)}`);
+    }
+  }
+}

--- a/backend/src/modules/coupons/coupons.module.ts
+++ b/backend/src/modules/coupons/coupons.module.ts
@@ -3,14 +3,27 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Coupon } from './entities/coupon.entity';
 import { UserCoupon } from './entities/user-coupon.entity';
 import { PointHistory } from './entities/point-history.entity';
+import { CouponRule } from './entities/coupon-rule.entity';
 import { CouponsController, AdminCouponsController } from './coupons.controller';
+import { AdminCouponRulesController } from './coupon-rules.controller';
 import { CouponsService } from './coupons.service';
+import { CouponRulesService } from './coupon-rules.service';
 import { PointsModule } from '../points/points.module';
+import { MembershipModule } from '../membership/membership.module';
+import { AuthEventsModule } from '../auth/auth-events.module';
+import { OrderEventsModule } from '../orders/order-events.module';
+import { User } from '../users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Coupon, UserCoupon, PointHistory]), PointsModule],
-  controllers: [CouponsController, AdminCouponsController],
-  providers: [CouponsService],
-  exports: [CouponsService],
+  imports: [
+    TypeOrmModule.forFeature([Coupon, UserCoupon, PointHistory, CouponRule, User]),
+    PointsModule,
+    MembershipModule,
+    AuthEventsModule,
+    OrderEventsModule,
+  ],
+  controllers: [CouponsController, AdminCouponsController, AdminCouponRulesController],
+  providers: [CouponsService, CouponRulesService],
+  exports: [CouponsService, CouponRulesService],
 })
 export class CouponsModule {}

--- a/backend/src/modules/coupons/dto/create-coupon-rule.dto.ts
+++ b/backend/src/modules/coupons/dto/create-coupon-rule.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsOptional, IsBoolean, IsObject, Min } from 'class-validator';
+import { CouponRuleTrigger } from '../entities/coupon-rule.entity';
+
+export class CreateCouponRuleDto {
+  @ApiProperty({
+    example: 'signup',
+    enum: CouponRuleTrigger,
+    description: '트리거 종류 (signup, first_purchase, birthday, tier_up)',
+  })
+  @IsEnum(CouponRuleTrigger)
+  trigger!: CouponRuleTrigger;
+
+  @ApiProperty({ example: 1, description: '쿠폰 템플릿 ID (coupons 테이블)' })
+  @IsNumber()
+  @Min(1)
+  couponTemplateId!: number;
+
+  @ApiProperty({
+    example: { minTier: 'Silver' },
+    description: '조건 JSON (tier_up 시 minTier 등)',
+    required: false,
+  })
+  @IsObject()
+  @IsOptional()
+  conditionsJson?: Record<string, unknown> | null;
+
+  @ApiProperty({ example: true, description: '활성 여부', required: false })
+  @IsBoolean()
+  @IsOptional()
+  active?: boolean;
+}

--- a/backend/src/modules/coupons/dto/update-coupon-rule.dto.ts
+++ b/backend/src/modules/coupons/dto/update-coupon-rule.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsOptional, IsBoolean, IsObject, Min } from 'class-validator';
+import { CouponRuleTrigger } from '../entities/coupon-rule.entity';
+
+export class UpdateCouponRuleDto {
+  @ApiProperty({
+    example: 'signup',
+    enum: CouponRuleTrigger,
+    required: false,
+  })
+  @IsEnum(CouponRuleTrigger)
+  @IsOptional()
+  trigger?: CouponRuleTrigger;
+
+  @ApiProperty({ example: 1, description: '쿠폰 템플릿 ID', required: false })
+  @IsNumber()
+  @Min(1)
+  @IsOptional()
+  couponTemplateId?: number;
+
+  @ApiProperty({ example: { minTier: 'Silver' }, required: false })
+  @IsObject()
+  @IsOptional()
+  conditionsJson?: Record<string, unknown> | null;
+
+  @ApiProperty({ example: true, required: false })
+  @IsBoolean()
+  @IsOptional()
+  active?: boolean;
+}

--- a/backend/src/modules/coupons/entities/coupon-rule.entity.ts
+++ b/backend/src/modules/coupons/entities/coupon-rule.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Coupon } from './coupon.entity';
+
+export enum CouponRuleTrigger {
+  SIGNUP = 'signup',
+  FIRST_PURCHASE = 'first_purchase',
+  BIRTHDAY = 'birthday',
+  TIER_UP = 'tier_up',
+}
+
+@Entity('coupon_rules')
+@Index(['trigger'])
+@Index(['active'])
+export class CouponRule {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({ type: 'enum', enum: CouponRuleTrigger })
+  trigger!: CouponRuleTrigger;
+
+  @Column({ name: 'coupon_template_id', type: 'bigint' })
+  couponTemplateId!: number;
+
+  @Column({ name: 'conditions_json', type: 'json', nullable: true })
+  conditionsJson!: Record<string, unknown> | null;
+
+  @Column({ type: 'tinyint', width: 1, default: true })
+  active!: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+
+  @ManyToOne(() => Coupon, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'coupon_template_id' })
+  couponTemplate!: Coupon;
+}

--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -10,6 +10,7 @@ import { PointsService } from '../../points/points.service';
 import { NotificationService } from '../../notification/notification.service';
 import { CouponsService } from '../../coupons/coupons.service';
 import { ShippingFeeCalculatorService } from '../../shipping/services/shipping-fee-calculator.service';
+import { OrderEventEmitter } from '../order-event.emitter';
 
 const mockQueryRunner = {
   connect: jest.fn(),
@@ -32,6 +33,7 @@ const mockDataSource = {
 
 const mockOrderRepository = {
   createQueryBuilder: jest.fn(),
+  count: jest.fn().mockResolvedValue(1),
 };
 
 const mockPointsService = {
@@ -73,6 +75,7 @@ describe('OrdersService', () => {
         { provide: NotificationService, useValue: { sendOrderConfirmed: jest.fn() } },
         { provide: CouponsService, useValue: mockCouponsService },
         { provide: ShippingFeeCalculatorService, useValue: mockShippingFeeCalculator },
+        { provide: OrderEventEmitter, useValue: { emitOrderCompleted: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/modules/orders/events/order-completed.event.ts
+++ b/backend/src/modules/orders/events/order-completed.event.ts
@@ -1,0 +1,10 @@
+export class OrderCompletedEvent {
+  constructor(
+    public readonly userId: number,
+    public readonly orderId: number,
+    public readonly orderNumber: string,
+    public readonly isFirstPurchase: boolean,
+  ) {}
+}
+
+export const ORDER_COMPLETED_EVENT = 'order.completed';

--- a/backend/src/modules/orders/order-event.emitter.ts
+++ b/backend/src/modules/orders/order-event.emitter.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter } from 'events';
+import { OrderCompletedEvent, ORDER_COMPLETED_EVENT } from './events/order-completed.event';
+
+@Injectable()
+export class OrderEventEmitter {
+  private readonly emitter = new EventEmitter();
+
+  emitOrderCompleted(event: OrderCompletedEvent): void {
+    this.emitter.emit(ORDER_COMPLETED_EVENT, event);
+  }
+
+  onOrderCompleted(handler: (event: OrderCompletedEvent) => void): void {
+    this.emitter.on(ORDER_COMPLETED_EVENT, handler);
+  }
+}

--- a/backend/src/modules/orders/order-events.module.ts
+++ b/backend/src/modules/orders/order-events.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { OrderEventEmitter } from './order-event.emitter';
+
+@Module({
+  providers: [OrderEventEmitter],
+  exports: [OrderEventEmitter],
+})
+export class OrderEventsModule {}

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -9,6 +9,7 @@ import { OrdersController } from './orders.controller';
 import { PointsModule } from '../points/points.module';
 import { CouponsModule } from '../coupons/coupons.module';
 import { ShippingModule } from '../shipping/shipping.module';
+import { OrderEventsModule } from './order-events.module';
 
 @Module({
   imports: [
@@ -16,9 +17,10 @@ import { ShippingModule } from '../shipping/shipping.module';
     PointsModule,
     CouponsModule,
     ShippingModule,
+    OrderEventsModule,
   ],
   controllers: [OrdersController],
   providers: [OrdersService],
-  exports: [OrdersService],
+  exports: [OrdersService, OrderEventsModule],
 })
 export class OrdersModule {}

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -19,6 +19,8 @@ import { NotificationService } from '../notification/notification.service';
 import { CouponsService } from '../coupons/coupons.service';
 import { CalculateDiscountDto } from '../coupons/dto/calculate-discount.dto';
 import { ShippingFeeCalculatorService } from '../shipping/services/shipping-fee-calculator.service';
+import { OrderEventEmitter } from './order-event.emitter';
+import { OrderCompletedEvent } from './events/order-completed.event';
 
 @Injectable()
 export class OrdersService {
@@ -35,6 +37,7 @@ export class OrdersService {
     private readonly notificationService: NotificationService,
     private readonly couponsService: CouponsService,
     private readonly shippingFeeCalculator: ShippingFeeCalculatorService,
+    private readonly orderEventEmitter: OrderEventEmitter,
   ) {}
 
   private generateOrderNumber(): string {
@@ -197,6 +200,12 @@ export class OrdersService {
 
       await queryRunner.commitTransaction();
       this.logger.log(`Order created: ${savedOrder.orderNumber} userId=${userId}`);
+
+      const priorOrderCount = await this.orderRepository.count({ where: { userId } });
+      const isFirstPurchase = priorOrderCount <= 1;
+      this.orderEventEmitter.emitOrderCompleted(
+        new OrderCompletedEvent(userId, Number(savedOrder.id), savedOrder.orderNumber, isFirstPurchase),
+      );
 
       void this.notifyOrderCreated(userId, savedOrder.orderNumber, totalPayable, dto.recipientName);
 


### PR DESCRIPTION
## Summary
- Closes #514
- coupon_rules 테이블 마이그레이션
- signup/first_purchase/birthday/tier_up 트리거 지원
- 이벤트 기반 자동 발급 (signup, order-completed, tier-up)
- 생일 쿠폰 매일 00:00 배치 Cron
- 관리자 CRUD API

## Test plan
- [ ] npm run build
- [ ] npm run test