### PR TITLE
feat: AnnouncementBar를 레이아웃에 추가

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
 import { Toaster } from 'sonner';
 import Header from '@/components/Header';
+import AnnouncementBar from '@/components/shared/layout/AnnouncementBar';
 import Footer from '@/components/Footer';
 import MobileBottomNavWrapper from '@/components/MobileBottomNavWrapper';
 import { MobileNavProvider } from '@/contexts/MobileNavContext';
@@ -131,6 +132,7 @@ export default async function LocaleLayout({
           <Providers locale={safeLocale}>
             <MobileNavProvider initialVisible={mobileBottomNavVisible}>
               <div className="flex min-h-screen flex-col">
+              <AnnouncementBar />
               <Header />
               <main id="main-content" className="flex-1 pb-16 md:pb-0">{children}</main>
               <Footer />


### PR DESCRIPTION
## Summary
- AnnouncementBar 컴포넌트가 존재했으나 레이아웃에 포함되지 않아 en/ko 페이지 최상단에 표시되지 않던 문제 수정

## Changes
- `src/app/[locale]/layout.tsx`에 `AnnouncementBar` import 및 `Header` 위에 배치

## Test plan
- [x] npm run build
- [x] npm run test:run
- [x] cd backend && npm run build && npm run test