### PR TITLE
refactor: #604 backend 설정 경계를 typed config provider로 통일

### DIFF
--- a/backend/src/config/__tests__/auth.config.spec.ts
+++ b/backend/src/config/__tests__/auth.config.spec.ts
@@ -1,0 +1,67 @@
+import { createAuthConfig } from '../auth.config';
+
+describe('createAuthConfig', () => {
+  const makeEnv = (overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+    NODE_ENV: 'development',
+    JWT_SECRET: 'jwt-secret',
+    JWT_PRIVATE_KEY: 'private-key',
+    JWT_PUBLIC_KEY: 'public-key',
+    FRONTEND_URL: 'https://frontend.test',
+    ...overrides,
+  });
+
+  it('production에서 JWT_REFRESH_SECRET 누락 시 에러를 던진다', () => {
+    expect(() =>
+      createAuthConfig(
+        makeEnv({
+          NODE_ENV: 'production',
+          JWT_REFRESH_SECRET: '',
+        }),
+      ),
+    ).toThrow('JWT_REFRESH_SECRET must be set in production');
+  });
+
+  it('FRONTEND_URL 누락 시 에러를 던진다', () => {
+    expect(() =>
+      createAuthConfig(
+        makeEnv({
+          FRONTEND_URL: '',
+        }),
+      ),
+    ).toThrow('FRONTEND_URL environment variable is required');
+  });
+
+  it('oauth/jwt 설정을 typed object로 반환한다', () => {
+    const config = createAuthConfig(
+      makeEnv({
+        JWT_REFRESH_SECRET: 'refresh-secret',
+        JWT_EXPIRES_IN: '2h',
+        JWT_REFRESH_EXPIRES_IN: '14d',
+        KAKAO_CLIENT_ID: 'kakao-client',
+        KAKAO_CLIENT_SECRET: 'kakao-secret',
+        KAKAO_REDIRECT_URI: 'https://frontend.test/auth/kakao/callback',
+        GOOGLE_CLIENT_ID: 'google-client',
+        GOOGLE_CLIENT_SECRET: 'google-secret',
+        GOOGLE_REDIRECT_URI: 'https://frontend.test/auth/google/callback',
+        FRONTEND_URLS: 'https://front-a.test, https://front-b.test',
+      }),
+    );
+
+    expect(config.jwt).toMatchObject({
+      secret: 'jwt-secret',
+      refreshSecret: 'refresh-secret',
+      expiresIn: '2h',
+      refreshExpiresIn: '14d',
+      privateKey: 'private-key',
+      publicKey: 'public-key',
+    });
+    expect(config.oauth.kakao).toMatchObject({
+      clientId: 'kakao-client',
+      clientSecret: 'kakao-secret',
+    });
+    expect(config.frontend.allowedOrigins).toEqual([
+      'https://front-a.test',
+      'https://front-b.test',
+    ]);
+  });
+});

--- a/backend/src/config/__tests__/notification.config.spec.ts
+++ b/backend/src/config/__tests__/notification.config.spec.ts
@@ -1,0 +1,29 @@
+import { createNotificationConfig } from '../notification.config';
+
+describe('createNotificationConfig', () => {
+  it('production에서 mock 알림 provider를 차단한다', () => {
+    expect(() =>
+      createNotificationConfig({
+        NODE_ENV: 'production',
+        NOTIFICATION_PROVIDER: 'mock',
+      }),
+    ).toThrow('Mock notification provider는 프로덕션에서 사용할 수 없습니다');
+  });
+
+  it('development에서는 기본 mock provider를 허용한다', () => {
+    const config = createNotificationConfig({
+      NODE_ENV: 'development',
+    });
+
+    expect(config.provider).toBe('mock');
+  });
+
+  it('알 수 없는 provider는 에러를 던진다', () => {
+    expect(() =>
+      createNotificationConfig({
+        NODE_ENV: 'development',
+        NOTIFICATION_PROVIDER: 'legacy',
+      }),
+    ).toThrow('Unknown NOTIFICATION_PROVIDER: legacy');
+  });
+});

--- a/backend/src/config/__tests__/payment.config.spec.ts
+++ b/backend/src/config/__tests__/payment.config.spec.ts
@@ -1,0 +1,38 @@
+import { createPaymentConfig } from '../payment.config';
+
+describe('createPaymentConfig', () => {
+  it('production에서 mock 게이트웨이를 차단한다', () => {
+    expect(() =>
+      createPaymentConfig({
+        NODE_ENV: 'production',
+        PAYMENT_GATEWAY: 'mock',
+      }),
+    ).toThrow('Mock payment gateway는 프로덕션에서 사용할 수 없습니다');
+  });
+
+  it('production에서 PAYMENT_GATEWAY 누락 시 차단한다', () => {
+    expect(() =>
+      createPaymentConfig({
+        NODE_ENV: 'production',
+      }),
+    ).toThrow('Mock payment gateway는 프로덕션에서 사용할 수 없습니다');
+  });
+
+  it('development에서는 기본 mock 게이트웨이를 허용한다', () => {
+    const config = createPaymentConfig({
+      NODE_ENV: 'development',
+      JWT_SECRET: 'secret',
+    });
+
+    expect(config.gateway).toBe('mock');
+  });
+
+  it('알 수 없는 결제 게이트웨이는 에러를 던진다', () => {
+    expect(() =>
+      createPaymentConfig({
+        NODE_ENV: 'development',
+        PAYMENT_GATEWAY: 'legacy',
+      }),
+    ).toThrow('Unknown PAYMENT_GATEWAY: legacy');
+  });
+});

--- a/backend/src/config/__tests__/storage.config.spec.ts
+++ b/backend/src/config/__tests__/storage.config.spec.ts
@@ -1,0 +1,38 @@
+import { createStorageConfig } from '../storage.config';
+
+describe('createStorageConfig', () => {
+  it('기본값(local, ap-northeast-2)을 사용한다', () => {
+    const config = createStorageConfig({});
+
+    expect(config.provider).toBe('local');
+    expect(config.s3.region).toBe('ap-northeast-2');
+  });
+
+  it('unknown STORAGE_PROVIDER는 local로 fallback한다', () => {
+    const config = createStorageConfig({
+      STORAGE_PROVIDER: 'unknown',
+    });
+
+    expect(config.provider).toBe('local');
+  });
+
+  it('s3 provider 선택 시 자격증명을 반영한다', () => {
+    const config = createStorageConfig({
+      STORAGE_PROVIDER: 's3',
+      AWS_S3_BUCKET_NAME: 'bucket',
+      AWS_REGION: 'us-east-1',
+      AWS_ACCESS_KEY_ID: 'ak',
+      AWS_SECRET_ACCESS_KEY: 'sk',
+      AWS_CDN_URL: 'https://cdn.example.com',
+    });
+
+    expect(config.provider).toBe('s3');
+    expect(config.s3).toMatchObject({
+      bucket: 'bucket',
+      region: 'us-east-1',
+      accessKeyId: 'ak',
+      secretAccessKey: 'sk',
+      cdnUrl: 'https://cdn.example.com',
+    });
+  });
+});

--- a/backend/src/config/auth-config.module.ts
+++ b/backend/src/config/auth-config.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { authConfigProvider } from './auth.config';
+
+@Module({
+  providers: [authConfigProvider],
+  exports: [authConfigProvider],
+})
+export class AuthConfigModule {}

