### PR TITLE
refactor: #594 #595 #596 #597 백엔드 P1 모놀리식 서비스 분해

### DIFF
--- a/backend/src/modules/auth/__tests__/auth-login-policy.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth-login-policy.service.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForbiddenException } from '@nestjs/common';
+import { User, UserRole } from '../../users/entities/user.entity';
+import { AuthLoginPolicyService } from '../services/auth-login-policy.service';
+import { AuthAuditService } from '../services/auth-audit.service';
+
+const mockUserRepository = {
+  update: jest.fn(),
+};
+
+const mockAuthAuditService = {
+  logLoginFailure: jest.fn(),
+};
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    email: 'test@example.com',
+    password: 'hashed-password',
+    name: '홍길동',
+    phone: null,
+    role: UserRole.USER,
+    tier: 'Bronze',
+    tierAccumulatedAmount: 0,
+    tierEvaluatedAt: null,
+    isActive: true,
+    isEmailVerified: true,
+    emailVerifiedAt: new Date(),
+    refreshToken: null,
+    failedLoginAttempts: 0,
+    lastFailedLoginAt: null,
+    lockedUntil: null,
+    deletionRequestedAt: null,
+    deletionScheduledAt: null,
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('AuthLoginPolicyService', () => {
+  let service: AuthLoginPolicyService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthLoginPolicyService,
+        { provide: getRepositoryToken(User), useValue: mockUserRepository },
+        { provide: AuthAuditService, useValue: mockAuthAuditService },
+      ],
+    }).compile();
+
+    service = module.get<AuthLoginPolicyService>(AuthLoginPolicyService);
+  });
+
+  it('실패 횟수 5회 도달 시 15분 잠금 정책 적용', async () => {
+    const user = makeUser({ failedLoginAttempts: 4 });
+
+    await expect(
+      service.handlePasswordMismatch(user, user.email),
+    ).rejects.toThrow(ForbiddenException);
+
+    expect(mockUserRepository.update).toHaveBeenCalledWith(
+      user.id,
+      expect.objectContaining({
+        failedLoginAttempts: 5,
+        lockedUntil: expect.any(Date),
+      }),
+    );
+    expect(mockAuthAuditService.logLoginFailure).toHaveBeenCalledWith(
+      user,
+      expect.objectContaining({
+        reason: 'account_locked_15m',
+        attempts: 5,
+      }),
+    );
+  });
+
+  it('실패 횟수 10회 도달 시 1시간 잠금 정책 적용', async () => {
+    const user = makeUser({ failedLoginAttempts: 9 });
+
+    await expect(
+      service.handlePasswordMismatch(user, user.email),
+    ).rejects.toThrow(ForbiddenException);
+
+    expect(mockUserRepository.update).toHaveBeenCalledWith(
+      user.id,
+      expect.objectContaining({
+        failedLoginAttempts: 10,
+        lockedUntil: expect.any(Date),
+      }),
+    );
+    expect(mockAuthAuditService.logLoginFailure).toHaveBeenCalledWith(
+      user,
+      expect.objectContaining({
+        reason: 'account_locked_1h',
+        attempts: 10,
+      }),
+    );
+  });
+
+  it('실패 횟수 15회 도달 시 관리자 해제 필요 상태로 전환', async () => {
+    const user = makeUser({ failedLoginAttempts: 14 });
+
+    await expect(
+      service.handlePasswordMismatch(user, user.email),
+    ).rejects.toThrow(ForbiddenException);
+
+    expect(mockUserRepository.update).toHaveBeenCalledWith(
+      user.id,
+      expect.objectContaining({
+        failedLoginAttempts: 15,
+        lockedUntil: null,
+      }),
+    );
+    expect(mockAuthAuditService.logLoginFailure).toHaveBeenCalledWith(
+      user,
+      expect.objectContaining({
+        reason: 'account_locked_manual',
+        attempts: 15,
+      }),
+    );
+  });
+});
+

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -11,6 +11,9 @@ import { NotificationService } from '../../notification/notification.service';
 import { AuditLogService } from '../../audit-logs/audit-log.service';
 import { TokenBlacklistService } from '../token-blacklist.service';
 import { AuthEventEmitter } from '../auth-event.emitter';
+import { TokenIssuerService } from '../services/token-issuer.service';
+import { AuthLoginPolicyService } from '../services/auth-login-policy.service';
+import { AuthAuditService } from '../services/auth-audit.service';
 
 const mockUserRepository = {
   findOne: jest.fn(),
@@ -51,6 +54,26 @@ const mockTokenBlacklistService = {
   addToBlacklist: jest.fn(),
   isBlacklisted: jest.fn(),
   revokeAllUserTokens: jest.fn(),
+};
+
+const mockTokenIssuerService = {
+  issueAndPersistRefresh: jest.fn().mockResolvedValue({
+    accessToken: 'mock-access-token',
+    refreshToken: 'mock-refresh-token',
+  }),
+};
+
+const mockAuthLoginPolicyService = {
+  assertNotLocked: jest.fn(),
+  handlePasswordMismatch: jest.fn(async () => {
+    throw new UnauthorizedException('비밀번호가 올바르지 않습니다.');
+  }),
+};
+
+const mockAuthAuditService = {
+  logUserNotFound: jest.fn(),
+  logLoginFailure: jest.fn(),
+  logLoginSuccess: jest.fn(),
 };
 
 function makeUser(overrides: Partial<User> = {}): User {
@@ -102,6 +125,9 @@ describe('AuthService', () => {
           useValue: mockVerificationTokenRepository,
         },
         { provide: JwtService, useValue: mockJwtService },
+        { provide: TokenIssuerService, useValue: mockTokenIssuerService },
+        { provide: AuthLoginPolicyService, useValue: mockAuthLoginPolicyService },
+        { provide: AuthAuditService, useValue: mockAuthAuditService },
         { provide: NotificationService, useValue: mockNotificationService },
         { provide: AuditLogService, useValue: mockAuditLogService },
         { provide: TokenBlacklistService, useValue: mockTokenBlacklistService },
@@ -198,15 +224,15 @@ describe('AuthService', () => {
     it('로그인 성공 시 refreshToken을 DB에 해싱 저장', async () => {
       const hashed = await bcrypt.hash('Test1234!', 10);
       mockUserRepository.findOne.mockResolvedValue(makeUser({ password: hashed, isEmailVerified: true }));
-      mockUserRepository.update.mockResolvedValue(undefined);
+      mockTokenIssuerService.issueAndPersistRefresh.mockResolvedValue({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+      });
 
       await service.login({ email: 'test@example.com', password: 'Test1234!' });
 
-      expect(mockUserRepository.update).toHaveBeenCalledWith(
-        1,
-        expect.objectContaining({
-          refreshToken: expect.stringMatching(/^\$2b\$/),
-        }),
+      expect(mockTokenIssuerService.issueAndPersistRefresh).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1, email: 'test@example.com' }),
       );
     });
   });
@@ -217,7 +243,10 @@ describe('AuthService', () => {
       const hashedRefresh = await bcrypt.hash(rawRefresh, 10);
       mockJwtService.verify.mockReturnValueOnce({ sub: 1, email: 'test@example.com', role: 'user', tokenType: 'refresh' });
       mockUserRepository.findOne.mockResolvedValue(makeUser({ refreshToken: hashedRefresh }));
-      mockUserRepository.update.mockResolvedValue(undefined);
+      mockTokenIssuerService.issueAndPersistRefresh.mockResolvedValue({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+      });
 
       const result = await service.refresh(rawRefresh);
 
@@ -253,7 +282,10 @@ describe('AuthService', () => {
       const hashedRefresh = await bcrypt.hash(rawRefresh, 10);
       mockJwtService.verify.mockReturnValueOnce({ sub: 1, email: 'test@example.com', role: 'user', tokenType: 'refresh' });
       mockUserRepository.findOne.mockResolvedValue(makeUser({ isActive: true, refreshToken: hashedRefresh }));
-      mockUserRepository.update.mockResolvedValue(undefined);
+      mockTokenIssuerService.issueAndPersistRefresh.mockResolvedValue({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+      });
 
       const result = await service.refresh(rawRefresh);
 
@@ -475,7 +507,10 @@ describe('AuthService', () => {
       mockUserRepository.findOne.mockResolvedValue(
         makeUser({ password: hashed, isEmailVerified: true }),
       );
-      mockUserRepository.update.mockResolvedValue(undefined);
+      mockTokenIssuerService.issueAndPersistRefresh.mockResolvedValue({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+      });
 
       const result = await service.login({ email: 'test@example.com', password: 'Test1234!' });
 

--- a/backend/src/modules/auth/__tests__/oauth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/oauth.service.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
-import { JwtService } from '@nestjs/jwt';
 import { HttpService } from '@nestjs/axios';
 import { BadGatewayException, BadRequestException, NotFoundException } from '@nestjs/common';
 import { of, throwError } from 'rxjs';
@@ -9,6 +8,7 @@ import { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { OAuthService } from '../oauth.service';
 import { User, UserRole } from '../../users/entities/user.entity';
 import { UserAuthentication, OAuthProvider } from '../../users/entities/user-authentication.entity';
+import { TokenIssuerService } from '../services/token-issuer.service';
 
 const mockUserRepository = {
   findOne: jest.fn(),
@@ -29,13 +29,16 @@ const mockDataSource = {
   transaction: jest.fn(),
 };
 
-const mockJwtService = {
-  sign: jest.fn().mockReturnValue('mock-token'),
-};
-
 const mockHttpService = {
   post: jest.fn(),
   get: jest.fn(),
+};
+
+const mockTokenIssuerService = {
+  issueAndPersistRefresh: jest.fn().mockResolvedValue({
+    accessToken: 'mock-access-token',
+    refreshToken: 'mock-refresh-token',
+  }),
 };
 
 function makeAxiosResponse<T>(data: T): AxiosResponse<T> {
@@ -111,7 +114,7 @@ describe('OAuthService', () => {
         OAuthService,
         { provide: getRepositoryToken(User), useValue: mockUserRepository },
         { provide: getRepositoryToken(UserAuthentication), useValue: mockUserAuthRepository },
-        { provide: JwtService, useValue: mockJwtService },
+        { provide: TokenIssuerService, useValue: mockTokenIssuerService },
         { provide: HttpService, useValue: mockHttpService },
         { provide: DataSource, useValue: mockDataSource },
       ],
@@ -142,7 +145,7 @@ describe('OAuthService', () => {
       const result = await service.handleKakao('auth-code');
 
       expect(result.isNewUser).toBe(true);
-      expect(result.accessToken).toBe('mock-token');
+      expect(result.accessToken).toBe('mock-access-token');
       expect(result.user.email).toBe('new@kakao.com');
     });
 
@@ -312,41 +315,30 @@ describe('OAuthService', () => {
     });
   });
 
-  describe('generateTokens', () => {
-    it('accessToken payload에 tokenType: access 포함', async () => {
-      const user = makeUser({ id: 1, email: 'test@example.com', role: UserRole.USER });
-      const signCalls: { payload: Record<string, unknown> }[] = [];
-      mockJwtService.sign.mockImplementation((payload: Record<string, unknown>) => {
-        signCalls.push({ payload });
-        return 'mock-token';
-      });
+  describe('token issuing integration', () => {
+    it('OAuth 로그인 시 TokenIssuerService를 통해 토큰 발급', async () => {
+      mockHttpService.post.mockReturnValue(
+        of(makeAxiosResponse({ access_token: 'kakao-access-token' })),
+      );
+      mockHttpService.get.mockReturnValue(
+        of(makeAxiosResponse({
+          id: 12345,
+          kakao_account: { email: 'existing@kakao.com', profile: { nickname: '기존유저' } },
+        })),
+      );
+      const existingUser = makeUser({ id: 1, email: 'existing@kakao.com', name: '기존유저' });
+      mockUserAuthRepository.findOne.mockResolvedValue(
+        makeUserAuth({ user: existingUser, userId: 1 }),
+      );
 
-      // Access private method via prototype
-      const generateTokens = (service as unknown as { generateTokens: (user: User) => Promise<{ accessToken: string; refreshToken: string }> }).generateTokens.bind(service);
-      await generateTokens(user);
+      await service.handleKakao('auth-code');
 
-      // First sign call should be access token with tokenType: 'access'
-      const accessTokenCall = signCalls[0];
-      expect(accessTokenCall.payload).toHaveProperty('tokenType', 'access');
-      expect(accessTokenCall.payload).toHaveProperty('sub', user.id);
-      expect(accessTokenCall.payload).toHaveProperty('email', user.email);
-      expect(accessTokenCall.payload).toHaveProperty('role', user.role);
-    });
-
-    it('refreshToken payload에 tokenType: refresh 포함', async () => {
-      const user = makeUser({ id: 1, email: 'test@example.com', role: UserRole.USER });
-      const signCalls: { payload: Record<string, unknown> }[] = [];
-      mockJwtService.sign.mockImplementation((payload: Record<string, unknown>) => {
-        signCalls.push({ payload });
-        return 'mock-token';
-      });
-
-      const generateTokens = (service as unknown as { generateTokens: (user: User) => Promise<{ accessToken: string; refreshToken: string }> }).generateTokens.bind(service);
-      await generateTokens(user);
-
-      // Second sign call should be refresh token with tokenType: 'refresh'
-      const refreshTokenCall = signCalls[1];
-      expect(refreshTokenCall.payload).toHaveProperty('tokenType', 'refresh');
+      expect(mockTokenIssuerService.issueAndPersistRefresh).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 1,
+          email: 'existing@kakao.com',
+        }),
+      );
     });
   });
 });

--- a/backend/src/modules/auth/__tests__/token-issuer.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/token-issuer.service.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as bcrypt from 'bcrypt';
+import { JwtService } from '@nestjs/jwt';
+import { User, UserRole } from '../../users/entities/user.entity';
+import { TokenIssuerService } from '../services/token-issuer.service';
+
+const mockUserRepository = {
+  update: jest.fn(),
+};
+
+const mockJwtService = {
+  sign: jest
+    .fn()
+    .mockReturnValueOnce('access-token')
+    .mockReturnValueOnce('refresh-token'),
+};
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    email: 'test@example.com',
+    password: 'hashed-password',
+    name: '홍길동',
+    phone: null,
+    role: UserRole.USER,
+    tier: 'Bronze',
+    tierAccumulatedAmount: 0,
+    tierEvaluatedAt: null,
+    isActive: true,
+    isEmailVerified: true,
+    emailVerifiedAt: new Date(),
+    refreshToken: null,
+    failedLoginAttempts: 0,
+    lastFailedLoginAt: null,
+    lockedUntil: null,
+    deletionRequestedAt: null,
+    deletionScheduledAt: null,
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('TokenIssuerService', () => {
+  let service: TokenIssuerService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockJwtService.sign
+      .mockReturnValueOnce('access-token')
+      .mockReturnValueOnce('refresh-token');
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TokenIssuerService,
+        { provide: JwtService, useValue: mockJwtService },
+        { provide: getRepositoryToken(User), useValue: mockUserRepository },
+      ],
+    }).compile();
+
+    service = module.get<TokenIssuerService>(TokenIssuerService);
+  });
+
+  it('access/refresh token payload에 tokenType을 각각 부여한다', () => {
+    const user = makeUser();
+
+    service.issueTokens(user);
+
+    expect(mockJwtService.sign).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        sub: user.id,
+        email: user.email,
+        role: user.role,
+        tokenType: 'access',
+        jti: expect.any(String),
+      }),
+    );
+    expect(mockJwtService.sign).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        sub: user.id,
+        email: user.email,
+        role: user.role,
+        tokenType: 'refresh',
+      }),
+      expect.objectContaining({
+        algorithm: 'HS256',
+      }),
+    );
+  });
+
+  it('refresh token은 해시해서 DB에 저장한다', async () => {
+    const user = makeUser();
+
+    const result = await service.issueAndPersistRefresh(user);
+
+    expect(result).toEqual({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+    expect(mockUserRepository.update).toHaveBeenCalledWith(
+      user.id,
+      expect.objectContaining({
+        refreshToken: expect.any(String),
+      }),
+    );
+
+    const updatedPayload = mockUserRepository.update.mock.calls[0][1] as { refreshToken: string };
+    expect(await bcrypt.compare('refresh-token', updatedPayload.refreshToken)).toBe(true);
+  });
+});
+

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -10,6 +10,9 @@ import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { OAuthService } from './oauth.service';
+import { TokenIssuerService } from './services/token-issuer.service';
+import { AuthAuditService } from './services/auth-audit.service';
+import { AuthLoginPolicyService } from './services/auth-login-policy.service';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { TokenBlacklist } from './entities/token-blacklist.entity';
 import { TokenBlacklistService } from './token-blacklist.service';
