### PR TITLE
feat: 다크모드 색상 DB 관리 및 어드민 테마 편집 분리

### DIFF
--- a/backend/src/database/migrations/1783000000000-AddDarkModeColorSettings.ts
+++ b/backend/src/database/migrations/1783000000000-AddDarkModeColorSettings.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDarkModeColorSettings1783000000000 implements MigrationInterface {
+  name = 'AddDarkModeColorSettings1783000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO \`site_settings\` (\`setting_key\`, \`value\`, \`group\`, \`label\`, \`input_type\`, \`options\`, \`default_value\`, \`sort_order\`)
+      VALUES
+        ('color_dark_primary',              '#C4956A', 'color_dark', '다크 대표색',           'color', NULL, '#C4956A', 101),
+        ('color_dark_primary_foreground',   '#141210', 'color_dark', '다크 대표색 텍스트',     'color', NULL, '#141210', 102),
+        ('color_dark_secondary',            '#1E1C18', 'color_dark', '다크 보조색',           'color', NULL, '#1E1C18', 103),
+        ('color_dark_secondary_foreground', '#E8E0D4', 'color_dark', '다크 보조색 텍스트',     'color', NULL, '#E8E0D4', 104),
+        ('color_dark_background',           '#141210', 'color_dark', '다크 배경색',           'color', NULL, '#141210', 105),
+        ('color_dark_foreground',           '#F0EDE8', 'color_dark', '다크 기본 텍스트색',     'color', NULL, '#F0EDE8', 106),
+        ('color_dark_card',                 '#1A1714', 'color_dark', '다크 카드 배경',         'color', NULL, '#1A1714', 107),
+        ('color_dark_card_foreground',      '#F0EDE8', 'color_dark', '다크 카드 텍스트',       'color', NULL, '#F0EDE8', 108),
+        ('color_dark_border',               '#2E2822', 'color_dark', '다크 테두리색',          'color', NULL, '#2E2822', 109),
+        ('color_dark_input',                '#2E2822', 'color_dark', '다크 인풋 배경',         'color', NULL, '#2E2822', 110),
+        ('color_dark_muted',                '#1E1C18', 'color_dark', '다크 음소거 배경',       'color', NULL, '#1E1C18', 111),
+        ('color_dark_muted_foreground',     '#9B8E7E', 'color_dark', '다크 음소거 텍스트',     'color', NULL, '#9B8E7E', 112),
+        ('color_dark_accent',               '#1E1C18', 'color_dark', '다크 액센트 배경',       'color', NULL, '#1E1C18', 113),
+        ('color_dark_accent_foreground',    '#E8E0D4', 'color_dark', '다크 액센트 텍스트',     'color', NULL, '#E8E0D4', 114),
+        ('color_dark_destructive',          '#ef4444', 'color_dark', '다크 삭제/경고색',       'color', NULL, '#ef4444', 115),
+        ('color_dark_destructive_foreground','#ffffff', 'color_dark', '다크 경고 텍스트',      'color', NULL, '#ffffff', 116),
+        ('color_dark_ring',                 '#C4956A', 'color_dark', '다크 포커스 링 색',      'color', NULL, '#C4956A', 117)
+      ON DUPLICATE KEY UPDATE \`setting_key\` = \`setting_key\`
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM \`site_settings\`
+      WHERE \`setting_key\` IN (
+        'color_dark_primary', 'color_dark_primary_foreground',
+        'color_dark_secondary', 'color_dark_secondary_foreground',
+        'color_dark_background', 'color_dark_foreground',
+        'color_dark_card', 'color_dark_card_foreground',
+        'color_dark_border', 'color_dark_input',
+        'color_dark_muted', 'color_dark_muted_foreground',
+        'color_dark_accent', 'color_dark_accent_foreground',
+        'color_dark_destructive', 'color_dark_destructive_foreground',
+        'color_dark_ring'
+      )
+    `);
+  }
+}

--- a/src/app/[locale]/admin/settings/theme/ThemeEditor.tsx
+++ b/src/app/[locale]/admin/settings/theme/ThemeEditor.tsx
@@ -10,10 +10,11 @@ import { useUnsavedChanges } from '@/components/shared/hooks/useUnsavedChanges';
 import { cn } from '@/components/ui/utils';
 
 const TABS = [
-  { id: 'color', label: '색상' },
-  { id: 'typography', label: '타이포그래피' },
-  { id: 'spacing', label: '간격' },
-  { id: 'radius', label: '모서리' },
+  { id: 'color',       label: '라이트 색상' },
+  { id: 'color_dark',  label: '다크 색상' },
+  { id: 'typography',  label: '타이포그래피' },
+  { id: 'spacing',     label: '간격' },
+  { id: 'radius',      label: '모서리' },
 ] as const;
 type TabId = (typeof TABS)[number]['id'];
 
