### PR TITLE
fix: en 라이트 모드 및 언어 전환 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ cd backend && docker compose down -v # Reset dev DB
 ## Issue Tracker
 * Phase 0-7 (Setup → MVP → Core → Payment → Admin → CMS → Polish → Ops)
 * Labels: `phase-N`, `backend`, `frontend`, `infra`, `P0`~`P3`
-* Latest merged PR: #576
+* Latest merged PR: #585
 
 ## Rules Reference
 | Subject | File |

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -112,7 +112,7 @@ export default async function LocaleLayout({
   // 클라이언트의 FOUC 스크립트가 localStorage 에 저장된 사용자 선호가 있으면 즉시 덮어씀.
   const initialTheme = safeLocale === 'ko' ? 'dark' : 'light';
 
-  const foucScript = "(function(){try{var s=localStorage.getItem('theme');if(s==='dark'||s==='light'){document.documentElement.dataset.theme=s;}}catch(e){}})();";
+  const foucScript = `(function(){try{var d='${initialTheme}';var s=localStorage.getItem('theme');document.documentElement.dataset.theme=d==='light'?'light':(s==='dark'||s==='light'?s:d);}catch(e){document.documentElement.dataset.theme='${initialTheme}';}})();`;
 
   return (
     <html lang={safeLocale} data-theme={initialTheme} suppressHydrationWarning>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { ShoppingCart, Menu, X, Search, User, LogOut, LogIn, UserPlus, MessageSquare, Package } from 'lucide-react';
 import { cn } from '@/components/ui/utils';

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { Moon, Sun } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
-import { useTheme } from '@/contexts/ThemeContext';
+import { getDefaultThemeForLocale, useTheme } from '@/contexts/ThemeContext';
 
 interface ThemeToggleProps {
   className?: string;
@@ -17,8 +17,14 @@ interface ThemeToggleProps {
  * - aria-label/title은 next-intl `header.themeToggle*` 키에서 조회
  */
 export default function ThemeToggle({ className, iconClassName }: ThemeToggleProps) {
+  const locale = useLocale();
   const { theme, toggleTheme } = useTheme();
   const t = useTranslations('header');
+
+  if (getDefaultThemeForLocale(locale) === 'light') {
+    return null;
+  }
+
   const label = theme === 'dark' ? t('themeToggleToLight') : t('themeToggleToDark');
 
   return (

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -46,13 +46,17 @@ vi.mock('next-intl', async (importOriginal) => {
   };
 });
 
-vi.mock('@/contexts/ThemeContext', () => ({
-  useTheme: () => ({
-    theme: 'dark',
-    setTheme: vi.fn(),
-    toggleTheme: vi.fn(),
-  }),
-}));
+vi.mock('@/contexts/ThemeContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/contexts/ThemeContext')>();
+  return {
+    ...actual,
+    useTheme: () => ({
+      theme: 'dark',
+      setTheme: vi.fn(),
+      toggleTheme: vi.fn(),
+    }),
+  };
+});
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({

--- a/src/components/__tests__/LanguageSelector.test.tsx
+++ b/src/components/__tests__/LanguageSelector.test.tsx
@@ -1,20 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import LanguageSelector from '@/components/shared/LanguageSelector';
 
-const mockReplace = vi.fn();
-let mockPathname = '/';
 let mockLocale = 'ko';
-const mockNextPush = vi.fn();
-const mockNextReplace = vi.fn();
-const mockNextBack = vi.fn();
-
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockNextPush, replace: mockNextReplace, back: mockNextBack }),
-  usePathname: () => mockPathname,
-  useSearchParams: () => new URLSearchParams(),
-}));
+let openMock: ReturnType<typeof vi.fn>;
 
 vi.mock('@/hooks/useUrlModal', async () => {
   const React = await import('react');
@@ -28,10 +18,6 @@ vi.mock('@/hooks/useUrlModal', async () => {
   };
 });
 
-vi.mock('@/i18n/navigation', () => ({
-  useRouter: () => ({ replace: mockReplace }),
-  usePathname: () => mockPathname,
-}));
 
 const translations: Record<string, string> = {
   'header.languageSelector': '언어 선택',
@@ -47,11 +33,15 @@ vi.mock('next-intl', () => ({
 }));
 
 beforeEach(() => {
-  mockReplace.mockClear();
-  mockPathname = '/';
   mockLocale = 'ko';
-  // Reset document.cookie
+  openMock = vi.fn();
+  vi.stubGlobal('open', openMock);
+  window.history.replaceState({}, '', 'http://localhost:3000/ko');
   document.cookie = 'NEXT_LOCALE=; max-age=0; path=/';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('LanguageSelector', () => {
@@ -78,23 +68,31 @@ describe('LanguageSelector', () => {
     expect(screen.getAllByText('한국어').length).toBeGreaterThan(0);
   });
 
-  it('selecting a different language calls router.replace and closes dropdown', async () => {
+  it('selecting a different language navigates to the localized path and closes dropdown', async () => {
     const user = userEvent.setup();
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
     await user.click(screen.getByText('English'));
-    expect(mockReplace).toHaveBeenCalledWith('/', { locale: 'en' });
+    expect(openMock).toHaveBeenCalledWith('/en', '_self');
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
-  it('selecting current locale does not call router.replace', async () => {
+  it('keeps the current pathname when switching language', async () => {
+    window.history.replaceState({}, '', 'http://localhost:3000/ko/products/123?language=1#details');
     const user = userEvent.setup();
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
-    // Click 한국어 (current locale is 'ko')
+    await user.click(screen.getByText('English'));
+    expect(openMock).toHaveBeenCalledWith('/en/products/123#details', '_self');
+  });
+
+  it('selecting current locale does not navigate', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector />);
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
     const options = screen.getAllByText('한국어');
     await user.click(options[options.length - 1]);
-    expect(mockReplace).not.toHaveBeenCalled();
+    expect(openMock).not.toHaveBeenCalled();
   });
 
   it('sets NEXT_LOCALE cookie on language change', async () => {

--- a/src/components/__tests__/ThemeContext.test.tsx
+++ b/src/components/__tests__/ThemeContext.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
 import { ThemeProvider, useTheme, THEME_STORAGE_KEY } from '@/contexts/ThemeContext';
 
 function ThemeDisplay() {
@@ -12,6 +13,10 @@ function ThemeDisplay() {
       <button onClick={() => setTheme('dark')}>set-dark</button>
     </div>
   );
+}
+
+function TestThemeProvider({ locale, children }: { locale: string; children: ReactNode }) {
+  return <ThemeProvider locale={locale}>{children}</ThemeProvider>;
 }
 
 describe('ThemeContext', () => {
@@ -40,7 +45,7 @@ describe('ThemeContext', () => {
     expect(document.documentElement.dataset.theme).toBe('light');
   });
 
-  it('localStorage 값이 있으면 로케일 기본값보다 우선한다', () => {
+  it('ko 로케일은 localStorage 값을 반영한다', () => {
     localStorage.setItem(THEME_STORAGE_KEY, 'light');
     render(
       <ThemeProvider locale="ko">
@@ -48,6 +53,17 @@ describe('ThemeContext', () => {
       </ThemeProvider>,
     );
     expect(screen.getByTestId('theme').textContent).toBe('light');
+  });
+
+  it('en 로케일은 localStorage에 dark가 있어도 light로 고정된다', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    render(
+      <ThemeProvider locale="en">
+        <ThemeDisplay />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
   });
 
   it('localStorage 값이 잘못된 경우 로케일 기본값으로 폴백', () => {
@@ -96,5 +112,25 @@ describe('ThemeContext', () => {
     expect(screen.getByTestId('theme').textContent).toBe('dark');
     expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
     expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  it('locale이 ko에서 en으로 바뀌면 theme가 light로 재동기화된다', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    const { rerender } = render(
+      <TestThemeProvider locale="ko">
+        <ThemeDisplay />
+      </TestThemeProvider>,
+    );
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+
+    rerender(
+      <TestThemeProvider locale="en">
+        <ThemeDisplay />
+      </TestThemeProvider>,
+    );
+
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
   });
 });

--- a/src/components/shared/LanguageSelector.tsx
+++ b/src/components/shared/LanguageSelector.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRef, useEffect } from 'react';
-import { useRouter, usePathname } from '@/i18n/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
 import { useUrlModal } from '@/hooks/useUrlModal';
@@ -27,9 +26,27 @@ interface LanguageSelectorProps {
   compact?: boolean;
 }
 
+function getLocalizedHref(nextLocale: Locale): string {
+  if (typeof window === 'undefined') {
+    return `/${nextLocale}`;
+  }
+
+  const url = new URL(window.location.href);
+  const segments = url.pathname.split('/').filter(Boolean);
+
+  if (segments.length > 0 && routing.locales.includes(segments[0] as Locale)) {
+    segments[0] = nextLocale;
+  } else {
+    segments.unshift(nextLocale);
+  }
+
+  url.pathname = `/${segments.join('/')}`;
+  url.searchParams.delete('language');
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 export default function LanguageSelector({ className, compact = false }: LanguageSelectorProps) {
-  const router = useRouter();
-  const pathname = usePathname();
   const currentLocale = useLocale() as Locale;
   const t = useTranslations('header');
   const [isOpen, setIsOpen] = useUrlModal('language');
@@ -40,9 +57,8 @@ export default function LanguageSelector({ className, compact = false }: Languag
   const handleSelect = (locale: Locale) => {
     setIsOpen(false);
     if (locale === currentLocale) return;
-    // Save to cookie (NEXT_LOCALE) — next-intl reads this automatically
     document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
-    router.replace(pathname, { locale });
+    window.open(getLocalizedHref(locale), '_self');
   };
 
   // Close on outside click

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -30,8 +30,12 @@ export function getDefaultThemeForLocale(locale: string): Theme {
 }
 
 export function getInitialTheme(locale: string): Theme {
+  const defaultTheme = getDefaultThemeForLocale(locale);
   if (typeof window === 'undefined') {
-    return getDefaultThemeForLocale(locale);
+    return defaultTheme;
+  }
+  if (defaultTheme === 'light') {
+    return 'light';
   }
   try {
     const saved = window.localStorage.getItem(THEME_STORAGE_KEY);
@@ -39,7 +43,7 @@ export function getInitialTheme(locale: string): Theme {
   } catch {
     // localStorage unavailable (e.g. private mode) — fall back to locale default
   }
-  return getDefaultThemeForLocale(locale);
+  return defaultTheme;
 }
 
 interface ThemeProviderProps {
@@ -49,6 +53,10 @@ interface ThemeProviderProps {
 
 export function ThemeProvider({ children, locale }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(() => getInitialTheme(locale));
+
+  useEffect(() => {
+    setThemeState(getInitialTheme(locale));
+  }, [locale]);
 
   // Sync dataset on mount and whenever theme changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- English locale now stays in light mode and hides the dark-mode toggle
- Header language switching now navigates to the matching locale path while preserving the current route
- Closes #585

## Changes
- Sync locale-based theme initialization and hydration behavior for non-Korean locales
- Make header links locale-aware and update language selector navigation behavior
- Add regression coverage for theme and locale switching behavior

## Test plan
- [x] npm run build
- [x] npm run test:run
- [x] npm --prefix backend run build
- [x] npm --prefix backend test

🤖 Generated with [Claude Code](https://claude.com/claude-code)