### PR TITLE
feat: #622 AnnouncementBar UI 개선 + DB 관리 + 어드민 CRUD

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -34,6 +34,7 @@ import { NotificationModule } from './modules/notification/notification.module';
 import { SchedulerModule } from './modules/scheduler/scheduler.module';
 import { SeoModule } from './modules/seo/seo.module';
 import { MembershipModule } from './modules/membership/membership.module';
+import { AnnouncementBarsModule } from './modules/announcement-bars/announcement-bars.module';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.guard';
@@ -118,6 +119,7 @@ import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.gu
     SchedulerModule,
     SeoModule,
     MembershipModule,
+    AnnouncementBarsModule,
   ],
   providers: [
     // Guard execution order: ThrottlerGuard → JwtAuthGuard → RolesGuard

--- a/backend/src/database/migrations/1782700000000-CreateAnnouncementBarsTable.ts
+++ b/backend/src/database/migrations/1782700000000-CreateAnnouncementBarsTable.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAnnouncementBarsTable1782700000000 implements MigrationInterface {
+  name = 'CreateAnnouncementBarsTable1782700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE \`announcement_bars\` (
+        \`id\` bigint NOT NULL AUTO_INCREMENT,
+        \`message\` varchar(255) NOT NULL,
+        \`message_en\` varchar(255) NULL,
+        \`href\` varchar(255) NULL,
+        \`sort_order\` int NOT NULL DEFAULT 0,
+        \`is_active\` tinyint(1) NOT NULL DEFAULT 1,
+        \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        INDEX \`IDX_announcement_bars_sort_order\` (\`sort_order\`),
+        INDEX \`IDX_announcement_bars_is_active\` (\`is_active\`),
+        PRIMARY KEY (\`id\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE \`announcement_bars\`');
+  }
+}

--- a/backend/src/database/seeds/data/seed-data.ts
+++ b/backend/src/database/seeds/data/seed-data.ts
@@ -957,6 +957,27 @@ export const navigationItems: SeedNavigationItem[] = [
 ];
 
 // ============================================================
+// 공지 바 (AnnouncementBar)
+// ============================================================
+export interface SeedAnnouncementBar {
+  message: string;
+  message_en: string | null;
+  href: string | null;
+  sort_order: number;
+  is_active: boolean;
+}
+
+export const announcementBars: SeedAnnouncementBar[] = [
+  {
+    message: '아직 작업중인 쇼핑몰이며, 모든 것들은 더미 데이터입니다',
+    message_en: 'This shop is still under construction. All data shown is for demo purposes only.',
+    href: null,
+    sort_order: 0,
+    is_active: true,
+  },
+];
+
+// ============================================================
 // 배너 (Banner)
 // ============================================================
 export interface SeedBanner {

--- a/backend/src/database/seeds/okhwadang-seed.sql
+++ b/backend/src/database/seeds/okhwadang-seed.sql
@@ -23,6 +23,7 @@ TRUNCATE TABLE products;
 TRUNCATE TABLE attribute_types;
 TRUNCATE TABLE categories;
 TRUNCATE TABLE navigation_items;
+TRUNCATE TABLE announcement_bars;
 TRUNCATE TABLE banners;
 TRUNCATE TABLE promotions;
 TRUNCATE TABLE notices;
@@ -543,7 +544,13 @@ INSERT INTO navigation_items (id, `group`, label, url, sort_order, is_active, pa
 (29, 'footer', '저널',           '/journal',        9, 1, NULL);
 
 -- ============================================================
--- 7. 배너
+-- 7. 공지 바
+-- ============================================================
+INSERT INTO announcement_bars (message, message_en, href, sort_order, is_active) VALUES
+('아직 작업중인 쇼핑몰이며, 모든 것들은 더미 데이터입니다', 'This shop is still under construction. All data shown is for demo purposes only.', NULL, 0, 1);
+
+-- ============================================================
+-- 8. 배너
 -- ============================================================
 INSERT INTO banners (title, image_url, link_url, sort_order, is_active, starts_at, ends_at) VALUES
 ('봄 기획전 — <b>주니 신작</b> 입고', 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png', '/p/spring-2026', 0, 1, '2026-03-01 00:00:00', '2026-04-30 23:59:59'),
@@ -551,7 +558,7 @@ INSERT INTO banners (title, image_url, link_url, sort_order, is_active, starts_a
 ('입문 다도구 세트 — <b>14% 특가</b> 240,000원', 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png', '/products/okhwadang-starter-tea-set', 2, 1, NULL, NULL);
 
 -- ============================================================
--- 8. 프로모션
+-- 9. 프로모션
 -- ============================================================
 INSERT INTO promotions (title, description, type, starts_at, ends_at, is_active, discount_rate, image_url) VALUES
 ('봄 기획전 — 주니 신작', '<b>복건 주니(朱泥)</b> 신작 자사호 선착순 특가. <b>주니 서시호·주형호·석표호</b> 한정 수량 입고. 재고 소진 시 조기 마감될 수 있습니다.', 'exhibition', '2026-03-29 00:00:00', '2026-04-30 23:59:59', 1, NULL, 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png'),
@@ -559,7 +566,7 @@ INSERT INTO promotions (title, description, type, starts_at, ends_at, is_active,
 ('보이차 입문 이벤트', '<b>대익 7572 숙병</b> 구매 시 <b>대나무 차도구 5종 세트</b> 증정. 차도구(차칙·차침·차협·차루·차침)가 모두 포함된 입문 필수 세트.', 'event', '2026-04-01 00:00:00', '2026-04-30 23:59:59', 1, NULL, 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png');
 
 -- ============================================================
--- 9. 공지사항
+-- 10. 공지사항
 -- ============================================================
 INSERT INTO notices (title, content, is_pinned, is_published) VALUES
 ('옥화당 오픈 안내', '안녕하세요. 자사호·보이차·다구 전문 D2C 쇼핑몰 옥화당(玉花堂)이 정식 오픈하였습니다.\n앞으로 좋은 자사호와 보이차를 직접 소개해 드리겠습니다.', 1, 1),

--- a/backend/src/database/seeds/run-seed.ts
+++ b/backend/src/database/seeds/run-seed.ts
@@ -15,6 +15,7 @@ import { UserSeeder } from './seeders/user.seeder';
 import { OrderSeeder } from './seeders/order.seeder';
 import { PageSeeder } from './seeders/page.seeder';
 import { PageBlockSeeder } from './seeders/page-block.seeder';
+import { AnnouncementBarSeeder } from './seeders/announcement-bar.seeder';
 import { Seeder } from './base/seeder';
 import dataSource from '../typeorm.config';
 
@@ -33,6 +34,7 @@ const seeders: Seeder[] = [
   new OrderSeeder(dataSource),
   new PageSeeder(dataSource),
   new PageBlockSeeder(dataSource),
+  new AnnouncementBarSeeder(dataSource),
 ];
 
 async function runSeed() {

--- a/backend/src/database/seeds/seeders/announcement-bar.seeder.ts
+++ b/backend/src/database/seeds/seeders/announcement-bar.seeder.ts
@@ -1,0 +1,21 @@
+/* eslint-disable no-console */
+import { DataSource } from 'typeorm';
+import { Seeder } from '../base/seeder';
+import { AnnouncementBar } from '../../../modules/announcement-bars/entities/announcement-bar.entity';
+import { announcementBars } from '../data/seed-data';
+
+export class AnnouncementBarSeeder extends Seeder {
+  constructor(dataSource: DataSource) {
+    super(dataSource);
+  }
+
+  async run(): Promise<void> {
+    const repo = this.dataSource.getRepository(AnnouncementBar);
+    const inserted = await this.upsert(
+      repo,
+      announcementBars as unknown as Partial<AnnouncementBar>[],
+      (e) => `${e.message}:${e.sort_order}`,
+    );
+    console.log(`✓ Announcement bars: ${inserted} inserted, ${announcementBars.length - inserted} existing`);
+  }
+}

--- a/backend/src/modules/announcement-bars/__tests__/announcement-bars.service.spec.ts
+++ b/backend/src/modules/announcement-bars/__tests__/announcement-bars.service.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { AnnouncementBarsService } from '../announcement-bars.service';
+import { AnnouncementBar } from '../entities/announcement-bar.entity';
+
+const mockAnnouncementBarRepository = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+  update: jest.fn(),
+};
+
+const makeAnnouncementBar = (overrides: Partial<AnnouncementBar> = {}): AnnouncementBar => ({
+  id: 1,
+  message: '기본 메시지',
+  message_en: 'Default message',
+  href: '/products',
+  sort_order: 0,
+  is_active: true,
+  created_at: new Date(),
+  updated_at: new Date(),
+  ...overrides,
+} as AnnouncementBar);
+
+describe('AnnouncementBarsService', () => {
+  let service: AnnouncementBarsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnnouncementBarsService,
+        { provide: getRepositoryToken(AnnouncementBar), useValue: mockAnnouncementBarRepository },
+      ],
+    }).compile();
+
+    service = module.get<AnnouncementBarsService>(AnnouncementBarsService);
+    jest.clearAllMocks();
+  });
+
+  describe('findActive', () => {
+    it('활성 항목만 sort_order 순으로 조회한다', async () => {
+      mockAnnouncementBarRepository.find.mockResolvedValue([makeAnnouncementBar()]);
+
+      await service.findActive('ko');
+
+      expect(mockAnnouncementBarRepository.find).toHaveBeenCalledWith({
+        where: { is_active: true },
+        order: { sort_order: 'ASC' },
+      });
+    });
+
+    it('locale=en이면 message_en이 있으면 message로 치환한다', async () => {
+      mockAnnouncementBarRepository.find.mockResolvedValue([
+        makeAnnouncementBar({ message: '기본', message_en: 'English message' }),
+      ]);
+
+      const result = await service.findActive('en');
+
+      expect(result[0].message).toBe('English message');
+    });
+
+    it('locale=en이어도 message_en이 비어있으면 message fallback을 유지한다', async () => {
+      mockAnnouncementBarRepository.find.mockResolvedValue([
+        makeAnnouncementBar({ message: '기본', message_en: null }),
+      ]);
+
+      const result = await service.findActive('en');
+
+      expect(result[0].message).toBe('기본');
+    });
+  });
+
+  describe('findAll', () => {
+    it('관리자 목록은 활성/비활성 전체를 반환한다', async () => {
+      mockAnnouncementBarRepository.find.mockResolvedValue([makeAnnouncementBar({ is_active: false })]);
+
+      await service.findAll();
+
+      expect(mockAnnouncementBarRepository.find).toHaveBeenCalledWith({
+        order: { sort_order: 'ASC' },
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('생성 성공', async () => {
+      const created = makeAnnouncementBar({ id: 10 });
+      mockAnnouncementBarRepository.create.mockReturnValue(created);
+      mockAnnouncementBarRepository.save.mockResolvedValue(created);
+
+      const result = await service.create({
+        message: '새 메시지',
+        message_en: 'New message',
+        href: '/journal',
+        sort_order: 1,
+        is_active: true,
+      });
+
+      expect(result).toEqual(created);
+      expect(mockAnnouncementBarRepository.create).toHaveBeenCalled();
+      expect(mockAnnouncementBarRepository.save).toHaveBeenCalledWith(created);
+    });
+  });
+
+  describe('update', () => {
+    it('수정 성공', async () => {
+      const existing = makeAnnouncementBar();
+      const updated = makeAnnouncementBar({ message: '수정됨' });
+      mockAnnouncementBarRepository.findOne.mockResolvedValue(existing);
+      mockAnnouncementBarRepository.save.mockResolvedValue(updated);
+
+      const result = await service.update(1, { message: '수정됨' });
+
+      expect(result.message).toBe('수정됨');
+      expect(mockAnnouncementBarRepository.save).toHaveBeenCalled();
+    });
+
+    it('없는 ID 수정 시 NotFoundException', async () => {
+      mockAnnouncementBarRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.update(999, { message: '없음' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('삭제 성공', async () => {
+      const existing = makeAnnouncementBar();
+      mockAnnouncementBarRepository.findOne.mockResolvedValue(existing);
+      mockAnnouncementBarRepository.remove.mockResolvedValue(existing);
+
+      await expect(service.remove(1)).resolves.toBeUndefined();
+      expect(mockAnnouncementBarRepository.remove).toHaveBeenCalledWith(existing);
+    });
+
+    it('없는 ID 삭제 시 NotFoundException', async () => {
+      mockAnnouncementBarRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.remove(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('reorder', () => {
+    it('순서를 일괄 업데이트한다', async () => {
+      mockAnnouncementBarRepository.update.mockResolvedValue({ affected: 1 });
+
+      await service.reorder({
+        orders: [
+          { id: 1, sort_order: 3 },
+          { id: 2, sort_order: 1 },
+        ],
+      });
+
+      expect(mockAnnouncementBarRepository.update).toHaveBeenCalledTimes(2);
+      expect(mockAnnouncementBarRepository.update).toHaveBeenCalledWith(1, { sort_order: 3 });
+      expect(mockAnnouncementBarRepository.update).toHaveBeenCalledWith(2, { sort_order: 1 });
+    });
+  });
+});

--- a/backend/src/modules/announcement-bars/admin-announcement-bars.controller.ts
+++ b/backend/src/modules/announcement-bars/admin-announcement-bars.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiCookieAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { AnnouncementBarsService } from './announcement-bars.service';
+import { CreateAnnouncementBarDto } from './dto/create-announcement-bar.dto';
+import { UpdateAnnouncementBarDto } from './dto/update-announcement-bar.dto';
+import { ReorderAnnouncementBarsDto } from './dto/reorder-announcement-bars.dto';
+
+@ApiTags('관리자 - 안내 바')
+@Controller('admin/announcement-bars')
+@Roles('admin', 'super_admin')
+export class AdminAnnouncementBarsController {
+  constructor(private readonly announcementBarsService: AnnouncementBarsService) {}
+
+  @Get()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '안내 바 전체 목록 조회 (관리자)' })
+  @ApiResponse({ status: 200, description: '안내 바 전체 목록 조회 성공' })
+  findAll() {
+    return this.announcementBarsService.findAll();
+  }
+
+  @Post()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '안내 바 생성' })
+  @ApiResponse({ status: 201, description: '안내 바 생성 성공' })
+  create(@Body() dto: CreateAnnouncementBarDto) {
+    return this.announcementBarsService.create(dto);
+  }
+
+  @Patch('reorder')
+  @ApiCookieAuth()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: '안내 바 정렬 순서 변경' })
+  @ApiResponse({ status: 204, description: '안내 바 정렬 순서 변경 성공' })
+  reorder(@Body() dto: ReorderAnnouncementBarsDto) {
+    return this.announcementBarsService.reorder(dto);
+  }
+
+  @Patch(':id')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '안내 바 수정' })
+  @ApiResponse({ status: 200, description: '안내 바 수정 성공' })
+  @ApiParam({ name: 'id', type: Number, description: '안내 바 ID' })
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateAnnouncementBarDto,
+  ) {
+    return this.announcementBarsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiCookieAuth()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: '안내 바 삭제' })
+  @ApiResponse({ status: 204, description: '안내 바 삭제 성공' })
+  @ApiParam({ name: 'id', type: Number, description: '안내 바 ID' })
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.announcementBarsService.remove(id);
+  }
+}

--- a/backend/src/modules/announcement-bars/announcement-bars.controller.ts
+++ b/backend/src/modules/announcement-bars/announcement-bars.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Public } from '../../common/decorators/public.decorator';
+import { AnnouncementBarsService } from './announcement-bars.service';
+
+@ApiTags('안내 바')
+@Controller('announcement-bars')
+export class AnnouncementBarsController {
+  constructor(private readonly announcementBarsService: AnnouncementBarsService) {}
+
+  @Get()
+  @Public()
+  @ApiOperation({ summary: '활성 안내 바 목록 조회' })
+  @ApiResponse({ status: 200, description: '활성 안내 바 목록 조회 성공' })
+  @ApiQuery({ name: 'locale', required: false, enum: ['ko', 'en'] })
+  findActive(@Query('locale') locale?: string) {
+    return this.announcementBarsService.findActive(locale);
+  }
+}

--- a/backend/src/modules/announcement-bars/announcement-bars.module.ts
+++ b/backend/src/modules/announcement-bars/announcement-bars.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AnnouncementBar } from './entities/announcement-bar.entity';
+import { AnnouncementBarsService } from './announcement-bars.service';
+import { AnnouncementBarsController } from './announcement-bars.controller';
+import { AdminAnnouncementBarsController } from './admin-announcement-bars.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AnnouncementBar])],
+  controllers: [AnnouncementBarsController, AdminAnnouncementBarsController],
+  providers: [AnnouncementBarsService],
+  exports: [AnnouncementBarsService],
+})
+export class AnnouncementBarsModule {}

--- a/backend/src/modules/announcement-bars/announcement-bars.service.ts
+++ b/backend/src/modules/announcement-bars/announcement-bars.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { reorderEntities } from '../../common/utils/reorder.util';
+import { AnnouncementBar } from './entities/announcement-bar.entity';
+import { CreateAnnouncementBarDto } from './dto/create-announcement-bar.dto';
+import { UpdateAnnouncementBarDto } from './dto/update-announcement-bar.dto';
+import { ReorderAnnouncementBarsDto } from './dto/reorder-announcement-bars.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
+
+@Injectable()
+export class AnnouncementBarsService {
+  constructor(
+    @InjectRepository(AnnouncementBar)
+    private readonly announcementBarRepository: Repository<AnnouncementBar>,
+  ) {}
+
+  async findActive(locale?: string): Promise<AnnouncementBar[]> {
+    const items = await this.announcementBarRepository.find({
+      where: { is_active: true },
+      order: { sort_order: 'ASC' },
+    });
+
+    if (locale !== 'en') {
+      return items;
+    }
+
+    return items.map((item) => ({
+      ...item,
+      message: item.message_en && item.message_en.trim().length > 0 ? item.message_en : item.message,
+    }));
+  }
+
+  async findAll(): Promise<AnnouncementBar[]> {
+    return this.announcementBarRepository.find({
+      order: { sort_order: 'ASC' },
+    });
+  }
+
+  async create(dto: CreateAnnouncementBarDto): Promise<AnnouncementBar> {
+    const item = this.announcementBarRepository.create({
+      message: dto.message,
+      message_en: dto.message_en ?? null,
+      href: dto.href ?? null,
+      sort_order: dto.sort_order ?? 0,
+      is_active: dto.is_active ?? true,
+    });
+
+    return this.announcementBarRepository.save(item);
+  }
+
+  async update(id: number, dto: UpdateAnnouncementBarDto): Promise<AnnouncementBar> {
+    const item = await findOrThrow(
+      this.announcementBarRepository,
+      { id },
+      '존재하지 않는 안내 바입니다.'
+    );
+
+    Object.assign(item, {
+      ...dto,
+      message_en: dto.message_en === undefined ? item.message_en : (dto.message_en ?? null),
+      href: dto.href === undefined ? item.href : (dto.href ?? null),
+    });
+
+    return this.announcementBarRepository.save(item);
+  }
+
+  async remove(id: number): Promise<void> {
+    const item = await findOrThrow(
+      this.announcementBarRepository,
+      { id },
+      '존재하지 않는 안내 바입니다.'
+    );
+
+    await this.announcementBarRepository.remove(item);
+  }
+
+  async reorder(dto: ReorderAnnouncementBarsDto): Promise<void> {
+    const items = dto.orders.map((o) => ({ id: o.id, sortOrder: o.sort_order }));
+    await reorderEntities(this.announcementBarRepository, items, 'sort_order');
+  }
+}

--- a/backend/src/modules/announcement-bars/dto/create-announcement-bar.dto.ts
+++ b/backend/src/modules/announcement-bars/dto/create-announcement-bar.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+
+export class CreateAnnouncementBarDto {
+  @ApiProperty({ example: '아직 작업중인 쇼핑몰이며, 모든 것들은 더미 데이터입니다' })
+  @IsString()
+  @MaxLength(255)
+  message!: string;
+
+  @ApiProperty({ example: 'This shop is still under construction. All data shown is for demo purposes only.', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  message_en?: string | null;
+
+  @ApiProperty({ example: '/products', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  href?: string | null;
+
+  @ApiProperty({ example: 0, required: false })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sort_order?: number;
+
+  @ApiProperty({ example: true, required: false })
+  @IsOptional()
+  @IsBoolean()
+  is_active?: boolean;
+}

--- a/backend/src/modules/announcement-bars/dto/reorder-announcement-bars.dto.ts
+++ b/backend/src/modules/announcement-bars/dto/reorder-announcement-bars.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsInt, Min, ValidateNested } from 'class-validator';
+
+export class AnnouncementBarOrderItemDto {
+  @ApiProperty({ example: 1 })
+  @IsInt()
+  id!: number;
+
+  @ApiProperty({ example: 0 })
+  @IsInt()
+  @Min(0)
+  sort_order!: number;
+}
+
+export class ReorderAnnouncementBarsDto {
+  @ApiProperty({ type: [AnnouncementBarOrderItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AnnouncementBarOrderItemDto)
+  orders!: AnnouncementBarOrderItemDto[];
+}

--- a/backend/src/modules/announcement-bars/dto/update-announcement-bar.dto.ts
+++ b/backend/src/modules/announcement-bars/dto/update-announcement-bar.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAnnouncementBarDto } from './create-announcement-bar.dto';
+
+export class UpdateAnnouncementBarDto extends PartialType(CreateAnnouncementBarDto) {}

--- a/backend/src/modules/announcement-bars/entities/announcement-bar.entity.ts
+++ b/backend/src/modules/announcement-bars/entities/announcement-bar.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('announcement_bars')
+@Index(['is_active'])
+@Index(['sort_order'])
+export class AnnouncementBar {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  message!: string;
+
+  @Column({ name: 'message_en', type: 'varchar', length: 255, nullable: true })
+  message_en!: string | null;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  href!: string | null;
+
+  @Column({ name: 'sort_order', type: 'int', default: 0 })
+  sort_order!: number;
+
+  @Column({ name: 'is_active', type: 'boolean', default: true })
+  is_active!: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at!: Date;
+}

--- a/src/app/[locale]/admin/announcement-bars/error.tsx
+++ b/src/app/[locale]/admin/announcement-bars/error.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+export default function ErrorPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <h2 className="text-xl font-semibold">안내 바 페이지를 불러오지 못했습니다.</h2>
+      <p className="mt-2 text-sm text-muted-foreground">잠시 후 다시 시도해주세요.</p>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/announcement-bars/page.tsx
+++ b/src/app/[locale]/admin/announcement-bars/page.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
+import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
+import { useFormModal } from '@/components/shared/hooks/useFormModal';
+import { AdminTable } from '@/components/shared/admin/AdminTable';
+import { StatusBadge } from '@/components/shared/admin/StatusBadge';
+import { Button } from '@/components/ui/button';
+import Modal from '@/components/ui/Modal';
+import FormInput from '@/components/ui/FormInput';
+import { adminAnnouncementBarsApi, type AnnouncementBarItem, type CreateAnnouncementBarData } from '@/lib/api';
+import { handleApiError } from '@/utils/error';
+
+const FORM_DEFAULTS: CreateAnnouncementBarData = {
+  message: '',
+  message_en: '',
+  href: '',
+  sort_order: 0,
+  is_active: true,
+};
+
+export default function AdminAnnouncementBarsPage() {
+  const { isAdmin } = useAdminGuard();
+  const [items, setItems] = useState<AnnouncementBarItem[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const editingItem = useMemo(
+    () => (editingId == null ? null : items.find((item) => item.id === editingId) ?? null),
+    [editingId, items],
+  );
+
+  const { formData, setFormData } = useFormModal<CreateAnnouncementBarData>(
+    FORM_DEFAULTS,
+    editingItem
+      ? {
+          message: editingItem.message,
+          message_en: editingItem.message_en ?? '',
+          href: editingItem.href ?? '',
+          sort_order: editingItem.sort_order,
+          is_active: editingItem.is_active,
+        }
+      : null,
+    isModalOpen,
+  );
+
+  const { execute: loadItems, isLoading } = useAsyncAction(
+    async () => {
+      const data = await adminAnnouncementBarsApi.getAll();
+      setItems(data);
+    },
+    { errorMessage: '안내 바 목록을 불러오지 못했습니다.' },
+  );
+
+  useEffect(() => {
+    if (isAdmin) {
+      void loadItems();
+    }
+  }, [isAdmin, loadItems]);
+
+  const openCreate = () => {
+    setEditingId(null);
+    setIsModalOpen(true);
+  };
+
+  const openEdit = (id: number) => {
+    setEditingId(id);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setEditingId(null);
+    setIsModalOpen(false);
+  };
+
+  const handleSave = async () => {
+    if (!formData.message?.trim()) {
+      toast.error('국문 메시지를 입력해주세요.');
+      return;
+    }
+
+    const payload: CreateAnnouncementBarData = {
+      message: formData.message.trim(),
+      message_en: formData.message_en?.trim() ? formData.message_en.trim() : null,
+      href: formData.href?.trim() ? formData.href.trim() : null,
+      sort_order: formData.sort_order ?? 0,
+      is_active: formData.is_active ?? true,
+    };
+
+    try {
+      if (editingId == null) {
+        const created = await adminAnnouncementBarsApi.create(payload);
+        setItems((prev) => [...prev, created].sort((a, b) => a.sort_order - b.sort_order));
+        toast.success('안내 바가 생성되었습니다.');
+      } else {
+        const updated = await adminAnnouncementBarsApi.update(editingId, payload);
+        setItems((prev) => prev.map((item) => (item.id === editingId ? updated : item)).sort((a, b) => a.sort_order - b.sort_order));
+        toast.success('안내 바가 수정되었습니다.');
+      }
+
+      closeModal();
+    } catch (error) {
+      toast.error(handleApiError(error, '안내 바 저장에 실패했습니다.'));
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!window.confirm('이 안내 바를 삭제하시겠습니까?')) return;
+
+    try {
+      await adminAnnouncementBarsApi.remove(id);
+      setItems((prev) => prev.filter((item) => item.id !== id));
+      toast.success('안내 바가 삭제되었습니다.');
+    } catch (error) {
+      toast.error(handleApiError(error, '안내 바 삭제에 실패했습니다.'));
+    }
+  };
+
+  const saveOrder = async (nextItems: AnnouncementBarItem[]) => {
+    const orders = nextItems.map((item, index) => ({ id: item.id, sort_order: index }));
+
+    try {
+      await adminAnnouncementBarsApi.reorder(orders);
+      setItems(
+        nextItems.map((item, index) => ({
+          ...item,
+          sort_order: index,
+        })),
+      );
+    } catch (error) {
+      toast.error(handleApiError(error, '순서 변경에 실패했습니다.'));
+    }
+  };
+
+  const moveItem = async (id: number, direction: -1 | 1) => {
+    const index = items.findIndex((item) => item.id === id);
+    const targetIndex = index + direction;
+
+    if (index < 0 || targetIndex < 0 || targetIndex >= items.length) {
+      return;
+    }
+
+    const nextItems = [...items];
+    const [selected] = nextItems.splice(index, 1);
+    nextItems.splice(targetIndex, 0, selected);
+
+    await saveOrder(nextItems);
+  };
+
+  const toggleActive = async (item: AnnouncementBarItem) => {
+    try {
+      const updated = await adminAnnouncementBarsApi.update(item.id, { is_active: !item.is_active });
+      setItems((prev) => prev.map((prevItem) => (prevItem.id === item.id ? updated : prevItem)));
+      toast.success(`안내 바가 ${updated.is_active ? '활성화' : '비활성화'}되었습니다.`);
+    } catch (error) {
+      toast.error(handleApiError(error, '상태 변경에 실패했습니다.'));
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        <div className="h-8 w-48 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">안내 바 관리</h1>
+        <Button onClick={openCreate}>새 안내 바</Button>
+      </div>
+
+      <p className="text-sm text-muted-foreground">상단 안내 메시지를 다국어로 관리하고 노출 순서를 조정하세요.</p>
+
+      <AdminTable
+        columns={[
+          { label: '순서', width: 'w-20' },
+          { label: '국문 메시지' },
+          { label: '영문 메시지' },
+          { label: '링크', width: 'w-56' },
+          { label: '상태', width: 'w-24' },
+          { label: '작업', width: 'w-48' },
+        ]}
+        isEmpty={items.length === 0}
+        emptyMessage="등록된 안내 바가 없습니다."
+      >
+        {items.map((item, index) => (
+          <tr key={item.id} className="border-b hover:bg-muted/40">
+            <td className="px-4 py-3 text-sm text-muted-foreground">{item.sort_order}</td>
+            <td className="px-4 py-3 text-sm">{item.message}</td>
+            <td className="px-4 py-3 text-sm text-muted-foreground">{item.message_en ?? '-'}</td>
+            <td className="px-4 py-3 text-sm text-muted-foreground truncate max-w-56">{item.href ?? '-'}</td>
+            <td className="px-4 py-3">
+              <button type="button" onClick={() => toggleActive(item)} className="text-left">
+                <StatusBadge isActive={item.is_active} />
+              </button>
+            </td>
+            <td className="px-4 py-3">
+              <div className="flex items-center gap-2 text-sm">
+                <button type="button" onClick={() => moveItem(item.id, -1)} disabled={index === 0} className="text-muted-foreground enabled:hover:text-foreground disabled:opacity-40">↑</button>
+                <button type="button" onClick={() => moveItem(item.id, 1)} disabled={index === items.length - 1} className="text-muted-foreground enabled:hover:text-foreground disabled:opacity-40">↓</button>
+                <button type="button" onClick={() => openEdit(item.id)} className="text-foreground hover:underline">수정</button>
+                <button type="button" onClick={() => handleDelete(item.id)} className="text-destructive hover:underline">삭제</button>
+              </div>
+            </td>
+          </tr>
+        ))}
+      </AdminTable>
+
+      <Modal isOpen={isModalOpen} onClose={closeModal}>
+        <div className="space-y-4 p-6">
+          <h2 className="text-lg font-semibold">{editingId == null ? '새 안내 바' : '안내 바 수정'}</h2>
+
+          <FormInput
+            label="국문 메시지"
+            value={formData.message ?? ''}
+            onChange={(e) => setFormData((prev) => ({ ...prev, message: e.target.value }))}
+            placeholder="국문 메시지를 입력하세요"
+          />
+
+          <FormInput
+            label="영문 메시지"
+            value={formData.message_en ?? ''}
+            onChange={(e) => setFormData((prev) => ({ ...prev, message_en: e.target.value }))}
+            placeholder="영문 메시지를 입력하세요 (선택)"
+          />
+
+          <FormInput
+            label="링크 URL"
+            value={formData.href ?? ''}
+            onChange={(e) => setFormData((prev) => ({ ...prev, href: e.target.value }))}
+            placeholder="예: /products"
+          />
+
+          <FormInput
+            label="정렬 순서"
+            type="number"
+            value={String(formData.sort_order ?? 0)}
+            onChange={(e) => setFormData((prev) => ({ ...prev, sort_order: Number(e.target.value) }))}
+          />
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={formData.is_active ?? true}
+              onChange={(e) => setFormData((prev) => ({ ...prev, is_active: e.target.checked }))}
+            />
+            활성화
+          </label>
+
+          <div className="flex gap-3 pt-2">
+            <Button variant="outline" onClick={closeModal} className="flex-1">취소</Button>
+            <Button onClick={handleSave} className="flex-1">{editingId == null ? '생성' : '저장'}</Button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -132,7 +132,7 @@ export default async function LocaleLayout({
           <Providers locale={safeLocale}>
             <MobileNavProvider initialVisible={mobileBottomNavVisible}>
               <div className="flex min-h-screen flex-col">
-              <AnnouncementBar />
+              <AnnouncementBar locale={safeLocale} />
               <Header />
               <main id="main-content" className="flex-1 pb-16 md:pb-0">{children}</main>
               <Footer />

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -60,6 +60,7 @@ const NAV_ITEMS: NavItem[] = [
     children: [
       { label: '페이지관리', href: '/admin/pages' },
       { label: '네비게이션관리', href: '/admin/navigation' },
+      { label: '안내바관리', href: '/admin/announcement-bars' },
       { label: '컬렉션관리', href: '/admin/collections' },
       { label: '저널관리', href: '/admin/journal' },
       { label: '아카이브관리', href: '/admin/archives' },

--- a/src/components/__tests__/AdminLayout.test.tsx
+++ b/src/components/__tests__/AdminLayout.test.tsx
@@ -79,5 +79,6 @@ describe('AdminSidebar', () => {
     fireEvent.click(screen.getByText('CMS'));
     expect(screen.getByText('페이지관리')).toBeInTheDocument();
     expect(screen.getByText('네비게이션관리')).toBeInTheDocument();
+    expect(screen.getByText('안내바관리')).toBeInTheDocument();
   });
 });

--- a/src/components/shared/layout/AnnouncementBar.tsx
+++ b/src/components/shared/layout/AnnouncementBar.tsx
@@ -1,57 +1,16 @@
-'use client';
+import { fetchAnnouncementBars } from '@/lib/api-server';
+import AnnouncementBarClient from './AnnouncementBarClient';
 
-import { useState, useEffect } from 'react';
-import Link from 'next/link';
-import { useParams } from 'next/navigation';
+interface AnnouncementBarProps {
+  locale: string;
+}
 
-const ANNOUNCEMENTS = [
-  { id: 1, label: '옥화당 핸드메이드 차茶', href: '/collection' },
-  { id: 2, label: '다실 도자기 특가', href: '/products?isFeatured=true' },
-  { id: 3, label: '신상품 입고', href: '/products?sort=latest' },
-];
+export default async function AnnouncementBar({ locale }: AnnouncementBarProps) {
+  const items = await fetchAnnouncementBars(locale);
 
-export default function AnnouncementBar() {
-  const params = useParams();
-  const locale = params.locale as string;
-  const [current, setCurrent] = useState(0);
+  if (items.length === 0) {
+    return <div data-testid="announcement-bar-empty" className="h-0 overflow-hidden" />;
+  }
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrent((prev) => (prev + 1) % ANNOUNCEMENTS.length);
-    }, 4000);
-    return () => clearInterval(interval);
-  }, []);
-
-  return (
-    <div className="bg-[#1A1815] border-b border-border/50 overflow-hidden">
-      <div className="hidden md:flex mx-auto max-w-8xl items-center justify-between px-4 md:px-20">
-        {ANNOUNCEMENTS.map((item) => (
-          <Link
-            key={item.id}
-            href={`/${locale}${item.href}`}
-            className="flex items-center py-2.5 px-6 text-sm transition-colors hover:text-[#D4BC8E] text-[#F5F3EF]/80"
-          >
-            {item.label}
-          </Link>
-        ))}
-      </div>
-
-      <div className="md:hidden relative">
-        <div
-          className="flex transition-transform duration-500 ease-out"
-          style={{ transform: `translateX(-${current * 100}%)` }}
-        >
-          {ANNOUNCEMENTS.map((item) => (
-            <Link
-              key={item.id}
-              href={`/${locale}${item.href}`}
-              className="min-w-full flex items-center justify-center py-2.5 px-6 text-sm transition-colors hover:text-[#D4BC8E] text-[#F5F3EF]/80"
-            >
-              {item.label}
-            </Link>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+  return <AnnouncementBarClient locale={locale} items={items} />;
 }

--- a/src/components/shared/layout/AnnouncementBarClient.tsx
+++ b/src/components/shared/layout/AnnouncementBarClient.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import type { AnnouncementBarItem } from '@/lib/api-server';
+
+interface AnnouncementBarClientProps {
+  locale: string;
+  items: AnnouncementBarItem[];
+}
+
+function resolveHref(locale: string, href: string | null): string | null {
+  if (!href || href.trim().length === 0) return null;
+  const trimmed = href.trim();
+  if (/^(https?:|mailto:|tel:)/.test(trimmed)) return trimmed;
+  if (trimmed.startsWith(`/${locale}`)) return trimmed;
+  if (trimmed.startsWith('/')) return `/${locale}${trimmed}`;
+  return `/${locale}/${trimmed}`;
+}
+
+export default function AnnouncementBarClient({ locale, items }: AnnouncementBarClientProps) {
+  const t = useTranslations('announcementBar');
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const normalizedItems = useMemo(
+    () => items.map((item) => ({ ...item, href: resolveHref(locale, item.href) })),
+    [items, locale],
+  );
+
+  useEffect(() => {
+    if (normalizedItems.length <= 1) return;
+
+    const timer = window.setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % normalizedItems.length);
+    }, 5000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [normalizedItems.length]);
+
+  if (normalizedItems.length === 0) {
+    return <div data-testid="announcement-bar-empty" className="h-0 overflow-hidden" />;
+  }
+
+  const goPrev = () => setCurrentIndex((prev) => (prev - 1 + normalizedItems.length) % normalizedItems.length);
+  const goNext = () => setCurrentIndex((prev) => (prev + 1) % normalizedItems.length);
+
+  return (
+    <div
+      className="relative flex items-center justify-center px-4 text-white md:justify-between"
+      style={{ height: '37px', backgroundColor: '#000000', paddingLeft: '15px', paddingRight: '15px' }}
+    >
+      <div className="hidden md:block" />
+
+      <div className="relative overflow-hidden" style={{ maxWidth: '360px', width: '100%' }}>
+        <div
+          className="transition-transform ease-out"
+          data-testid="announcement-track"
+          style={{ transform: `translateY(-${currentIndex * 100}%)`, transitionDuration: '500ms' }}
+        >
+          {normalizedItems.map((item) => {
+            const content = (
+              <span
+                className="block text-center"
+                style={{ fontWeight: 300, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em', lineHeight: '14px', height: '37px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+              >
+                {item.message}
+              </span>
+            );
+
+            if (!item.href) {
+              return <div key={item.id}>{content}</div>;
+            }
+
+            return (
+              <Link key={item.id} href={item.href} className="block text-white hover:text-white/80">
+                {content}
+              </Link>
+            );
+          })}
+        </div>
+
+        {normalizedItems.length > 1 ? (
+          <>
+            <button
+              type="button"
+              aria-label={t('prev')}
+              onClick={goPrev}
+              className="absolute left-0 top-1/2 z-10 -translate-y-1/2 bg-transparent text-white opacity-75 transition-all hover:opacity-100 hover:text-[#757575]"
+              style={{ width: '20px', height: '20px' }}
+            >
+              <ChevronLeft className="mx-auto h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              aria-label={t('next')}
+              onClick={goNext}
+              className="absolute right-0 top-1/2 z-10 -translate-y-1/2 bg-transparent text-white opacity-75 transition-all hover:opacity-100 hover:text-[#757575]"
+              style={{ width: '20px', height: '20px' }}
+            >
+              <ChevronRight className="mx-auto h-4 w-4" />
+            </button>
+          </>
+        ) : null}
+      </div>
+
+      <div className="hidden md:block" />
+    </div>
+  );
+}

--- a/src/components/shared/layout/__tests__/AnnouncementBar.test.tsx
+++ b/src/components/shared/layout/__tests__/AnnouncementBar.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import AnnouncementBar from '@/components/shared/layout/AnnouncementBar';
+import * as apiServer from '@/lib/api-server';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    if (key === 'prev') return 'Previous announcement';
+    if (key === 'next') return 'Next announcement';
+    return key;
+  },
+}));
+
+describe('AnnouncementBar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('SSR에서 locale 파라미터로 안내 문구를 조회해 렌더링한다', async () => {
+    vi.spyOn(apiServer, 'fetchAnnouncementBars').mockResolvedValue([
+      {
+        id: 1,
+        message: '영문 공지',
+        message_en: 'English notice',
+        href: '/products',
+        sort_order: 0,
+        is_active: true,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    const jsx = await AnnouncementBar({ locale: 'en' });
+    render(jsx);
+
+    expect(apiServer.fetchAnnouncementBars).toHaveBeenCalledWith('en');
+    const link = screen.getByRole('link', { name: '영문 공지' });
+    expect(link).toHaveAttribute('href', '/en/products');
+  });
+
+  it('데이터가 비어있으면 높이 0으로 숨긴다', async () => {
+    vi.spyOn(apiServer, 'fetchAnnouncementBars').mockResolvedValue([]);
+
+    const jsx = await AnnouncementBar({ locale: 'ko' });
+    render(jsx);
+
+    expect(screen.getByTestId('announcement-bar-empty')).toBeInTheDocument();
+  });
+});

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -57,6 +57,10 @@
     "myPage": "My Page",
     "home": "Home"
   },
+  "announcementBar": {
+    "prev": "Previous announcement",
+    "next": "Next announcement"
+  },
   "header": {
     "searchPlaceholder": "Search products...",
     "searchLabel": "Search products",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -57,6 +57,10 @@
     "myPage": "마이",
     "home": "홈"
   },
+  "announcementBar": {
+    "prev": "이전 공지",
+    "next": "다음 공지"
+  },
   "header": {
     "searchPlaceholder": "상품 검색...",
     "searchLabel": "상품 검색",

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -88,3 +88,22 @@ export function fetchSettings(group?: string, locale?: string) {
 export function fetchSettingsMap(locale?: string) {
   return fetchFromBackend<Record<string, string>>('/settings/map', locale ? { locale } : undefined);
 }
+
+export interface AnnouncementBarItem {
+  id: number;
+  message: string;
+  message_en: string | null;
+  href: string | null;
+  sort_order: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function fetchAnnouncementBars(locale?: string): Promise<AnnouncementBarItem[]> {
+  try {
+    return await fetchFromBackend<AnnouncementBarItem[]>('/announcement-bars', locale ? { locale } : undefined);
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -953,9 +953,25 @@ export interface NavigationItem {
   children: NavigationItem[];
 }
 
+export interface AnnouncementBarItem {
+  id: number;
+  message: string;
+  message_en: string | null;
+  href: string | null;
+  sort_order: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export const navigationApi = {
   getByGroup: (group: 'gnb' | 'sidebar' | 'footer', locale?: string) =>
     apiClient.get<NavigationItem[]>(`/navigation?group=${group}${locale ? `&locale=${locale}` : ''}`),
+};
+
+export const announcementBarsApi = {
+  getActive: (locale?: string) =>
+    apiClient.get<AnnouncementBarItem[]>(locale ? `/announcement-bars?locale=${locale}` : '/announcement-bars'),
 };
 
 export const adminNavigationApi = {
@@ -969,6 +985,26 @@ export const adminNavigationApi = {
     apiClient.delete<void>(`/navigation/${id}`),
   reorder: (orders: Array<{ id: number; sort_order: number }>) =>
     apiClient.patch<void>('/navigation/reorder', { orders }),
+};
+
+export interface CreateAnnouncementBarData {
+  message: string;
+  message_en?: string | null;
+  href?: string | null;
+  sort_order?: number;
+  is_active?: boolean;
+}
+
+export const adminAnnouncementBarsApi = {
+  getAll: () => apiClient.get<AnnouncementBarItem[]>('/admin/announcement-bars'),
+  create: (data: CreateAnnouncementBarData) =>
+    apiClient.post<AnnouncementBarItem>('/admin/announcement-bars', data),
+  update: (id: number, data: Partial<CreateAnnouncementBarData>) =>
+    apiClient.patch<AnnouncementBarItem>(`/admin/announcement-bars/${id}`, data),
+  remove: (id: number) =>
+    apiClient.delete<void>(`/admin/announcement-bars/${id}`),
+  reorder: (orders: Array<{ id: number; sort_order: number }>) =>
+    apiClient.patch<void>('/admin/announcement-bars/reorder', { orders }),
 };
 
 export interface ReviewItem {


### PR DESCRIPTION
## 요약
- AnnouncementBar를 하드코딩 배열에서 DB 기반 SSR(locale 파라미터 포함) 렌더링으로 전환했습니다.
- The Ordinary 스타일의 상단 공지바(세로 슬라이드, autoplay, prev/next) UI를 적용했습니다.
- backend에 announcement_bars 테이블/마이그레이션/공개+어드민 CRUD/reorder API를 추가했습니다.
- 어드민 페이지 /admin/announcement-bars를 추가해 ko/en 메시지, 링크, 활성화, 순서(up/down) 관리가 가능해졌습니다.
- 시드 데이터(TypeORM seed + SQL seed)에 기본 공지 ko/en 문구를 추가했습니다.

## 검증
- npm run build && npm run test:run
- cd backend && npm run build && npm run test
- cd backend && TEST_DATABASE_URL/DATABASE_URL/JWT_PRIVATE_KEY/JWT_PUBLIC_KEY 주입 후 npm run test:e2e
- bash scripts/start-local.sh

## 참고
- npm run review:graph는 로컬 code-review-graph 미설치로 실행 불가였습니다.

Closes #622
