### PR TITLE
refactor: #600 Upload 이미지 업로드 파이프라인 중복 제거

### DIFF
--- a/backend/src/modules/upload/__tests__/upload.service.spec.ts
+++ b/backend/src/modules/upload/__tests__/upload.service.spec.ts
@@ -143,11 +143,17 @@ describe('UploadService', () => {
     it('MIME 검증 실패 — gif 거부', async () => {
       const file = makeFile({ mimetype: 'image/gif', originalname: 'anim.gif' });
       await expect(service.uploadCategoryImage(file)).rejects.toThrow(BadRequestException);
+      await expect(service.uploadCategoryImage(file)).rejects.toThrow(
+        '허용되지 않는 이미지 형식입니다. (jpeg, png, webp만 허용)',
+      );
     });
 
     it('파일 크기 초과 — 5MB 이상 거부', async () => {
       const file = makeFile({ size: 6 * 1024 * 1024 });
       await expect(service.uploadCategoryImage(file)).rejects.toThrow(PayloadTooLargeException);
+      await expect(service.uploadCategoryImage(file)).rejects.toThrow(
+        '파일 크기는 5MB를 초과할 수 없습니다.',
+      );
     });
 
     it('UUID 재명명 확인 — 원본 파일명과 다름', async () => {

--- a/backend/src/modules/upload/upload.constants.ts
+++ b/backend/src/modules/upload/upload.constants.ts
@@ -1,0 +1,4 @@
+export const ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+export const MAX_UPLOAD_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+export const MAX_UPLOAD_IMAGE_WIDTH = 1920;
+export const MAX_UPLOAD_IMAGE_HEIGHT = 1920;

--- a/backend/src/modules/upload/upload.controller.ts
+++ b/backend/src/modules/upload/upload.controller.ts
@@ -18,6 +18,19 @@ import { UploadService } from './upload.service';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { UploadedFile as UploadedFileType } from './interfaces/storage.interface';
 
+const IMAGE_UPLOAD_BODY_SCHEMA = {
+  schema: {
+    type: 'object',
+    properties: {
+      file: { type: 'string', format: 'binary' },
+    },
+  },
+} as const;
+
+const FILE_UPLOAD_INTERCEPTOR = FileInterceptor('file', {
+  storage: memoryStorage(),
+});
+
 @ApiTags('업로드')
 @Controller('upload')
 export class UploadController {
@@ -26,20 +39,16 @@ export class UploadController {
   @Post('image')
   @Roles('admin')
   @ApiCookieAuth()
-  @ApiOperation({ summary: '이미지 업로드', description: '관리자가 이미지를 업로드합니다.' })
+  @ApiOperation({
+    summary: '이미지 업로드',
+    description: '관리자가 이미지를 업로드합니다.',
+  })
   @ApiResponse({ status: 201, description: '이미지 업로드 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
   @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        file: { type: 'string', format: 'binary' },
-      },
-    },
-  })
-  @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() }))
+  @ApiBody(IMAGE_UPLOAD_BODY_SCHEMA)
+  @UseInterceptors(FILE_UPLOAD_INTERCEPTOR)
   uploadImage(
     @UploadedFile() file: Express.Multer.File,
   ): Promise<UploadedFileType> {
@@ -49,20 +58,16 @@ export class UploadController {
   @Post('category-image')
   @Roles('admin')
   @ApiCookieAuth()
-  @ApiOperation({ summary: '카테고리 이미지 업로드', description: '관리자가 카테고리 이미지를 업로드합니다.' })
+  @ApiOperation({
+    summary: '카테고리 이미지 업로드',
+    description: '관리자가 카테고리 이미지를 업로드합니다.',
+  })
   @ApiResponse({ status: 201, description: '카테고리 이미지 업로드 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
   @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        file: { type: 'string', format: 'binary' },
-      },
-    },
-  })
-  @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() }))
+  @ApiBody(IMAGE_UPLOAD_BODY_SCHEMA)
+  @UseInterceptors(FILE_UPLOAD_INTERCEPTOR)
   uploadCategoryImage(
     @UploadedFile() file: Express.Multer.File,
   ): Promise<UploadedFileType> {

--- a/backend/src/modules/upload/upload.service.ts
+++ b/backend/src/modules/upload/upload.service.ts
@@ -11,11 +11,12 @@ import { StorageAdapter, UploadedFile } from './interfaces/storage.interface';
 import { LocalStorageAdapter } from './adapters/local.adapter';
 import { MockStorageAdapter } from './adapters/mock.adapter';
 import { S3StorageAdapter } from './adapters/s3.adapter';
-
-const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
-const MAX_WIDTH = 1920;
-const MAX_HEIGHT = 1920;
+import {
+  ALLOWED_IMAGE_MIME_TYPES,
+  MAX_UPLOAD_FILE_SIZE_BYTES,
+  MAX_UPLOAD_IMAGE_HEIGHT,
+  MAX_UPLOAD_IMAGE_WIDTH,
+} from './upload.constants';
 
 @Injectable()
 export class UploadService {
@@ -41,60 +42,64 @@ export class UploadService {
     this.logger.log(`StorageAdapter: ${provider}`);
   }
 
-  async uploadImage(file: Express.Multer.File): Promise<UploadedFile> {
-    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
-      throw new BadRequestException(
-        `허용되지 않는 이미지 형식입니다. (jpeg, png, webp만 허용)`,
-      );
-    }
-
-    if (file.size > MAX_FILE_SIZE_BYTES) {
-      throw new PayloadTooLargeException('파일 크기는 5MB를 초과할 수 없습니다.');
-    }
-
-    const detectedMime = detectMimeFromMagicBytes(file.buffer);
-    if (!detectedMime || !ALLOWED_MIME_TYPES.includes(detectedMime)) {
-      throw new BadRequestException('허용되지 않는 이미지 형식입니다.');
-    }
-
-    const ext = path.extname(file.originalname).toLowerCase() || `.${file.mimetype.split('/')[1]}`;
-    const filename = `${randomUUID()}${ext}`;
-
-    const resized = await sharp(file.buffer)
-      .resize(MAX_WIDTH, MAX_HEIGHT, { fit: 'inside', withoutEnlargement: true })
-      .toBuffer();
-
-    return this.adapter.save(filename, resized, file.mimetype);
+  uploadImage(file: Express.Multer.File): Promise<UploadedFile> {
+    return this.uploadWithPipeline(file, (filename, buffer, mimetype) =>
+      this.adapter.save(filename, buffer, mimetype),
+    );
   }
 
-  async uploadCategoryImage(file: Express.Multer.File): Promise<UploadedFile> {
-    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+  uploadCategoryImage(file: Express.Multer.File): Promise<UploadedFile> {
+    return this.uploadWithPipeline(file, (filename, buffer, mimetype) =>
+      this.adapter.saveCategoryImage(filename, buffer, mimetype),
+    );
+  }
+
+  private async uploadWithPipeline(
+    file: Express.Multer.File,
+    save: (filename: string, buffer: Buffer, mimetype: string) => Promise<UploadedFile>,
+  ): Promise<UploadedFile> {
+    this.validateFile(file);
+
+    const ext =
+      path.extname(file.originalname).toLowerCase() ||
+      `.${file.mimetype.split('/')[1]}`;
+    const filename = `${randomUUID()}${ext}`;
+
+    const resized = await sharp(file.buffer)
+      .resize(MAX_UPLOAD_IMAGE_WIDTH, MAX_UPLOAD_IMAGE_HEIGHT, {
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .toBuffer();
+
+    return save(filename, resized, file.mimetype);
+  }
+
+  private validateFile(file: Express.Multer.File): void {
+    if (!isAllowedImageMimeType(file.mimetype)) {
       throw new BadRequestException(
-        `허용되지 않는 이미지 형식입니다. (jpeg, png, webp만 허용)`,
+        '허용되지 않는 이미지 형식입니다. (jpeg, png, webp만 허용)',
       );
     }
 
-    if (file.size > MAX_FILE_SIZE_BYTES) {
+    if (file.size > MAX_UPLOAD_FILE_SIZE_BYTES) {
       throw new PayloadTooLargeException('파일 크기는 5MB를 초과할 수 없습니다.');
     }
 
     const detectedMime = detectMimeFromMagicBytes(file.buffer);
-    if (!detectedMime || !ALLOWED_MIME_TYPES.includes(detectedMime)) {
+    if (!detectedMime || !isAllowedImageMimeType(detectedMime)) {
       throw new BadRequestException('허용되지 않는 이미지 형식입니다.');
     }
-
-    const ext = path.extname(file.originalname).toLowerCase() || `.${file.mimetype.split('/')[1]}`;
-    const filename = `${randomUUID()}${ext}`;
-
-    const resized = await sharp(file.buffer)
-      .resize(MAX_WIDTH, MAX_HEIGHT, { fit: 'inside', withoutEnlargement: true })
-      .toBuffer();
-
-    return this.adapter.saveCategoryImage(filename, resized, file.mimetype);
   }
 }
 
-function detectMimeFromMagicBytes(buffer: Buffer): string | null {
+function isAllowedImageMimeType(mimeType: string): mimeType is (typeof ALLOWED_IMAGE_MIME_TYPES)[number] {
+  return ALLOWED_IMAGE_MIME_TYPES.some((allowedType) => allowedType === mimeType);
+}
+
+function detectMimeFromMagicBytes(
+  buffer: Buffer,
+): (typeof ALLOWED_IMAGE_MIME_TYPES)[number] | null {
   if (buffer.length < 4) return null;
 
   // JPEG: FF D8 FF
@@ -103,15 +108,26 @@ function detectMimeFromMagicBytes(buffer: Buffer): string | null {
   }
 
   // PNG: 89 50 4E 47
-  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47
+  ) {
     return 'image/png';
   }
 
   // WebP: RIFF....WEBP
   if (
     buffer.length >= 12 &&
-    buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
-    buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
   ) {
     return 'image/webp';
   }


### PR DESCRIPTION
## 작업 내용
- `UploadService`의 image/category-image 처리 경로를 `uploadWithPipeline` 공통 파이프라인으로 통합
- MIME/크기/매직바이트 검증 + 리사이즈 규칙을 단일 검증 흐름에서 적용
- 허용 포맷/크기/리사이즈 상수를 `upload.constants.ts`로 분리해 정책 변경 지점을 단일화
- `UploadController`의 multipart body schema와 multer interceptor 설정을 공통 상수로 재사용
- 카테고리 이미지 실패 케이스가 일반 이미지와 동일한 에러 메시지 계약을 따르는지 테스트 보강

## 테스트
- [x] `cd backend && npm run test -- upload.service.spec.ts`
- [x] `cd backend && npm run build && npm run test`
- [x] `npm run build && npm run test:run`

Closes #600
