### PR TITLE
feat: 모바일 사이드바 언어전환 UX 개선

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -194,9 +194,9 @@ function MobileMenuFooter({ isAuthenticated, userName, onLogout, onLinkClick }: 
           {t('orderTracking')}
         </Link>
       </div>
-      <div className="mt-4">
-        <LanguageSelector />
-        <ThemeToggle className="-ml-2 mt-1" />
+      <div className="mt-4 flex items-center justify-between">
+        <LanguageSelector variant="inline" />
+        <ThemeToggle />
       </div>
     </div>
   );

--- a/src/components/__tests__/LanguageSelector.test.tsx
+++ b/src/components/__tests__/LanguageSelector.test.tsx
@@ -45,10 +45,10 @@ afterEach(() => {
 });
 
 describe('LanguageSelector', () => {
-  it('renders current language flag and label', () => {
+  it('renders trigger button with current locale shortLabel (KO)', () => {
     render(<LanguageSelector />);
     expect(screen.getByRole('button', { name: '언어 선택' })).toBeInTheDocument();
-    expect(screen.getByText('한국어')).toBeInTheDocument();
+    expect(screen.getByText('KO')).toBeInTheDocument();
   });
 
   it('opens dropdown on button click', async () => {
@@ -58,14 +58,14 @@ describe('LanguageSelector', () => {
     expect(screen.getByRole('listbox', { name: '언어 목록' })).toBeInTheDocument();
   });
 
-  it('shows ko and en language options', async () => {
+  it('shows ko and en language options in dropdown', async () => {
     const user = userEvent.setup();
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    expect(screen.getByText('한국어')).toBeInTheDocument();
     expect(screen.getByText('English')).toBeInTheDocument();
     expect(screen.queryByText('日本語')).not.toBeInTheDocument();
     expect(screen.queryByText('中文')).not.toBeInTheDocument();
-    expect(screen.getAllByText('한국어').length).toBeGreaterThan(0);
   });
 
   it('selecting a different language navigates to the localized path and closes dropdown', async () => {
@@ -90,8 +90,7 @@ describe('LanguageSelector', () => {
     const user = userEvent.setup();
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
-    const options = screen.getAllByText('한국어');
-    await user.click(options[options.length - 1]);
+    await user.click(screen.getByText('한국어'));
     expect(openMock).not.toHaveBeenCalled();
   });
 
@@ -126,16 +125,36 @@ describe('LanguageSelector', () => {
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
-  it('compact mode shows only flag (no label)', () => {
+  it('compact mode hides the shortLabel text', () => {
     render(<LanguageSelector compact />);
-    // label is not rendered
-    expect(screen.queryByText('한국어')).not.toBeInTheDocument();
+    expect(screen.queryByText('KO')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: '언어 선택' })).toBeInTheDocument();
   });
 
-  it('shows English as current language when locale is en', () => {
+  it('shows EN as trigger label when locale is en', () => {
     mockLocale = 'en';
     render(<LanguageSelector />);
-    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.getByText('EN')).toBeInTheDocument();
+  });
+
+  it('inline variant renders segment buttons without dropdown', () => {
+    render(<LanguageSelector variant="inline" />);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '한국어' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'English' })).toBeInTheDocument();
+  });
+
+  it('inline variant switches locale on button click', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector variant="inline" />);
+    await user.click(screen.getByRole('button', { name: 'English' }));
+    expect(openMock).toHaveBeenCalledWith('/en', '_self');
+  });
+
+  it('inline variant does not navigate when clicking current locale', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector variant="inline" />);
+    await user.click(screen.getByRole('button', { name: '한국어' }));
+    expect(openMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/shared/LanguageSelector.tsx
+++ b/src/components/shared/LanguageSelector.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useEffect } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
+import { Globe } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import { useUrlModal } from '@/hooks/useUrlModal';
 import { routing } from '@/i18n/routing';
@@ -9,25 +10,28 @@ import type { Locale } from '@/i18n/routing';
 
 interface LangOption {
   locale: Locale;
-  flag: string;
   label: string;
+  shortLabel: string;
 }
 
 const LANG_OPTIONS: LangOption[] = [
-  { locale: 'ko', flag: '🇰🇷', label: '한국어' },
-  { locale: 'en', flag: '🇺🇸', label: 'English' },
+  { locale: 'ko', label: '한국어', shortLabel: 'KO' },
+  { locale: 'en', label: 'English', shortLabel: 'EN' },
 ];
 
 interface LanguageSelectorProps {
   className?: string;
-  /** compact: flag only; full: flag + label (default full) */
+  /** compact: icon only; full: icon + label (default full) */
   compact?: boolean;
+  /**
+   * inline: 모바일 사이드바용 — 드롭다운 없이 세그먼트 버튼으로 표시
+   * dropdown: 기본 드롭다운 방식 (default)
+   */
+  variant?: 'dropdown' | 'inline';
 }
 
 function getLocalizedHref(nextLocale: Locale): string {
-  if (typeof window === 'undefined') {
-    return `/${nextLocale}`;
-  }
+  if (typeof window === 'undefined') return `/${nextLocale}`;
 
   const url = new URL(window.location.href);
   const segments = url.pathname.split('/').filter(Boolean);
@@ -40,11 +44,52 @@ function getLocalizedHref(nextLocale: Locale): string {
 
   url.pathname = `/${segments.join('/')}`;
   url.searchParams.delete('language');
-
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
-export default function LanguageSelector({ className, compact = false }: LanguageSelectorProps) {
+function switchLocale(locale: Locale, currentLocale: Locale) {
+  if (locale === currentLocale) return;
+  document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
+  window.open(getLocalizedHref(locale), '_self');
+}
+
+/** 모바일 사이드바용 — 세그먼트 버튼, 드롭다운 없음 */
+function InlineLanguageSelector({ className }: { className?: string }) {
+  const currentLocale = useLocale() as Locale;
+  const t = useTranslations('header');
+
+  return (
+    <div className={cn('flex items-center gap-3', className)} role="group" aria-label={t('languageSelector')}>
+      <Globe className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+      <div className="flex rounded-md border border-border overflow-hidden">
+        {LANG_OPTIONS.map((option, idx) => {
+          const isSelected = option.locale === currentLocale;
+          return (
+            <button
+              key={option.locale}
+              type="button"
+              onClick={() => switchLocale(option.locale, currentLocale)}
+              aria-pressed={isSelected}
+              aria-label={option.label}
+              className={cn(
+                'px-3 py-1.5 text-sm font-medium transition-colors min-h-9',
+                idx > 0 && 'border-l border-border',
+                isSelected
+                  ? 'bg-foreground text-background'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+              )}
+            >
+              {option.shortLabel}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** 데스크탑용 드롭다운 언어 전환 */
+function DropdownLanguageSelector({ className, compact = false }: { className?: string; compact?: boolean }) {
   const currentLocale = useLocale() as Locale;
   const t = useTranslations('header');
   const [isOpen, setIsOpen] = useUrlModal('language');
@@ -54,25 +99,19 @@ export default function LanguageSelector({ className, compact = false }: Languag
 
   const handleSelect = (locale: Locale) => {
     setIsOpen(false);
-    if (locale === currentLocale) return;
-    document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
-    window.open(getLocalizedHref(locale), '_self');
+    switchLocale(locale, currentLocale);
   };
 
-  // Close on outside click
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false, 'replace');
       }
     };
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
+    if (isOpen) document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isOpen, setIsOpen]);
 
-  // Close on Escape
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setIsOpen(false);
@@ -90,23 +129,19 @@ export default function LanguageSelector({ className, compact = false }: Languag
         aria-label={t('languageSelector')}
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
-          'flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors',
+          'flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors',
           'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm',
         )}
       >
-        <span aria-hidden="true">{current.flag}</span>
-        {!compact && <span>{current.label}</span>}
+        <Globe className="h-4 w-4" aria-hidden="true" />
+        {!compact && <span>{current.shortLabel}</span>}
       </button>
 
       {isOpen && (
         <ul
           role="listbox"
           aria-label={t('languageList')}
-          className={cn(
-            'absolute right-0 top-full mt-1 z-50',
-            'min-w-[8rem] rounded-md border border-border bg-background shadow-md',
-            'py-1',
-          )}
+          className="absolute right-0 top-full mt-1 z-50 min-w-[8rem] rounded-md border border-border bg-background shadow-md py-1"
         >
           {LANG_OPTIONS.map((option) => {
             const isSelected = option.locale === currentLocale;
@@ -122,8 +157,7 @@ export default function LanguageSelector({ className, compact = false }: Languag
                       : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
                   )}
                 >
-                  <span aria-hidden="true">{option.flag}</span>
-                  <span>{option.label}</span>
+                  {option.label}
                 </button>
               </li>
             );
@@ -134,5 +168,9 @@ export default function LanguageSelector({ className, compact = false }: Languag
   );
 }
 
-// Re-export for tree-shaking convenience
+export default function LanguageSelector({ className, compact = false, variant = 'dropdown' }: LanguageSelectorProps) {
+  if (variant === 'inline') return <InlineLanguageSelector className={className} />;
+  return <DropdownLanguageSelector className={className} compact={compact} />;
+}
+
 export { LANG_OPTIONS, routing };


### PR DESCRIPTION
## 변경 내용

### 문제
- 모바일 사이드바 푸터의 언어전환이 드롭다운 팝업 방식이라 `absolute` 위치 문제로 잘 동작하지 않음
- 다른 메뉴 아이템들과 스타일이 달라 UI 일관성 부족

### 해결

**`LanguageSelector` — `variant` prop 추가**
- `variant="dropdown"` (기본): 기존 데스크탑 드롭다운 방식 유지
- `variant="inline"`: 드롭다운 없이 KO / EN 세그먼트 버튼을 나란히 표시

**모바일 사이드바 푸터 (`MobileMenuFooter`)**
- `<LanguageSelector variant="inline" />` 사용
- ThemeToggle과 같은 줄에 `justify-between`으로 배치

**데스크탑**
- 기존 드롭다운 동작 그대로 유지
- 이모지 플래그 제거 → `Globe` 아이콘 + `KO/EN` 텍스트로 통일