@@ -56,7 +59,15 @@ function getJwtPrivateKey(): string {
     AuthEventsModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, OAuthService, JwtStrategy, TokenBlacklistService],
+  providers: [
+    AuthService,
+    OAuthService,
+    TokenIssuerService,
+    AuthAuditService,
+    AuthLoginPolicyService,
+    JwtStrategy,
+    TokenBlacklistService,
+  ],
   exports: [PassportModule, JwtModule, AuditLogModule, AuthEventsModule],
 })
 export class AuthModule {}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -11,8 +11,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
-import { createHash, randomBytes, randomUUID } from 'crypto';
-import type ms from 'ms';
+import { createHash, randomBytes } from 'crypto';
 import { User } from '../users/entities/user.entity';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
@@ -23,17 +22,13 @@ import { ResendVerificationDto } from './dto/resend-verification.dto';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { VerificationToken } from './entities/verification-token.entity';
 import { NotificationService } from '../notification/notification.service';
-import { AuditLogService } from '../audit-logs/audit-log.service';
-import { AuditAction } from '../audit-logs/entities/audit-log.entity';
 import { TokenBlacklistService } from './token-blacklist.service';
 import { AuthEventEmitter } from './auth-event.emitter';
 import { UserRegisteredEvent } from './events/user-registered.event';
+import { TokenIssuerService } from './services/token-issuer.service';
+import { AuthLoginPolicyService } from './services/auth-login-policy.service';
+import { AuthAuditService } from './services/auth-audit.service';
 
-const LOCK_LEVEL_1_ATTEMPTS = 5;
-const LOCK_LEVEL_2_ATTEMPTS = 10;
-const LOCK_LEVEL_3_ATTEMPTS = 15;
-const LOCKOUT_LEVEL_1_MS = 15 * 60 * 1000;
-const LOCKOUT_LEVEL_2_MS = 60 * 60 * 1000;
 const PASSWORD_RESET_TTL_MS = 60 * 60 * 1000;
 const EMAIL_VERIFICATION_TTL_MIN = 15;
 const EMAIL_VERIFICATION_TTL_MS = EMAIL_VERIFICATION_TTL_MIN * 60 * 1000;
@@ -82,8 +77,10 @@ export class AuthService implements OnModuleInit {
     @InjectRepository(VerificationToken)
     private readonly verificationTokenRepository: Repository<VerificationToken>,
     private readonly jwtService: JwtService,
+    private readonly tokenIssuerService: TokenIssuerService,
+    private readonly authLoginPolicyService: AuthLoginPolicyService,
+    private readonly authAuditService: AuthAuditService,
     private readonly notificationService: NotificationService,
-    private readonly auditLogService: AuditLogService,
     private readonly tokenBlacklistService: TokenBlacklistService,
     private readonly authEventEmitter: AuthEventEmitter,
   ) {}
