### PR TITLE
refactor: #588 CMS 블록 데이터 로딩 패턴 공통화 (useBlockData 훅)

### DIFF
--- a/src/components/shared/blocks/CategoryNavBlock.tsx
+++ b/src/components/shared/blocks/CategoryNavBlock.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { categoriesApi } from '@/lib/api';
 import { useScrollAnimation } from '@/components/shared/hooks/useScrollAnimation';
+import { useBlockData } from '@/components/shared/hooks/useBlockData';
 import type { Category, CategoryNavContent } from '@/lib/api';
 
 /* ── 니료(泥料) 컬러 매핑 — 카테고리 slug으로 매칭 ── */
@@ -64,35 +65,18 @@ interface Props {
 
 export default function CategoryNavBlock({ content }: Props) {
   const { title, category_ids = [], template, prefetched_categories } = content;
-  const [categories, setCategories] = useState<Category[]>(prefetched_categories ?? []);
-  const [loading, setLoading] = useState(!prefetched_categories);
   const { ref, visible } = useScrollAnimation<HTMLElement>();
 
-  useEffect(() => {
-    if (prefetched_categories && prefetched_categories.length > 0) return;
-
-    let cancelled = false;
-
-    async function fetchCategories() {
-      try {
-        const all = await categoriesApi.getTree();
-        if (!cancelled) {
-          if (category_ids.length > 0) {
-            setCategories(all.filter((c) => category_ids.includes(c.id)));
-          } else {
-            setCategories(all.filter((c) => c.parentId === null));
-          }
-        }
-      } catch (err) {
-        void err;
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    fetchCategories();
-    return () => { cancelled = true; };
-  }, [category_ids, prefetched_categories]);
+  const { data: categories, loading } = useBlockData<Category>({
+    prefetched: prefetched_categories,
+    fetch: async () => {
+      const all = await categoriesApi.getTree();
+      return category_ids.length > 0
+        ? all.filter((c) => category_ids.includes(c.id))
+        : all.filter((c) => c.parentId === null);
+    },
+    deps: [category_ids],
+  });
 
   if (loading) {
     return (

--- a/src/components/shared/blocks/JournalPreviewBlock.tsx
+++ b/src/components/shared/blocks/JournalPreviewBlock.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { journalsApi, type Journal, JournalCategory } from '@/lib/api';
 import { useScrollAnimation } from '@/components/shared/hooks/useScrollAnimation';
+import { useBlockData } from '@/components/shared/hooks/useBlockData';
 import { cn } from '@/components/ui/utils';
 
 interface JournalPreviewContent {
@@ -85,31 +85,16 @@ function JournalCard({ journal, index }: { journal: Journal; index: number }) {
 export default function JournalPreviewBlock({ content }: Props) {
   const tCommon = useTranslations('common');
   const { title, limit = 6, category, more_href, prefetched_journals } = content;
-  const [journals, setJournals] = useState<Journal[]>(prefetched_journals ?? []);
-  const [loading, setLoading] = useState(!prefetched_journals);
   const { ref, visible } = useScrollAnimation<HTMLElement>();
 
-  useEffect(() => {
-    if (prefetched_journals && prefetched_journals.length > 0) return;
-
-    let cancelled = false;
-
-    async function fetchJournals() {
-      try {
-        const data = await journalsApi.getAll(category);
-        if (!cancelled) {
-          setJournals(data.slice(0, limit));
-        }
-      } catch {
-        // Silently fail
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    fetchJournals();
-    return () => { cancelled = true; };
-  }, [category, limit, prefetched_journals]);
+  const { data: journals, loading } = useBlockData<Journal>({
+    prefetched: prefetched_journals,
+    fetch: async () => {
+      const data = await journalsApi.getAll(category);
+      return data.slice(0, limit);
+    },
+    deps: [category, limit],
+  });
 
   if (loading) {
     return (

--- a/src/components/shared/blocks/ProductCarouselBlock.tsx
+++ b/src/components/shared/blocks/ProductCarouselBlock.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { productsApi } from '@/lib/api';
 import type { Product, ProductCarouselContent } from '@/lib/api';
 import ProductCard from '@/components/shared/products/ProductCard';
+import { useBlockData } from '@/components/shared/hooks/useBlockData';
 import { cn } from '@/components/ui/utils';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
@@ -20,8 +21,6 @@ export default function ProductCarouselBlock({ content }: Props) {
   const t = useTranslations('product');
   const tCommon = useTranslations('common');
   const { product_ids, category_id, sort, limit, template, title } = content;
-  const [products, setProducts] = useState<Product[]>([]);
-  const [loading, setLoading] = useState(true);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -29,30 +28,21 @@ export default function ProductCarouselBlock({ content }: Props) {
   const cardWidth = template === 'large' ? 288 : 224;
   const gap = 24;
 
-  useEffect(() => {
-    let cancelled = false;
-
-    async function fetchProducts() {
-      try {
-        if (product_ids && product_ids.length > 0) {
-          const results = await productsApi.getBulk(product_ids.slice(0, limit), locale);
-          if (!cancelled) setProducts(results);
-        } else if (category_id) {
-          const res = await productsApi.getList({ categoryId: category_id, sort, limit, locale });
-          if (!cancelled) setProducts(res.items);
-        } else {
-          const res = await productsApi.getList({ sort, limit, locale });
-          if (!cancelled) setProducts(res.items);
-        }
-      } catch {
-      } finally {
-        if (!cancelled) setLoading(false);
+  const { data: products, loading } = useBlockData<Product>({
+    prefetched: null,
+    fetch: async () => {
+      if (product_ids && product_ids.length > 0) {
+        return productsApi.getBulk(product_ids.slice(0, limit), locale);
+      } else if (category_id) {
+        const res = await productsApi.getList({ categoryId: category_id, sort, limit, locale });
+        return res.items;
+      } else {
+        const res = await productsApi.getList({ sort, limit, locale });
+        return res.items;
       }
-    }
-
-    fetchProducts();
-    return () => { cancelled = true; };
-  }, [product_ids, category_id, sort, limit, locale]);
+    },
+    deps: [product_ids, category_id, sort, limit, locale],
+  });
 
   const updateScrollState = useCallback(() => {
     const el = scrollRef.current;

--- a/src/components/shared/blocks/ProductGridBlock.tsx
+++ b/src/components/shared/blocks/ProductGridBlock.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -9,6 +8,7 @@ import type { Product, ProductGridContent } from '@/lib/api';
 import ProductCard from '@/components/shared/products/ProductCard';
 import { CardSkeleton } from '@/components/ui/Skeleton';
 import { useScrollAnimation } from '@/components/shared/hooks/useScrollAnimation';
+import { useBlockData } from '@/components/shared/hooks/useBlockData';
 import { cn } from '@/components/ui/utils';
 
 interface Props {
@@ -26,39 +26,23 @@ export default function ProductGridBlock({ content }: Props) {
   const locale = params.locale as string;
   const t = useTranslations('common');
   const { product_ids, category_id, auto, limit, template, title, more_href, prefetched_products } = content;
-  const [products, setProducts] = useState<Product[]>(prefetched_products ?? []);
-  const [loading, setLoading] = useState(!prefetched_products);
   const { ref, visible } = useScrollAnimation<HTMLElement>();
 
-  useEffect(() => {
-    if (prefetched_products && prefetched_products.length > 0) return;
-
-    let cancelled = false;
-
-    async function fetchProducts() {
-      try {
-        if (product_ids && product_ids.length > 0) {
-          const results = await productsApi.getBulk(product_ids.slice(0, limit), locale);
-          if (!cancelled) {
-            setProducts(results);
-          }
-        } else if (category_id) {
-          const res = await productsApi.getList({ categoryId: category_id, limit, locale });
-          if (!cancelled) setProducts(res.items);
-        } else {
-          const res = await productsApi.getList({ limit, locale });
-          if (!cancelled) setProducts(res.items);
-        }
-      } catch {
-        // Silently fail
-      } finally {
-        if (!cancelled) setLoading(false);
+  const { data: products, loading } = useBlockData<Product>({
+    prefetched: prefetched_products,
+    fetch: async () => {
+      if (product_ids && product_ids.length > 0) {
+        return productsApi.getBulk(product_ids.slice(0, limit), locale);
+      } else if (category_id) {
+        const res = await productsApi.getList({ categoryId: category_id, limit, locale });
+        return res.items;
+      } else {
+        const res = await productsApi.getList({ limit, locale });
+        return res.items;
       }
-    }
-
-    fetchProducts();
-    return () => { cancelled = true; };
-  }, [product_ids, category_id, auto, limit, prefetched_products, locale]);
+    },
+    deps: [product_ids, category_id, auto, limit, locale],
+  });
 
   const gridCols = gridColsMap[template] ?? gridColsMap['4col'];
 

--- a/src/components/shared/hooks/useBlockData.ts
+++ b/src/components/shared/hooks/useBlockData.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface UseBlockDataOptions<T> {
+  prefetched?: T[] | null;
+  fetch: () => Promise<T[]>;
+  deps: unknown[];
+}
+
+interface UseBlockDataResult<T> {
+  data: T[];
+  loading: boolean;
+}
+
+export function useBlockData<T>({
+  prefetched,
+  fetch,
+  deps,
+}: UseBlockDataOptions<T>): UseBlockDataResult<T> {
+  const [data, setData] = useState<T[]>(prefetched ?? []);
+  const [loading, setLoading] = useState(!prefetched);
+
+  useEffect(() => {
+    if (prefetched && prefetched.length > 0) return;
+
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const result = await fetch();
+        if (!cancelled) setData(result);
+      } catch {
+        // network errors are non-fatal for CMS blocks
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefetched, ...deps]);
+
+  return { data, loading };
+}


### PR DESCRIPTION
## 변경 내용

`useBlockData` 공통 훅을 도입하여 CMS 블록 컴포넌트의 반복 패턴을 제거했습니다.

### 도입 배경
`prefetched_*` 우선 사용 → 없으면 `useEffect` fetch → `cancelled` 플래그 보호 → `loading`/empty 처리 패턴이 4개 블록에 복제되어 있었습니다.

### 변경 파일
- **신규**: `src/components/shared/hooks/useBlockData.ts` — prefetch 우선, fallback fetch, cancel-safe 패턴 내장
- **리팩토링**: `CategoryNavBlock.tsx`, `ProductGridBlock.tsx`, `ProductCarouselBlock.tsx`, `JournalPreviewBlock.tsx`

### 검증
- [x] `npm run build` 통과
- [x] `npm run test:run` 통과 (64 files, 404 tests)
- [x] 각 블록의 prefetch 우선/fallback/cancel-safe 동작 유지
- [x] loading/empty 상태 UX 기존과 동일

Closes #588