### PR TITLE
refactor: #587 상품/검색 query-state URL 로직 공통 훅 일원화 + 보안 점검 리포트

### DIFF
--- a/docs/audit/security-audit-2026-04-21.md
+++ b/docs/audit/security-audit-2026-04-21.md
@@ -1,0 +1,69 @@
+# Security Audit Snapshot (2026-04-21)
+
+대상 이슈: #612, #613, #614, #617
+
+## #612 인증·인가·접근 제어
+
+### 확인 결과
+- 프론트 라우트 보호 존재: `src/middleware.ts`
+  - `/admin*` : accessToken + 관리자 role 검증 실패 시 리다이렉트
+  - `/my*`, `/checkout*` : 비인증 접근 차단
+- 백엔드 전역 가드 기반 인증/인가 존재
+  - `backend/src/common/guards/jwt-auth.guard.ts`
+  - `backend/src/common/guards/roles.guard.ts`
+- 공개 엔드포인트는 `@Public()` 명시 패턴 유지 (`backend/src/modules/auth/auth.controller.ts` 등)
+- 비밀번호 재설정 API
+  - 계정 존재 여부 비노출 설명/구현 존재 (`forgot-password`)
+  - rate limit 설정 존재 (`@Throttle`)
+- OAuth state 검증 로직은 프론트/백엔드에서 명시적으로 확인되는 구현 증거를 현재 코드 탐색에서 찾지 못함 (추가 검증 필요)
+- MFA 정책/구현은 현재 코드상 확인되지 않음
+
+### 우선순위 제안
+- P1: OAuth state 파라미터 검증 경로 명시/테스트 추가
+- P2: MFA 정책 결정 및 도입 여부 확정
+
+## #613 시크릿·데이터 보호·AI 입력 보안
+
+### 확인 결과
+- `.gitignore`에 `.env`, `*.pem`, `*.key` 제외 규칙 존재 (`.gitignore`)
+- `console.log`는 런타임 코드가 아닌 seed/스크립트 경로에만 존재 (`backend/src/database/seeds/**`)
+- 민감정보 마스킹 로그 인터셉터 테스트 다수 통과 (`backend/src/common/interceptors/logging.interceptor.spec.ts`)
+- 주의사항: `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`가 백엔드에서도 참조됨
+  - `backend/src/modules/payments/adapters/stripe.adapter.ts`
+  - publishable key라 치명 시크릿은 아니지만, 서버 측 변수 명명 분리 권장
+- AI 프롬프트 인젝션 방어 체계(시스템 프롬프트 분리/출력 필터/탐지 로깅)는 코드 내 명시적 전용 계층 확인 어려움 (추가 점검 필요)
+
+### 우선순위 제안
+- P1: AI 입력 보안 정책/필터/로깅 경로 문서화 및 테스트
+- P2: 서버 변수명에서 `NEXT_PUBLIC_*` 네이밍 분리
+
+## #617 IMDS SSRF 노출
+
+### 코드 기반 확인 결과
+- 앱 코드에서 `169.254.169.254` 직접 호출 흔적 없음
+- 미들웨어 백엔드 프록시는 런타임 `BACKEND_URL` 기반 forward (`src/middleware.ts`)
+  - 현재 코드상 private/link-local 차단 로직은 명시적으로 없음
+- 외부 HTTP 호출 어댑터 존재 (`backend/src/modules/**/adapters/*`)
+  - 호스트 allowlist/사설대역 차단 유틸은 코드에서 명시적으로 확인되지 않음
+
+### 운영 환경 확인 필요(리포지토리 밖)
+- EC2 IMDSv2 강제(`HttpTokens=required`)
+- IAM Role 최소권한
+- SG/NACL/egress에서 metadata 접근 차단
+- 이상 아웃바운드 탐지 로깅
+
+### 우선순위 제안
+- P1: 백엔드 outbound 요청 공통 SSRF 방어 유틸(사설/link-local 차단, redirect 재검증) 도입
+- P1: 운영 계정에서 IMDSv2/IAM/egress 설정 증빙 캡처
+
+## #614 인프라·모니터링·비용 보안
+
+리포지토리만으로는 아래 항목의 실제 설정 여부를 확정할 수 없음.
+
+- CloudWatch/GuardDuty/WAF/알림 채널
+- IAM 권한, Security Group, S3 공개 정책
+- 비용 알림(AWS/OpenAI/Stripe), usage cap
+
+### 상태
+- **Blocked (infra console 접근 필요)**
+- 코드 저장소 외부 증빙(스크린샷/정책 JSON/알림 규칙) 확보 후 체크리스트 완료 가능