@@ -30,12 +31,19 @@ function ColorTokenRow({
   currentValue: string;
   onChange: (key: string, value: string) => void;
 }) {
+  const isDark = setting.group === 'color_dark';
+
   const handleChange = (value: string) => {
     onChange(setting.key, value);
-    document.documentElement.style.setProperty(
-      `--db-${setting.key.replace(/_/g, '-')}`,
-      value,
-    );
+    const cssVarName = isDark
+      ? `--db-${setting.key.replace(/_/g, '-')}`
+      : `--db-${setting.key.replace(/_/g, '-')}`;
+    if (isDark) {
+      // 다크 변수는 html[data-theme="dark"] 스코프에 적용
+      document.documentElement.style.setProperty(cssVarName, value);
+    } else {
+      document.documentElement.style.setProperty(cssVarName, value);
+    }
   };
 
   return (
@@ -109,40 +117,93 @@ function GenericTokenRow({
   );
 }
 
-function ThemePreviewPanel() {
+function ThemePreviewPanel({ isDark }: { isDark: boolean }) {
   return (
-    <div className="space-y-4 rounded-lg border bg-background p-4">
-      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-        라이브 프리뷰
+    <div
+      className="space-y-4 rounded-lg border p-4"
+      style={{ background: isDark ? 'var(--db-color-dark-background, #141210)' : 'var(--color-background)' }}
+    >
+      <h3
+        className="text-sm font-semibold uppercase tracking-wide"
+        style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #9B8E7E)' : 'var(--color-muted-foreground)' }}
+      >
+        라이브 프리뷰 {isDark ? '(다크)' : '(라이트)'}
       </h3>
       <div className="flex flex-wrap gap-2">
-        <button className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90">
+        <button
+          className="rounded-md px-4 py-2 text-sm hover:opacity-90"
+          style={{
+            background: isDark ? 'var(--db-color-dark-primary, #C4956A)' : 'var(--color-primary)',
+            color: isDark ? 'var(--db-color-dark-primary-foreground, #141210)' : 'var(--color-primary-foreground)',
+          }}
+        >
           Primary 버튼
         </button>
-        <button className="rounded-md bg-secondary px-4 py-2 text-sm text-secondary-foreground hover:opacity-90">
+        <button
+          className="rounded-md px-4 py-2 text-sm hover:opacity-90"
+          style={{
+            background: isDark ? 'var(--db-color-dark-secondary, #1E1C18)' : 'var(--color-secondary)',
+            color: isDark ? 'var(--db-color-dark-secondary-foreground, #E8E0D4)' : 'var(--color-secondary-foreground)',
+          }}
+        >
           Secondary 버튼
         </button>
-        <button className="rounded-md bg-destructive px-4 py-2 text-sm text-white hover:opacity-90">
+        <button
+          className="rounded-md px-4 py-2 text-sm text-white hover:opacity-90"
+          style={{ background: isDark ? 'var(--db-color-dark-destructive, #ef4444)' : 'var(--color-destructive)' }}
+        >
           Destructive 버튼
         </button>
       </div>
-      <div className="rounded-lg border bg-background p-4 shadow-sm">
-        <h4 className="font-semibold text-foreground">카드 제목</h4>
-        <p className="mt-1 text-sm text-muted-foreground">
+      <div
+        className="rounded-lg border p-4 shadow-sm"
+        style={{
+          background: isDark ? 'var(--db-color-dark-card, #1A1714)' : 'var(--color-card)',
+          borderColor: isDark ? 'var(--db-color-dark-border, #2E2822)' : 'var(--color-border)',
+        }}
+      >
+        <h4
+          className="font-semibold"
+          style={{ color: isDark ? 'var(--db-color-dark-card-foreground, #F0EDE8)' : 'var(--color-card-foreground)' }}
+        >
+          카드 제목
+        </h4>
+        <p
+          className="mt-1 text-sm"
+          style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #9B8E7E)' : 'var(--color-muted-foreground)' }}
+        >
           카드 본문 텍스트 예시입니다.
         </p>
       </div>
       <div className="space-y-1">
-        <p className="text-lg font-bold text-foreground">Heading 텍스트</p>
-        <p className="text-sm text-foreground">Body 텍스트 예시입니다.</p>
-        <p className="text-sm text-muted-foreground">
+        <p
+          className="text-lg font-bold"
+          style={{ color: isDark ? 'var(--db-color-dark-foreground, #F0EDE8)' : 'var(--color-foreground)' }}
+        >
+          Heading 텍스트
+        </p>
+        <p
+          className="text-sm"
+          style={{ color: isDark ? 'var(--db-color-dark-foreground, #F0EDE8)' : 'var(--color-foreground)' }}
+        >
+          Body 텍스트 예시입니다.
+        </p>
+        <p
+          className="text-sm"
+          style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #9B8E7E)' : 'var(--color-muted-foreground)' }}
+        >
           Muted 텍스트 예시입니다.
         </p>
       </div>
       <input
         readOnly
         value="Input 필드 예시"
-        className="w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring"
+        className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none"
+        style={{
+          background: isDark ? 'var(--db-color-dark-background, #141210)' : 'var(--color-background)',
+          borderColor: isDark ? 'var(--db-color-dark-input, #2E2822)' : 'var(--color-input)',
+          color: isDark ? 'var(--db-color-dark-foreground, #F0EDE8)' : 'var(--color-foreground)',
+        }}
       />
     </div>
   );
@@ -236,6 +297,7 @@ export default function ThemeEditor({ initialSettings }: Props) {
   };
 
   const filteredSettings = settings.filter((s) => s.group === activeTab);
+  const isDarkTab = activeTab === 'color_dark';
 
   return (
     <div className="space-y-6">
@@ -322,7 +384,7 @@ export default function ThemeEditor({ initialSettings }: Props) {
           )}
         </div>
 
-        <ThemePreviewPanel />
+        <ThemePreviewPanel isDark={isDarkTab} />
       </div>
     </div>
   );

--- a/src/app/[locale]/admin/settings/theme/__tests__/ThemeEditor.test.tsx
+++ b/src/app/[locale]/admin/settings/theme/__tests__/ThemeEditor.test.tsx
@@ -32,6 +32,7 @@ const makeSetting = (overrides: Partial<SiteSetting> = {}): SiteSetting => ({
   id: 1,
   key: 'primary_color',
   value: '#000000',
+  valueEn: null,
   group: 'color',
   label: 'Primary Color',
   inputType: 'color',
@@ -67,7 +68,8 @@ describe('ThemeEditor', () => {
 
   it('renders tabs', () => {
     render(<ThemeEditor initialSettings={[]} />);
-    expect(screen.getByText('색상')).toBeInTheDocument();
+    expect(screen.getByText('라이트 색상')).toBeInTheDocument();
+    expect(screen.getByText('다크 색상')).toBeInTheDocument();
     expect(screen.getByText('타이포그래피')).toBeInTheDocument();
     expect(screen.getByText('간격')).toBeInTheDocument();
     expect(screen.getByText('모서리')).toBeInTheDocument();
@@ -116,7 +118,7 @@ describe('ThemeEditor', () => {
 
   it('renders preview panel', () => {
     render(<ThemeEditor initialSettings={[]} />);
-    expect(screen.getByText('라이브 프리뷰')).toBeInTheDocument();
+    expect(screen.getByText(/라이브 프리뷰/)).toBeInTheDocument();
     expect(screen.getByText('Primary 버튼')).toBeInTheDocument();
   });
 });

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -62,14 +62,24 @@ async function getThemeStyle(map: Record<string, string> | null): Promise<string
     return false;
   }
 
-  const vars = Object.entries(map)
-    .filter(([k, v]) => isValidCssValue(k, String(v)))
-    .map(([k, v]) => {
-      const safeKey = k.replace(/[^a-zA-Z0-9_-]/g, '');
-      return `--db-${safeKey.replace(/_/g, '-')}: ${String(v).trim()}`;
-    })
-    .join('; ');
-  return vars ? `:root { ${vars} }` : '';
+  const lightVars: string[] = [];
+  const darkVars: string[] = [];
+
+  for (const [k, v] of Object.entries(map)) {
+    if (!isValidCssValue(k, String(v))) continue;
+    const safeKey = k.replace(/[^a-zA-Z0-9_-]/g, '');
+    const cssVar = `--db-${safeKey.replace(/_/g, '-')}: ${String(v).trim()}`;
+    if (k.startsWith('color_dark_')) {
+      darkVars.push(cssVar);
+    } else {
+      lightVars.push(cssVar);
+    }
+  }
+
+  const parts: string[] = [];
+  if (lightVars.length > 0) parts.push(`:root { ${lightVars.join('; ')} }`);
+  if (darkVars.length > 0) parts.push(`[data-theme="dark"] { ${darkVars.join('; ')} }`);
+  return parts.join('\n');
 }
 
 async function getSettingsMap(locale?: string): Promise<Record<string, string> | null> {

--- a/src/styles/tokens-dark.css
+++ b/src/styles/tokens-dark.css
@@ -10,24 +10,24 @@ html[data-theme="dark"] {
   --color-brand-secondary: #D4C5B0;
   --color-accent-danni: #C4A882;
 
-  /* shadcn/ui 호환 시맨틱 토큰 */
-  --color-primary: #C4956A;
-  --color-primary-foreground: #141210;
-  --color-secondary: #1E1C18;
-  --color-secondary-foreground: #E8E0D4;
-  --color-destructive: #ef4444;
-  --color-destructive-foreground: #ffffff;
-  --color-muted: #1E1C18;
-  --color-muted-foreground: #9B8E7E;
-  --color-accent: #1E1C18;
-  --color-accent-foreground: #E8E0D4;
-  --color-background: #141210;
-  --color-foreground: #F0EDE8;
-  --color-card: #1A1714;
-  --color-card-foreground: #F0EDE8;
-  --color-border: #2E2822;
-  --color-input: #2E2822;
-  --color-ring: #C4956A;
+  /* shadcn/ui 호환 시맨틱 토큰 — DB 오버라이드 우선 */
+  --color-primary:               var(--db-color-dark-primary, #C4956A);
+  --color-primary-foreground:    var(--db-color-dark-primary-foreground, #141210);
+  --color-secondary:             var(--db-color-dark-secondary, #1E1C18);
+  --color-secondary-foreground:  var(--db-color-dark-secondary-foreground, #E8E0D4);
+  --color-destructive:           var(--db-color-dark-destructive, #ef4444);
+  --color-destructive-foreground:var(--db-color-dark-destructive-foreground, #ffffff);
+  --color-muted:                 var(--db-color-dark-muted, #1E1C18);
+  --color-muted-foreground:      var(--db-color-dark-muted-foreground, #9B8E7E);
+  --color-accent:                var(--db-color-dark-accent, #1E1C18);
+  --color-accent-foreground:     var(--db-color-dark-accent-foreground, #E8E0D4);
+  --color-background:            var(--db-color-dark-background, #141210);
+  --color-foreground:            var(--db-color-dark-foreground, #F0EDE8);
+  --color-card:                  var(--db-color-dark-card, #1A1714);
+  --color-card-foreground:       var(--db-color-dark-card-foreground, #F0EDE8);
+  --color-border:                var(--db-color-dark-border, #2E2822);
+  --color-input:                 var(--db-color-dark-input, #2E2822);
+  --color-ring:                  var(--db-color-dark-ring, #C4956A);
 
   /* 니료(泥料) 악센트 토큰 */
   --color-zuni: #8B4513;


### PR DESCRIPTION
## 변경 내용

### 문제
- 라이트 테마는 DB `site_settings`의 `color_*` 키로 색상을 관리하고 있었지만
- 다크 테마는 `tokens-dark.css`에 하드코딩되어 DB에서 수정 불가

### 해결

**1. DB 마이그레이션 — `color_dark_*` 키 17개 추가**
- `color_dark_primary`, `color_dark_background`, `color_dark_foreground` 등 다크모드 전용 색상 17종
- 기본값: 기존 `tokens-dark.css` 하드코딩 값 그대로 사용

**2. `tokens-dark.css` — DB 변수 참조 패턴 적용**
- 모든 시맨틱 토큰을 `var(--db-color-dark-*, fallback)` 형태로 변경
- 기존 폴백값 유지로 마이그레이션 전에도 정상 동작

**3. `layout.tsx` — 다크 변수를 `[data-theme="dark"]` 스코프로 주입**
- `getThemeStyle()`: `color_dark_*` 키는 `[data-theme="dark"] { ... }`, 나머지는 `:root { ... }`로 분리 출력

**4. `ThemeEditor.tsx` — 라이트/다크 탭 분리**
- 탭: 라이트 색상 / 다크 색상 / 타이포그래피 / 간격 / 모서리
- 다크 색상 탭 선택 시 프리뷰 패널도 다크 색상 변수 기반으로 렌더링