--- a/backend/src/config/auth.config.ts
+++ b/backend/src/config/auth.config.ts
@@ -1,0 +1,174 @@
+import { Provider } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import type ms from 'ms';
+
+export const AUTH_CONFIG = Symbol('AUTH_CONFIG');
+
+export interface OAuthClientConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+export interface AuthConfig {
+  nodeEnv: string;
+  cookie: {
+    secure: boolean;
+  };
+  frontend: {
+    baseUrl: string;
+    allowedOrigins: string[];
+  };
+  jwt: {
+    secret: string;
+    refreshSecret: string | null;
+    expiresIn: ms.StringValue;
+    refreshExpiresIn: ms.StringValue;
+    privateKey: string;
+    publicKey: string;
+  };
+  oauth: {
+    kakao: OAuthClientConfig;
+    google: OAuthClientConfig;
+  };
+}
+
+function normalizeEnvValue(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function readKeyFromPath(filePath: string | null): string | null {
+  if (!filePath) {
+    return null;
+  }
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  const contents = fs.readFileSync(filePath, 'utf-8').trim();
+  return contents.length > 0 ? contents : null;
+}
+
+function resolveJwtPrivateKey(env: NodeJS.ProcessEnv): string {
+  const inlinePrivateKey = normalizeEnvValue(env.JWT_PRIVATE_KEY);
+  if (inlinePrivateKey) {
+    return inlinePrivateKey;
+  }
+
+  const envPrivateKeyPath =
+    normalizeEnvValue(env.JWT_PRIVATE_KEY_PATH) ?? normalizeEnvValue(env.JWT_PRIVATE_KEY_FILE);
+  const fromConfiguredPath = readKeyFromPath(envPrivateKeyPath);
+  if (fromConfiguredPath) {
+    return fromConfiguredPath;
+  }
+
+  const possiblePaths = [
+    path.resolve(process.cwd(), 'keys', 'jwt-private.pem'),
+    path.resolve(process.cwd(), '..', 'keys', 'jwt-private.pem'),
+    path.resolve(__dirname, '..', '..', 'keys', 'jwt-private.pem'),
+    path.resolve(__dirname, '..', '..', '..', 'keys', 'jwt-private.pem'),
+  ];
+
+  for (const keyPath of possiblePaths) {
+    const key = readKeyFromPath(keyPath);
+    if (key) {
+      return key;
+    }
+  }
+
+  throw new Error('JWT_PRIVATE_KEY environment variable or keys/jwt-private.pem file is required');
+}
+
+function resolveJwtPublicKey(env: NodeJS.ProcessEnv): string {
+  const inlinePublicKey = normalizeEnvValue(env.JWT_PUBLIC_KEY);
+  if (inlinePublicKey) {
+    return inlinePublicKey;
+  }
+
+  const envPublicKeyPath =
+    normalizeEnvValue(env.JWT_PUBLIC_KEY_PATH) ?? normalizeEnvValue(env.JWT_PUBLIC_KEY_FILE);
+  const fromConfiguredPath = readKeyFromPath(envPublicKeyPath);
+  if (fromConfiguredPath) {
+    return fromConfiguredPath;
+  }
+
+  const possiblePaths = [
+    path.resolve(process.cwd(), 'keys', 'jwt-public.pem'),
+    path.resolve(process.cwd(), '..', 'keys', 'jwt-public.pem'),
+    path.resolve(__dirname, '..', '..', 'keys', 'jwt-public.pem'),
+    path.resolve(__dirname, '..', '..', '..', 'keys', 'jwt-public.pem'),
+  ];
+
+  for (const keyPath of possiblePaths) {
+    const key = readKeyFromPath(keyPath);
+    if (key) {
+      return key;
+    }
+  }
+
+  throw new Error('JWT_PUBLIC_KEY environment variable or keys/jwt-public.pem file is required');
+}
+
+function parseAllowedOrigins(frontendUrls: string | undefined): string[] {
+  if (!frontendUrls) {
+    return [];
+  }
+
+  return frontendUrls
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+}
+
+export function createAuthConfig(env: NodeJS.ProcessEnv = process.env): AuthConfig {
+  const nodeEnv = env.NODE_ENV ?? 'development';
+  const refreshSecret = normalizeEnvValue(env.JWT_REFRESH_SECRET);
+
+  if (nodeEnv === 'production' && !refreshSecret) {
+    throw new Error('JWT_REFRESH_SECRET must be set in production');
+  }
+
+  const frontendBaseUrl = normalizeEnvValue(env.FRONTEND_URL);
+  if (!frontendBaseUrl) {
+    throw new Error('FRONTEND_URL environment variable is required');
+  }
+
+  return {
+    nodeEnv,
+    cookie: {
+      secure: nodeEnv === 'production',
+    },
+    frontend: {
+      baseUrl: frontendBaseUrl,
+      allowedOrigins: parseAllowedOrigins(env.FRONTEND_URLS),
+    },
+    jwt: {
+      secret: env.JWT_SECRET ?? '',
+      refreshSecret,
+      expiresIn: (env.JWT_EXPIRES_IN ?? '1h') as ms.StringValue,
+      refreshExpiresIn: (env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue,
+      privateKey: resolveJwtPrivateKey(env),
+      publicKey: resolveJwtPublicKey(env),
+    },
+    oauth: {
+      kakao: {
+        clientId: env.KAKAO_CLIENT_ID ?? '',
+        clientSecret: env.KAKAO_CLIENT_SECRET ?? '',
+        redirectUri: env.KAKAO_REDIRECT_URI ?? '',
+      },
+      google: {
+        clientId: env.GOOGLE_CLIENT_ID ?? '',
+        clientSecret: env.GOOGLE_CLIENT_SECRET ?? '',
+        redirectUri: env.GOOGLE_REDIRECT_URI ?? '',
+      },
+    },
+  };
+}
+
+export const authConfigProvider: Provider = {
+  provide: AUTH_CONFIG,
+  useFactory: () => createAuthConfig(),
+};

--- a/backend/src/config/notification.config.ts
+++ b/backend/src/config/notification.config.ts
@@ -1,0 +1,49 @@
+import { Provider } from '@nestjs/common';
+
+export const NOTIFICATION_CONFIG = Symbol('NOTIFICATION_CONFIG');
+
+export type NotificationProviderName = 'mock' | 'resend' | 'ses';
+
+export interface NotificationConfig {
+  nodeEnv: string;
+  provider: NotificationProviderName;
+  resend: {
+    apiKey: string;
+    fromAddress: string;
+  };
+}
+
+function isNotificationProviderName(value: string): value is NotificationProviderName {
+  return value === 'mock' || value === 'resend' || value === 'ses';
+}
+
+export function createNotificationConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): NotificationConfig {
+  const nodeEnv = env.NODE_ENV ?? 'development';
+  const provider = (env.NOTIFICATION_PROVIDER ?? 'mock').trim().toLowerCase();
+
+  if (nodeEnv === 'production' && (provider === 'mock' || !env.NOTIFICATION_PROVIDER)) {
+    throw new Error(
+      'Mock notification provider는 프로덕션에서 사용할 수 없습니다. NOTIFICATION_PROVIDER 환경변수를 설정하세요.',
+    );
+  }
+
+  if (!isNotificationProviderName(provider)) {
+    throw new Error(`Unknown NOTIFICATION_PROVIDER: ${provider}`);
+  }
+
+  return {
+    nodeEnv,
+    provider,
+    resend: {
+      apiKey: env.RESEND_API_KEY ?? '',
+      fromAddress: env.EMAIL_FROM ?? 'no-reply@okhwadang.com',
+    },
+  };
+}
+
+export const notificationConfigProvider: Provider = {
+  provide: NOTIFICATION_CONFIG,
+  useFactory: () => createNotificationConfig(),
+};

--- a/backend/src/config/payment.config.ts
+++ b/backend/src/config/payment.config.ts
@@ -1,0 +1,59 @@
+import { Provider } from '@nestjs/common';
+
+export const PAYMENT_CONFIG = Symbol('PAYMENT_CONFIG');
+
+export type PaymentGatewayName = 'mock' | 'toss' | 'stripe';
+
+export interface PaymentConfig {
+  nodeEnv: string;
+  gateway: PaymentGatewayName;
+  defaultCarrier: string;
+  toss: {
+    secretKey: string;
+    clientKey: string;
+  };
+  stripe: {
+    secretKey: string;
+    publishableKey: string;
+    webhookSecret: string;
+  };
+}
+
+function isPaymentGatewayName(value: string): value is PaymentGatewayName {
+  return value === 'mock' || value === 'toss' || value === 'stripe';
+}
+
+export function createPaymentConfig(env: NodeJS.ProcessEnv = process.env): PaymentConfig {
+  const nodeEnv = env.NODE_ENV ?? 'development';
+  const gateway = (env.PAYMENT_GATEWAY ?? 'mock').trim().toLowerCase();
+
+  if (nodeEnv === 'production' && (gateway === 'mock' || !env.PAYMENT_GATEWAY)) {
+    throw new Error(
+      'Mock payment gateway는 프로덕션에서 사용할 수 없습니다. PAYMENT_GATEWAY 환경변수를 설정하세요.',
+    );
+  }
+
+  if (!isPaymentGatewayName(gateway)) {
+    throw new Error(`Unknown PAYMENT_GATEWAY: ${gateway}`);
+  }
+
+  return {
+    nodeEnv,
+    gateway,
+    defaultCarrier: env.DEFAULT_CARRIER || 'mock',
+    toss: {
+      secretKey: env.TOSS_SECRET_KEY ?? '',
+      clientKey: env.TOSS_CLIENT_KEY ?? '',
+    },
+    stripe: {
+      secretKey: env.STRIPE_SECRET_KEY ?? '',
+      publishableKey: env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '',
+      webhookSecret: env.STRIPE_WEBHOOK_SECRET ?? '',
+    },
+  };
+}
+
+export const paymentConfigProvider: Provider = {
+  provide: PAYMENT_CONFIG,
+  useFactory: () => createPaymentConfig(),
+};

--- a/backend/src/config/storage.config.ts
+++ b/backend/src/config/storage.config.ts
@@ -1,0 +1,48 @@
+import { Provider } from '@nestjs/common';
+
+export const STORAGE_CONFIG = Symbol('STORAGE_CONFIG');
+
+export type StorageProviderName = 'local' | 'mock' | 's3';
+
+export interface StorageConfig {
+  provider: StorageProviderName;
+  s3: {
+    bucket: string;
+    region: string;
+    cdnUrl: string | null;
+    accessKeyId: string;
+    secretAccessKey: string;
+  };
+}
+
+function resolveStorageProvider(rawProvider: string | undefined): StorageProviderName {
+  const provider = rawProvider?.trim().toLowerCase();
+
+  switch (provider) {
+    case 's3':
+      return 's3';
+    case 'mock':
+      return 'mock';
+    case 'local':
+    default:
+      return 'local';
+  }
+}
+
+export function createStorageConfig(env: NodeJS.ProcessEnv = process.env): StorageConfig {
+  return {
+    provider: resolveStorageProvider(env.STORAGE_PROVIDER),
+    s3: {
+      bucket: env.AWS_S3_BUCKET_NAME ?? '',
+      region: env.AWS_REGION ?? 'ap-northeast-2',
+      cdnUrl: env.AWS_CDN_URL ?? null,
+      accessKeyId: env.AWS_ACCESS_KEY_ID ?? '',
+      secretAccessKey: env.AWS_SECRET_ACCESS_KEY ?? '',
+    },
+  };
+}
+
+export const storageConfigProvider: Provider = {
+  provide: STORAGE_CONFIG,
+  useFactory: () => createStorageConfig(),
+};

--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -14,6 +14,7 @@ import { AuthEventEmitter } from '../auth-event.emitter';
 import { TokenIssuerService } from '../services/token-issuer.service';
 import { AuthLoginPolicyService } from '../services/auth-login-policy.service';
 import { AuthAuditService } from '../services/auth-audit.service';
+import { AUTH_CONFIG, AuthConfig, createAuthConfig } from '../../../config/auth.config';
 
 const mockUserRepository = {
   findOne: jest.fn(),
@@ -105,13 +106,18 @@ function makeUser(overrides: Partial<User> = {}): User {
 
 describe('AuthService', () => {
   let service: AuthService;
-  let originalFrontendUrl: string | undefined;
 
-  beforeEach(async () => {
-    jest.clearAllMocks();
-    originalFrontendUrl = process.env.FRONTEND_URL;
-    process.env.FRONTEND_URL = 'https://frontend.test';
+  const buildAuthConfig = (overrides: NodeJS.ProcessEnv = {}): AuthConfig =>
+    createAuthConfig({
+      NODE_ENV: 'development',
+      JWT_SECRET: 'jwt-secret',
+      JWT_PRIVATE_KEY: 'private-key',
+      JWT_PUBLIC_KEY: 'public-key',
+      FRONTEND_URL: 'https://frontend.test',
+      ...overrides,
+    });
 
+  const createService = async (authConfig: AuthConfig): Promise<AuthService> => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
@@ -132,19 +138,16 @@ describe('AuthService', () => {
         { provide: AuditLogService, useValue: mockAuditLogService },
         { provide: TokenBlacklistService, useValue: mockTokenBlacklistService },
         { provide: AuthEventEmitter, useValue: { emitUserRegistered: jest.fn() } },
+        { provide: AUTH_CONFIG, useValue: authConfig },
       ],
     }).compile();
 
-    service = module.get<AuthService>(AuthService);
-  });
+    return module.get<AuthService>(AuthService);
+  };
 
-  afterEach(() => {
-    if (originalFrontendUrl === undefined) {
-      delete process.env.FRONTEND_URL;
-      return;
-    }
-
-    process.env.FRONTEND_URL = originalFrontendUrl;
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    service = await createService(buildAuthConfig());
   });
 
   describe('register', () => {
@@ -409,9 +412,6 @@ describe('AuthService', () => {
 
   describe('onModuleInit (JWT_REFRESH_SECRET warning)', () => {
     it('JWT_REFRESH_SECRET 미설정 시 시작 경고 로그 출력', () => {
-      const originalRefreshSecret = process.env.JWT_REFRESH_SECRET;
-      delete process.env.JWT_REFRESH_SECRET;
-
       const warnSpy = jest.spyOn(service['logger'], 'warn');
 
       service.onModuleInit();
@@ -419,12 +419,14 @@ describe('AuthService', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('JWT_REFRESH_SECRET is not set'),
       );
-
-      process.env.JWT_REFRESH_SECRET = originalRefreshSecret;
     });
 
-    it('JWT_REFRESH_SECRET 설정 시 경고 로그 미출력', () => {
-      process.env.JWT_REFRESH_SECRET = 'separate-refresh-secret';
+    it('JWT_REFRESH_SECRET 설정 시 경고 로그 미출력', async () => {
+      service = await createService(
+        buildAuthConfig({
+          JWT_REFRESH_SECRET: 'separate-refresh-secret',
+        }),
+      );
 
       const warnSpy = jest.spyOn(service['logger'], 'warn');
 
@@ -433,8 +435,6 @@ describe('AuthService', () => {
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('JWT_REFRESH_SECRET is not set'),
       );
-
-      delete process.env.JWT_REFRESH_SECRET;
     });
   });
 

--- a/backend/src/modules/auth/__tests__/oauth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/oauth.service.spec.ts
@@ -9,6 +9,7 @@ import { OAuthService } from '../oauth.service';
 import { User, UserRole } from '../../users/entities/user.entity';
 import { UserAuthentication, OAuthProvider } from '../../users/entities/user-authentication.entity';
 import { TokenIssuerService } from '../services/token-issuer.service';
+import { AUTH_CONFIG, createAuthConfig } from '../../../config/auth.config';
 
 const mockUserRepository = {
   findOne: jest.fn(),
@@ -117,6 +118,22 @@ describe('OAuthService', () => {
         { provide: TokenIssuerService, useValue: mockTokenIssuerService },
         { provide: HttpService, useValue: mockHttpService },
         { provide: DataSource, useValue: mockDataSource },
+        {
+          provide: AUTH_CONFIG,
+          useValue: createAuthConfig({
+            NODE_ENV: 'development',
+            JWT_SECRET: 'jwt-secret',
+            JWT_PRIVATE_KEY: 'private-key',
+            JWT_PUBLIC_KEY: 'public-key',
+            FRONTEND_URL: 'https://frontend.test',
+            KAKAO_CLIENT_ID: 'kakao-client-id',
+            KAKAO_CLIENT_SECRET: 'kakao-secret',
+            KAKAO_REDIRECT_URI: 'https://frontend.test/auth/kakao/callback',
+            GOOGLE_CLIENT_ID: 'google-client-id',
+            GOOGLE_CLIENT_SECRET: 'google-secret',
+            GOOGLE_REDIRECT_URI: 'https://frontend.test/auth/google/callback',
+          }),
+        },
       ],
     }).compile();
 

--- a/backend/src/modules/auth/__tests__/token-issuer.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/token-issuer.service.spec.ts
@@ -4,6 +4,7 @@ import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
 import { User, UserRole } from '../../users/entities/user.entity';
 import { TokenIssuerService } from '../services/token-issuer.service';
+import { AUTH_CONFIG, createAuthConfig } from '../../../config/auth.config';
 
 const mockUserRepository = {
   update: jest.fn(),
@@ -57,6 +58,18 @@ describe('TokenIssuerService', () => {
         TokenIssuerService,
         { provide: JwtService, useValue: mockJwtService },
         { provide: getRepositoryToken(User), useValue: mockUserRepository },
+        {
+          provide: AUTH_CONFIG,
+          useValue: createAuthConfig({
+            NODE_ENV: 'development',
+            JWT_SECRET: 'jwt-secret',
+            JWT_PRIVATE_KEY: 'private-key',
+            JWT_PUBLIC_KEY: 'public-key',
+            FRONTEND_URL: 'https://frontend.test',
+            JWT_REFRESH_SECRET: 'refresh-secret',
+            JWT_REFRESH_EXPIRES_IN: '7d',
+          }),
+        },
       ],
     }).compile();
 
@@ -112,4 +125,3 @@ describe('TokenIssuerService', () => {
     expect(await bcrypt.compare('refresh-token', updatedPayload.refreshToken)).toBe(true);
   });
 });
-

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Inject,
   Controller,
   Post,
   Get,
@@ -29,6 +30,7 @@ import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { SkipThrottle, Throttle } from '@nestjs/throttler';
 import { JwtService } from '@nestjs/jwt';
+import { AUTH_CONFIG, AuthConfig } from '../../config/auth.config';
 
 interface JwtUser {
   id: number;
@@ -40,29 +42,29 @@ interface JwtUser {
 const ACCESS_TOKEN_MAX_AGE = 60 * 60 * 1000;
 const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
 
-function getBaseOptions(): CookieOptions {
+function getBaseOptions(secure: boolean): CookieOptions {
   return {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure,
     sameSite: 'strict',
   };
 }
 
-function setAuthCookies(res: Response, accessToken: string, refreshToken: string): void {
+function setAuthCookies(res: Response, accessToken: string, refreshToken: string, secure: boolean): void {
   res.cookie('accessToken', accessToken, {
-    ...getBaseOptions(),
+    ...getBaseOptions(secure),
     maxAge: ACCESS_TOKEN_MAX_AGE,
   });
   res.cookie('refreshToken', refreshToken, {
-    ...getBaseOptions(),
+    ...getBaseOptions(secure),
     maxAge: REFRESH_TOKEN_MAX_AGE,
     path: '/api/auth/refresh',
   });
 }
 
-function clearAuthCookies(res: Response): void {
-  res.clearCookie('accessToken', getBaseOptions());
-  res.clearCookie('refreshToken', { ...getBaseOptions(), path: '/api/auth/refresh' });
+function clearAuthCookies(res: Response, secure: boolean): void {
+  res.clearCookie('accessToken', getBaseOptions(secure));
+  res.clearCookie('refreshToken', { ...getBaseOptions(secure), path: '/api/auth/refresh' });
 }
 
 @Throttle({ auth: { limit: 30, ttl: 60000 } })
@@ -74,6 +76,8 @@ export class AuthController {
     private readonly authService: AuthService,
     private readonly oauthService: OAuthService,
     private readonly jwtService: JwtService,
+    @Inject(AUTH_CONFIG)
+    private readonly authConfig: AuthConfig,
   ) {}
 
   @Post('register')
@@ -83,7 +87,7 @@ export class AuthController {
   @ApiResponse({ status: 400, description: '입력값 오류 또는 이미 존재하는 이메일' })
   async register(@Body() dto: RegisterDto, @Res({ passthrough: true }) res: Response) {
     const { accessToken, refreshToken, user } = await this.authService.register(dto);
-    setAuthCookies(res, accessToken, refreshToken);
+    setAuthCookies(res, accessToken, refreshToken, this.authConfig.cookie.secure);
     return { user, accessToken, refreshToken };
   }
 
@@ -101,7 +105,7 @@ export class AuthController {
       null;
     const userAgent = req.headers['user-agent'] ?? null;
     const { accessToken, refreshToken, user } = await this.authService.login(dto, ip, userAgent);
-    setAuthCookies(res, accessToken, refreshToken);
+    setAuthCookies(res, accessToken, refreshToken, this.authConfig.cookie.secure);
     return { user, accessToken, refreshToken };
   }
 
@@ -190,7 +194,7 @@ export class AuthController {
   async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     const rawRefreshToken = (req.cookies as Record<string, string | undefined>)?.refreshToken ?? '';
     const { accessToken, refreshToken } = await this.authService.refresh(rawRefreshToken);
-    setAuthCookies(res, accessToken, refreshToken);
+    setAuthCookies(res, accessToken, refreshToken, this.authConfig.cookie.secure);
     return { message: '토큰이 갱신되었습니다.' };
   }
 
@@ -208,12 +212,12 @@ export class AuthController {
       if (decoded?.jti && decoded?.exp) {
         const expiresAt = new Date(decoded.exp * 1000);
         await this.authService.logout(user.id, decoded.jti, expiresAt);
-        clearAuthCookies(res);
+        clearAuthCookies(res, this.authConfig.cookie.secure);
         return;
       }
     }
     await this.authService.logoutAll(user.id);
-    clearAuthCookies(res);
+    clearAuthCookies(res, this.authConfig.cookie.secure);
   }
 
   @Post('logout-all')
@@ -225,7 +229,7 @@ export class AuthController {
   @ApiResponse({ status: 401, description: '인증 필요' })
   async logoutAll(@CurrentUser() user: JwtUser, @Res({ passthrough: true }) res: Response) {
     await this.authService.logoutAll(user.id);
-    clearAuthCookies(res);
+    clearAuthCookies(res, this.authConfig.cookie.secure);
   }
 
   @Post('kakao')
@@ -236,7 +240,7 @@ export class AuthController {
   @ApiResponse({ status: 400, description: '유효하지 않은 인가 코드' })
   async kakaoLogin(@Body() dto: OAuthCallbackDto, @Res({ passthrough: true }) res: Response) {
     const { accessToken, refreshToken, user } = await this.oauthService.handleKakao(dto.code);
-    setAuthCookies(res, accessToken, refreshToken);
+    setAuthCookies(res, accessToken, refreshToken, this.authConfig.cookie.secure);
     return { user };
   }
 
@@ -248,7 +252,7 @@ export class AuthController {
   @ApiResponse({ status: 400, description: '유효하지 않은 인가 코드' })
   async googleLogin(@Body() dto: OAuthCallbackDto, @Res({ passthrough: true }) res: Response) {
     const { accessToken, refreshToken, user } = await this.oauthService.handleGoogle(dto.code);
-    setAuthCookies(res, accessToken, refreshToken);
+    setAuthCookies(res, accessToken, refreshToken, this.authConfig.cookie.secure);
     return { user };
   }
 

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -18,17 +18,16 @@ import { User } from '../users/entities/user.entity';
 import { UserAuthentication } from '../users/entities/user-authentication.entity';
 import { AuditLogModule } from '../audit-logs/audit-log.module';
 import { AuthEventsModule } from './auth-events.module';
-import {
-  AUTH_CONFIG,
-  AuthConfig,
-  authConfigProvider,
-} from '../../config/auth.config';
+import { AUTH_CONFIG, AuthConfig } from '../../config/auth.config';
+import { AuthConfigModule } from '../../config/auth-config.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, UserAuthentication, PasswordResetToken, TokenBlacklist, VerificationToken]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
+    AuthConfigModule,
     JwtModule.registerAsync({
+      imports: [AuthConfigModule],
       inject: [AUTH_CONFIG],
       useFactory: (authConfig: AuthConfig) => ({
         privateKey: authConfig.jwt.privateKey,
@@ -44,7 +43,6 @@ import {
   ],
   controllers: [AuthController],
   providers: [
-    authConfigProvider,
     AuthService,
     OAuthService,
     TokenIssuerService,

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -3,9 +3,6 @@ import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
-import * as fs from 'fs';
-import * as path from 'path';
-import type ms from 'ms';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -21,38 +18,25 @@ import { User } from '../users/entities/user.entity';
 import { UserAuthentication } from '../users/entities/user-authentication.entity';
 import { AuditLogModule } from '../audit-logs/audit-log.module';
 import { AuthEventsModule } from './auth-events.module';
-
-function getJwtPrivateKey(): string {
-  if (process.env.JWT_PRIVATE_KEY) {
-    return process.env.JWT_PRIVATE_KEY;
-  }
-  if (process.env.JWT_PRIVATE_KEY_FILE && fs.existsSync(process.env.JWT_PRIVATE_KEY_FILE)) {
-    return fs.readFileSync(process.env.JWT_PRIVATE_KEY_FILE, 'utf-8');
-  }
-  const possiblePaths = [
-    path.resolve(process.cwd(), 'keys', 'jwt-private.pem'),
-    path.resolve(process.cwd(), '..', 'keys', 'jwt-private.pem'),
-    path.resolve(__dirname, '..', '..', 'keys', 'jwt-private.pem'),
-    path.resolve(__dirname, '..', '..', '..', 'keys', 'jwt-private.pem'),
-  ];
-  for (const keyPath of possiblePaths) {
-    if (fs.existsSync(keyPath)) {
-      return fs.readFileSync(keyPath, 'utf-8');
-    }
-  }
-  throw new Error('JWT_PRIVATE_KEY environment variable or keys/jwt-private.pem file is required');
-}
+import {
+  AUTH_CONFIG,
+  AuthConfig,
+  authConfigProvider,
+} from '../../config/auth.config';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, UserAuthentication, PasswordResetToken, TokenBlacklist, VerificationToken]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
-    JwtModule.register({
-      privateKey: getJwtPrivateKey(),
-      signOptions: {
-        expiresIn: (process.env.JWT_EXPIRES_IN ?? '1h') as ms.StringValue,
-        algorithm: 'RS256',
-      },
+    JwtModule.registerAsync({
+      inject: [AUTH_CONFIG],
+      useFactory: (authConfig: AuthConfig) => ({
+        privateKey: authConfig.jwt.privateKey,
+        signOptions: {
+          expiresIn: authConfig.jwt.expiresIn,
+          algorithm: 'RS256',
+        },
+      }),
     }),
     HttpModule,
     AuditLogModule,
@@ -60,6 +44,7 @@ function getJwtPrivateKey(): string {
   ],
   controllers: [AuthController],
   providers: [
+    authConfigProvider,
     AuthService,
     OAuthService,
     TokenIssuerService,

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -6,6 +6,7 @@ import {
   BadRequestException,
   Logger,
   OnModuleInit,
+  Inject,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
@@ -28,6 +29,7 @@ import { UserRegisteredEvent } from './events/user-registered.event';
 import { TokenIssuerService } from './services/token-issuer.service';
 import { AuthLoginPolicyService } from './services/auth-login-policy.service';
 import { AuthAuditService } from './services/auth-audit.service';
+import { AUTH_CONFIG, AuthConfig } from '../../config/auth.config';
 
 const PASSWORD_RESET_TTL_MS = 60 * 60 * 1000;
 const EMAIL_VERIFICATION_TTL_MIN = 15;
@@ -83,11 +85,13 @@ export class AuthService implements OnModuleInit {
     private readonly notificationService: NotificationService,
     private readonly tokenBlacklistService: TokenBlacklistService,
     private readonly authEventEmitter: AuthEventEmitter,
+    @Inject(AUTH_CONFIG)
+    private readonly authConfig: AuthConfig,
   ) {}
 
   onModuleInit() {
-    if (!process.env.JWT_REFRESH_SECRET) {
-      if (process.env.NODE_ENV === 'production') {
+    if (!this.authConfig.jwt.refreshSecret) {
+      if (this.authConfig.nodeEnv === 'production') {
         throw new Error('JWT_REFRESH_SECRET must be set in production');
       }
       this.logger.warn(
@@ -198,7 +202,7 @@ export class AuthService implements OnModuleInit {
     let payload: { sub: number; email: string; role: string; tokenType?: string };
     try {
       payload = this.jwtService.verify(rawRefreshToken, {
-        secret: process.env.JWT_REFRESH_SECRET ?? process.env.JWT_SECRET,
+        secret: this.authConfig.jwt.refreshSecret ?? this.authConfig.jwt.secret,
         algorithms: ['HS256'],
       });
     } catch {
@@ -390,12 +394,7 @@ export class AuthService implements OnModuleInit {
   }
 
   private buildPasswordResetUrl(token: string): string {
-    const baseUrl = process.env.FRONTEND_URL;
-    if (!baseUrl) {
-      throw new Error('FRONTEND_URL environment variable is required');
-    }
-
-    const url = new URL('/reset-password', baseUrl);
+    const url = new URL('/reset-password', this.authConfig.frontend.baseUrl);
     url.searchParams.set('token', token);
     return url.toString();
   }
@@ -405,12 +404,7 @@ export class AuthService implements OnModuleInit {
   }
 
   private buildEmailVerificationUrl(token: string): string {
-    const baseUrl = process.env.FRONTEND_URL;
-    if (!baseUrl) {
-      throw new Error('FRONTEND_URL environment variable is required');
-    }
-
-    const url = new URL('/verify-email', baseUrl);
+    const url = new URL('/verify-email', this.authConfig.frontend.baseUrl);
     url.searchParams.set('token', token);
     return url.toString();
   }

--- a/backend/src/modules/auth/oauth.service.ts
+++ b/backend/src/modules/auth/oauth.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   NotFoundException,
   Logger,
+  Inject,
 } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
@@ -15,6 +16,7 @@ import {
   OAuthProvider,
 } from '../users/entities/user-authentication.entity';
 import { TokenIssuerService } from './services/token-issuer.service';
+import { AUTH_CONFIG, AuthConfig } from '../../config/auth.config';
 
 export interface OAuthAuthResponse {
   accessToken: string;
@@ -66,6 +68,8 @@ export class OAuthService {
     private readonly httpService: HttpService,
     @InjectDataSource()
     private readonly dataSource: DataSource,
+    @Inject(AUTH_CONFIG)
+    private readonly authConfig: AuthConfig,
   ) {}
 
   async disconnect(userId: number, provider: OAuthProvider): Promise<void> {
@@ -198,9 +202,9 @@ export class OAuthService {
     try {
       const params = new URLSearchParams({
         grant_type: 'authorization_code',
-        client_id: process.env.KAKAO_CLIENT_ID ?? '',
-        client_secret: process.env.KAKAO_CLIENT_SECRET ?? '',
-        redirect_uri: process.env.KAKAO_REDIRECT_URI ?? '',
+        client_id: this.authConfig.oauth.kakao.clientId,
+        client_secret: this.authConfig.oauth.kakao.clientSecret,
+        redirect_uri: this.authConfig.oauth.kakao.redirectUri,
         code,
       });
 
@@ -234,9 +238,9 @@ export class OAuthService {
     try {
       const params = new URLSearchParams({
         grant_type: 'authorization_code',
-        client_id: process.env.GOOGLE_CLIENT_ID ?? '',
-        client_secret: process.env.GOOGLE_CLIENT_SECRET ?? '',
-        redirect_uri: process.env.GOOGLE_REDIRECT_URI ?? '',
+        client_id: this.authConfig.oauth.google.clientId,
+        client_secret: this.authConfig.oauth.google.clientSecret,
+        redirect_uri: this.authConfig.oauth.google.redirectUri,
         code,
       });
 

--- a/backend/src/modules/auth/services/token-issuer.service.ts
+++ b/backend/src/modules/auth/services/token-issuer.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { Repository } from 'typeorm';
@@ -6,6 +6,7 @@ import * as bcrypt from 'bcrypt';
 import { randomUUID } from 'crypto';
 import type ms from 'ms';
 import { User } from '../../users/entities/user.entity';
+import { AUTH_CONFIG, AuthConfig } from '../../../config/auth.config';
 
 export interface TokenPair {
   accessToken: string;
@@ -18,18 +19,20 @@ export class TokenIssuerService {
     private readonly jwtService: JwtService,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @Inject(AUTH_CONFIG)
+    private readonly authConfig: AuthConfig,
   ) {}
 
   issueTokens(user: Pick<User, 'id' | 'email' | 'role'>): TokenPair {
     const payload = { sub: user.id, email: user.email, role: user.role };
     const jti = randomUUID();
     const accessToken = this.jwtService.sign({ ...payload, tokenType: 'access', jti });
-    const refreshExpiresIn = (process.env.JWT_REFRESH_EXPIRES_IN ?? '7d') as ms.StringValue;
-    const refreshSecret = process.env.JWT_REFRESH_SECRET;
+    const refreshExpiresIn = this.authConfig.jwt.refreshExpiresIn as ms.StringValue;
+    const refreshSecret = this.authConfig.jwt.refreshSecret;
     const refreshToken = this.jwtService.sign(
       { ...payload, tokenType: 'refresh' },
       {
-        secret: refreshSecret ?? process.env.JWT_SECRET,
+        secret: refreshSecret ?? this.authConfig.jwt.secret,
         expiresIn: refreshExpiresIn,
         algorithm: 'HS256',
       },
@@ -44,4 +47,3 @@ export class TokenIssuerService {
     return tokens;
   }
 }
-

--- a/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { JwtStrategy } from './jwt.strategy';
 import { User } from '../../users/entities/user.entity';
 import { TokenBlacklistService } from '../token-blacklist.service';
+import { createAuthConfig } from '../../../config/auth.config';
 
 const mockUserRepository = {
   findOne: jest.fn(),
@@ -18,18 +19,19 @@ describe('JwtStrategy', () => {
   let strategy: JwtStrategy;
 
   beforeEach(() => {
-    process.env.JWT_SECRET = 'test-secret';
-    process.env.JWT_PUBLIC_KEY = 'test-public-key';
     jest.clearAllMocks();
 
     strategy = new JwtStrategy(
       mockUserRepository as unknown as Repository<User>,
       mockTokenBlacklistService as unknown as TokenBlacklistService,
+      createAuthConfig({
+        NODE_ENV: 'development',
+        JWT_SECRET: 'test-secret',
+        JWT_PRIVATE_KEY: 'test-private-key',
+        JWT_PUBLIC_KEY: 'test-public-key',
+        FRONTEND_URL: 'https://frontend.test',
+      }),
     );
-  });
-
-  afterEach(() => {
-    delete process.env.JWT_PUBLIC_KEY;
   });
 
   describe('validate()', () => {

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,13 +1,12 @@
-import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException, Logger } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import * as fs from 'fs';
-import * as path from 'path';
 import type { Request } from 'express';
 import { User } from '../../users/entities/user.entity';
 import { TokenBlacklistService } from '../token-blacklist.service';
+import { AUTH_CONFIG, AuthConfig } from '../../../config/auth.config';
 
 export interface JwtPayload {
   sub: number;
@@ -24,20 +23,6 @@ function cookieExtractor(req: Request): string | null {
   return null;
 }
 
-function getJwtPublicKey(): string {
-  if (process.env.JWT_PUBLIC_KEY) {
-    return process.env.JWT_PUBLIC_KEY;
-  }
-  if (process.env.JWT_PUBLIC_KEY_FILE && fs.existsSync(process.env.JWT_PUBLIC_KEY_FILE)) {
-    return fs.readFileSync(process.env.JWT_PUBLIC_KEY_FILE, 'utf-8');
-  }
-  const keyPath = path.resolve(process.cwd(), 'keys', 'jwt-public.pem');
-  if (fs.existsSync(keyPath)) {
-    return fs.readFileSync(keyPath, 'utf-8');
-  }
-  throw new Error('JWT_PUBLIC_KEY environment variable or keys/jwt-public.pem file is required');
-}
-
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   private readonly logger = new Logger(JwtStrategy.name);
@@ -46,6 +31,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
     private readonly tokenBlacklistService: TokenBlacklistService,
+    @Inject(AUTH_CONFIG)
+    authConfig: AuthConfig,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
@@ -53,7 +40,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         ExtractJwt.fromAuthHeaderAsBearerToken(),
       ]),
       ignoreExpiration: false,
-      secretOrKey: getJwtPublicKey(),
+      secretOrKey: authConfig.jwt.publicKey,
       algorithms: ['RS256'],
       passReqToCallback: false,
     });

--- a/backend/src/modules/notification/adapters/resend.adapter.ts
+++ b/backend/src/modules/notification/adapters/resend.adapter.ts
@@ -1,5 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { EmailMessage, EmailProvider, EmailSendResult } from '../interfaces/email-provider.interface';
+import {
+  NOTIFICATION_CONFIG,
+  NotificationConfig,
+} from '../../../config/notification.config';
 
 @Injectable()
 export class ResendEmailAdapter implements EmailProvider {
@@ -7,9 +11,12 @@ export class ResendEmailAdapter implements EmailProvider {
   private readonly apiKey: string;
   private readonly fromAddress: string;
 
-  constructor() {
-    this.apiKey = process.env.RESEND_API_KEY ?? '';
-    this.fromAddress = process.env.EMAIL_FROM ?? 'no-reply@okhwadang.com';
+  constructor(
+    @Inject(NOTIFICATION_CONFIG)
+    config: NotificationConfig,
+  ) {
+    this.apiKey = config.resend.apiKey;
+    this.fromAddress = config.resend.fromAddress;
     if (!this.apiKey) {
       this.logger.warn('RESEND_API_KEY not set — ResendEmailAdapter will fail on send.');
     }

--- a/backend/src/modules/notification/notification.module.ts
+++ b/backend/src/modules/notification/notification.module.ts
@@ -3,34 +3,32 @@ import { NotificationService, EMAIL_PROVIDER_TOKEN } from './notification.servic
 import { MockEmailAdapter } from './adapters/mock.adapter';
 import { ResendEmailAdapter } from './adapters/resend.adapter';
 import { SesEmailAdapter } from './adapters/ses.adapter';
+import {
+  NotificationConfig,
+  NOTIFICATION_CONFIG,
+  notificationConfigProvider,
+} from '../../config/notification.config';
 
-export function resolveNotificationProvider(): string {
-  const provider = process.env.NOTIFICATION_PROVIDER ?? 'mock';
-  if (
-    process.env.NODE_ENV === 'production' &&
-    (provider === 'mock' || !process.env.NOTIFICATION_PROVIDER)
-  ) {
-    throw new Error(
-      'Mock notification provider는 프로덕션에서 사용할 수 없습니다. NOTIFICATION_PROVIDER 환경변수를 설정하세요.',
-    );
-  }
-  return provider;
+export function resolveNotificationProvider(config: NotificationConfig): string {
+  return config.provider;
 }
 
 @Global()
 @Module({
   providers: [
+    notificationConfigProvider,
     MockEmailAdapter,
     ResendEmailAdapter,
     SesEmailAdapter,
     {
       provide: EMAIL_PROVIDER_TOKEN,
       useFactory: (
+        config: NotificationConfig,
         mock: MockEmailAdapter,
         resend: ResendEmailAdapter,
         ses: SesEmailAdapter,
       ) => {
-        const name = resolveNotificationProvider();
+        const name = resolveNotificationProvider(config);
         switch (name) {
           case 'resend':
             return resend;
@@ -42,7 +40,7 @@ export function resolveNotificationProvider(): string {
             throw new Error(`Unknown NOTIFICATION_PROVIDER: ${name}`);
         }
       },
-      inject: [MockEmailAdapter, ResendEmailAdapter, SesEmailAdapter],
+      inject: [NOTIFICATION_CONFIG, MockEmailAdapter, ResendEmailAdapter, SesEmailAdapter],
     },
     NotificationService,
   ],

--- a/backend/src/modules/payments/__tests__/payments.module.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.module.spec.ts
@@ -1,47 +1,40 @@
-import { resolvePaymentGateway } from '../payments.module';
+import { createPaymentConfig } from '../../../config/payment.config';
 
-describe('resolvePaymentGateway — 프로덕션 Mock 차단', () => {
-  const originalNodeEnv = process.env.NODE_ENV;
-  const originalGateway = process.env.PAYMENT_GATEWAY;
-
-  afterEach(() => {
-    process.env.NODE_ENV = originalNodeEnv;
-    if (originalGateway === undefined) {
-      delete process.env.PAYMENT_GATEWAY;
-    } else {
-      process.env.PAYMENT_GATEWAY = originalGateway;
-    }
-  });
-
+describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
   it('NODE_ENV=production, PAYMENT_GATEWAY=mock → 시작 실패', () => {
-    process.env.NODE_ENV = 'production';
-    process.env.PAYMENT_GATEWAY = 'mock';
-
-    expect(() => resolvePaymentGateway()).toThrow(
+    expect(() =>
+      createPaymentConfig({
+        NODE_ENV: 'production',
+        PAYMENT_GATEWAY: 'mock',
+      }),
+    ).toThrow(
       'Mock payment gateway는 프로덕션에서 사용할 수 없습니다',
     );
   });
 
   it('NODE_ENV=production, PAYMENT_GATEWAY 미설정 → 시작 실패', () => {
-    process.env.NODE_ENV = 'production';
-    delete process.env.PAYMENT_GATEWAY;
-
-    expect(() => resolvePaymentGateway()).toThrow(
+    expect(() =>
+      createPaymentConfig({
+        NODE_ENV: 'production',
+      }),
+    ).toThrow(
       'Mock payment gateway는 프로덕션에서 사용할 수 없습니다',
     );
   });
 
   it('NODE_ENV=development, PAYMENT_GATEWAY=mock → 정상 동작', () => {
-    process.env.NODE_ENV = 'development';
-    process.env.PAYMENT_GATEWAY = 'mock';
-
-    expect(resolvePaymentGateway()).toBe('mock');
+    const config = createPaymentConfig({
+      NODE_ENV: 'development',
+      PAYMENT_GATEWAY: 'mock',
+    });
+    expect(config.gateway).toBe('mock');
   });
 
   it('NODE_ENV=production, PAYMENT_GATEWAY=toss → 정상 동작', () => {
-    process.env.NODE_ENV = 'production';
-    process.env.PAYMENT_GATEWAY = 'toss';
-
-    expect(resolvePaymentGateway()).toBe('toss');
+    const config = createPaymentConfig({
+      NODE_ENV: 'production',
+      PAYMENT_GATEWAY: 'toss',
+    });
+    expect(config.gateway).toBe('toss');
   });
 });

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -12,6 +12,7 @@ import { MockPaymentAdapter, MOCK_TEST_SIGNATURE } from '../adapters/mock.adapte
 import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
 import { NotificationService } from '../../notification/notification.service';
+import { PAYMENT_CONFIG, createPaymentConfig } from '../../../config/payment.config';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order =>
   ({
@@ -150,6 +151,14 @@ describe('PaymentsService', () => {
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockShippingRepo },
         { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
+        {
+          provide: PAYMENT_CONFIG,
+          useValue: createPaymentConfig({
+            NODE_ENV: 'development',
+            PAYMENT_GATEWAY: 'mock',
+            DEFAULT_CARRIER: 'mock',
+          }),
+        },
         { provide: 'PaymentGateway', useValue: mockDefaultGateway },
         { provide: TossPaymentAdapter, useValue: mockTossAdapter },
         { provide: StripePaymentAdapter, useValue: mockStripeAdapter },

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -11,6 +11,7 @@ import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
 import { User } from '../../users/entities/user.entity';
 import { NotificationService } from '../../notification/notification.service';
+import { PAYMENT_CONFIG, createPaymentConfig } from '../../../config/payment.config';
 
 describe('PaymentsService — webhook', () => {
   let service: PaymentsService;
@@ -49,6 +50,14 @@ describe('PaymentsService — webhook', () => {
         { provide: getRepositoryToken(Shipping), useValue: mockRepo },
         { provide: getRepositoryToken(User), useValue: mockRepo },
         { provide: 'PaymentGateway', useValue: mockGateway },
+        {
+          provide: PAYMENT_CONFIG,
+          useValue: createPaymentConfig({
+            NODE_ENV: 'development',
+            PAYMENT_GATEWAY: 'mock',
+            DEFAULT_CARRIER: 'mock',
+          }),
+        },
         { provide: TossPaymentAdapter, useValue: mockGateway },
         { provide: StripePaymentAdapter, useValue: mockGateway },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },

--- a/backend/src/modules/payments/__tests__/stripe.adapter.spec.ts
+++ b/backend/src/modules/payments/__tests__/stripe.adapter.spec.ts
@@ -1,4 +1,5 @@
 import { BadGatewayException } from '@nestjs/common';
+import { createPaymentConfig } from '../../../config/payment.config';
 
 // Shared mock refs — assigned after mock module loads
 const mocks = {
@@ -26,15 +27,19 @@ describe('StripePaymentAdapter', () => {
   let adapter: StripePaymentAdapter;
 
   beforeEach(() => {
-    process.env.STRIPE_SECRET_KEY = 'sk_test_secret';
-    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test_publishable';
-    process.env.STRIPE_WEBHOOK_SECRET = 'test_webhook_secret';
-
     mocks.paymentIntentsCreate.mockReset();
     mocks.paymentIntentsRetrieve.mockReset();
     mocks.refundsCreate.mockReset();
 
-    adapter = new StripePaymentAdapter();
+    adapter = new StripePaymentAdapter(
+      createPaymentConfig({
+        NODE_ENV: 'development',
+        PAYMENT_GATEWAY: 'stripe',
+        STRIPE_SECRET_KEY: 'sk_test_secret',
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: 'pk_test_publishable',
+        STRIPE_WEBHOOK_SECRET: 'test_webhook_secret',
+      }),
+    );
   });
 
   describe('prepare', () => {

--- a/backend/src/modules/payments/__tests__/toss.adapter.spec.ts
+++ b/backend/src/modules/payments/__tests__/toss.adapter.spec.ts
@@ -1,5 +1,6 @@
 import { BadGatewayException } from '@nestjs/common';
 import { TossPaymentAdapter } from '../adapters/toss.adapter';
+import { createPaymentConfig } from '../../../config/payment.config';
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
@@ -8,7 +9,14 @@ describe('TossPaymentAdapter', () => {
   let adapter: TossPaymentAdapter;
 
   beforeEach(() => {
-    adapter = new TossPaymentAdapter();
+    adapter = new TossPaymentAdapter(
+      createPaymentConfig({
+        NODE_ENV: 'development',
+        PAYMENT_GATEWAY: 'toss',
+        TOSS_SECRET_KEY: 'test_secret',
+        TOSS_CLIENT_KEY: 'test_ck_abc',
+      }),
+    );
     jest.clearAllMocks();
   });
 
@@ -78,7 +86,6 @@ describe('TossPaymentAdapter', () => {
 
   describe('verifyWebhook', () => {
     it('올바른 서명 → true', () => {
-      process.env.TOSS_SECRET_KEY = 'test_secret';
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const crypto = require('crypto');
       const payload = { eventType: 'PAYMENT_STATUS_CHANGED' };
@@ -91,7 +98,6 @@ describe('TossPaymentAdapter', () => {
     });
 
     it('잘못된 서명 → false', () => {
-      process.env.TOSS_SECRET_KEY = 'test_secret';
       expect(adapter.verifyWebhook({ event: 'test' }, 'wrong_signature')).toBe(
         false,
       );
@@ -100,7 +106,6 @@ describe('TossPaymentAdapter', () => {
 
   describe('prepare', () => {
     it('clientKey 반환', async () => {
-      process.env.TOSS_CLIENT_KEY = 'test_ck_abc';
       const result = await adapter.prepare('ORDER-123', 50000);
       expect(result.clientKey).toBe('test_ck_abc');
       expect(result.orderId).toBe('ORDER-123');

--- a/backend/src/modules/payments/adapters/stripe.adapter.ts
+++ b/backend/src/modules/payments/adapters/stripe.adapter.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
 import Stripe from 'stripe';
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { BadGatewayException } from '@nestjs/common';
 import {
   PaymentGateway,
@@ -10,14 +10,22 @@ import {
   PartialCancelParams,
   PartialCancelResult,
 } from '../interfaces/payment-gateway.interface';
+import { PAYMENT_CONFIG, PaymentConfig } from '../../../config/payment.config';
 
 @Injectable()
 export class StripePaymentAdapter implements PaymentGateway {
   private readonly logger = new Logger(StripePaymentAdapter.name);
   private readonly stripe: Stripe | null;
+  private readonly publishableKey: string;
+  private readonly webhookSecret: string;
 
-  constructor() {
-    const secretKey = process.env.STRIPE_SECRET_KEY;
+  constructor(
+    @Inject(PAYMENT_CONFIG)
+    config: PaymentConfig,
+  ) {
+    const secretKey = config.stripe.secretKey;
+    this.publishableKey = config.stripe.publishableKey;
+    this.webhookSecret = config.stripe.webhookSecret;
     if (secretKey) {
       this.stripe = new Stripe(secretKey);
     } else {
@@ -31,14 +39,6 @@ export class StripePaymentAdapter implements PaymentGateway {
       throw new BadGatewayException('Stripe is not configured');
     }
     return this.stripe;
-  }
-
-  private get publishableKey(): string {
-    return process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '';
-  }
-
-  private get webhookSecret(): string {
-    return process.env.STRIPE_WEBHOOK_SECRET ?? '';
   }
 
   async prepare(orderId: string, amount: number): Promise<PrepareResult> {

--- a/backend/src/modules/payments/adapters/toss.adapter.ts
+++ b/backend/src/modules/payments/adapters/toss.adapter.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { BadGatewayException } from '@nestjs/common';
 import {
   PaymentGateway,
@@ -9,17 +9,20 @@ import {
   PartialCancelParams,
   PartialCancelResult,
 } from '../interfaces/payment-gateway.interface';
+import { PAYMENT_CONFIG, PaymentConfig } from '../../../config/payment.config';
 
 @Injectable()
 export class TossPaymentAdapter implements PaymentGateway {
   private readonly logger = new Logger(TossPaymentAdapter.name);
+  private readonly secretKey: string;
+  private readonly clientKey: string;
 
-  private get secretKey(): string {
-    return process.env.TOSS_SECRET_KEY ?? '';
-  }
-
-  private get clientKey(): string {
-    return process.env.TOSS_CLIENT_KEY ?? '';
+  constructor(
+    @Inject(PAYMENT_CONFIG)
+    config: PaymentConfig,
+  ) {
+    this.secretKey = config.toss.secretKey;
+    this.clientKey = config.toss.clientKey;
   }
 
   private get authHeader(): string {

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -11,18 +11,14 @@ import { AdminOrderRefundsController } from './admin-order-refunds.controller';
 import { MockPaymentAdapter } from './adapters/mock.adapter';
 import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
+import {
+  PAYMENT_CONFIG,
+  PaymentConfig,
+  paymentConfigProvider,
+} from '../../config/payment.config';
 
-export function resolvePaymentGateway(): string {
-  const gateway = process.env.PAYMENT_GATEWAY ?? 'mock';
-  if (
-    process.env.NODE_ENV === 'production' &&
-    (gateway === 'mock' || !process.env.PAYMENT_GATEWAY)
-  ) {
-    throw new Error(
-      'Mock payment gateway는 프로덕션에서 사용할 수 없습니다. PAYMENT_GATEWAY 환경변수를 설정하세요.',
-    );
-  }
-  return gateway;
+export function resolvePaymentGateway(config: PaymentConfig): string {
+  return config.gateway;
 }
 
 /**
@@ -35,25 +31,32 @@ export function resolveGatewayByLocale(locale: string): string {
 }
 
 const gatewayProviders = [
+  paymentConfigProvider,
+  MockPaymentAdapter,
+  TossPaymentAdapter,
+  StripePaymentAdapter,
   {
     provide: 'PaymentGateway',
-    useFactory: () => {
-      const gateway = resolvePaymentGateway();
+    useFactory: (
+      config: PaymentConfig,
+      mock: MockPaymentAdapter,
+      toss: TossPaymentAdapter,
+      stripe: StripePaymentAdapter,
+    ) => {
+      const gateway = resolvePaymentGateway(config);
       switch (gateway) {
         case 'toss':
-          return new TossPaymentAdapter();
+          return toss;
         case 'stripe':
-          return new StripePaymentAdapter();
+          return stripe;
         case 'mock':
-          return new MockPaymentAdapter();
+          return mock;
         default:
           throw new Error(`Unknown PAYMENT_GATEWAY: ${gateway}`);
       }
     },
+    inject: [PAYMENT_CONFIG, MockPaymentAdapter, TossPaymentAdapter, StripePaymentAdapter],
   },
-  MockPaymentAdapter,
-  TossPaymentAdapter,
-  StripePaymentAdapter,
 ];
 
 @Module({

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -23,8 +23,7 @@ import { NotificationService } from '../notification/notification.service';
 import { PaymentConfirmationService } from './services/payment-confirmation.service';
 import { PaymentRefundService } from './services/payment-refund.service';
 import { PaymentWebhookService } from './services/payment-webhook.service';
-
-const DEFAULT_CARRIER = process.env.DEFAULT_CARRIER || 'mock';
+import { PAYMENT_CONFIG, PaymentConfig } from '../../config/payment.config';
 
 @Injectable()
 export class PaymentsService {
@@ -46,6 +45,8 @@ export class PaymentsService {
     private readonly userRepository: Repository<User>,
     @Inject('PaymentGateway')
     private readonly gateway: PaymentGateway,
+    @Inject(PAYMENT_CONFIG)
+    private readonly paymentConfig: PaymentConfig,
     private readonly tossAdapter: TossPaymentAdapter,
     private readonly stripeAdapter: StripePaymentAdapter,
     private readonly notificationService: NotificationService,
@@ -60,7 +61,7 @@ export class PaymentsService {
       notificationService: this.notificationService,
       resolveGatewayByType: (gatewayType) => this.resolveGatewayByType(gatewayType),
       logger: this.logger,
-      defaultCarrier: DEFAULT_CARRIER,
+      defaultCarrier: this.paymentConfig.defaultCarrier,
     });
     this.paymentRefundService = new PaymentRefundService({
       paymentRepository: this.paymentRepository,

--- a/backend/src/modules/upload/__tests__/upload.service.spec.ts
+++ b/backend/src/modules/upload/__tests__/upload.service.spec.ts
@@ -4,9 +4,7 @@ import { UploadService } from '../upload.service';
 import { LocalStorageAdapter } from '../adapters/local.adapter';
 import { MockStorageAdapter } from '../adapters/mock.adapter';
 import { S3StorageAdapter } from '../adapters/s3.adapter';
-
-// Use mock adapter in tests
-process.env.STORAGE_PROVIDER = 'mock';
+import { STORAGE_CONFIG, createStorageConfig } from '../../../config/storage.config';
 
 // Real JPEG magic bytes: FF D8 FF
 const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00]);
@@ -51,6 +49,10 @@ describe('UploadService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: STORAGE_CONFIG,
+          useValue: createStorageConfig({ STORAGE_PROVIDER: 'mock' }),
+        },
         UploadService,
         LocalStorageAdapter,
         MockStorageAdapter,

--- a/backend/src/modules/upload/adapters/s3.adapter.ts
+++ b/backend/src/modules/upload/adapters/s3.adapter.ts
@@ -1,10 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
   S3Client,
   PutObjectCommand,
   DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
 import { StorageAdapter, UploadedFile } from '../interfaces/storage.interface';
+import { STORAGE_CONFIG, StorageConfig } from '../../../config/storage.config';
 
 @Injectable()
 export class S3StorageAdapter implements StorageAdapter {
@@ -14,16 +15,19 @@ export class S3StorageAdapter implements StorageAdapter {
   private readonly region: string;
   private readonly cdnUrl: string | null;
 
-  constructor() {
-    this.bucket = process.env.AWS_S3_BUCKET_NAME ?? '';
-    this.region = process.env.AWS_REGION ?? 'ap-northeast-2';
-    this.cdnUrl = process.env.AWS_CDN_URL ?? null;
+  constructor(
+    @Inject(STORAGE_CONFIG)
+    config: StorageConfig,
+  ) {
+    this.bucket = config.s3.bucket;
+    this.region = config.s3.region;
+    this.cdnUrl = config.s3.cdnUrl;
 
     this.client = new S3Client({
       region: this.region,
       credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+        accessKeyId: config.s3.accessKeyId,
+        secretAccessKey: config.s3.secretAccessKey,
       },
     });
 

--- a/backend/src/modules/upload/upload.module.ts
+++ b/backend/src/modules/upload/upload.module.ts
@@ -4,10 +4,17 @@ import { UploadService } from './upload.service';
 import { LocalStorageAdapter } from './adapters/local.adapter';
 import { MockStorageAdapter } from './adapters/mock.adapter';
 import { S3StorageAdapter } from './adapters/s3.adapter';
+import { storageConfigProvider } from '../../config/storage.config';
 
 @Module({
   controllers: [UploadController],
-  providers: [UploadService, LocalStorageAdapter, MockStorageAdapter, S3StorageAdapter],
+  providers: [
+    storageConfigProvider,
+    UploadService,
+    LocalStorageAdapter,
+    MockStorageAdapter,
+    S3StorageAdapter,
+  ],
   exports: [UploadService],
 })
 export class UploadModule {}

--- a/backend/src/modules/upload/upload.service.ts
+++ b/backend/src/modules/upload/upload.service.ts
@@ -1,4 +1,5 @@
 import {
+  Inject,
   Injectable,
   BadRequestException,
   PayloadTooLargeException,
@@ -17,6 +18,10 @@ import {
   MAX_UPLOAD_IMAGE_HEIGHT,
   MAX_UPLOAD_IMAGE_WIDTH,
 } from './upload.constants';
+import {
+  STORAGE_CONFIG,
+  StorageConfig,
+} from '../../config/storage.config';
 
 @Injectable()
 export class UploadService {
@@ -24,11 +29,13 @@ export class UploadService {
   private readonly adapter: StorageAdapter;
 
   constructor(
+    @Inject(STORAGE_CONFIG)
+    storageConfig: StorageConfig,
     localAdapter: LocalStorageAdapter,
     mockAdapter: MockStorageAdapter,
     s3Adapter: S3StorageAdapter,
   ) {
-    const provider = process.env.STORAGE_PROVIDER ?? 'local';
+    const provider = storageConfig.provider;
     switch (provider) {
       case 's3':
         this.adapter = s3Adapter;


### PR DESCRIPTION
## 요약
- auth/payment/notification/upload 도메인의 process.env 직접 참조를 config provider 경계로 이동
- 도메인 서비스/모듈/어댑터는 typed config 주입만 사용하도록 정리
- 기존 부팅 정책(프로덕션 mock 차단, JWT refresh secret, 키 로딩) 유지

## 테스트
- cd backend && npm run build && npm run test
- npx tsc --noEmit --pretty false --project backend/tsconfig.json

Closes #604