### PR TITLE
refactor: #602 주문/결제/배송 상태전이 규칙 중앙화

### DIFF
--- a/backend/src/common/policies/state-transition.policy.ts
+++ b/backend/src/common/policies/state-transition.policy.ts
@@ -1,0 +1,22 @@
+export type TransitionMap<TState extends string> = Record<TState, readonly TState[]>;
+
+export function isTransitionAllowed<TState extends string>(
+  transitions: TransitionMap<TState>,
+  current: TState,
+  next: TState,
+  options?: { allowSameStatus?: boolean },
+): boolean {
+  if (options?.allowSameStatus && current === next) {
+    return true;
+  }
+
+  const allowed = transitions[current] ?? [];
+  return allowed.includes(next);
+}
+
+export function formatInvalidTransitionMessage(
+  current: string,
+  next: string,
+): string {
+  return `상태 전이가 허용되지 않습니다: ${current} → ${next}`;
+}

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -16,18 +16,7 @@ import { AdminOrderQueryDto } from './dto/admin-order-query.dto';
 import { RegisterShippingDto } from './dto/register-shipping.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
-
-const ALLOWED_ORDER_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
-  [OrderStatus.PENDING]: [OrderStatus.PAID],
-  [OrderStatus.PAID]: [OrderStatus.PREPARING, OrderStatus.CANCELLED, OrderStatus.REFUNDED],
-  [OrderStatus.PREPARING]: [OrderStatus.SHIPPED, OrderStatus.CANCELLED, OrderStatus.REFUNDED],
-  [OrderStatus.SHIPPED]: [OrderStatus.DELIVERED, OrderStatus.REFUNDED],
-  [OrderStatus.DELIVERED]: [OrderStatus.COMPLETED, OrderStatus.REFUND_REQUESTED],
-  [OrderStatus.COMPLETED]: [],
-  [OrderStatus.CANCELLED]: [],
-  [OrderStatus.REFUND_REQUESTED]: [OrderStatus.REFUNDED],
-  [OrderStatus.REFUNDED]: [],
-};
+import { assertOrderStatusTransition } from '../orders/policies/order-status-transition.policy';
 
 @Injectable()
 export class AdminOrdersService {
@@ -86,13 +75,7 @@ export class AdminOrdersService {
     }
 
     const currentStatus = order.status;
-    const allowed = ALLOWED_ORDER_TRANSITIONS[currentStatus] ?? [];
-
-    if (!allowed.includes(nextStatus)) {
-      throw new BadRequestException(
-        `상태 전이가 허용되지 않습니다: ${currentStatus} → ${nextStatus}`,
-      );
-    }
+    assertOrderStatusTransition(currentStatus, nextStatus);
 
     if (nextStatus === OrderStatus.SHIPPED) {
       const shipping = await this.shippingRepository.findOne({ where: { orderId } });

--- a/backend/src/modules/orders/policies/order-status-transition.policy.ts
+++ b/backend/src/modules/orders/policies/order-status-transition.policy.ts
@@ -1,0 +1,45 @@
+import { BadRequestException } from '@nestjs/common';
+import { OrderStatus } from '../entities/order.entity';
+import {
+  formatInvalidTransitionMessage,
+  isTransitionAllowed,
+  TransitionMap,
+} from '../../../common/policies/state-transition.policy';
+
+export const ORDER_STATUS_TRANSITIONS: TransitionMap<OrderStatus> = {
+  [OrderStatus.PENDING]: [OrderStatus.PAID],
+  [OrderStatus.PAID]: [
+    OrderStatus.PREPARING,
+    OrderStatus.CANCELLED,
+    OrderStatus.REFUNDED,
+  ],
+  [OrderStatus.PREPARING]: [
+    OrderStatus.SHIPPED,
+    OrderStatus.CANCELLED,
+    OrderStatus.REFUNDED,
+  ],
+  [OrderStatus.SHIPPED]: [OrderStatus.DELIVERED, OrderStatus.REFUNDED],
+  [OrderStatus.DELIVERED]: [OrderStatus.COMPLETED, OrderStatus.REFUND_REQUESTED],
+  [OrderStatus.COMPLETED]: [],
+  [OrderStatus.CANCELLED]: [],
+  [OrderStatus.REFUND_REQUESTED]: [OrderStatus.REFUNDED],
+  [OrderStatus.REFUNDED]: [],
+};
+
+export function canOrderStatusTransition(
+  current: OrderStatus,
+  next: OrderStatus,
+  options?: { allowSameStatus?: boolean },
+): boolean {
+  return isTransitionAllowed(ORDER_STATUS_TRANSITIONS, current, next, options);
+}
+
+export function assertOrderStatusTransition(
+  current: OrderStatus,
+  next: OrderStatus,
+  options?: { allowSameStatus?: boolean },
+): void {
+  if (!canOrderStatusTransition(current, next, options)) {
+    throw new BadRequestException(formatInvalidTransitionMessage(current, next));
+  }
+}

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -3,9 +3,9 @@ import { UnauthorizedException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { PaymentsService } from '../payments.service';
-import { Payment } from '../entities/payment.entity';
+import { Payment, PaymentStatus } from '../entities/payment.entity';
 import { Refund } from '../entities/refund.entity';
-import { Order } from '../../orders/entities/order.entity';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { Shipping } from '../entities/shipping.entity';
 import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
@@ -26,8 +26,20 @@ describe('PaymentsService — webhook', () => {
     save: jest.fn(),
     update: jest.fn(),
   };
+  const mockWebhookManager = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+  };
+  const mockDataSource = {
+    transaction: jest.fn(
+      async (
+        fn: (manager: typeof mockWebhookManager) => Promise<unknown>,
+      ) => fn(mockWebhookManager),
+    ),
+  };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PaymentsService,
@@ -40,7 +52,7 @@ describe('PaymentsService — webhook', () => {
         { provide: TossPaymentAdapter, useValue: mockGateway },
         { provide: StripePaymentAdapter, useValue: mockGateway },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
-        { provide: DataSource, useValue: { transaction: jest.fn() } },
+        { provide: DataSource, useValue: mockDataSource },
       ],
     }).compile();
 
@@ -93,5 +105,36 @@ describe('PaymentsService — webhook', () => {
     const logArg: string = logSpy.mock.calls[0][0] as string;
     const logged = JSON.parse(logArg.replace('Webhook received: ', '')) as Record<string, unknown>;
     expect(Object.keys(logged)).toEqual(['orderId', 'status', 'type']);
+  });
+
+  it('허용 전이(pending → paid)면 payment/order 상태를 함께 갱신한다', async () => {
+    mockGateway.verifyWebhook.mockReturnValue(true);
+    mockRepo.findOne.mockResolvedValue({ id: 10, orderId: 7, paidAt: null });
+    mockWebhookManager.findOne.mockResolvedValue({ id: 7, status: 'pending' });
+
+    await service.handleWebhook({ orderId: 7, status: 'DONE' }, 'valid_sig');
+
+    expect(mockWebhookManager.update).toHaveBeenCalledWith(
+      Payment,
+      10,
+      expect.objectContaining({ status: PaymentStatus.CONFIRMED }),
+    );
+    expect(mockWebhookManager.update).toHaveBeenCalledWith(
+      Order,
+      7,
+      { status: OrderStatus.PAID },
+    );
+  });
+
+  it('차단 전이(delivered → paid)면 상태 업데이트를 수행하지 않는다', async () => {
+    mockGateway.verifyWebhook.mockReturnValue(true);
+    mockRepo.findOne.mockResolvedValue({ id: 10, orderId: 7, paidAt: null });
+    mockWebhookManager.findOne.mockResolvedValue({ id: 7, status: 'delivered' });
+
+    await expect(
+      service.handleWebhook({ orderId: 7, status: 'DONE' }, 'valid_sig'),
+    ).resolves.not.toThrow();
+
+    expect(mockWebhookManager.update).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/payments/services/payment-webhook.service.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.ts
@@ -4,6 +4,7 @@ import { Payment, PaymentStatus } from '../entities/payment.entity';
 import { Order } from '../../orders/entities/order.entity';
 import { PaymentGateway } from '../interfaces/payment-gateway.interface';
 import { PAYMENT_WEBHOOK_TRANSITIONS } from './payment-webhook-transition.policy';
+import { canOrderStatusTransition } from '../../orders/policies/order-status-transition.policy';
 
 interface PaymentWebhookDependencies {
   gateway: PaymentGateway;
@@ -58,6 +59,23 @@ export class PaymentWebhookService {
     }
 
     await this.deps.dataSource.transaction(async (manager) => {
+      const order = await manager.findOne(Order, { where: { id: parsedOrderId } });
+      if (!order) {
+        this.deps.logger.warn(`Webhook ignored: order not found (orderId=${parsedOrderId})`);
+        return;
+      }
+
+      if (
+        !canOrderStatusTransition(order.status, matchedTransition.orderStatus, {
+          allowSameStatus: true,
+        })
+      ) {
+        this.deps.logger.warn(
+          `Webhook ignored: blocked transition ${order.status} → ${matchedTransition.orderStatus} (orderId=${parsedOrderId})`,
+        );
+        return;
+      }
+
       await manager.update(Payment, payment.id, {
         status: matchedTransition.paymentStatus as PaymentStatus,
         paidAt: matchedTransition.setPaidAt ? payment.paidAt ?? new Date() : payment.paidAt,
@@ -68,4 +86,3 @@ export class PaymentWebhookService {
     });
   }
 }
-

--- a/backend/src/modules/scheduler/jobs/order-scheduler.job.ts
+++ b/backend/src/modules/scheduler/jobs/order-scheduler.job.ts
@@ -7,6 +7,7 @@ import { User } from '../../users/entities/user.entity';
 import { NotificationService } from '../../notification/notification.service';
 import { SettingsService } from '../../settings/settings.service';
 import { MembershipService } from '../../membership/membership.service';
+import { canOrderStatusTransition } from '../../orders/policies/order-status-transition.policy';
 
 interface OrderSchedulerJobDependencies {
   orderRepo: Repository<Order>;
@@ -61,6 +62,13 @@ export class OrderSchedulerJob {
     this.deps.logger.log(`[cron:delivered-order-confirm] Confirming ${deliveredOrders.length} delivered orders`);
 
     for (const order of deliveredOrders) {
+      if (!canOrderStatusTransition(order.status, OrderStatus.COMPLETED)) {
+        this.deps.logger.warn(
+          `[cron:delivered-order-confirm] transition blocked: ${order.status} → ${OrderStatus.COMPLETED} (order=${order.orderNumber})`,
+        );
+        continue;
+      }
+
       await this.deps.orderRepo.update(order.id, { status: OrderStatus.COMPLETED });
 
       const completedAmount = Number(order.totalAmount) - Number(order.discountAmount ?? 0);
@@ -83,6 +91,13 @@ export class OrderSchedulerJob {
   }
 
   private async cancelOrderAndRestoreStock(order: Order): Promise<void> {
+    if (!canOrderStatusTransition(order.status, OrderStatus.CANCELLED)) {
+      this.deps.logger.warn(
+        `[cron:pending-order-cancel] transition blocked: ${order.status} → ${OrderStatus.CANCELLED} (order=${order.orderNumber})`,
+      );
+      return;
+    }
+
     const queryRunner = this.deps.dataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();

--- a/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
+++ b/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
@@ -111,7 +111,11 @@ describe('ShippingService', () => {
     it('DELIVERED → PREPARING 역방향 전이 → BadRequestException(유효하지 않은 배송 상태 변경입니다.)', () => {
       expect(() =>
         service.validateTransition(ShippingStatus.DELIVERED, ShippingStatus.PREPARING),
-      ).toThrow(new BadRequestException('유효하지 않은 배송 상태 변경입니다.'));
+      ).toThrow(
+        new BadRequestException(
+          '상태 전이가 허용되지 않습니다: delivered → preparing',
+        ),
+      );
     });
 
     it('shipped → preparing 역방향 전이 → BadRequestException', () => {
@@ -187,7 +191,9 @@ describe('ShippingService', () => {
         makeShipping({ status: ShippingStatus.PREPARING }),
       );
       await expect(service.registerTracking(1, dto)).rejects.toThrow(
-        new BadRequestException('유효하지 않은 배송 상태 변경입니다.'),
+        new BadRequestException(
+          '상태 전이가 허용되지 않습니다: preparing → preparing',
+        ),
       );
     });
 

--- a/backend/src/modules/shipping/policies/shipping-status-transition.policy.ts
+++ b/backend/src/modules/shipping/policies/shipping-status-transition.policy.ts
@@ -1,0 +1,34 @@
+import { BadRequestException } from '@nestjs/common';
+import { ShippingStatus } from '../../payments/entities/shipping.entity';
+import {
+  formatInvalidTransitionMessage,
+  isTransitionAllowed,
+  TransitionMap,
+} from '../../../common/policies/state-transition.policy';
+
+export const SHIPPING_STATUS_TRANSITIONS: TransitionMap<ShippingStatus> = {
+  [ShippingStatus.PAYMENT_CONFIRMED]: [ShippingStatus.PREPARING],
+  [ShippingStatus.PREPARING]: [ShippingStatus.SHIPPED, ShippingStatus.FAILED],
+  [ShippingStatus.SHIPPED]: [ShippingStatus.IN_TRANSIT, ShippingStatus.FAILED],
+  [ShippingStatus.IN_TRANSIT]: [ShippingStatus.DELIVERED, ShippingStatus.FAILED],
+  [ShippingStatus.DELIVERED]: [],
+  [ShippingStatus.FAILED]: [],
+};
+
+export function canShippingStatusTransition(
+  current: ShippingStatus,
+  next: ShippingStatus,
+  options?: { allowSameStatus?: boolean },
+): boolean {
+  return isTransitionAllowed(SHIPPING_STATUS_TRANSITIONS, current, next, options);
+}
+
+export function assertShippingStatusTransition(
+  current: ShippingStatus,
+  next: ShippingStatus,
+  options?: { allowSameStatus?: boolean },
+): void {
+  if (!canShippingStatusTransition(current, next, options)) {
+    throw new BadRequestException(formatInvalidTransitionMessage(current, next));
+  }
+}

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -20,15 +20,7 @@ import { findOrThrow } from '../../common/utils/repository.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { NotificationService } from '../notification/notification.service';
 import { ShippingFeeCalculatorService, ShippingFeeQuote } from './services/shipping-fee-calculator.service';
-
-const ALLOWED_TRANSITIONS: Record<ShippingStatus, ShippingStatus[]> = {
-  [ShippingStatus.PAYMENT_CONFIRMED]: [ShippingStatus.PREPARING],
-  [ShippingStatus.PREPARING]: [ShippingStatus.SHIPPED, ShippingStatus.FAILED],
-  [ShippingStatus.SHIPPED]: [ShippingStatus.IN_TRANSIT, ShippingStatus.FAILED],
-  [ShippingStatus.IN_TRANSIT]: [ShippingStatus.DELIVERED, ShippingStatus.FAILED],
-  [ShippingStatus.DELIVERED]: [],
-  [ShippingStatus.FAILED]: [],
-};
+import { assertShippingStatusTransition } from './policies/shipping-status-transition.policy';
 
 @Injectable()
 export class ShippingService {
@@ -161,10 +153,7 @@ export class ShippingService {
   }
 
   validateTransition(current: ShippingStatus, next: ShippingStatus): void {
-    const allowed = ALLOWED_TRANSITIONS[current] ?? [];
-    if (!allowed.includes(next)) {
-      throw new BadRequestException('유효하지 않은 배송 상태 변경입니다.');
-    }
+    assertShippingStatusTransition(current, next);
   }
 
   private resolveProvider(carrier: CarrierCode): ShippingProvider {


### PR DESCRIPTION
## 작업 내용
- 주문/배송 상태 전이 규칙을 공통 policy로 분리
  - `order-status-transition.policy.ts`
  - `shipping-status-transition.policy.ts`
  - 공통 helper: `state-transition.policy.ts`
- 관리자 주문 상태 변경(`AdminOrdersService`)이 공통 주문 전이 정책을 사용하도록 변경
- 스케줄러 주문 상태 변경(`OrderSchedulerJob`)도 동일 주문 정책으로 검증 후 전이하도록 변경
- 결제 웹훅(`PaymentWebhookService`)에서 이벤트 매핑 후 주문 현재 상태를 정책으로 검증해 차단 전이는 무시하도록 보강
- 배송 상태 검증(`ShippingService`)을 공통 배송 정책으로 통일
- 불법 전이 예외 메시지 형식을 공통 formatter로 통일
- 웹훅/배송 전이 테스트 보강

## 테스트
- [x] `cd backend && npm run test -- admin-orders.service.spec.ts shipping.service.spec.ts payments.webhook.spec.ts scheduler.service.spec.ts`
- [x] `cd backend && npm run build && npm run test`
- [x] `npm run build && npm run test:run`

Closes #602