--- a/src/components/__tests__/SearchPage.test.tsx
+++ b/src/components/__tests__/SearchPage.test.tsx
@@ -7,6 +7,7 @@ let mockSearchParams = new URLSearchParams('q=shoes');
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
   useSearchParams: () => mockSearchParams,
+  usePathname: () => '/search',
 }));
 
 const translations: Record<string, string> = {

--- a/src/components/shared/filters/FilterSidebar.tsx
+++ b/src/components/shared/filters/FilterSidebar.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useCallback } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
 import { useUrlModal } from '@/hooks/useUrlModal';
+import { buildAttrs, useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
 import CategoryTree from './CategoryTree';
 import PriceRangeFilter from './PriceRangeFilter';
 import ClayTypeFilter from './ClayTypeFilter';
@@ -18,98 +18,52 @@ interface FilterSidebarProps {
   shapeCollections: Collection[];
 }
 
-function parseAttrsParam(attrs: string | null): Map<string, string> {
-  const result = new Map<string, string>();
-  if (!attrs) return result;
-  const pairs = attrs.split(',');
-  for (const pair of pairs) {
-    const [code, value] = pair.split(':');
-    if (code && value) {
-      result.set(code.trim(), value.trim());
-    }
-  }
-  return result;
-}
-
-function buildAttrsParam(current: Map<string, string>, key: string, value: string | undefined): string | undefined {
-  const next = new Map(current);
-  if (value === undefined) {
-    next.delete(key);
-  } else {
-    next.set(key, value);
-  }
-  if (next.size === 0) return undefined;
-  return Array.from(next.entries())
-    .map(([k, v]) => `${k}:${v}`)
-    .join(',');
-}
-
 export default function FilterSidebar({ categories, clayCollections, shapeCollections }: FilterSidebarProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const t = useTranslations('product.filter');
   const [mobileOpen, setMobileOpen] = useUrlModal('filters');
+  const {
+    attrs,
+    categoryId,
+    priceMin,
+    priceMax,
+    updateQuery,
+    resetQuery,
+  } = useCatalogQueryParams();
 
-  const categoryIdParam = searchParams.get('categoryId');
-  const selectedCategoryId = categoryIdParam ? Number(categoryIdParam) : undefined;
-  const priceMin = searchParams.get('price_min') ? Number(searchParams.get('price_min')) : undefined;
-  const priceMax = searchParams.get('price_max') ? Number(searchParams.get('price_max')) : undefined;
-
-  const attrsParam = searchParams.get('attrs');
-  const parsedAttrs = parseAttrsParam(attrsParam);
-  const selectedClayType = parsedAttrs.get('clay_type');
-  const selectedShape = parsedAttrs.get('teapot_shape');
+  const selectedClayType = attrs.get('clay_type');
+  const selectedShape = attrs.get('teapot_shape');
 
   const hasActiveFilters =
-    selectedCategoryId !== undefined ||
+    categoryId !== undefined ||
     priceMin !== undefined ||
     priceMax !== undefined ||
     selectedClayType !== undefined ||
     selectedShape !== undefined;
 
-  const updateParams = useCallback((updates: Record<string, string | undefined>) => {
-    const params = new URLSearchParams(searchParams.toString());
-    for (const [key, value] of Object.entries(updates)) {
-      if (value === undefined) {
-        params.delete(key);
-      } else {
-        params.set(key, value);
-      }
-    }
-    params.delete('page');
-    router.push(`/products?${params.toString()}`);
-  }, [searchParams, router]);
-
   const handleCategorySelect = useCallback((id: number | undefined) => {
-    updateParams({ categoryId: id !== undefined ? String(id) : undefined });
-  }, [updateParams]);
+    updateQuery({ categoryId: id });
+  }, [updateQuery]);
 
   const handlePriceChange = useCallback((min?: number, max?: number) => {
-    updateParams({
-      price_min: min !== undefined ? String(min) : undefined,
-      price_max: max !== undefined ? String(max) : undefined,
+    updateQuery({
+      price_min: min,
+      price_max: max,
     });
-  }, [updateParams]);
+  }, [updateQuery]);
 
   const handleClayTypeSelect = useCallback((value: string | undefined) => {
-    const newAttrs = buildAttrsParam(parsedAttrs, 'clay_type', value);
-    updateParams({ attrs: newAttrs });
-  }, [parsedAttrs, updateParams]);
+    const nextAttrs = buildAttrs(attrs, 'clay_type', value);
+    updateQuery({ attrs: nextAttrs });
+  }, [attrs, updateQuery]);
 
   const handleShapeSelect = useCallback((value: string | undefined) => {
-    const newAttrs = buildAttrsParam(parsedAttrs, 'teapot_shape', value);
-    updateParams({ attrs: newAttrs });
-  }, [parsedAttrs, updateParams]);
+    const nextAttrs = buildAttrs(attrs, 'teapot_shape', value);
+    updateQuery({ attrs: nextAttrs });
+  }, [attrs, updateQuery]);
 
   const handleReset = useCallback(() => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('categoryId');
-    params.delete('price_min');
-    params.delete('price_max');
-    params.delete('attrs');
-    params.delete('page');
-    router.push(`/products?${params.toString()}`);
-  }, [searchParams, router]);
+    resetQuery(['categoryId', 'price_min', 'price_max', 'attrs']);
+  }, [resetQuery]);
 
   const sidebarContent = (
     <aside aria-label={t('filterLabel')} className="flex flex-col">
@@ -126,10 +80,10 @@ export default function FilterSidebar({ categories, clayCollections, shapeCollec
         )}
       </div>
 
-      <FilterSection title={t('category')} defaultOpen={selectedCategoryId !== undefined}>
+      <FilterSection title={t('category')} defaultOpen={categoryId !== undefined}>
         <CategoryTree
           categories={categories}
-          selectedId={selectedCategoryId}
+          selectedId={categoryId}
           onSelect={handleCategorySelect}
         />
       </FilterSection>

--- a/src/components/shared/filters/MobileFilterBar.tsx
+++ b/src/components/shared/filters/MobileFilterBar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
 import { useUrlModal } from '@/hooks/useUrlModal';
+import { buildAttrs, useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
 import PriceRangeFilter from './PriceRangeFilter';
 import TeapotShapeFilter from './TeapotShapeFilter';
 import type { Category, Collection } from '@/lib/api';
@@ -14,100 +14,59 @@ interface MobileFilterBarProps {
   shapeCollections: Collection[];
 }
 
-function parseAttrsParam(attrs: string | null): Map<string, string> {
-  const result = new Map<string, string>();
-  if (!attrs) return result;
-  const pairs = attrs.split(',');
-  for (const pair of pairs) {
-    const [code, value] = pair.split(':');
-    if (code && value) {
-      result.set(code.trim(), value.trim());
-    }
-  }
-  return result;
-}
-
-function buildAttrsParam(current: Map<string, string>, key: string, value: string | undefined): string | undefined {
-  const next = new Map(current);
-  if (value === undefined) {
-    next.delete(key);
-  } else {
-    next.set(key, value);
-  }
-  if (next.size === 0) return undefined;
-  return Array.from(next.entries())
-    .map(([k, v]) => `${k}:${v}`)
-    .join(',');
-}
-
 export default function MobileFilterBar({ categories, shapeCollections }: MobileFilterBarProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const t = useTranslations('product.filter');
   const tCommon = useTranslations('common');
   const [filterOpen, setFilterOpen] = useUrlModal('filters');
+  const {
+    attrs,
+    categoryId,
+    priceMin,
+    priceMax,
+    updateQuery,
+    resetQuery,
+  } = useCatalogQueryParams();
 
-  const categoryIdParam = searchParams.get('categoryId');
-  const selectedCategoryId = categoryIdParam ? Number(categoryIdParam) : undefined;
-  const priceMin = searchParams.get('price_min') ? Number(searchParams.get('price_min')) : undefined;
-  const priceMax = searchParams.get('price_max') ? Number(searchParams.get('price_max')) : undefined;
+  const selectedShape = attrs.get('teapot_shape');
 
-  const attrsParam = searchParams.get('attrs');
-  const parsedAttrs = parseAttrsParam(attrsParam);
-  const selectedShape = parsedAttrs.get('teapot_shape');
-
-  const rootCategories = categories.filter((c) => c.parentId === null);
+  const rootCategories = categories.filter((category) => category.parentId === null);
 
   const isRootActive = (cat: Category): boolean => {
-    if (selectedCategoryId === Number(cat.id)) return true;
-    return (cat.children ?? []).some((child) => Number(child.id) === selectedCategoryId);
-  };
-
-  const updateParams = (updates: Record<string, string | undefined>) => {
-    const params = new URLSearchParams(searchParams.toString());
-    for (const [key, value] of Object.entries(updates)) {
-      if (value === undefined) params.delete(key);
-      else params.set(key, value);
-    }
-    params.delete('page');
-    router.push(`/products?${params.toString()}`);
+    if (categoryId === Number(cat.id)) return true;
+    return (cat.children ?? []).some((child) => Number(child.id) === categoryId);
   };
 
   const handleCategorySelect = (id: number | undefined) => {
-    updateParams({ categoryId: id !== undefined ? String(id) : undefined });
+    updateQuery({ categoryId: id });
   };
 
   const handlePriceChange = (min?: number, max?: number) => {
-    updateParams({
-      price_min: min !== undefined ? String(min) : undefined,
-      price_max: max !== undefined ? String(max) : undefined,
+    updateQuery({
+      price_min: min,
+      price_max: max,
     });
   };
 
   const handleShapeSelect = (value: string | undefined) => {
-    const newAttrs = buildAttrsParam(parsedAttrs, 'teapot_shape', value);
-    updateParams({ attrs: newAttrs });
+    const nextAttrs = buildAttrs(attrs, 'teapot_shape', value);
+    updateQuery({ attrs: nextAttrs });
   };
 
   const handleReset = () => {
-    const params = new URLSearchParams();
-    params.delete('page');
-    router.push(`/products?${params.toString()}`);
+    resetQuery(['categoryId', 'price_min', 'price_max', 'attrs']);
     setFilterOpen(false);
   };
 
   return (
     <div className="md:hidden">
-      {/* 카테고리 칩 행 */}
       <div className="flex items-center gap-2 border-b border-border pb-3">
-        {/* 가로 스크롤 카테고리 칩 */}
         <div className="flex flex-1 gap-2 overflow-x-auto pb-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <button
             type="button"
             onClick={() => handleCategorySelect(undefined)}
             className={cn(
               'shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-              selectedCategoryId === undefined
+              categoryId === undefined
                 ? 'border-primary bg-primary text-primary-foreground'
                 : 'border-border bg-background text-muted-foreground',
             )}
@@ -132,7 +91,6 @@ export default function MobileFilterBar({ categories, shapeCollections }: Mobile
         </div>
       </div>
 
-      {/* 필터 패널 */}
       {filterOpen && (
         <div className="mt-4 space-y-4 rounded-lg border border-border bg-background p-4">
           <PriceRangeFilter

--- a/src/components/shared/hooks/__tests__/useCatalogQueryParams.test.tsx
+++ b/src/components/shared/hooks/__tests__/useCatalogQueryParams.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildAttrs, parseAttrs, useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
+
+const mockPush = vi.fn();
+let mockSearchParams = new URLSearchParams('sort=latest&page=3');
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/products',
+  useSearchParams: () => mockSearchParams,
+}));
+
+function QueryHarness() {
+  const { updateQuery } = useCatalogQueryParams();
+  return (
+    <button type="button" onClick={() => updateQuery({ sort: 'price_asc' })}>
+      update
+    </button>
+  );
+}
+
+describe('useCatalogQueryParams helpers', () => {
+  it('parseAttrs parses comma-separated key:value pairs', () => {
+    const parsed = parseAttrs('clay_type:zini,teapot_shape:round');
+
+    expect(parsed.get('clay_type')).toBe('zini');
+    expect(parsed.get('teapot_shape')).toBe('round');
+  });
+
+  it('buildAttrs removes key when value is undefined', () => {
+    const current = new Map<string, string>([
+      ['clay_type', 'zini'],
+      ['teapot_shape', 'round'],
+    ]);
+
+    expect(buildAttrs(current, 'clay_type', undefined)).toBe('teapot_shape:round');
+  });
+});
+
+describe('useCatalogQueryParams', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockSearchParams = new URLSearchParams('sort=latest&page=3');
+  });
+
+  it('resets page to 1 semantics when filters/sort change', async () => {
+    render(<QueryHarness />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'update' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/products?sort=price_asc');
+  });
+});

--- a/src/components/shared/hooks/useCatalogQueryParams.ts
+++ b/src/components/shared/hooks/useCatalogQueryParams.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+const EMPTY_QUERY_SUFFIX = '?';
+
+export function parseAttrs(attrs: string | null): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!attrs) return result;
+
+  for (const pair of attrs.split(',')) {
+    const [code, value] = pair.split(':');
+    if (!code || !value) continue;
+    result.set(code.trim(), value.trim());
+  }
+
+  return result;
+}
+
+export function buildAttrs(current: Map<string, string>, key: string, value: string | undefined): string | undefined {
+  const next = new Map(current);
+
+  if (value === undefined) {
+    next.delete(key);
+  } else {
+    next.set(key, value);
+  }
+
+  if (next.size === 0) return undefined;
+
+  return Array.from(next.entries())
+    .map(([attrKey, attrValue]) => `${attrKey}:${attrValue}`)
+    .join(',');
+}
+
+interface UpdateCatalogQueryOptions {
+  resetPage?: boolean;
+}
+
+type QueryValue = string | number | undefined;
+
+export function useCatalogQueryParams() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const attrs = useMemo(() => parseAttrs(searchParams.get('attrs')), [searchParams]);
+
+  const categoryId = useMemo(() => {
+    const value = searchParams.get('categoryId');
+    return value ? Number(value) : undefined;
+  }, [searchParams]);
+
+  const priceMin = useMemo(() => {
+    const value = searchParams.get('price_min');
+    return value ? Number(value) : undefined;
+  }, [searchParams]);
+
+  const priceMax = useMemo(() => {
+    const value = searchParams.get('price_max');
+    return value ? Number(value) : undefined;
+  }, [searchParams]);
+
+  const page = useMemo(() => {
+    const value = searchParams.get('page');
+    return value ? Number(value) : 1;
+  }, [searchParams]);
+
+  const q = searchParams.get('q') ?? '';
+  const sort = searchParams.get('sort') ?? undefined;
+
+  const pushParams = useCallback((params: URLSearchParams) => {
+    const query = params.toString();
+    const target = query.length > 0 ? `${pathname}?${query}` : `${pathname}${EMPTY_QUERY_SUFFIX}`;
+    router.push(target);
+  }, [pathname, router]);
+
+  const updateQuery = useCallback((updates: Record<string, QueryValue>, options?: UpdateCatalogQueryOptions) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    for (const [key, rawValue] of Object.entries(updates)) {
+      if (rawValue === undefined || rawValue === '') {
+        params.delete(key);
+      } else {
+        params.set(key, String(rawValue));
+      }
+    }
+
+    if (options?.resetPage !== false) {
+      params.delete('page');
+    }
+
+    pushParams(params);
+  }, [pushParams, searchParams]);
+
+  const resetQuery = useCallback((keys: string[]) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    for (const key of keys) {
+      params.delete(key);
+    }
+
+    params.delete('page');
+    pushParams(params);
+  }, [pushParams, searchParams]);
+
+  return {
+    searchParams,
+    attrs,
+    q,
+    sort,
+    page,
+    categoryId,
+    priceMin,
+    priceMax,
+    updateQuery,
+    resetQuery,
+  };
+}