@@ -124,9 +121,7 @@ export class AuthService implements OnModuleInit {
 
     await this.createVerificationTokenAndSendEmail(user);
 
-    const tokens = this.generateTokens(user);
-    const hashedRefresh = await bcrypt.hash(tokens.refreshToken, 10);
-    await this.userRepository.update(user.id, { refreshToken: hashedRefresh });
+    const tokens = await this.tokenIssuerService.issueAndPersistRefresh(user);
 
     this.logger.log(`User registered: ${dto.email}`);
     return {
@@ -140,16 +135,7 @@ export class AuthService implements OnModuleInit {
       where: { email: dto.email },
     });
     if (!user) {
-      await this.auditLogService.log({
-        actorId: 0,
-        actorRole: 'anonymous',
-        action: AuditAction.LOGIN_FAILURE,
-        resourceType: 'auth',
-        beforeJson: { email: dto.email },
-        afterJson: { reason: 'user_not_found' },
-        ip: ip ?? null,
-        userAgent: userAgent ?? null,
-      });
+      await this.authAuditService.logUserNotFound(dto.email, ip, userAgent);
       throw new UnauthorizedException('가입되지 않은 이메일입니다.');
     }
     if (!user.password) {
@@ -164,17 +150,7 @@ export class AuthService implements OnModuleInit {
       );
     }
 
-    if (user.failedLoginAttempts >= LOCK_LEVEL_3_ATTEMPTS) {
-      throw new ForbiddenException('보안 정책에 의해 계정이 잠겼습니다. 관리자에게 잠금 해제를 요청해 주세요.');
-    }
-
-    if (user.lockedUntil && user.lockedUntil > new Date()) {
-      const remainingMs = user.lockedUntil.getTime() - Date.now();
-      const remainingSec = Math.ceil(remainingMs / 1000);
-      throw new ForbiddenException(
-        `계정이 잠겼습니다. ${remainingSec}초 후 다시 시도하세요.`,
-      );
-    }
+    this.authLoginPolicyService.assertNotLocked(user);
 
     if (!user.isActive) {
       throw new ForbiddenException('비활성화된 계정입니다.');
@@ -182,92 +158,7 @@ export class AuthService implements OnModuleInit {
 
     const valid = await bcrypt.compare(dto.password, user.password);
     if (!valid) {
-      const now = new Date();
-      const attempts = user.failedLoginAttempts + 1;
-
-      if (attempts >= LOCK_LEVEL_3_ATTEMPTS) {
-        await this.userRepository.update(user.id, {
-          failedLoginAttempts: attempts,
-          lastFailedLoginAt: now,
-          lockedUntil: null,
-        });
-        await this.auditLogService.log({
-          actorId: user.id,
-          actorRole: user.role,
-          action: AuditAction.LOGIN_FAILURE,
-          resourceType: 'auth',
-          beforeJson: { email: dto.email },
-          afterJson: { reason: 'account_locked_manual', attempts },
-          ip: ip ?? null,
-          userAgent: userAgent ?? null,
-        });
-        this.logger.warn(`Account permanently locked until admin unlock: ${dto.email}`);
-        throw new ForbiddenException('연속 로그인 실패로 계정이 잠겼습니다. 관리자에게 잠금 해제를 요청해 주세요.');
-      }
-
-      if (attempts >= LOCK_LEVEL_2_ATTEMPTS) {
-        const lockedUntil = new Date(Date.now() + LOCKOUT_LEVEL_2_MS);
-        await this.userRepository.update(user.id, {
-          failedLoginAttempts: attempts,
-          lastFailedLoginAt: now,
-          lockedUntil,
-        });
-        await this.auditLogService.log({
-          actorId: user.id,
-          actorRole: user.role,
-          action: AuditAction.LOGIN_FAILURE,
-          resourceType: 'auth',
-          beforeJson: { email: dto.email },
-          afterJson: { reason: 'account_locked_1h', attempts, lockedUntil: lockedUntil.toISOString() },
-          ip: ip ?? null,
-          userAgent: userAgent ?? null,
-        });
-        this.logger.warn(`Account locked (1h) due to failed login attempts: ${dto.email}`);
-        throw new ForbiddenException(
-          `연속 로그인 실패로 계정이 잠겼습니다. ${Math.ceil(LOCKOUT_LEVEL_2_MS / 1000)}초 후 다시 시도하세요.`,
-        );
-      }
-
-      if (attempts >= LOCK_LEVEL_1_ATTEMPTS) {
-        const lockedUntil = new Date(Date.now() + LOCKOUT_LEVEL_1_MS);
-        await this.userRepository.update(user.id, {
-          failedLoginAttempts: attempts,
-          lastFailedLoginAt: now,
-          lockedUntil,
-        });
-        await this.auditLogService.log({
-          actorId: user.id,
-          actorRole: user.role,
-          action: AuditAction.LOGIN_FAILURE,
-          resourceType: 'auth',
-          beforeJson: { email: dto.email },
-          afterJson: { reason: 'account_locked_15m', attempts, lockedUntil: lockedUntil.toISOString() },
-          ip: ip ?? null,
-          userAgent: userAgent ?? null,
-        });
-        this.logger.warn(`Account locked (15m) due to failed login attempts: ${dto.email}`);
-        throw new ForbiddenException(
-          `연속 로그인 실패로 계정이 잠겼습니다. ${Math.ceil(LOCKOUT_LEVEL_1_MS / 1000)}초 후 다시 시도하세요.`,
-        );
-      }
-
-      await this.userRepository.update(user.id, {
-        failedLoginAttempts: attempts,
-        lastFailedLoginAt: now,
-      });
-      const delaySec = Math.pow(2, attempts);
-      await this.delay(delaySec * 1000);
-      await this.auditLogService.log({
-        actorId: user.id,
-        actorRole: user.role,
-        action: AuditAction.LOGIN_FAILURE,
-        resourceType: 'auth',
-        beforeJson: { email: dto.email },
-        afterJson: { reason: 'invalid_password', attempts },
-        ip: ip ?? null,
-        userAgent: userAgent ?? null,
-      });
-      throw new UnauthorizedException('비밀번호가 올바르지 않습니다.');
+      await this.authLoginPolicyService.handlePasswordMismatch(user, dto.email, ip, userAgent);
     }
 
     if (!user.isEmailVerified) {
@@ -282,21 +173,10 @@ export class AuthService implements OnModuleInit {
       });
     }
 
-    const tokens = this.generateTokens(user);
-    const hashedRefresh = await bcrypt.hash(tokens.refreshToken, 10);
-    await this.userRepository.update(user.id, { refreshToken: hashedRefresh });
+    const tokens = await this.tokenIssuerService.issueAndPersistRefresh(user);
 
     this.logger.log(`User logged in: ${dto.email}`);
-    await this.auditLogService.log({
-      actorId: user.id,
-      actorRole: user.role,
-      action: AuditAction.LOGIN_SUCCESS,
-      resourceType: 'auth',
-      beforeJson: { email: dto.email },
-      afterJson: { userId: user.id },
-      ip: ip ?? null,
-      userAgent: userAgent ?? null,
-    });
+    await this.authAuditService.logLoginSuccess(user, dto.email, ip, userAgent);
     return {
       ...tokens,
       user: { id: user.id, email: user.email, name: user.name, role: user.role },
@@ -339,9 +219,7 @@ export class AuthService implements OnModuleInit {
       throw new UnauthorizedException('유효하지 않은 리프레시 토큰입니다.');
     }
 
-    const tokens = this.generateTokens(user);
-    const hashedRefresh = await bcrypt.hash(tokens.refreshToken, 10);
-    await this.userRepository.update(user.id, { refreshToken: hashedRefresh });
+    const tokens = await this.tokenIssuerService.issueAndPersistRefresh(user);
 
     this.logger.log(`Tokens refreshed for user: ${user.email}`);
     return tokens;
@@ -505,29 +383,6 @@ export class AuthService implements OnModuleInit {
       verificationUrl: this.buildEmailVerificationUrl(rawToken),
       expiresInMinutes: EMAIL_VERIFICATION_TTL_MIN,
     });
-  }
-
-  private generateTokens(user: User): TokenPair {
-    const payload = { sub: user.id, email: user.email, role: user.role };
-    const jti = randomUUID();
-    // accessToken includes tokenType: 'access' and jti (JWT ID) for blacklist tracking
-    const accessToken = this.jwtService.sign({ ...payload, tokenType: 'access', jti });
-    // refreshToken uses longer expiry; cast to ms.StringValue required by jsonwebtoken types
-    const refreshExpiresIn = (process.env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue;
-    const refreshSecret = process.env.JWT_REFRESH_SECRET;
-    const refreshToken = this.jwtService.sign(
-      { ...payload, tokenType: 'refresh' },
-      {
-        secret: refreshSecret ?? process.env.JWT_SECRET,
-        expiresIn: refreshExpiresIn,
-        algorithm: 'HS256',
-      },
-    );
-    return { accessToken, refreshToken };
-  }
-
-  private delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   private hashPasswordResetToken(token: string): string {

--- a/backend/src/modules/auth/oauth.service.ts
+++ b/backend/src/modules/auth/oauth.service.ts
@@ -7,16 +7,14 @@ import {
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
-import { JwtService } from '@nestjs/jwt';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
-import * as bcrypt from 'bcrypt';
-import type ms from 'ms';
 import { User, UserRole } from '../users/entities/user.entity';
 import {
   UserAuthentication,
   OAuthProvider,
 } from '../users/entities/user-authentication.entity';
+import { TokenIssuerService } from './services/token-issuer.service';
 
 export interface OAuthAuthResponse {
   accessToken: string;
@@ -64,7 +62,7 @@ export class OAuthService {
     private readonly userRepository: Repository<User>,
     @InjectRepository(UserAuthentication)
     private readonly userAuthRepository: Repository<UserAuthentication>,
-    private readonly jwtService: JwtService,
+    private readonly tokenIssuerService: TokenIssuerService,
     private readonly httpService: HttpService,
     @InjectDataSource()
     private readonly dataSource: DataSource,
@@ -124,7 +122,7 @@ export class OAuthService {
       name,
     );
 
-    const tokens = await this.generateTokens(user);
+    const tokens = await this.tokenIssuerService.issueAndPersistRefresh(user);
     this.logger.log(`Kakao login: userId=${user.id} isNewUser=${isNewUser}`);
     return { ...tokens, user: { id: user.id, email: user.email, name: user.name, role: user.role }, isNewUser };
   }
@@ -140,7 +138,7 @@ export class OAuthService {
       userInfo.name,
     );
 
-    const tokens = await this.generateTokens(user);
+    const tokens = await this.tokenIssuerService.issueAndPersistRefresh(user);
     this.logger.log(`Google login: userId=${user.id} isNewUser=${isNewUser}`);
     return { ...tokens, user: { id: user.id, email: user.email, name: user.name, role: user.role }, isNewUser };
   }
@@ -266,22 +264,5 @@ export class OAuthService {
     } catch {
       throw new BadGatewayException('소셜 로그인 서비스에 일시적 문제가 발생했습니다.');
     }
-  }
-
-  private async generateTokens(user: User): Promise<{ accessToken: string; refreshToken: string }> {
-    const payload = { sub: user.id, email: user.email, role: user.role };
-    const accessToken = this.jwtService.sign({ ...payload, tokenType: 'access' });
-    const refreshExpiresIn = (process.env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue;
-    const refreshToken = this.jwtService.sign(
-      { ...payload, tokenType: 'refresh' },
-      {
-        secret: process.env.JWT_REFRESH_SECRET ?? process.env.JWT_SECRET,
-        expiresIn: refreshExpiresIn,
-        algorithm: 'HS256',
-      },
-    );
-    const hashedRefresh = await bcrypt.hash(refreshToken, 10);
-    await this.userRepository.update(user.id, { refreshToken: hashedRefresh });
-    return { accessToken, refreshToken };
   }
 }

--- a/backend/src/modules/auth/services/auth-audit.service.ts
+++ b/backend/src/modules/auth/services/auth-audit.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '../../users/entities/user.entity';
+import { AuditLogService } from '../../audit-logs/audit-log.service';
+import { AuditAction } from '../../audit-logs/entities/audit-log.entity';
+
+interface LoginFailureMeta {
+  email: string;
+  reason: string;
+  attempts?: number;
+  lockedUntil?: Date;
+  ip?: string | null;
+  userAgent?: string | null;
+}
+
+@Injectable()
+export class AuthAuditService {
+  constructor(private readonly auditLogService: AuditLogService) {}
+
+  async logUserNotFound(email: string, ip?: string | null, userAgent?: string | null): Promise<void> {
+    await this.auditLogService.log({
+      actorId: 0,
+      actorRole: 'anonymous',
+      action: AuditAction.LOGIN_FAILURE,
+      resourceType: 'auth',
+      beforeJson: { email },
+      afterJson: { reason: 'user_not_found' },
+      ip: ip ?? null,
+      userAgent: userAgent ?? null,
+    });
+  }
+
+  async logLoginFailure(user: User, meta: LoginFailureMeta): Promise<void> {
+    await this.auditLogService.log({
+      actorId: user.id,
+      actorRole: user.role,
+      action: AuditAction.LOGIN_FAILURE,
+      resourceType: 'auth',
+      beforeJson: { email: meta.email },
+      afterJson: {
+        reason: meta.reason,
+        ...(meta.attempts !== undefined ? { attempts: meta.attempts } : {}),
+        ...(meta.lockedUntil ? { lockedUntil: meta.lockedUntil.toISOString() } : {}),
+      },
+      ip: meta.ip ?? null,
+      userAgent: meta.userAgent ?? null,
+    });
+  }
+
+  async logLoginSuccess(
+    user: User,
+    email: string,
+    ip?: string | null,
+    userAgent?: string | null,
+  ): Promise<void> {
+    await this.auditLogService.log({
+      actorId: user.id,
+      actorRole: user.role,
+      action: AuditAction.LOGIN_SUCCESS,
+      resourceType: 'auth',
+      beforeJson: { email },
+      afterJson: { userId: user.id },
+      ip: ip ?? null,
+      userAgent: userAgent ?? null,
+    });
+  }
+}
+

--- a/backend/src/modules/auth/services/auth-login-policy.service.ts
+++ b/backend/src/modules/auth/services/auth-login-policy.service.ts
@@ -1,0 +1,123 @@
+import {
+  Injectable,
+  Logger,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { AuthAuditService } from './auth-audit.service';
+
+const LOCK_LEVEL_1_ATTEMPTS = 5;
+const LOCK_LEVEL_2_ATTEMPTS = 10;
+const LOCK_LEVEL_3_ATTEMPTS = 15;
+const LOCKOUT_LEVEL_1_MS = 15 * 60 * 1000;
+const LOCKOUT_LEVEL_2_MS = 60 * 60 * 1000;
+
+type LockPolicy = {
+  minAttempts: number;
+  lockoutMs: number | null;
+  reason: string;
+  warnMessage: (email: string) => string;
+  forbiddenMessage: (lockoutMs: number | null) => string;
+};
+
+const LOCK_POLICIES: LockPolicy[] = [
+  {
+    minAttempts: LOCK_LEVEL_3_ATTEMPTS,
+    lockoutMs: null,
+    reason: 'account_locked_manual',
+    warnMessage: (email) => `Account permanently locked until admin unlock: ${email}`,
+    forbiddenMessage: () => '연속 로그인 실패로 계정이 잠겼습니다. 관리자에게 잠금 해제를 요청해 주세요.',
+  },
+  {
+    minAttempts: LOCK_LEVEL_2_ATTEMPTS,
+    lockoutMs: LOCKOUT_LEVEL_2_MS,
+    reason: 'account_locked_1h',
+    warnMessage: (email) => `Account locked (1h) due to failed login attempts: ${email}`,
+    forbiddenMessage: (lockoutMs) =>
+      `연속 로그인 실패로 계정이 잠겼습니다. ${Math.ceil((lockoutMs ?? 0) / 1000)}초 후 다시 시도하세요.`,
+  },
+  {
+    minAttempts: LOCK_LEVEL_1_ATTEMPTS,
+    lockoutMs: LOCKOUT_LEVEL_1_MS,
+    reason: 'account_locked_15m',
+    warnMessage: (email) => `Account locked (15m) due to failed login attempts: ${email}`,
+    forbiddenMessage: (lockoutMs) =>
+      `연속 로그인 실패로 계정이 잠겼습니다. ${Math.ceil((lockoutMs ?? 0) / 1000)}초 후 다시 시도하세요.`,
+  },
+];
+
+@Injectable()
+export class AuthLoginPolicyService {
+  private readonly logger = new Logger(AuthLoginPolicyService.name);
+
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly authAuditService: AuthAuditService,
+  ) {}
+
+  assertNotLocked(user: User): void {
+    if (user.failedLoginAttempts >= LOCK_LEVEL_3_ATTEMPTS) {
+      throw new ForbiddenException('보안 정책에 의해 계정이 잠겼습니다. 관리자에게 잠금 해제를 요청해 주세요.');
+    }
+
+    if (user.lockedUntil && user.lockedUntil > new Date()) {
+      const remainingMs = user.lockedUntil.getTime() - Date.now();
+      const remainingSec = Math.ceil(remainingMs / 1000);
+      throw new ForbiddenException(`계정이 잠겼습니다. ${remainingSec}초 후 다시 시도하세요.`);
+    }
+  }
+
+  async handlePasswordMismatch(
+    user: User,
+    email: string,
+    ip?: string | null,
+    userAgent?: string | null,
+  ): Promise<never> {
+    const now = new Date();
+    const attempts = user.failedLoginAttempts + 1;
+    const matchedPolicy = LOCK_POLICIES.find((policy) => attempts >= policy.minAttempts);
+
+    if (matchedPolicy) {
+      const lockedUntil = matchedPolicy.lockoutMs ? new Date(Date.now() + matchedPolicy.lockoutMs) : null;
+      await this.userRepository.update(user.id, {
+        failedLoginAttempts: attempts,
+        lastFailedLoginAt: now,
+        lockedUntil,
+      });
+      await this.authAuditService.logLoginFailure(user, {
+        email,
+        reason: matchedPolicy.reason,
+        attempts,
+        lockedUntil: lockedUntil ?? undefined,
+        ip,
+        userAgent,
+      });
+      this.logger.warn(matchedPolicy.warnMessage(email));
+      throw new ForbiddenException(matchedPolicy.forbiddenMessage(matchedPolicy.lockoutMs));
+    }
+
+    await this.userRepository.update(user.id, {
+      failedLoginAttempts: attempts,
+      lastFailedLoginAt: now,
+    });
+    const delaySec = Math.pow(2, attempts);
+    await this.delay(delaySec * 1000);
+    await this.authAuditService.logLoginFailure(user, {
+      email,
+      reason: 'invalid_password',
+      attempts,
+      ip,
+      userAgent,
+    });
+    throw new UnauthorizedException('비밀번호가 올바르지 않습니다.');
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+

--- a/backend/src/modules/auth/services/token-issuer.service.ts
+++ b/backend/src/modules/auth/services/token-issuer.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { randomUUID } from 'crypto';
+import type ms from 'ms';
+import { User } from '../../users/entities/user.entity';
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+@Injectable()
+export class TokenIssuerService {
+  constructor(
+    private readonly jwtService: JwtService,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  issueTokens(user: Pick<User, 'id' | 'email' | 'role'>): TokenPair {
+    const payload = { sub: user.id, email: user.email, role: user.role };
+    const jti = randomUUID();
+    const accessToken = this.jwtService.sign({ ...payload, tokenType: 'access', jti });
+    const refreshExpiresIn = (process.env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue;
+    const refreshSecret = process.env.JWT_REFRESH_SECRET;
+    const refreshToken = this.jwtService.sign(
+      { ...payload, tokenType: 'refresh' },
+      {
+        secret: refreshSecret ?? process.env.JWT_SECRET,
+        expiresIn: refreshExpiresIn,
+        algorithm: 'HS256',
+      },
+    );
+    return { accessToken, refreshToken };
+  }
+
+  async issueAndPersistRefresh(user: Pick<User, 'id' | 'email' | 'role'>): Promise<TokenPair> {
+    const tokens = this.issueTokens(user);
+    const hashedRefresh = await bcrypt.hash(tokens.refreshToken, 10);
+    await this.userRepository.update(user.id, { refreshToken: hashedRefresh });
+    return tokens;
+  }
+}
+

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -2,7 +2,7 @@ import {
   Injectable, NotFoundException, BadRequestException, Logger,
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { randomBytes } from 'crypto';
 import { Order, OrderStatus } from './entities/order.entity';
 import { OrderItem } from './entities/order-item.entity';
@@ -21,6 +21,18 @@ import { CalculateDiscountDto } from '../coupons/dto/calculate-discount.dto';
 import { ShippingFeeCalculatorService } from '../shipping/services/shipping-fee-calculator.service';
 import { OrderEventEmitter } from './order-event.emitter';
 import { OrderCompletedEvent } from './events/order-completed.event';
+
+interface OrderItemBuildResult {
+  orderItems: Partial<OrderItem>[];
+  subtotalAmount: number;
+}
+
+interface OrderPriceResult {
+  discountAmount: number;
+  discountedAmount: number;
+  shippingFee: number;
+  totalPayable: number;
+}
 
 @Injectable()
 export class OrdersService {
@@ -58,156 +70,33 @@ export class OrdersService {
     await queryRunner.startTransaction();
 
     try {
-      if (pointsToUse > 0) {
-        const latest = await queryRunner.manager.getRepository(PointHistory).findOne({
-          where: { userId },
-          order: { createdAt: 'DESC', id: 'DESC' },
-        });
-        const balance = latest ? latest.balance : 0;
-        if (pointsToUse > balance) {
-          throw new BadRequestException('적립금이 부족합니다.');
-        }
-      }
+      await this.ensureSufficientPoints(queryRunner.manager, userId, pointsToUse);
 
-      const orderItems: Partial<OrderItem>[] = [];
-      let subtotalAmount = 0;
-
-      for (const item of dto.items) {
-        const product = await queryRunner.manager
-          .createQueryBuilder(Product, 'product')
-          .setLock('pessimistic_write')
-          .where('product.id = :id', { id: item.productId })
-          .getOne();
-
-        if (!product) {
-          throw new NotFoundException(`상품을 찾을 수 없습니다. (id: ${item.productId})`);
-        }
-
-        let optionName: string | null = null;
-        let priceAdjustment = 0;
-
-        if (item.productOptionId != null) {
-          const option = await queryRunner.manager
-            .createQueryBuilder(ProductOption, 'option')
-            .setLock('pessimistic_write')
-            .where('option.id = :id', { id: item.productOptionId })
-            .getOne();
-
-          if (!option || Number(option.productId) !== Number(item.productId)) {
-            throw new BadRequestException('해당 상품의 옵션을 찾을 수 없습니다.');
-          }
-
-          if (option.stock < item.quantity) {
-            throw new BadRequestException(
-              `재고가 부족합니다. (${product.name} - ${option.name}: ${option.value}: ${option.stock}개 남음)`,
-            );
-          }
-
-          optionName = `${option.name}: ${option.value}`;
-          priceAdjustment = Number(option.priceAdjustment);
-
-          await queryRunner.manager.update(ProductOption, option.id, {
-            stock: option.stock - item.quantity,
-          });
-        } else {
-          if (product.stock < item.quantity) {
-            throw new BadRequestException(
-              `재고가 부족합니다. (${product.name}: ${product.stock}개 남음)`,
-            );
-          }
-        }
-
-        await queryRunner.manager.update(Product, product.id, {
-          stock: product.stock - item.quantity,
-        });
-
-        const unitPrice = Number(product.salePrice ?? product.price) + priceAdjustment;
-        const subtotal = unitPrice * item.quantity;
-        subtotalAmount += subtotal;
-
-        orderItems.push({
-          productId: Number(item.productId),
-          productOptionId: item.productOptionId ?? null,
-          productName: product.name,
-          optionName,
-          price: unitPrice,
-          quantity: item.quantity,
-        });
-      }
-
-      let discountAmount = 0;
-      let discountedAmount = subtotalAmount;
-
-      if (dto.userCouponId || pointsToUse > 0) {
-        const calculateDto: CalculateDiscountDto = {
-          orderAmount: subtotalAmount,
-          userCouponId: dto.userCouponId,
-          pointsToUse,
-        };
-        const discountResult = await this.couponsService.calculate(userId, calculateDto);
-        discountAmount = discountResult.couponDiscount;
-        discountedAmount = discountResult.finalAmount;
-      }
-
-      const shippingQuote = await this.shippingFeeCalculator.calculate(subtotalAmount, dto.zipcode);
-      const totalPayable = discountedAmount + shippingQuote.shippingFee;
-
-      const order = queryRunner.manager.create(Order, {
-        userId,
-        orderNumber: this.generateOrderNumber(),
-        status: OrderStatus.PENDING,
-        totalAmount: totalPayable,
-        discountAmount,
-        shippingFee: shippingQuote.shippingFee,
-        recipientName: dto.recipientName,
-        recipientPhone: dto.recipientPhone,
-        zipcode: dto.zipcode,
-        address: dto.address,
-        addressDetail: dto.addressDetail ?? null,
-        memo: dto.memo ?? null,
-        pointsUsed: pointsToUse,
-      });
-      const savedOrder = await queryRunner.manager.save(Order, order);
-
-      if (dto.userCouponId) {
-        await this.couponsService.useCoupon(dto.userCouponId, userId, Number(savedOrder.id));
-      }
-
-      if (pointsToUse > 0) {
-        await this.pointsService.deductFifo(
-          queryRunner.manager,
-          userId,
-          pointsToUse,
-          `주문 사용 (${savedOrder.orderNumber})`,
-          Number(savedOrder.id),
-        );
-      }
-
-      const itemEntities = orderItems.map((item) =>
-        queryRunner.manager.create(OrderItem, { ...item, orderId: Number(savedOrder.id) }),
+      const { orderItems, subtotalAmount } = await this.validateAndReserveStock(
+        queryRunner.manager,
+        dto,
       );
-      await queryRunner.manager.save(OrderItem, itemEntities);
-
-      await queryRunner.manager
-        .createQueryBuilder()
-        .delete()
-        .from(CartItem)
-        .where('userId = :userId', { userId })
-        .andWhere('productId IN (:...productIds)', {
-          productIds: dto.items.map((i) => i.productId),
-        })
-        .execute();
+      const pricing = await this.calculateDiscountAndShipping(userId, dto, subtotalAmount, pointsToUse);
+      const savedOrder = await this.persistOrder(
+        queryRunner.manager,
+        userId,
+        dto,
+        pointsToUse,
+        pricing,
+      );
+      await this.applyCouponAndPoints(queryRunner.manager, userId, dto, pointsToUse, savedOrder);
+      await this.saveOrderItems(queryRunner.manager, orderItems, Number(savedOrder.id));
+      await this.clearCartItems(queryRunner.manager, userId, dto);
 
       await queryRunner.commitTransaction();
       this.logger.log(`Order created: ${savedOrder.orderNumber} userId=${userId}`);
 
-      const priorOrderCount = await this.orderRepository.count({ where: { userId } });
-      const isFirstPurchase = priorOrderCount <= 1;
-      this.orderEventEmitter.emitOrderCompleted(
-        new OrderCompletedEvent(userId, Number(savedOrder.id), savedOrder.orderNumber, isFirstPurchase),
+      await this.postCommitActions(
+        userId,
+        savedOrder,
+        pricing.totalPayable,
+        dto.recipientName,
       );
-
-      void this.notifyOrderCreated(userId, savedOrder.orderNumber, totalPayable, dto.recipientName);
 
       return this.findOne(Number(savedOrder.id), userId);
     } catch (err) {
@@ -216,6 +105,215 @@ export class OrdersService {
     } finally {
       await queryRunner.release();
     }
+  }
+
+  private async ensureSufficientPoints(
+    manager: EntityManager,
+    userId: number,
+    pointsToUse: number,
+  ): Promise<void> {
+    if (pointsToUse <= 0) return;
+
+    const latest = await manager.getRepository(PointHistory).findOne({
+      where: { userId },
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+    const balance = latest ? latest.balance : 0;
+    if (pointsToUse > balance) {
+      throw new BadRequestException('적립금이 부족합니다.');
+    }
+  }
+
+  private async validateAndReserveStock(
+    manager: EntityManager,
+    dto: CreateOrderDto,
+  ): Promise<OrderItemBuildResult> {
+    const orderItems: Partial<OrderItem>[] = [];
+    let subtotalAmount = 0;
+
+    for (const item of dto.items) {
+      const product = await manager
+        .createQueryBuilder(Product, 'product')
+        .setLock('pessimistic_write')
+        .where('product.id = :id', { id: item.productId })
+        .getOne();
+
+      if (!product) {
+        throw new NotFoundException(`상품을 찾을 수 없습니다. (id: ${item.productId})`);
+      }
+
+      let optionName: string | null = null;
+      let priceAdjustment = 0;
+
+      if (item.productOptionId != null) {
+        const option = await manager
+          .createQueryBuilder(ProductOption, 'option')
+          .setLock('pessimistic_write')
+          .where('option.id = :id', { id: item.productOptionId })
+          .getOne();
+
+        if (!option || Number(option.productId) !== Number(item.productId)) {
+          throw new BadRequestException('해당 상품의 옵션을 찾을 수 없습니다.');
+        }
+
+        if (option.stock < item.quantity) {
+          throw new BadRequestException(
+            `재고가 부족합니다. (${product.name} - ${option.name}: ${option.value}: ${option.stock}개 남음)`,
+          );
+        }
+
+        optionName = `${option.name}: ${option.value}`;
+        priceAdjustment = Number(option.priceAdjustment);
+
+        await manager.update(ProductOption, option.id, {
+          stock: option.stock - item.quantity,
+        });
+      } else if (product.stock < item.quantity) {
+        throw new BadRequestException(
+          `재고가 부족합니다. (${product.name}: ${product.stock}개 남음)`,
+        );
+      }
+
+      await manager.update(Product, product.id, {
+        stock: product.stock - item.quantity,
+      });
+
+      const unitPrice = Number(product.salePrice ?? product.price) + priceAdjustment;
+      const subtotal = unitPrice * item.quantity;
+      subtotalAmount += subtotal;
+
+      orderItems.push({
+        productId: Number(item.productId),
+        productOptionId: item.productOptionId ?? null,
+        productName: product.name,
+        optionName,
+        price: unitPrice,
+        quantity: item.quantity,
+      });
+    }
+
+    return { orderItems, subtotalAmount };
+  }
+
+  private async calculateDiscountAndShipping(
+    userId: number,
+    dto: CreateOrderDto,
+    subtotalAmount: number,
+    pointsToUse: number,
+  ): Promise<OrderPriceResult> {
+    let discountAmount = 0;
+    let discountedAmount = subtotalAmount;
+
+    if (dto.userCouponId || pointsToUse > 0) {
+      const calculateDto: CalculateDiscountDto = {
+        orderAmount: subtotalAmount,
+        userCouponId: dto.userCouponId,
+        pointsToUse,
+      };
+      const discountResult = await this.couponsService.calculate(userId, calculateDto);
+      discountAmount = discountResult.couponDiscount;
+      discountedAmount = discountResult.finalAmount;
+    }
+
+    const shippingQuote = await this.shippingFeeCalculator.calculate(subtotalAmount, dto.zipcode);
+    const shippingFee = shippingQuote.shippingFee;
+    const totalPayable = discountedAmount + shippingFee;
+
+    return {
+      discountAmount,
+      discountedAmount,
+      shippingFee,
+      totalPayable,
+    };
+  }
+
+  private async persistOrder(
+    manager: EntityManager,
+    userId: number,
+    dto: CreateOrderDto,
+    pointsToUse: number,
+    pricing: OrderPriceResult,
+  ): Promise<Order> {
+    const order = manager.create(Order, {
+      userId,
+      orderNumber: this.generateOrderNumber(),
+      status: OrderStatus.PENDING,
+      totalAmount: pricing.totalPayable,
+      discountAmount: pricing.discountAmount,
+      shippingFee: pricing.shippingFee,
+      recipientName: dto.recipientName,
+      recipientPhone: dto.recipientPhone,
+      zipcode: dto.zipcode,
+      address: dto.address,
+      addressDetail: dto.addressDetail ?? null,
+      memo: dto.memo ?? null,
+      pointsUsed: pointsToUse,
+    });
+    return manager.save(Order, order);
+  }
+
+  private async applyCouponAndPoints(
+    manager: EntityManager,
+    userId: number,
+    dto: CreateOrderDto,
+    pointsToUse: number,
+    savedOrder: Order,
+  ): Promise<void> {
+    if (dto.userCouponId) {
+      await this.couponsService.useCoupon(dto.userCouponId, userId, Number(savedOrder.id));
+    }
+
+    if (pointsToUse > 0) {
+      await this.pointsService.deductFifo(
+        manager,
+        userId,
+        pointsToUse,
+        `주문 사용 (${savedOrder.orderNumber})`,
+        Number(savedOrder.id),
+      );
+    }
+  }
+
+  private async saveOrderItems(
+    manager: EntityManager,
+    orderItems: Partial<OrderItem>[],
+    orderId: number,
+  ): Promise<void> {
+    const itemEntities = orderItems.map((item) =>
+      manager.create(OrderItem, { ...item, orderId }),
+    );
+    await manager.save(OrderItem, itemEntities);
+  }
+
+  private async clearCartItems(
+    manager: EntityManager,
+    userId: number,
+    dto: CreateOrderDto,
+  ): Promise<void> {
+    await manager
+      .createQueryBuilder()
+      .delete()
+      .from(CartItem)
+      .where('userId = :userId', { userId })
+      .andWhere('productId IN (:...productIds)', {
+        productIds: dto.items.map((i) => i.productId),
+      })
+      .execute();
+  }
+
+  private async postCommitActions(
+    userId: number,
+    savedOrder: Order,
+    totalPayable: number,
+    recipientName: string,
+  ): Promise<void> {
+    const priorOrderCount = await this.orderRepository.count({ where: { userId } });
+    const isFirstPurchase = priorOrderCount <= 1;
+    this.orderEventEmitter.emitOrderCompleted(
+      new OrderCompletedEvent(userId, Number(savedOrder.id), savedOrder.orderNumber, isFirstPurchase),
+    );
+
+    void this.notifyOrderCreated(userId, savedOrder.orderNumber, totalPayable, recipientName);
   }
 
   async findAll(userId: number, page = 1, limit = 10): Promise<PaginatedResult<Order>> {

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -1,13 +1,12 @@
 import {
   Injectable, BadRequestException, ConflictException,
-  Logger, Inject, InternalServerErrorException,
-  UnauthorizedException,
+  Logger, Inject,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { Payment, PaymentStatus, PaymentGatewayType, PaymentMethod } from './entities/payment.entity';
-import { Refund, RefundStatus } from './entities/refund.entity';
-import { Shipping, ShippingStatus } from './entities/shipping.entity';
+import { Refund } from './entities/refund.entity';
+import { Shipping } from './entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
 import { User } from '../users/entities/user.entity';
 import { PaymentGateway } from './interfaces/payment-gateway.interface';
@@ -21,12 +20,18 @@ import { resolveGatewayByLocale } from './payments.module';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { NotificationService } from '../notification/notification.service';
+import { PaymentConfirmationService } from './services/payment-confirmation.service';
+import { PaymentRefundService } from './services/payment-refund.service';
+import { PaymentWebhookService } from './services/payment-webhook.service';
 
 const DEFAULT_CARRIER = process.env.DEFAULT_CARRIER || 'mock';
 
 @Injectable()
 export class PaymentsService {
   private readonly logger = new Logger(PaymentsService.name);
+  private readonly paymentConfirmationService: PaymentConfirmationService;
+  private readonly paymentRefundService: PaymentRefundService;
+  private readonly paymentWebhookService: PaymentWebhookService;
 
   constructor(
     @InjectRepository(Payment)
@@ -45,7 +50,32 @@ export class PaymentsService {
     private readonly stripeAdapter: StripePaymentAdapter,
     private readonly notificationService: NotificationService,
     private readonly dataSource: DataSource,
-  ) {}
+  ) {
+    this.paymentConfirmationService = new PaymentConfirmationService({
+      paymentRepository: this.paymentRepository,
+      orderRepository: this.orderRepository,
+      shippingRepository: this.shippingRepository,
+      userRepository: this.userRepository,
+      dataSource: this.dataSource,
+      notificationService: this.notificationService,
+      resolveGatewayByType: (gatewayType) => this.resolveGatewayByType(gatewayType),
+      logger: this.logger,
+      defaultCarrier: DEFAULT_CARRIER,
+    });
+    this.paymentRefundService = new PaymentRefundService({
+      paymentRepository: this.paymentRepository,
+      refundRepository: this.refundRepository,
+      dataSource: this.dataSource,
+      resolveGatewayByType: (gatewayType) => this.resolveGatewayByType(gatewayType),
+      logger: this.logger,
+    });
+    this.paymentWebhookService = new PaymentWebhookService({
+      gateway: this.gateway,
+      paymentRepository: this.paymentRepository,
+      dataSource: this.dataSource,
+      logger: this.logger,
+    });
+  }
 
   private resolveGateway(locale?: string): PaymentGateway {
     if (!locale) return this.gateway;
@@ -138,69 +168,7 @@ export class PaymentsService {
     amount: number;
     paidAt: Date;
   }> {
-    const payment = await findOrThrow(this.paymentRepository, { orderId: dto.orderId }, '결제 정보를 찾을 수 없습니다.', ['order']);
-    assertOwnership(payment.order.userId, userId);
-
-    if (payment.status === PaymentStatus.CONFIRMED) {
-      throw new ConflictException('이미 승인된 결제입니다.');
-    }
-    if (payment.status !== PaymentStatus.PENDING) {
-      throw new BadRequestException('결제 승인이 불가능한 상태입니다.');
-    }
-
-    if (Number(payment.order.totalAmount) !== Number(dto.amount)) {
-      throw new BadRequestException('결제 금액이 일치하지 않습니다.');
-    }
-
-    try {
-      const confirmGateway = this.resolveGatewayByType(payment.gateway);
-      const result = await confirmGateway.confirm(dto.paymentKey, Number(payment.amount), payment.order.orderNumber);
-
-      await this.dataSource.transaction(async (manager) => {
-        await manager.update(Payment, payment.id, {
-          status: PaymentStatus.CONFIRMED,
-          paymentKey: dto.paymentKey,
-          method: result.method as PaymentMethod,
-          paidAt: new Date(),
-          rawResponse: result.rawResponse as object,
-        });
-
-        await manager.update(Order, dto.orderId, { status: OrderStatus.PAID });
-
-        const existing = await manager.findOne(Shipping, { where: { orderId: dto.orderId } });
-        if (!existing) {
-          await manager.save(Shipping, {
-            orderId: dto.orderId,
-            carrier: DEFAULT_CARRIER,
-            status: ShippingStatus.PAYMENT_CONFIRMED,
-          });
-        }
-      });
-
-      this.logger.log(`Payment confirmed: orderId=${dto.orderId}`);
-
-      void this.notifyPaymentConfirmed(
-        payment.order.userId,
-        payment.order.orderNumber,
-        payment.order.recipientName,
-        Number(payment.amount),
-        result.method,
-      );
-
-      return {
-        paymentId: Number(payment.id),
-        orderId: dto.orderId,
-        orderNumber: payment.order.orderNumber,
-        status: PaymentStatus.CONFIRMED,
-        method: result.method,
-        amount: Number(payment.amount),
-        paidAt: new Date(),
-      };
-    } catch (err) {
-      await this.paymentRepository.update(payment.id, { status: PaymentStatus.FAILED });
-      if (err instanceof ConflictException || err instanceof BadRequestException) throw err;
-      throw new InternalServerErrorException('결제 승인에 실패했습니다.');
-    }
+    return this.paymentConfirmationService.confirm(dto, userId);
   }
 
   async cancel(dto: CancelPaymentDto, userId: number): Promise<{
@@ -272,206 +240,10 @@ export class PaymentsService {
   }
 
   async partialRefund(orderId: number, dto: CreateRefundDto): Promise<Refund> {
-    // Phase 1: lock payment + validate + create pending Refund
-    let refund = await this.dataSource.transaction(async (manager) => {
-      const payment = await manager.findOne(Payment, {
-        where: { orderId },
-        lock: { mode: 'pessimistic_write' },
-      });
-      if (!payment) {
-        throw new BadRequestException('결제 정보를 찾을 수 없습니다.');
-      }
-      if (payment.status !== PaymentStatus.CONFIRMED && payment.status !== PaymentStatus.PARTIAL_CANCELLED) {
-        throw new BadRequestException('환불 가능한 상태가 아닙니다.');
-      }
-      if (!payment.paymentKey) {
-        throw new BadRequestException('결제 키가 없습니다.');
-      }
-
-      // Validate remaining refundable amount
-      const completedRefundsResult = await manager
-        .createQueryBuilder(Refund, 'r')
-        .select('COALESCE(SUM(r.amount), 0)', 'total')
-        .where('r.paymentId = :paymentId AND r.status = :status', {
-          paymentId: payment.id,
-          status: RefundStatus.COMPLETED,
-        })
-        .getRawOne<{ total: string }>();
-      const alreadyRefunded = Number(completedRefundsResult?.total ?? 0);
-      const remaining = Number(payment.amount) - alreadyRefunded;
-      if (dto.amount > remaining) {
-        throw new BadRequestException(
-          `환불 가능 금액(${remaining}원)을 초과했습니다.`,
-        );
-      }
-
-      const pendingRefund = manager.create(Refund, {
-        paymentId: Number(payment.id),
-        orderItemId: null,
-        amount: dto.amount,
-        reason: dto.reason,
-        status: RefundStatus.PENDING,
-        gatewayRefundId: null,
-      });
-      return manager.save(Refund, pendingRefund);
-    });
-
-    // Phase 2: call gateway outside transaction
-    const payment = await findOrThrow(this.paymentRepository, { orderId }, '결제 정보를 찾을 수 없습니다.');
-    const cancelGateway = this.resolveGatewayByType(payment.gateway);
-
-    let gatewayResult: { refundId: string };
-    try {
-      gatewayResult = await cancelGateway.partialCancel({
-        paymentKey: payment.paymentKey!,
-        cancelAmount: dto.amount,
-        cancelReason: dto.reason,
-      });
-    } catch (err) {
-      await this.refundRepository.update(refund.id, { status: RefundStatus.FAILED });
-      this.logger.error(`partialRefund gateway failed: orderId=${orderId}, refundId=${refund.id}, error=${String(err)}`);
-      if (err instanceof BadRequestException) throw err;
-      throw new InternalServerErrorException('환불 처리에 실패했습니다.');
-    }
-
-    // Phase 3: DB sync of gateway success
-    try {
-      await this.dataSource.transaction(async (manager) => {
-        await manager.update(Refund, refund.id, {
-          status: RefundStatus.COMPLETED,
-          gatewayRefundId: gatewayResult.refundId,
-        });
-
-        // SUM already includes current refund (updated to COMPLETED above)
-        const completedRefundsResult = await manager
-          .createQueryBuilder(Refund, 'r')
-          .select('COALESCE(SUM(r.amount), 0)', 'total')
-          .where('r.paymentId = :paymentId AND r.status = :status', {
-            paymentId: payment.id,
-            status: RefundStatus.COMPLETED,
-          })
-          .getRawOne<{ total: string }>();
-        const totalRefunded = Number(completedRefundsResult?.total ?? 0);
-
-        if (totalRefunded >= Number(payment.amount)) {
-          await manager.update(Payment, payment.id, { status: PaymentStatus.REFUNDED });
-          await manager.update(Order, payment.orderId, { status: OrderStatus.REFUNDED });
-        } else {
-          await manager.update(Payment, payment.id, { status: PaymentStatus.PARTIAL_CANCELLED });
-        }
-      });
-    } catch (err) {
-      this.logger.error({
-        event: 'refund_db_sync_failed',
-        orderId,
-        refundId: refund.id,
-        gatewayRefundId: gatewayResult.refundId,
-        amount: dto.amount,
-        error: err instanceof Error ? err.message : String(err),
-      }, 'Gateway refund succeeded but DB sync failed - manual reconciliation required');
-      throw new InternalServerErrorException('환불이 처리됐으나 시스템 반영에 실패했습니다. 운영팀에 문의하세요.');
-    }
-
-    refund = await findOrThrow(this.refundRepository, { id: refund.id }, '환불 정보를 찾을 수 없습니다.');
-
-    // TODO(#481, #483): 재고 복구/포인트 환수 연계
-
-    return refund;
-  }
-
-  private async notifyPaymentConfirmed(
-    userId: number,
-    orderNumber: string,
-    recipientName: string,
-    amount: number,
-    method: string,
-  ): Promise<void> {
-    try {
-      const user = await this.userRepository.findOne({ where: { id: userId } });
-      if (!user?.email) return;
-      await this.notificationService.sendPaymentConfirmed(user.email, {
-        recipientName,
-        orderNumber,
-        amount,
-        method,
-      });
-    } catch (err) {
-      this.logger.warn(`Payment confirmation email failed: ${String(err)}`);
-    }
+    return this.paymentRefundService.partialRefund(orderId, dto);
   }
 
   async handleWebhook(payload: unknown, signature: string): Promise<void> {
-    if (!this.gateway.verifyWebhook(payload, signature)) {
-      throw new UnauthorizedException('웹훅 서명 검증 실패');
-    }
-    const safe = {
-      orderId: (payload as Record<string, unknown>)?.orderId,
-      status: (payload as Record<string, unknown>)?.status,
-      type: (payload as Record<string, unknown>)?.type,
-    };
-    this.logger.log(`Webhook received: ${JSON.stringify(safe)}`);
-
-    const parsedOrderId = Number(safe.orderId);
-    if (!Number.isFinite(parsedOrderId) || parsedOrderId <= 0) {
-      this.logger.warn('Webhook ignored: invalid orderId');
-      return;
-    }
-
-    const normalized = String(
-      (payload as Record<string, unknown>)?.eventType
-      ?? safe.status
-      ?? safe.type
-      ?? '',
-    ).toUpperCase();
-
-    if (!normalized) {
-      this.logger.warn(`Webhook ignored: unknown event for orderId=${parsedOrderId}`);
-      return;
-    }
-
-    const payment = await this.paymentRepository.findOne({ where: { orderId: parsedOrderId } });
-    if (!payment) {
-      this.logger.warn(`Webhook ignored: payment not found (orderId=${parsedOrderId})`);
-      return;
-    }
-
-    if (
-      normalized.includes('DONE')
-      || normalized.includes('PAID')
-      || normalized.includes('CONFIRM')
-    ) {
-      await this.dataSource.transaction(async (manager) => {
-        await manager.update(Payment, payment.id, {
-          status: PaymentStatus.CONFIRMED,
-          paidAt: payment.paidAt ?? new Date(),
-          rawResponse: payload as object,
-        });
-        await manager.update(Order, parsedOrderId, { status: OrderStatus.PAID });
-      });
-      return;
-    }
-
-    if (normalized.includes('REFUND')) {
-      await this.dataSource.transaction(async (manager) => {
-        await manager.update(Payment, payment.id, {
-          status: PaymentStatus.REFUNDED,
-          cancelledAt: new Date(),
-          rawResponse: payload as object,
-        });
-        await manager.update(Order, parsedOrderId, { status: OrderStatus.REFUNDED });
-      });
-      return;
-    }
-
-    if (normalized.includes('CANCEL')) {
-      await this.dataSource.transaction(async (manager) => {
-        await manager.update(Payment, payment.id, {
-          status: PaymentStatus.CANCELLED,
-          cancelledAt: new Date(),
-          rawResponse: payload as object,
-        });
-        await manager.update(Order, parsedOrderId, { status: OrderStatus.CANCELLED });
-      });
-    }
+    return this.paymentWebhookService.handleWebhook(payload, signature);
   }
 }

--- a/backend/src/modules/payments/services/payment-confirmation.service.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.ts
@@ -1,0 +1,142 @@
+import {
+  BadRequestException,
+  ConflictException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { ConfirmPaymentDto } from '../dto/confirm-payment.dto';
+import { Payment, PaymentMethod, PaymentStatus, PaymentGatewayType } from '../entities/payment.entity';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { Shipping, ShippingStatus } from '../entities/shipping.entity';
+import { User } from '../../users/entities/user.entity';
+import { PaymentGateway } from '../interfaces/payment-gateway.interface';
+import { NotificationService } from '../../notification/notification.service';
+import { assertOwnership } from '../../../common/utils/ownership.util';
+import { findOrThrow } from '../../../common/utils/repository.util';
+
+type ResolveGatewayByType = (gatewayType: PaymentGatewayType) => PaymentGateway;
+
+interface PaymentConfirmationDependencies {
+  paymentRepository: Repository<Payment>;
+  orderRepository: Repository<Order>;
+  shippingRepository: Repository<Shipping>;
+  userRepository: Repository<User>;
+  dataSource: DataSource;
+  notificationService: NotificationService;
+  resolveGatewayByType: ResolveGatewayByType;
+  logger: Logger;
+  defaultCarrier: string;
+}
+
+export class PaymentConfirmationService {
+  constructor(private readonly deps: PaymentConfirmationDependencies) {}
+
+  async confirm(
+    dto: ConfirmPaymentDto,
+    userId: number,
+  ): Promise<{
+    paymentId: number;
+    orderId: number;
+    orderNumber: string;
+    status: PaymentStatus;
+    method: string;
+    amount: number;
+    paidAt: Date;
+  }> {
+    const payment = await findOrThrow(
+      this.deps.paymentRepository,
+      { orderId: dto.orderId },
+      '결제 정보를 찾을 수 없습니다.',
+      ['order'],
+    );
+    assertOwnership(payment.order.userId, userId);
+
+    if (payment.status === PaymentStatus.CONFIRMED) {
+      throw new ConflictException('이미 승인된 결제입니다.');
+    }
+    if (payment.status !== PaymentStatus.PENDING) {
+      throw new BadRequestException('결제 승인이 불가능한 상태입니다.');
+    }
+
+    if (Number(payment.order.totalAmount) !== Number(dto.amount)) {
+      throw new BadRequestException('결제 금액이 일치하지 않습니다.');
+    }
+
+    try {
+      const confirmGateway = this.deps.resolveGatewayByType(payment.gateway);
+      const result = await confirmGateway.confirm(
+        dto.paymentKey,
+        Number(payment.amount),
+        payment.order.orderNumber,
+      );
+
+      await this.deps.dataSource.transaction(async (manager) => {
+        await manager.update(Payment, payment.id, {
+          status: PaymentStatus.CONFIRMED,
+          paymentKey: dto.paymentKey,
+          method: result.method as PaymentMethod,
+          paidAt: new Date(),
+          rawResponse: result.rawResponse as object,
+        });
+
+        await manager.update(Order, dto.orderId, { status: OrderStatus.PAID });
+
+        const existing = await manager.findOne(Shipping, { where: { orderId: dto.orderId } });
+        if (!existing) {
+          await manager.save(Shipping, {
+            orderId: dto.orderId,
+            carrier: this.deps.defaultCarrier,
+            status: ShippingStatus.PAYMENT_CONFIRMED,
+          });
+        }
+      });
+
+      this.deps.logger.log(`Payment confirmed: orderId=${dto.orderId}`);
+
+      void this.notifyPaymentConfirmed(
+        payment.order.userId,
+        payment.order.orderNumber,
+        payment.order.recipientName,
+        Number(payment.amount),
+        result.method,
+      );
+
+      return {
+        paymentId: Number(payment.id),
+        orderId: dto.orderId,
+        orderNumber: payment.order.orderNumber,
+        status: PaymentStatus.CONFIRMED,
+        method: result.method,
+        amount: Number(payment.amount),
+        paidAt: new Date(),
+      };
+    } catch (err) {
+      await this.deps.paymentRepository.update(payment.id, { status: PaymentStatus.FAILED });
+      if (err instanceof ConflictException || err instanceof BadRequestException) throw err;
+      throw new InternalServerErrorException('결제 승인에 실패했습니다.');
+    }
+  }
+
+  private async notifyPaymentConfirmed(
+    userId: number,
+    orderNumber: string,
+    recipientName: string,
+    amount: number,
+    method: string,
+  ): Promise<void> {
+    try {
+      const user = await this.deps.userRepository.findOne({ where: { id: userId } });
+      if (!user?.email) return;
+      await this.deps.notificationService.sendPaymentConfirmed(user.email, {
+        recipientName,
+        orderNumber,
+        amount,
+        method,
+      });
+    } catch (err) {
+      this.deps.logger.warn(`Payment confirmation email failed: ${String(err)}`);
+    }
+  }
+}
+

--- a/backend/src/modules/payments/services/payment-refund.service.ts
+++ b/backend/src/modules/payments/services/payment-refund.service.ts
@@ -1,0 +1,139 @@
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { CreateRefundDto } from '../dto/create-refund.dto';
+import { Payment, PaymentGatewayType, PaymentStatus } from '../entities/payment.entity';
+import { Refund, RefundStatus } from '../entities/refund.entity';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { PaymentGateway } from '../interfaces/payment-gateway.interface';
+import { findOrThrow } from '../../../common/utils/repository.util';
+
+type ResolveGatewayByType = (gatewayType: PaymentGatewayType) => PaymentGateway;
+
+interface PaymentRefundDependencies {
+  paymentRepository: Repository<Payment>;
+  refundRepository: Repository<Refund>;
+  dataSource: DataSource;
+  resolveGatewayByType: ResolveGatewayByType;
+  logger: Logger;
+}
+
+export class PaymentRefundService {
+  constructor(private readonly deps: PaymentRefundDependencies) {}
+
+  async partialRefund(orderId: number, dto: CreateRefundDto): Promise<Refund> {
+    // Phase 1: lock payment + validate + create pending Refund
+    let refund = await this.deps.dataSource.transaction(async (manager) => {
+      const payment = await manager.findOne(Payment, {
+        where: { orderId },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!payment) {
+        throw new BadRequestException('결제 정보를 찾을 수 없습니다.');
+      }
+      if (payment.status !== PaymentStatus.CONFIRMED && payment.status !== PaymentStatus.PARTIAL_CANCELLED) {
+        throw new BadRequestException('환불 가능한 상태가 아닙니다.');
+      }
+      if (!payment.paymentKey) {
+        throw new BadRequestException('결제 키가 없습니다.');
+      }
+
+      // Validate remaining refundable amount
+      const completedRefundsResult = await manager
+        .createQueryBuilder(Refund, 'r')
+        .select('COALESCE(SUM(r.amount), 0)', 'total')
+        .where('r.paymentId = :paymentId AND r.status = :status', {
+          paymentId: payment.id,
+          status: RefundStatus.COMPLETED,
+        })
+        .getRawOne<{ total: string }>();
+      const alreadyRefunded = Number(completedRefundsResult?.total ?? 0);
+      const remaining = Number(payment.amount) - alreadyRefunded;
+      if (dto.amount > remaining) {
+        throw new BadRequestException(
+          `환불 가능 금액(${remaining}원)을 초과했습니다.`,
+        );
+      }
+
+      const pendingRefund = manager.create(Refund, {
+        paymentId: Number(payment.id),
+        orderItemId: null,
+        amount: dto.amount,
+        reason: dto.reason,
+        status: RefundStatus.PENDING,
+        gatewayRefundId: null,
+      });
+      return manager.save(Refund, pendingRefund);
+    });
+
+    // Phase 2: call gateway outside transaction
+    const payment = await findOrThrow(
+      this.deps.paymentRepository,
+      { orderId },
+      '결제 정보를 찾을 수 없습니다.',
+    );
+    const cancelGateway = this.deps.resolveGatewayByType(payment.gateway);
+
+    let gatewayResult: { refundId: string };
+    try {
+      gatewayResult = await cancelGateway.partialCancel({
+        paymentKey: payment.paymentKey!,
+        cancelAmount: dto.amount,
+        cancelReason: dto.reason,
+      });
+    } catch (err) {
+      await this.deps.refundRepository.update(refund.id, { status: RefundStatus.FAILED });
+      this.deps.logger.error(`partialRefund gateway failed: orderId=${orderId}, refundId=${refund.id}, error=${String(err)}`);
+      if (err instanceof BadRequestException) throw err;
+      throw new InternalServerErrorException('환불 처리에 실패했습니다.');
+    }
+
+    // Phase 3: DB sync of gateway success
+    try {
+      await this.deps.dataSource.transaction(async (manager) => {
+        await manager.update(Refund, refund.id, {
+          status: RefundStatus.COMPLETED,
+          gatewayRefundId: gatewayResult.refundId,
+        });
+
+        // SUM already includes current refund (updated to COMPLETED above)
+        const completedRefundsResult = await manager
+          .createQueryBuilder(Refund, 'r')
+          .select('COALESCE(SUM(r.amount), 0)', 'total')
+          .where('r.paymentId = :paymentId AND r.status = :status', {
+            paymentId: payment.id,
+            status: RefundStatus.COMPLETED,
+          })
+          .getRawOne<{ total: string }>();
+        const totalRefunded = Number(completedRefundsResult?.total ?? 0);
+
+        if (totalRefunded >= Number(payment.amount)) {
+          await manager.update(Payment, payment.id, { status: PaymentStatus.REFUNDED });
+          await manager.update(Order, payment.orderId, { status: OrderStatus.REFUNDED });
+        } else {
+          await manager.update(Payment, payment.id, { status: PaymentStatus.PARTIAL_CANCELLED });
+        }
+      });
+    } catch (err) {
+      this.deps.logger.error({
+        event: 'refund_db_sync_failed',
+        orderId,
+        refundId: refund.id,
+        gatewayRefundId: gatewayResult.refundId,
+        amount: dto.amount,
+        error: err instanceof Error ? err.message : String(err),
+      }, 'Gateway refund succeeded but DB sync failed - manual reconciliation required');
+      throw new InternalServerErrorException('환불이 처리됐으나 시스템 반영에 실패했습니다. 운영팀에 문의하세요.');
+    }
+
+    refund = await findOrThrow(this.deps.refundRepository, { id: refund.id }, '환불 정보를 찾을 수 없습니다.');
+
+    // TODO(#481, #483): 재고 복구/포인트 환수 연계
+
+    return refund;
+  }
+}
+

--- a/backend/src/modules/payments/services/payment-webhook-transition.policy.ts
+++ b/backend/src/modules/payments/services/payment-webhook-transition.policy.ts
@@ -1,0 +1,32 @@
+import { OrderStatus } from '../../orders/entities/order.entity';
+import { PaymentStatus } from '../entities/payment.entity';
+
+export type WebhookTransition = {
+  paymentStatus: PaymentStatus;
+  orderStatus: OrderStatus;
+  keywords: string[];
+  setPaidAt?: boolean;
+  setCancelledAt?: boolean;
+};
+
+export const PAYMENT_WEBHOOK_TRANSITIONS: WebhookTransition[] = [
+  {
+    paymentStatus: PaymentStatus.CONFIRMED,
+    orderStatus: OrderStatus.PAID,
+    keywords: ['DONE', 'PAID', 'CONFIRM'],
+    setPaidAt: true,
+  },
+  {
+    paymentStatus: PaymentStatus.REFUNDED,
+    orderStatus: OrderStatus.REFUNDED,
+    keywords: ['REFUND'],
+    setCancelledAt: true,
+  },
+  {
+    paymentStatus: PaymentStatus.CANCELLED,
+    orderStatus: OrderStatus.CANCELLED,
+    keywords: ['CANCEL'],
+    setCancelledAt: true,
+  },
+];
+

--- a/backend/src/modules/payments/services/payment-webhook.service.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.ts
@@ -1,0 +1,71 @@
+import { UnauthorizedException, Logger } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Payment, PaymentStatus } from '../entities/payment.entity';
+import { Order } from '../../orders/entities/order.entity';
+import { PaymentGateway } from '../interfaces/payment-gateway.interface';
+import { PAYMENT_WEBHOOK_TRANSITIONS } from './payment-webhook-transition.policy';
+
+interface PaymentWebhookDependencies {
+  gateway: PaymentGateway;
+  paymentRepository: Repository<Payment>;
+  dataSource: DataSource;
+  logger: Logger;
+}
+
+export class PaymentWebhookService {
+  constructor(private readonly deps: PaymentWebhookDependencies) {}
+
+  async handleWebhook(payload: unknown, signature: string): Promise<void> {
+    if (!this.deps.gateway.verifyWebhook(payload, signature)) {
+      throw new UnauthorizedException('웹훅 서명 검증 실패');
+    }
+    const safe = {
+      orderId: (payload as Record<string, unknown>)?.orderId,
+      status: (payload as Record<string, unknown>)?.status,
+      type: (payload as Record<string, unknown>)?.type,
+    };
+    this.deps.logger.log(`Webhook received: ${JSON.stringify(safe)}`);
+
+    const parsedOrderId = Number(safe.orderId);
+    if (!Number.isFinite(parsedOrderId) || parsedOrderId <= 0) {
+      this.deps.logger.warn('Webhook ignored: invalid orderId');
+      return;
+    }
+
+    const normalized = String(
+      (payload as Record<string, unknown>)?.eventType
+      ?? safe.status
+      ?? safe.type
+      ?? '',
+    ).toUpperCase();
+
+    if (!normalized) {
+      this.deps.logger.warn(`Webhook ignored: unknown event for orderId=${parsedOrderId}`);
+      return;
+    }
+
+    const payment = await this.deps.paymentRepository.findOne({ where: { orderId: parsedOrderId } });
+    if (!payment) {
+      this.deps.logger.warn(`Webhook ignored: payment not found (orderId=${parsedOrderId})`);
+      return;
+    }
+
+    const matchedTransition = PAYMENT_WEBHOOK_TRANSITIONS.find((transition) =>
+      transition.keywords.some((keyword) => normalized.includes(keyword)),
+    );
+    if (!matchedTransition) {
+      return;
+    }
+
+    await this.deps.dataSource.transaction(async (manager) => {
+      await manager.update(Payment, payment.id, {
+        status: matchedTransition.paymentStatus as PaymentStatus,
+        paidAt: matchedTransition.setPaidAt ? payment.paidAt ?? new Date() : payment.paidAt,
+        cancelledAt: matchedTransition.setCancelledAt ? new Date() : payment.cancelledAt,
+        rawResponse: payload as object,
+      });
+      await manager.update(Order, parsedOrderId, { status: matchedTransition.orderStatus });
+    });
+  }
+}
+

--- a/backend/src/modules/scheduler/jobs/maintenance-scheduler.job.ts
+++ b/backend/src/modules/scheduler/jobs/maintenance-scheduler.job.ts
@@ -1,0 +1,31 @@
+import { Logger } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { Coupon } from '../../coupons/entities/coupon.entity';
+
+interface MaintenanceSchedulerJobDependencies {
+  couponRepo: Repository<Coupon>;
+  logger: Logger;
+}
+
+export class MaintenanceSchedulerJob {
+  constructor(private readonly deps: MaintenanceSchedulerJobDependencies) {}
+
+  async handleCouponExpiry(): Promise<void> {
+    const now = new Date();
+
+    const result = await this.deps.couponRepo
+      .createQueryBuilder()
+      .update(Coupon)
+      .set({ isActive: false })
+      .where('is_active = :isActive', { isActive: true })
+      .andWhere('expires_at < :now', { now })
+      .execute();
+
+    if (result.affected && result.affected > 0) {
+      this.deps.logger.log(`[cron:coupon-expiry] Deactivated ${result.affected} expired coupons`);
+    } else {
+      this.deps.logger.debug('[cron:coupon-expiry] No expired coupons to deactivate');
+    }
+  }
+}
+

--- a/backend/src/modules/scheduler/jobs/order-scheduler.job.ts
+++ b/backend/src/modules/scheduler/jobs/order-scheduler.job.ts
@@ -1,0 +1,145 @@
+import { DataSource, LessThan, Repository } from 'typeorm';
+import { Logger } from '@nestjs/common';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { Product } from '../../products/entities/product.entity';
+import { ProductOption } from '../../products/entities/product-option.entity';
+import { User } from '../../users/entities/user.entity';
+import { NotificationService } from '../../notification/notification.service';
+import { SettingsService } from '../../settings/settings.service';
+import { MembershipService } from '../../membership/membership.service';
+
+interface OrderSchedulerJobDependencies {
+  orderRepo: Repository<Order>;
+  userRepo: Repository<User>;
+  dataSource: DataSource;
+  notificationService: NotificationService;
+  settingsService: SettingsService;
+  membershipService: MembershipService;
+  logger: Logger;
+}
+
+export class OrderSchedulerJob {
+  constructor(private readonly deps: OrderSchedulerJobDependencies) {}
+
+  async handlePendingOrderCancellation(): Promise<void> {
+    const intervalHours = await this.getSettingNumber('scheduler_pending_cancel_hours', 24);
+    const cutoff = new Date(Date.now() - intervalHours * 60 * 60 * 1000);
+
+    const pendingOrders = await this.deps.orderRepo.find({
+      where: { status: OrderStatus.PENDING, createdAt: LessThan(cutoff) },
+      relations: { items: true },
+    });
+
+    if (pendingOrders.length === 0) {
+      this.deps.logger.debug('[cron:pending-order-cancel] No pending orders to cancel');
+      return;
+    }
+
+    this.deps.logger.log(`[cron:pending-order-cancel] Cancelling ${pendingOrders.length} pending orders`);
+
+    for (const order of pendingOrders) {
+      await this.cancelOrderAndRestoreStock(order);
+    }
+
+    this.deps.logger.log(`[cron:pending-order-cancel] Completed cancelling ${pendingOrders.length} orders`);
+  }
+
+  async handleDeliveredOrderAutoConfirm(): Promise<void> {
+    const intervalDays = await this.getSettingNumber('scheduler_delivered_confirm_days', 7);
+    const cutoff = new Date(Date.now() - intervalDays * 24 * 60 * 60 * 1000);
+
+    const deliveredOrders = await this.deps.orderRepo.find({
+      where: { status: OrderStatus.DELIVERED, updatedAt: LessThan(cutoff) },
+      relations: { user: true },
+    });
+
+    if (deliveredOrders.length === 0) {
+      this.deps.logger.debug('[cron:delivered-order-confirm] No delivered orders to confirm');
+      return;
+    }
+
+    this.deps.logger.log(`[cron:delivered-order-confirm] Confirming ${deliveredOrders.length} delivered orders`);
+
+    for (const order of deliveredOrders) {
+      await this.deps.orderRepo.update(order.id, { status: OrderStatus.COMPLETED });
+
+      const completedAmount = Number(order.totalAmount) - Number(order.discountAmount ?? 0);
+      void this.deps.membershipService.incrementAccumulatedAmount(order.userId, completedAmount)
+        .catch((err) => this.deps.logger.warn(`Failed to increment tier amount for user ${order.userId}: ${String(err)}`));
+
+      if (order.user?.email) {
+        void Promise.resolve(
+          this.deps.notificationService.sendOrderConfirmed(order.user.email, {
+            orderNumber: order.orderNumber,
+            totalAmount: order.totalAmount,
+            recipientName: order.recipientName,
+          }),
+        )
+          .catch((err) => this.deps.logger.warn(`Failed to send confirmation email: ${String(err)}`));
+      }
+    }
+
+    this.deps.logger.log(`[cron:delivered-order-confirm] Completed confirming ${deliveredOrders.length} orders`);
+  }
+
+  private async cancelOrderAndRestoreStock(order: Order): Promise<void> {
+    const queryRunner = this.deps.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      for (const item of order.items) {
+        if (item.productOptionId) {
+          await queryRunner.manager.increment(
+            ProductOption,
+            { id: item.productOptionId },
+            'stock',
+            item.quantity,
+          );
+        } else {
+          await queryRunner.manager.increment(
+            Product,
+            { id: item.productId },
+            'stock',
+            item.quantity,
+          );
+        }
+      }
+
+      await queryRunner.manager.update(Order, order.id, { status: OrderStatus.CANCELLED });
+
+      await queryRunner.commitTransaction();
+
+      const user = await this.deps.userRepo.findOne({ where: { id: order.userId } });
+      if (user?.email) {
+        void Promise.resolve(
+          this.deps.notificationService.sendEmail({
+            to: user.email,
+            subject: `[옥화당] 주문 자동 취소 안내`,
+            text: `안녕하세요. 고객님의 주문(${order.orderNumber})이 결제 미완료로 자동 취소되었습니다.`,
+            html: `<p>안녕하세요.</p><p>고객님의 주문(<strong>${order.orderNumber}</strong>)이 결제 미완료로 자동 취소되었습니다.</p>`,
+          }),
+        )
+          .catch((err) => this.deps.logger.warn(`Failed to send cancellation email: ${String(err)}`));
+      }
+
+      this.deps.logger.log(`[cron:pending-order-cancel] Cancelled order ${order.orderNumber}`);
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      this.deps.logger.error(`[cron:pending-order-cancel] Failed to cancel order ${order.orderNumber}: ${String(err)}`);
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  private async getSettingNumber(key: string, defaultValue: number): Promise<number> {
+    try {
+      const settings = await this.deps.settingsService.getMap();
+      const value = settings[key];
+      return value ? parseInt(value, 10) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  }
+}

--- a/backend/src/modules/scheduler/jobs/point-scheduler.job.ts
+++ b/backend/src/modules/scheduler/jobs/point-scheduler.job.ts
@@ -1,0 +1,156 @@
+import { DataSource, Repository } from 'typeorm';
+import { Logger } from '@nestjs/common';
+import { PointHistory } from '../../coupons/entities/point-history.entity';
+import { User } from '../../users/entities/user.entity';
+import { NotificationService } from '../../notification/notification.service';
+
+interface PointSchedulerJobDependencies {
+  dataSource: DataSource;
+  logger: Logger;
+  notificationService: NotificationService;
+  pointHistoryRepo: Repository<PointHistory>;
+  userRepo: Repository<User>;
+}
+
+export class PointSchedulerJob {
+  constructor(private readonly deps: PointSchedulerJobDependencies) {}
+
+  async handlePointExpiry(): Promise<void> {
+    const now = new Date();
+
+    // Only process earn entries that have expired and have NOT yet had an expire record created.
+    const expiredPoints = await this.deps.dataSource.query<
+      Array<{ id: number; user_id: number; amount: number; expires_at: string }>
+    >(
+      `SELECT ph.id, ph.user_id, ph.amount, ph.expires_at
+       FROM point_history ph
+       WHERE ph.type = 'earn'
+         AND ph.expires_at IS NOT NULL
+         AND ph.expires_at < ?
+         AND NOT EXISTS (
+           SELECT 1 FROM point_history ex
+           WHERE ex.user_id = ph.user_id
+             AND ex.type = 'expire'
+             AND ex.description = '포인트 만료'
+             AND DATE(ex.created_at) = DATE(?)
+         )`,
+      [now, now],
+    );
+
+    if (expiredPoints.length === 0) {
+      this.deps.logger.debug('[cron:point-expiry] No expired points to process');
+      return;
+    }
+
+    this.deps.logger.log(`[cron:point-expiry] Processing ${expiredPoints.length} expired point records`);
+
+    const userExpiredMap = new Map<number, number>();
+    for (const ph of expiredPoints) {
+      const uid = Number(ph.user_id);
+      const current = userExpiredMap.get(uid) || 0;
+      userExpiredMap.set(uid, current + Number(ph.amount));
+    }
+
+    for (const [userId, totalExpired] of userExpiredMap) {
+      const queryRunner = this.deps.dataSource.createQueryRunner();
+      await queryRunner.connect();
+      await queryRunner.startTransaction();
+
+      try {
+        const latestBalance = await queryRunner.manager.findOne(PointHistory, {
+          where: { userId },
+          order: { createdAt: 'DESC', id: 'DESC' },
+        });
+
+        const currentBalance = latestBalance?.balance ?? 0;
+        const expireAmount = Math.min(totalExpired, currentBalance);
+
+        if (expireAmount > 0 && currentBalance > 0) {
+          await queryRunner.manager.save(PointHistory, {
+            userId,
+            type: 'expire',
+            amount: -expireAmount,
+            balance: currentBalance - expireAmount,
+            description: '포인트 만료',
+            expiresAt: null,
+          });
+
+          const user = await queryRunner.manager.findOne(User, { where: { id: userId } });
+          if (user?.email) {
+            void Promise.resolve(
+              this.deps.notificationService.sendEmail({
+                to: user.email,
+                subject: '[옥화당] 포인트 만료 안내',
+                text: `안녕하세요. 고객님의 포인트 ${expireAmount.toLocaleString()}원이 만료되었습니다.`,
+                html: `<p>안녕하세요.</p><p>고객님의 포인트 <strong>${expireAmount.toLocaleString()}원</strong>이 만료되었습니다.</p>`,
+              }),
+            )
+              .catch((err) => this.deps.logger.warn(`Failed to send point expiry email: ${String(err)}`));
+          }
+        }
+
+        await queryRunner.commitTransaction();
+        this.deps.logger.log(`[cron:point-expiry] Expired ${expireAmount} points for user ${userId}`);
+      } catch (err) {
+        await queryRunner.rollbackTransaction();
+        this.deps.logger.error(`[cron:point-expiry] Failed to expire points for user ${userId}: ${String(err)}`);
+      } finally {
+        await queryRunner.release();
+      }
+    }
+
+    this.deps.logger.log(`[cron:point-expiry] Completed processing ${expiredPoints.length} expired point records`);
+  }
+
+  async handlePointExpiryNotification(): Promise<void> {
+    const now = new Date();
+
+    for (const daysAhead of [30, 7]) {
+      const windowStart = new Date(now.getTime() + daysAhead * 24 * 60 * 60 * 1000);
+      const windowEnd = new Date(windowStart.getTime() + 24 * 60 * 60 * 1000);
+
+      const expiringEntries = await this.deps.dataSource.query<
+        Array<{ user_id: number; total_amount: string; email: string | null; name: string | null }>
+      >(
+        `SELECT ph.user_id, SUM(ph.amount) AS total_amount, u.email, u.name
+         FROM point_history ph
+         JOIN users u ON u.id = ph.user_id
+         WHERE ph.type = 'earn'
+           AND ph.expires_at >= ?
+           AND ph.expires_at < ?
+         GROUP BY ph.user_id, u.email, u.name
+         HAVING SUM(ph.amount) > 0`,
+        [windowStart, windowEnd],
+      );
+
+      if (expiringEntries.length === 0) {
+        this.deps.logger.debug(`[cron:point-expiry-notification] No points expiring in ${daysAhead} days`);
+        continue;
+      }
+
+      this.deps.logger.log(
+        `[cron:point-expiry-notification] Sending ${daysAhead}-day expiry notifications to ${expiringEntries.length} users`,
+      );
+
+      for (const entry of expiringEntries) {
+        if (!entry.email) continue;
+        const amount = Number(entry.total_amount);
+        const expiryDateStr = windowStart.toLocaleDateString('ko-KR');
+
+        void Promise.resolve(
+          this.deps.notificationService.sendEmail({
+            to: entry.email,
+            subject: `[옥화당] 포인트 만료 ${daysAhead}일 전 안내`,
+            text: `안녕하세요${entry.name ? ` ${entry.name}` : ''}님. 보유하신 포인트 ${amount.toLocaleString()}원이 ${expiryDateStr}에 만료될 예정입니다.`,
+            html: `<p>안녕하세요${entry.name ? ` <strong>${entry.name}</strong>` : ''}님.</p><p>보유하신 포인트 <strong>${amount.toLocaleString()}원</strong>이 <strong>${expiryDateStr}</strong>에 만료될 예정입니다.</p><p>포인트를 사용하여 혜택을 누려보세요.</p>`,
+          }),
+        )
+          .catch((err) =>
+            this.deps.logger.warn(`Failed to send point expiry notification email: ${String(err)}`),
+          );
+      }
+    }
+
+    this.deps.logger.log('[cron:point-expiry-notification] Completed');
+  }
+}

--- a/backend/src/modules/scheduler/jobs/scheduler-lock-runner.ts
+++ b/backend/src/modules/scheduler/jobs/scheduler-lock-runner.ts
@@ -1,0 +1,63 @@
+import { DataSource } from 'typeorm';
+import { Logger } from '@nestjs/common';
+
+export class SchedulerLockRunner {
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly logger: Logger,
+  ) {}
+
+  async runWithLock(lockName: string, ttlMinutes: number, task: () => Promise<void>): Promise<void> {
+    if (!(await this.acquireLock(lockName, ttlMinutes))) {
+      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
+      return;
+    }
+
+    try {
+      await task();
+    } catch (err) {
+      this.logger.error(`[${lockName}] Error: ${String(err)}`);
+    } finally {
+      await this.releaseLock(lockName);
+    }
+  }
+
+  private async acquireLock(lockName: string, ttlMinutes: number): Promise<boolean> {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + ttlMinutes * 60 * 1000);
+
+    try {
+      await this.dataSource.query(
+        `INSERT INTO scheduler_locks (lock_name, instance_id, acquired_at, expires_at)
+         VALUES (?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+           acquired_at = IF(expires_at <= NOW(), VALUES(acquired_at), acquired_at),
+           expires_at = IF(expires_at <= NOW(), VALUES(expires_at), expires_at),
+           instance_id = IF(expires_at <= NOW(), VALUES(instance_id), instance_id)`,
+        [lockName, process.env.INSTANCE_ID || 'default', now, expiresAt],
+      );
+
+      const lock = await this.dataSource.query(
+        `SELECT instance_id FROM scheduler_locks WHERE lock_name = ? AND expires_at > NOW()`,
+        [lockName],
+      );
+
+      return lock.length > 0 && lock[0].instance_id === (process.env.INSTANCE_ID || 'default');
+    } catch (err) {
+      this.logger.error(`Failed to acquire lock ${lockName}: ${String(err)}`);
+      return false;
+    }
+  }
+
+  private async releaseLock(lockName: string): Promise<void> {
+    try {
+      await this.dataSource.query(
+        `DELETE FROM scheduler_locks WHERE lock_name = ? AND instance_id = ?`,
+        [lockName, process.env.INSTANCE_ID || 'default'],
+      );
+    } catch (err) {
+      this.logger.error(`Failed to release lock ${lockName}: ${String(err)}`);
+    }
+  }
+}
+

--- a/backend/src/modules/scheduler/jobs/user-lifecycle-scheduler.job.ts
+++ b/backend/src/modules/scheduler/jobs/user-lifecycle-scheduler.job.ts
@@ -1,0 +1,107 @@
+import { Logger } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { createHash } from 'crypto';
+import { User } from '../../users/entities/user.entity';
+import { UserAddress } from '../../users/entities/user-address.entity';
+import { RecentlyViewedProduct } from '../../products/entities/recently-viewed-product.entity';
+import { NotificationService } from '../../notification/notification.service';
+import { MembershipService } from '../../membership/membership.service';
+
+interface UserLifecycleSchedulerJobDependencies {
+  userRepo: Repository<User>;
+  recentlyViewedRepo: Repository<RecentlyViewedProduct>;
+  dataSource: DataSource;
+  notificationService: NotificationService;
+  membershipService: MembershipService;
+  logger: Logger;
+}
+
+export class UserLifecycleSchedulerJob {
+  constructor(private readonly deps: UserLifecycleSchedulerJobDependencies) {}
+
+  async handleScheduledAccountDeletion(): Promise<void> {
+    const now = new Date();
+    const targets = await this.deps.userRepo
+      .createQueryBuilder('user')
+      .where('user.deletionScheduledAt IS NOT NULL')
+      .andWhere('user.deletionScheduledAt <= :now', { now })
+      .andWhere('user.deletedAt IS NULL')
+      .getMany();
+
+    if (targets.length === 0) {
+      this.deps.logger.debug('[cron:account-deletion] No scheduled accounts to anonymize');
+      return;
+    }
+
+    this.deps.logger.log(`[cron:account-deletion] Processing ${targets.length} account(s)`);
+
+    for (const user of targets) {
+      await this.anonymizeUser(user);
+    }
+
+    this.deps.logger.log(`[cron:account-deletion] Completed ${targets.length} account(s)`);
+  }
+
+  async handleRecentlyViewedCleanup(): Promise<void> {
+    const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+
+    const result = await this.deps.recentlyViewedRepo
+      .createQueryBuilder()
+      .delete()
+      .from(RecentlyViewedProduct)
+      .where('viewed_at < :cutoff', { cutoff })
+      .execute();
+
+    const deleted = result.affected ?? 0;
+    if (deleted > 0) {
+      this.deps.logger.log(`[cron:recently-viewed-cleanup] Deleted ${deleted} records older than 90 days`);
+    } else {
+      this.deps.logger.debug('[cron:recently-viewed-cleanup] No old records to delete');
+    }
+  }
+
+  async handleMonthlyTierEvaluation(): Promise<void> {
+    this.deps.logger.log('[cron:monthly-tier-evaluation] Starting tier re-evaluation');
+    await this.deps.membershipService.evaluateAllUserTiers();
+    this.deps.logger.log('[cron:monthly-tier-evaluation] Completed tier re-evaluation');
+  }
+
+  private buildDeletionHash(userId: number, source: string): string {
+    return createHash('sha256')
+      .update(`${userId}:${source}:${Date.now()}`)
+      .digest('hex')
+      .slice(0, 16);
+  }
+
+  private async anonymizeUser(user: User): Promise<void> {
+    const hash = this.buildDeletionHash(Number(user.id), user.email);
+    const originalEmail = user.email;
+
+    await this.deps.dataSource.transaction(async (manager) => {
+      await manager.update(User, Number(user.id), {
+        name: `탈퇴회원-${hash.slice(0, 8)}`,
+        email: `deleted+${Number(user.id)}.${hash}@okhwadang.local`,
+        phone: `deleted-${hash.slice(0, 12)}`,
+        password: null,
+        refreshToken: null,
+        isActive: false,
+        isEmailVerified: false,
+        emailVerifiedAt: null,
+        deletedAt: new Date(),
+      });
+
+      await manager.delete(UserAddress, { userId: Number(user.id) });
+    });
+
+    if (originalEmail) {
+      void Promise.resolve(
+        this.deps.notificationService.sendEmail({
+          to: originalEmail,
+          subject: '[옥화당] 회원 탈퇴 처리 완료 안내',
+          text: '요청하신 회원 탈퇴가 완료되었습니다. 개인정보는 익명화되어 보관됩니다.',
+          html: '<p>요청하신 회원 탈퇴가 완료되었습니다.</p><p>개인정보는 익명화되어 보관됩니다.</p>',
+        }),
+      ).catch((err) => this.deps.logger.warn(`Failed to send account deletion email: ${String(err)}`));
+    }
+  }
+}

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -1,25 +1,33 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource, LessThan } from 'typeorm';
-import { createHash } from 'crypto';
-import { Order, OrderStatus } from '../orders/entities/order.entity';
+import { Repository, DataSource } from 'typeorm';
+import { Order } from '../orders/entities/order.entity';
 import { OrderItem } from '../orders/entities/order-item.entity';
 import { Product } from '../products/entities/product.entity';
 import { ProductOption } from '../products/entities/product-option.entity';
 import { Coupon } from '../coupons/entities/coupon.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { User } from '../users/entities/user.entity';
-import { UserAddress } from '../users/entities/user-address.entity';
 import { RecentlyViewedProduct } from '../products/entities/recently-viewed-product.entity';
 import { NotificationService } from '../notification/notification.service';
 import { SettingsService } from '../settings/settings.service';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { MembershipService } from '../membership/membership.service';
+import { SchedulerLockRunner } from './jobs/scheduler-lock-runner';
+import { OrderSchedulerJob } from './jobs/order-scheduler.job';
+import { MaintenanceSchedulerJob } from './jobs/maintenance-scheduler.job';
+import { PointSchedulerJob } from './jobs/point-scheduler.job';
+import { UserLifecycleSchedulerJob } from './jobs/user-lifecycle-scheduler.job';
 
 @Injectable()
 export class SchedulerService {
   private readonly logger = new Logger(SchedulerService.name);
+  private readonly lockRunner: SchedulerLockRunner;
+  private readonly orderSchedulerJob: OrderSchedulerJob;
+  private readonly maintenanceSchedulerJob: MaintenanceSchedulerJob;
+  private readonly pointSchedulerJob: PointSchedulerJob;
+  private readonly userLifecycleSchedulerJob: UserLifecycleSchedulerJob;
 
   constructor(
     @InjectRepository(Order)
@@ -43,498 +51,112 @@ export class SchedulerService {
     private readonly notificationService: NotificationService,
     private readonly settingsService: SettingsService,
     private readonly membershipService: MembershipService,
-  ) {}
+  ) {
+    this.lockRunner = new SchedulerLockRunner(this.dataSource, this.logger);
+    this.orderSchedulerJob = new OrderSchedulerJob({
+      orderRepo: this.orderRepo,
+      userRepo: this.userRepo,
+      dataSource: this.dataSource,
+      notificationService: this.notificationService,
+      settingsService: this.settingsService,
+      membershipService: this.membershipService,
+      logger: this.logger,
+    });
+    this.maintenanceSchedulerJob = new MaintenanceSchedulerJob({
+      couponRepo: this.couponRepo,
+      logger: this.logger,
+    });
+    this.pointSchedulerJob = new PointSchedulerJob({
+      dataSource: this.dataSource,
+      logger: this.logger,
+      notificationService: this.notificationService,
+      pointHistoryRepo: this.pointHistoryRepo,
+      userRepo: this.userRepo,
+    });
+    this.userLifecycleSchedulerJob = new UserLifecycleSchedulerJob({
+      userRepo: this.userRepo,
+      recentlyViewedRepo: this.recentlyViewedRepo,
+      dataSource: this.dataSource,
+      notificationService: this.notificationService,
+      membershipService: this.membershipService,
+      logger: this.logger,
+    });
 
-  private async acquireLock(lockName: string, ttlMinutes: number): Promise<boolean> {
-    const now = new Date();
-    const expiresAt = new Date(now.getTime() + ttlMinutes * 60 * 1000);
-
-    try {
-      await this.dataSource.query(
-        `INSERT INTO scheduler_locks (lock_name, instance_id, acquired_at, expires_at)
-         VALUES (?, ?, ?, ?)
-         ON DUPLICATE KEY UPDATE
-           acquired_at = IF(expires_at <= NOW(), VALUES(acquired_at), acquired_at),
-           expires_at = IF(expires_at <= NOW(), VALUES(expires_at), expires_at),
-           instance_id = IF(expires_at <= NOW(), VALUES(instance_id), instance_id)`,
-        [lockName, process.env.INSTANCE_ID || 'default', now, expiresAt],
-      );
-
-      const lock = await this.dataSource.query(
-        `SELECT instance_id FROM scheduler_locks WHERE lock_name = ? AND expires_at > NOW()`,
-        [lockName],
-      );
-
-      return lock.length > 0 && lock[0].instance_id === (process.env.INSTANCE_ID || 'default');
-    } catch (err) {
-      this.logger.error(`Failed to acquire lock ${lockName}: ${String(err)}`);
-      return false;
-    }
-  }
-
-  private async releaseLock(lockName: string): Promise<void> {
-    try {
-      await this.dataSource.query(
-        `DELETE FROM scheduler_locks WHERE lock_name = ? AND instance_id = ?`,
-        [lockName, process.env.INSTANCE_ID || 'default'],
-      );
-    } catch (err) {
-      this.logger.error(`Failed to release lock ${lockName}: ${String(err)}`);
-    }
+    void this.orderItemRepo;
+    void this.productRepo;
+    void this.productOptionRepo;
   }
 
   @Cron(CronExpression.EVERY_HOUR)
   async handlePendingOrderCancellation(): Promise<void> {
-    const lockName = 'cron:pending-order-cancel';
-    if (!(await this.acquireLock(lockName, 55))) {
-      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
-      return;
-    }
-
-    try {
-      const intervalHours = await this.getSettingNumber('scheduler_pending_cancel_hours', 24);
-      const cutoff = new Date(Date.now() - intervalHours * 60 * 60 * 1000);
-
-      const pendingOrders = await this.orderRepo.find({
-        where: { status: OrderStatus.PENDING, createdAt: LessThan(cutoff) },
-        relations: { items: true },
-      });
-
-      if (pendingOrders.length === 0) {
-        this.logger.debug('[cron:pending-order-cancel] No pending orders to cancel');
-        return;
-      }
-
-      this.logger.log(`[cron:pending-order-cancel] Cancelling ${pendingOrders.length} pending orders`);
-
-      for (const order of pendingOrders) {
-        await this.cancelOrderAndRestoreStock(order);
-      }
-
-      this.logger.log(`[cron:pending-order-cancel] Completed cancelling ${pendingOrders.length} orders`);
-    } catch (err) {
-      this.logger.error(`[cron:pending-order-cancel] Error: ${String(err)}`);
-    } finally {
-      await this.releaseLock(lockName);
-    }
-  }
-
-  private async cancelOrderAndRestoreStock(order: Order): Promise<void> {
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
-
-    try {
-      for (const item of order.items) {
-        if (item.productOptionId) {
-          await queryRunner.manager.increment(
-            ProductOption,
-            { id: item.productOptionId },
-            'stock',
-            item.quantity,
-          );
-        } else {
-          await queryRunner.manager.increment(
-            Product,
-            { id: item.productId },
-            'stock',
-            item.quantity,
-          );
-        }
-      }
-
-      await queryRunner.manager.update(Order, order.id, { status: OrderStatus.CANCELLED });
-
-      await queryRunner.commitTransaction();
-
-      const user = await this.userRepo.findOne({ where: { id: order.userId } });
-      if (user?.email) {
-        this.notificationService
-          .sendEmail({
-            to: user.email,
-            subject: `[옥화당] 주문 자동 취소 안내`,
-            text: `안녕하세요. 고객님의 주문(${order.orderNumber})이 결제 미완료로 자동 취소되었습니다.`,
-            html: `<p>안녕하세요.</p><p>고객님의 주문(<strong>${order.orderNumber}</strong>)이 결제 미완료로 자동 취소되었습니다.</p>`,
-          })
-          .catch((err) => this.logger.warn(`Failed to send cancellation email: ${String(err)}`));
-      }
-
-      this.logger.log(`[cron:pending-order-cancel] Cancelled order ${order.orderNumber}`);
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      this.logger.error(`[cron:pending-order-cancel] Failed to cancel order ${order.orderNumber}: ${String(err)}`);
-      throw err;
-    } finally {
-      await queryRunner.release();
-    }
+    await this.lockRunner.runWithLock(
+      'cron:pending-order-cancel',
+      55,
+      () => this.orderSchedulerJob.handlePendingOrderCancellation(),
+    );
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async handleDeliveredOrderAutoConfirm(): Promise<void> {
-    const lockName = 'cron:delivered-order-confirm';
-    if (!(await this.acquireLock(lockName, 55))) {
-      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
-      return;
-    }
-
-    try {
-      const intervalDays = await this.getSettingNumber('scheduler_delivered_confirm_days', 7);
-      const cutoff = new Date(Date.now() - intervalDays * 24 * 60 * 60 * 1000);
-
-      const deliveredOrders = await this.orderRepo.find({
-        where: { status: OrderStatus.DELIVERED, updatedAt: LessThan(cutoff) },
-        relations: { user: true },
-      });
-
-      if (deliveredOrders.length === 0) {
-        this.logger.debug('[cron:delivered-order-confirm] No delivered orders to confirm');
-        return;
-      }
-
-      this.logger.log(`[cron:delivered-order-confirm] Confirming ${deliveredOrders.length} delivered orders`);
-
-      for (const order of deliveredOrders) {
-        await this.orderRepo.update(order.id, { status: OrderStatus.COMPLETED });
-
-        const completedAmount = Number(order.totalAmount) - Number(order.discountAmount ?? 0);
-        void this.membershipService.incrementAccumulatedAmount(order.userId, completedAmount)
-          .catch((err) => this.logger.warn(`Failed to increment tier amount for user ${order.userId}: ${String(err)}`));
-
-        if (order.user?.email) {
-          this.notificationService
-            .sendOrderConfirmed(order.user.email, {
-              orderNumber: order.orderNumber,
-              totalAmount: order.totalAmount,
-              recipientName: order.recipientName,
-            })
-            .catch((err) => this.logger.warn(`Failed to send confirmation email: ${String(err)}`));
-        }
-      }
-
-      this.logger.log(`[cron:delivered-order-confirm] Completed confirming ${deliveredOrders.length} orders`);
-    } catch (err) {
-      this.logger.error(`[cron:delivered-order-confirm] Error: ${String(err)}`);
-    } finally {
-      await this.releaseLock(lockName);
-    }
+    await this.lockRunner.runWithLock(
+      'cron:delivered-order-confirm',
+      55,
+      () => this.orderSchedulerJob.handleDeliveredOrderAutoConfirm(),
+    );
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async handleCouponExpiry(): Promise<void> {
-    const lockName = 'cron:coupon-expiry';
-    if (!(await this.acquireLock(lockName, 55))) {
-      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
-      return;
-    }
-
-    try {
-      const now = new Date();
-
-      const result = await this.couponRepo
-        .createQueryBuilder()
-        .update(Coupon)
-        .set({ isActive: false })
-        .where('is_active = :isActive', { isActive: true })
-        .andWhere('expires_at < :now', { now })
-        .execute();
-
-      if (result.affected && result.affected > 0) {
-        this.logger.log(`[cron:coupon-expiry] Deactivated ${result.affected} expired coupons`);
-      } else {
-        this.logger.debug('[cron:coupon-expiry] No expired coupons to deactivate');
-      }
-    } catch (err) {
-      this.logger.error(`[cron:coupon-expiry] Error: ${String(err)}`);
-    } finally {
-      await this.releaseLock(lockName);
-    }
+    await this.lockRunner.runWithLock(
+      'cron:coupon-expiry',
+      55,
+      () => this.maintenanceSchedulerJob.handleCouponExpiry(),
+    );
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_2AM)
   async handlePointExpiry(): Promise<void> {
-    const lockName = 'cron:point-expiry';
-    if (!(await this.acquireLock(lockName, 55))) {
-      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
-      return;
-    }
-
-    try {
-      const now = new Date();
-
-      // Only process earn entries that have expired and have NOT yet had an expire record created.
-      // We use a subquery to exclude users where an expire record already covers this expiry window.
-      const expiredPoints = await this.dataSource.query<
-        Array<{ id: number; user_id: number; amount: number; expires_at: string }>
-      >(
-        `SELECT ph.id, ph.user_id, ph.amount, ph.expires_at
-         FROM point_history ph
-         WHERE ph.type = 'earn'
-           AND ph.expires_at IS NOT NULL
-           AND ph.expires_at < ?
-           AND NOT EXISTS (
-             SELECT 1 FROM point_history ex
-             WHERE ex.user_id = ph.user_id
-               AND ex.type = 'expire'
-               AND ex.description = '포인트 만료'
-               AND DATE(ex.created_at) = DATE(?)
-           )`,
-        [now, now],
-      );
-
-      if (expiredPoints.length === 0) {
-        this.logger.debug('[cron:point-expiry] No expired points to process');
-        return;
-      }
-
-      this.logger.log(`[cron:point-expiry] Processing ${expiredPoints.length} expired point records`);
-
-      const userExpiredMap = new Map<number, number>();
-      for (const ph of expiredPoints) {
-        const uid = Number(ph.user_id);
-        const current = userExpiredMap.get(uid) || 0;
-        userExpiredMap.set(uid, current + Number(ph.amount));
-      }
-
-      for (const [userId, totalExpired] of userExpiredMap) {
-        const queryRunner = this.dataSource.createQueryRunner();
-        await queryRunner.connect();
-        await queryRunner.startTransaction();
-
-        try {
-          const latestBalance = await queryRunner.manager.findOne(PointHistory, {
-            where: { userId },
-            order: { createdAt: 'DESC', id: 'DESC' },
-          });
-
-          const currentBalance = latestBalance?.balance ?? 0;
-          const expireAmount = Math.min(totalExpired, currentBalance);
-
-          if (expireAmount > 0 && currentBalance > 0) {
-            await queryRunner.manager.save(PointHistory, {
-              userId,
-              type: 'expire',
-              amount: -expireAmount,
-              balance: currentBalance - expireAmount,
-              description: '포인트 만료',
-              expiresAt: null,
-            });
-
-            const user = await queryRunner.manager.findOne(User, { where: { id: userId } });
-            if (user?.email) {
-              this.notificationService
-                .sendEmail({
-                  to: user.email,
-                  subject: '[옥화당] 포인트 만료 안내',
-                  text: `안녕하세요. 고객님의 포인트 ${expireAmount.toLocaleString()}원이 만료되었습니다.`,
-                  html: `<p>안녕하세요.</p><p>고객님의 포인트 <strong>${expireAmount.toLocaleString()}원</strong>이 만료되었습니다.</p>`,
-                })
-                .catch((err) => this.logger.warn(`Failed to send point expiry email: ${String(err)}`));
-            }
-          }
-
-          await queryRunner.commitTransaction();
-          this.logger.log(`[cron:point-expiry] Expired ${expireAmount} points for user ${userId}`);
-        } catch (err) {
-          await queryRunner.rollbackTransaction();
-          this.logger.error(`[cron:point-expiry] Failed to expire points for user ${userId}: ${String(err)}`);
-        } finally {
-          await queryRunner.release();
-        }
-      }
-
-      this.logger.log(`[cron:point-expiry] Completed processing ${expiredPoints.length} expired point records`);
-    } catch (err) {
-      this.logger.error(`[cron:point-expiry] Error: ${String(err)}`);
-    } finally {
-      await this.releaseLock(lockName);
-    }
+    await this.lockRunner.runWithLock(
+      'cron:point-expiry',
+      55,
+      () => this.pointSchedulerJob.handlePointExpiry(),
+    );
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
   async handlePointExpiryNotification(): Promise<void> {
-    const lockName = 'cron:point-expiry-notification';
-    if (!(await this.acquireLock(lockName, 55))) {
-      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
-      return;
-    }
-
-    try {
-      const now = new Date();
-
-      for (const daysAhead of [30, 7]) {
-        const windowStart = new Date(now.getTime() + daysAhead * 24 * 60 * 60 * 1000);
-        const windowEnd = new Date(windowStart.getTime() + 24 * 60 * 60 * 1000);
-
-        const expiringEntries = await this.dataSource.query<
-          Array<{ user_id: number; total_amount: string; email: string | null; name: string | null }>
-        >(
-          `SELECT ph.user_id, SUM(ph.amount) AS total_amount, u.email, u.name
-           FROM point_history ph
-           JOIN users u ON u.id = ph.user_id
-           WHERE ph.type = 'earn'
-             AND ph.expires_at >= ?
-             AND ph.expires_at < ?
-           GROUP BY ph.user_id, u.email, u.name
-           HAVING SUM(ph.amount) > 0`,
-          [windowStart, windowEnd],
-        );
-
-        if (expiringEntries.length === 0) {
-          this.logger.debug(`[cron:point-expiry-notification] No points expiring in ${daysAhead} days`);
-          continue;
-        }
-
-        this.logger.log(
-          `[cron:point-expiry-notification] Sending ${daysAhead}-day expiry notifications to ${expiringEntries.length} users`,
-        );
-
-        for (const entry of expiringEntries) {
-          if (!entry.email) continue;
-          const amount = Number(entry.total_amount);
-          const expiryDateStr = windowStart.toLocaleDateString('ko-KR');
-
-          this.notificationService
-            .sendEmail({
-              to: entry.email,
-              subject: `[옥화당] 포인트 만료 ${daysAhead}일 전 안내`,
-              text: `안녕하세요${entry.name ? ` ${entry.name}` : ''}님. 보유하신 포인트 ${amount.toLocaleString()}원이 ${expiryDateStr}에 만료될 예정입니다.`,
-              html: `<p>안녕하세요${entry.name ? ` <strong>${entry.name}</strong>` : ''}님.</p><p>보유하신 포인트 <strong>${amount.toLocaleString()}원</strong>이 <strong>${expiryDateStr}</strong>에 만료될 예정입니다.</p><p>포인트를 사용하여 혜택을 누려보세요.</p>`,
-            })
-            .catch((err) =>
-              this.logger.warn(`Failed to send point expiry notification email: ${String(err)}`),
-            );
-        }
-      }
-
-      this.logger.log('[cron:point-expiry-notification] Completed');
-    } catch (err) {
-      this.logger.error(`[cron:point-expiry-notification] Error: ${String(err)}`);
-    } finally {
-      await this.releaseLock(lockName);
-    }
+    await this.lockRunner.runWithLock(
+      'cron:point-expiry-notification',
+      55,
+      () => this.pointSchedulerJob.handlePointExpiryNotification(),
+    );
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_4AM)
   async handleScheduledAccountDeletion(): Promise<void> {
-    const lockName = 'cron:account-deletion';
-    if (!(await this.acquireLock(lockName, 55))) {
-      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
-      return;
-    }
-
-    try {
-      const now = new Date();
-      const targets = await this.userRepo
-        .createQueryBuilder('user')
-        .where('user.deletionScheduledAt IS NOT NULL')
-        .andWhere('user.deletionScheduledAt <= :now', { now })
-        .andWhere('user.deletedAt IS NULL')
-        .getMany();
-
-      if (targets.length === 0) {
-        this.logger.debug('[cron:account-deletion] No scheduled accounts to anonymize');
-        return;
-      }
-
-      this.logger.log(`[cron:account-deletion] Processing ${targets.length} account(s)`);
-
-      for (const user of targets) {
-        await this.anonymizeUser(user);
-      }
-
-      this.logger.log(`[cron:account-deletion] Completed ${targets.length} account(s)`);
-    } catch (err) {
-      this.logger.error(`[cron:account-deletion] Error: ${String(err)}`);
-    } finally {
-      await this.releaseLock(lockName);
-    }
-  }
-
-  private buildDeletionHash(userId: number, source: string): string {
-    return createHash('sha256')
-      .update(`${userId}:${source}:${Date.now()}`)
-      .digest('hex')
-      .slice(0, 16);
-  }
-
-  private async anonymizeUser(user: User): Promise<void> {
-    const hash = this.buildDeletionHash(Number(user.id), user.email);
-    const originalEmail = user.email;
-
-    await this.dataSource.transaction(async (manager) => {
-      await manager.update(User, Number(user.id), {
-        name: `탈퇴회원-${hash.slice(0, 8)}`,
-        email: `deleted+${Number(user.id)}.${hash}@okhwadang.local`,
-        phone: `deleted-${hash.slice(0, 12)}`,
-        password: null,
-        refreshToken: null,
-        isActive: false,
-        isEmailVerified: false,
-        emailVerifiedAt: null,
-        deletedAt: new Date(),
-      });
-
-      await manager.delete(UserAddress, { userId: Number(user.id) });
-    });
-
-    if (originalEmail) {
-      void this.notificationService.sendEmail({
-        to: originalEmail,
-        subject: '[옥화당] 회원 탈퇴 처리 완료 안내',
-        text: '요청하신 회원 탈퇴가 완료되었습니다. 개인정보는 익명화되어 보관됩니다.',
-        html: '<p>요청하신 회원 탈퇴가 완료되었습니다.</p><p>개인정보는 익명화되어 보관됩니다.</p>',
-      });
-    }
+    await this.lockRunner.runWithLock(
+      'cron:account-deletion',
+      55,
+      () => this.userLifecycleSchedulerJob.handleScheduledAccountDeletion(),
+    );
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
   async handleRecentlyViewedCleanup(): Promise<void> {
-    const lockName = 'cron:recently-viewed-cleanup';
-    if (!(await this.acquireLock(lockName, 55))) {
-      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
-      return;
-    }
-
-    try {
-      const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
-
-      const result = await this.recentlyViewedRepo
-        .createQueryBuilder()
-        .delete()
-        .from(RecentlyViewedProduct)
-        .where('viewed_at < :cutoff', { cutoff })
-        .execute();
-
-      const deleted = result.affected ?? 0;
-      if (deleted > 0) {
-        this.logger.log(`[cron:recently-viewed-cleanup] Deleted ${deleted} records older than 90 days`);
-      } else {
-        this.logger.debug('[cron:recently-viewed-cleanup] No old records to delete');
-      }
-    } catch (err) {
-      this.logger.error(`[cron:recently-viewed-cleanup] Error: ${String(err)}`);
-    } finally {
-      await this.releaseLock(lockName);
-    }
+    await this.lockRunner.runWithLock(
+      'cron:recently-viewed-cleanup',
+      55,
+      () => this.userLifecycleSchedulerJob.handleRecentlyViewedCleanup(),
+    );
   }
 
   @Cron('0 3 1 * *') // 01st of every month at 03:00
   async handleMonthlyTierEvaluation(): Promise<void> {
-    const lockName = 'cron:monthly-tier-evaluation';
-    if (!(await this.acquireLock(lockName, 55))) {
-      this.logger.debug(`[${lockName}] Skipped - another instance holds the lock`);
-      return;
-    }
-
-    try {
-      this.logger.log('[cron:monthly-tier-evaluation] Starting tier re-evaluation');
-      await this.membershipService.evaluateAllUserTiers();
-      this.logger.log('[cron:monthly-tier-evaluation] Completed tier re-evaluation');
-    } catch (err) {
-      this.logger.error(`[cron:monthly-tier-evaluation] Error: ${String(err)}`);
-    } finally {
-      await this.releaseLock(lockName);
-    }
+    await this.lockRunner.runWithLock(
+      'cron:monthly-tier-evaluation',
+      55,
+      () => this.userLifecycleSchedulerJob.handleMonthlyTierEvaluation(),
+    );
   }
 
   private async getSettingNumber(key: string, defaultValue: number): Promise<number> {
@@ -547,3 +169,4 @@ export class SchedulerService {
     }
   }
 }
+


### PR DESCRIPTION
## 요약
- Auth/OAuth 토큰 발급 책임을 `TokenIssuerService`로 통합하고 로그인 정책/감사 로깅을 분리했습니다.
- `OrdersService.create()`를 단계형 파이프라인으로 분해해 트랜잭션 내부/외부 책임을 명확히 했습니다.
- 결제 승인/부분환불/웹훅 처리를 전용 서비스로 분리하고, 웹훅 상태전이를 정책 테이블로 통합했습니다.
- 스케줄러를 공통 락 실행기 + 도메인별 Job 클래스로 분해했습니다.

## 주요 변경
### 1) Auth (#594)
- 추가:
  - `backend/src/modules/auth/services/token-issuer.service.ts`
  - `backend/src/modules/auth/services/auth-login-policy.service.ts`
  - `backend/src/modules/auth/services/auth-audit.service.ts`
- 변경:
  - `auth.service.ts`, `oauth.service.ts`, `auth.module.ts`
- 테스트 추가/수정:
  - `auth-login-policy.service.spec.ts` (잠금 단계 정책 테이블 검증)
  - `token-issuer.service.spec.ts` (access/refresh tokenType 및 refresh hash 저장 검증)
  - 기존 `auth.service.spec.ts`, `oauth.service.spec.ts` 갱신

### 2) Orders (#595)
- `OrdersService.create()`를 다음 단계로 분해:
  - `ensureSufficientPoints`
  - `validateAndReserveStock`
  - `calculateDiscountAndShipping`
  - `persistOrder`
  - `applyCouponAndPoints`
  - `saveOrderItems`
  - `clearCartItems`
  - `postCommitActions`

### 3) Payments (#596)
- 추가:
  - `payment-confirmation.service.ts`
  - `payment-refund.service.ts`
  - `payment-webhook.service.ts`
  - `payment-webhook-transition.policy.ts`
- 변경:
  - `payments.service.ts`는 prepare/cancel 계층 중심으로 유지하고 confirm/partialRefund/webhook은 전용 서비스로 위임

### 4) Scheduler (#597)
- 추가:
  - `scheduler-lock-runner.ts`
  - `order-scheduler.job.ts`
  - `maintenance-scheduler.job.ts`
  - `point-scheduler.job.ts`
  - `user-lifecycle-scheduler.job.ts`
- 변경:
  - `scheduler.service.ts`는 Cron entrypoint + orchestration만 담당

## 검증
- `npm run lint` (root)
- `npm run build && npm run test:run` (root)
- `cd backend && npm run lint`
- `cd backend && npm run build && npm run test`
- `bash scripts/start-local.sh`

## 참고
- 루트 빌드/린트 시 기존 i18n missing message(`journalPage`, `collectionPage`, `archivePage` ja/zh) 로그와 기존 hook lint warning 1건은 그대로 관찰되며, 본 PR 변경 범위 외 기존 이슈입니다.

Closes #594
Closes #595
Closes #596
Closes #597
