### PR TITLE
fix: #611 보안 헤더(X-Frame-Options, X-Content-Type-Options, HSTS) 적용 및 CSP img-src 보완

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,7 +35,7 @@ const nextConfig: NextConfig = {
           "script-src 'self' 'unsafe-inline' https://js.tosspayments.com https://js.sandbox.tosspayments.com https://static.cloudflareinsights.com",
           "object-src 'none'",
           "base-uri 'self'",
-          "img-src 'self' data: https://images.unsplash.com https://*.amazonaws.com https://cdn.ockhwadang.com https://ockhwadang.com https://i.pinimg.com https://m.cbw.co.kr https://gdimg.gmarket.co.kr https://cdn-optimized.imweb.me",
+          "img-src 'self' data: https://images.unsplash.com https://*.amazonaws.com https://*.cloudfront.net https://cdn.ockhwadang.com https://ockhwadang.com https://i.pinimg.com https://m.cbw.co.kr https://gdimg.gmarket.co.kr https://cdn-optimized.imweb.me",
           "font-src 'self' https://fonts.gstatic.com",
           "connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com",
         ].join('; ') + ';' },


### PR DESCRIPTION
## 변경 내용

### 보안 헤더 현황 확인
이슈 #611에서 요구하는 보안 헤더 3종은 이미 `next.config.ts`에 적용되어 있었습니다.

- `X-Frame-Options: DENY` ✅
- `X-Content-Type-Options: nosniff` ✅
- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` ✅ (이슈 요구인 1년보다 엄격한 2년 적용)

### 추가 수정: CSP img-src 누락 도메인 보완

`next.config.ts`의 `images.remotePatterns`에는 `*.cloudfront.net`이 포함되어 있으나, Content-Security-Policy의 `img-src` 지시문에서 누락되어 있었습니다. CloudFront CDN 이미지가 CSP에 의해 차단될 수 있는 문제를 수정했습니다.

```
img-src: ... https://*.cloudfront.net 추가
```

## 검증

- [x] `npm run build` 통과
- [x] `npm run test:run` 통과
- [x] `npm run lint` 통과 (기존 경고는 pre-existing)
- [ ] 배포 환경에서 `securityheaders.com` 점수 확인 (배포 후 수동 검증 필요)

## 참고

HSTS `preload` 지시자는 HTTPS가 안정적으로 적용된 Vercel 배포 환경에서만 유효합니다. HTTP 강제 리다이렉트는 Vercel 플랫폼이 처리합니다.

Closes #611