--- a/src/components/shared/products/CategoryFilterSidebar.tsx
+++ b/src/components/shared/products/CategoryFilterSidebar.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
+import { useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
 import type { Category } from '@/lib/api';
 
 interface CategoryFilterSidebarProps {
@@ -10,21 +10,12 @@ interface CategoryFilterSidebarProps {
 }
 
 export default function CategoryFilterSidebar({ categories }: CategoryFilterSidebarProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const t = useTranslations('product.filter');
   const tCommon = useTranslations('common');
-  const activeCategoryId = searchParams.get('categoryId');
+  const { categoryId, updateQuery } = useCatalogQueryParams();
 
-  const handleSelect = (categoryId: number | null) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (categoryId === null) {
-      params.delete('categoryId');
-    } else {
-      params.set('categoryId', String(categoryId));
-    }
-    params.delete('page');
-    router.push(`/products?${params.toString()}`);
+  const handleSelect = (nextCategoryId: number | undefined) => {
+    updateQuery({ categoryId: nextCategoryId });
   };
 
   return (
@@ -34,10 +25,10 @@ export default function CategoryFilterSidebar({ categories }: CategoryFilterSide
         <li>
           <button
             type="button"
-            onClick={() => handleSelect(null)}
+            onClick={() => handleSelect(undefined)}
             className={cn(
               'w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors',
-              activeCategoryId === null
+              categoryId === undefined
                 ? 'bg-primary text-primary-foreground'
                 : 'text-muted-foreground hover:bg-accent hover:text-foreground',
             )}
@@ -52,7 +43,7 @@ export default function CategoryFilterSidebar({ categories }: CategoryFilterSide
               onClick={() => handleSelect(category.id)}
               className={cn(
                 'w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors',
-                activeCategoryId === String(category.id)
+                categoryId === category.id
                   ? 'bg-primary text-primary-foreground'
                   : 'text-muted-foreground hover:bg-accent hover:text-foreground',
               )}
@@ -68,7 +59,7 @@ export default function CategoryFilterSidebar({ categories }: CategoryFilterSide
                       onClick={() => handleSelect(child.id)}
                       className={cn(
                         'w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors',
-                        activeCategoryId === String(child.id)
+                        categoryId === child.id
                           ? 'bg-primary text-primary-foreground'
                           : 'text-muted-foreground hover:bg-accent hover:text-foreground',
                       )}

--- a/src/components/shared/products/SortDropdown.tsx
+++ b/src/components/shared/products/SortDropdown.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
+import { useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
 import type { ProductSort } from '@/lib/api';
 
 const SORT_VALUES: { value: ProductSort; labelKey: 'latest' | 'priceAsc' | 'priceDesc' | 'popular' }[] = [
@@ -13,16 +13,12 @@ const SORT_VALUES: { value: ProductSort; labelKey: 'latest' | 'priceAsc' | 'pric
 ];
 
 export default function SortDropdown() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const t = useTranslations('product.sort');
-  const current = (searchParams.get('sort') as ProductSort) ?? 'latest';
+  const { sort, updateQuery } = useCatalogQueryParams();
+  const current = (sort as ProductSort) ?? 'latest';
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('sort', e.target.value);
-    params.delete('page');
-    router.push(`/products?${params.toString()}`);
+    updateQuery({ sort: e.target.value });
   };
 
   return (

--- a/src/components/shared/search/SearchPage.tsx
+++ b/src/components/shared/search/SearchPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
 import { Button } from '@/components/ui/button';
 import EmptyState from '@/components/shared/EmptyState';
@@ -9,6 +9,7 @@ import ProductCard from '@/components/shared/products/ProductCard';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { productsApi, type Product, type ProductSort } from '@/lib/api';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
+import { useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
 
 const SORT_OPTIONS: { value: ProductSort; label: string }[] = [
   { value: 'latest', label: '최신순' },
@@ -20,15 +21,18 @@ const SORT_OPTIONS: { value: ProductSort; label: string }[] = [
 const LIMIT = 20;
 
 export default function SearchPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const {
+    q,
+    sort,
+    page,
+    categoryId,
+    priceMin,
+    priceMax,
+    updateQuery,
+  } = useCatalogQueryParams();
+  const tProduct = useTranslations('product');
 
-  const q = searchParams.get('q') ?? '';
-  const sort = (searchParams.get('sort') as ProductSort) ?? 'latest';
-  const categoryId = searchParams.get('categoryId') ? Number(searchParams.get('categoryId')) : undefined;
-  const page = searchParams.get('page') ? Number(searchParams.get('page')) : 1;
-  const priceMin = searchParams.get('price_min') ? Number(searchParams.get('price_min')) : undefined;
-  const priceMax = searchParams.get('price_max') ? Number(searchParams.get('price_max')) : undefined;
+  const activeSort = (sort as ProductSort) ?? 'latest';
 
   const [products, setProducts] = useState<Product[]>([]);
   const [total, setTotal] = useState(0);
@@ -36,27 +40,11 @@ export default function SearchPage() {
   const [priceMinInput, setPriceMinInput] = useState(priceMin?.toString() ?? '');
   const [priceMaxInput, setPriceMaxInput] = useState(priceMax?.toString() ?? '');
 
-  const updateParams = useCallback(
-    (updates: Record<string, string | undefined>) => {
-      const params = new URLSearchParams(searchParams.toString());
-      for (const [key, value] of Object.entries(updates)) {
-        if (value !== undefined && value !== '') {
-          params.set(key, value);
-        } else {
-          params.delete(key);
-        }
-      }
-      params.delete('page');
-      router.push(`/search?${params.toString()}`);
-    },
-    [searchParams, router],
-  );
-
   const { execute: loadProducts, isLoading } = useAsyncAction(
     async () => {
       const data = await productsApi.getList({
         q: q || undefined,
-        sort,
+        sort: activeSort,
         categoryId,
         price_min: priceMin,
         price_max: priceMax,
@@ -71,14 +59,14 @@ export default function SearchPage() {
 
   useEffect(() => {
     void loadProducts();
-  }, [q, sort, categoryId, priceMin, priceMax, page, loadProducts]);
+  }, [q, activeSort, categoryId, priceMin, priceMax, page, loadProducts]);
 
   const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    updateParams({ sort: e.target.value });
+    updateQuery({ sort: e.target.value });
   };
 
   const handlePriceApply = () => {
-    updateParams({
+    updateQuery({
       price_min: priceMinInput || undefined,
       price_max: priceMaxInput || undefined,
     });
@@ -86,20 +74,18 @@ export default function SearchPage() {
 
   const hasMore = page * LIMIT < total;
 
-  const handleLoadMore = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('page', String(page + 1));
-    router.push(`/search?${params.toString()}`);
-  };
+  const handleLoadMore = useCallback(() => {
+    updateQuery({ page: page + 1 }, { resetPage: false });
+  }, [page, updateQuery]);
 
   return (
     <div className="mx-auto max-w-8xl px-4 py-8">
       <div className="mb-6 flex flex-col gap-2">
         <h1 className="text-xl font-bold text-foreground">
-          {q ? `"${q}" 검색 결과` : '전체 상품'}
+          {q ? tProduct('searchResults', { query: q }) : tProduct('productList')}
         </h1>
         {!isLoading && (
-          <p className="text-sm text-muted-foreground">총 {total.toLocaleString()}개 상품</p>
+          <p className="text-sm text-muted-foreground">{tProduct('totalItems', { count: total.toLocaleString() })}</p>
         )}
       </div>
 
@@ -110,7 +96,7 @@ export default function SearchPage() {
           </label>
           <select
             id="sort-select"
-            value={sort}
+            value={activeSort}
             onChange={handleSortChange}
             aria-label="정렬 기준"
             className={cn(


### PR DESCRIPTION
## 요약
- #587: 상품/검색 쿼리 상태(categoryId, sort, price_min/max, page, attrs) 로직을 `useCatalogQueryParams`로 공통화
- attrs 파싱/직렬화 로직을 `parseAttrs`/`buildAttrs`로 통합
- 필터/정렬/검색 컴포넌트의 page reset 규칙을 단일 훅에서 고정
- #612 #613 #614 #617: 코드 기반 보안 점검 결과를 `docs/audit/security-audit-2026-04-21.md`로 기록

## 검증
- `npx vitest run src/components/__tests__/FilterSidebar.test.tsx src/components/__tests__/ProductsPage.test.tsx src/components/__tests__/SearchPage.test.tsx src/components/shared/hooks/__tests__/useCatalogQueryParams.test.tsx`
- `npm run build && npm run test:run`
- `cd backend && npm ci && npm run build && npm run test`

Closes #587
Refs #612
Refs #613
Refs #614
Refs #617
