### PR TITLE
refactor: #589 #590 #591 #592 관리자/저널 공통 UI 정리

### DIFF
--- a/src/app/[locale]/admin/collections/page.tsx
+++ b/src/app/[locale]/admin/collections/page.tsx
@@ -12,6 +12,7 @@ import FormInput from '@/components/ui/FormInput';
 import Modal from '@/components/ui/Modal';
 import { AdminTable } from '@/components/shared/admin/AdminTable';
 import { StatusBadge } from '@/components/shared/admin/StatusBadge';
+import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
 import ProductImageUploader from '@/components/shared/admin/ProductImageUploader';
 import { GripVertical } from 'lucide-react';
 import { useAdminDndSensors } from '@/components/shared/hooks/useDndSensors';
@@ -443,15 +444,17 @@ export default function AdminCollectionsPage() {
       onDragEnd={handleDragEnd}
     >
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold">컬렉션 관리</h1>
-          <button
-            onClick={handleOpenCreate}
-            className="rounded-md bg-foreground px-4 py-2 text-sm text-background hover:opacity-90"
-          >
-            + 컬렉션 추가
-          </button>
-        </div>
+        <AdminPageHeader
+          title="컬렉션 관리"
+          action={(
+            <button
+              onClick={handleOpenCreate}
+              className="rounded-md bg-foreground px-4 py-2 text-sm text-background hover:opacity-90"
+            >
+              + 컬렉션 추가
+            </button>
+          )}
+        />
 
         <div className="space-y-8">
           <CollectionSection

--- a/src/app/[locale]/admin/faqs/page.tsx
+++ b/src/app/[locale]/admin/faqs/page.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { useFormModal } from '@/components/shared/hooks/useFormModal';
+import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
 import { adminFaqsApi } from '@/lib/api';
 import type { Faq, CreateFaqData } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
@@ -14,9 +15,15 @@ import FormInput from '@/components/ui/FormInput';
 import Modal from '@/components/ui/Modal';
 import { AdminTable } from '@/components/shared/admin/AdminTable';
 import { StatusBadge } from '@/components/shared/admin/StatusBadge';
-import { cn } from '@/components/ui/utils';
+import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
+import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
 
-const FAQ_CATEGORIES = ['배송', '결제', '교환/반품', '회원', '기타'];
+const FAQ_CATEGORIES = ['배송', '결제', '교환/반품', '회원', '기타'] as const;
+
+const FAQ_FILTERS = [
+  { label: '전체', value: '전체' },
+  ...FAQ_CATEGORIES.map((category) => ({ label: category, value: category })),
+] as const;
 
 const FAQ_DEFAULTS: CreateFaqData = {
   category: FAQ_CATEGORIES[0],
@@ -30,21 +37,45 @@ export default function AdminFaqsPage() {
   const { isAdmin } = useAdminGuard();
 
   const [faqs, setFaqs] = useState<Faq[]>([]);
-  const [filterCategory, setFilterCategory] = useState('전체');
   const [modalOpen, setModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
+  const { filters, setFilter } = useAdminListPage({
+    initialFilters: {
+      category: '전체',
+    },
+  });
 
-  const editingFaq = editingId != null ? faqs.find((f) => f.id === editingId) ?? null : null;
+  const editingFaq = editingId != null ? faqs.find((faq) => faq.id === editingId) ?? null : null;
 
   const { formData, setFormData } = useFormModal<CreateFaqData>(
     FAQ_DEFAULTS,
-    editingFaq ? { category: editingFaq.category, question: editingFaq.question, answer: editingFaq.answer, sortOrder: editingFaq.sortOrder, isPublished: editingFaq.isPublished } : null,
+    editingFaq
+      ? {
+        category: editingFaq.category,
+        question: editingFaq.question,
+        answer: editingFaq.answer,
+        sortOrder: editingFaq.sortOrder,
+        isPublished: editingFaq.isPublished,
+      }
+      : null,
     modalOpen,
   );
 
-  const openCreate = () => { setEditingId(null); setModalOpen(true); };
-  const openEdit = (id: number, data: CreateFaqData) => { setEditingId(id); setFormData(data); setModalOpen(true); };
-  const close = () => { setModalOpen(false); setEditingId(null); };
+  const openCreate = () => {
+    setEditingId(null);
+    setModalOpen(true);
+  };
+
+  const openEdit = (id: number, data: CreateFaqData) => {
+    setEditingId(id);
+    setFormData(data);
+    setModalOpen(true);
+  };
+
+  const close = () => {
+    setModalOpen(false);
+    setEditingId(null);
+  };
 
   const { execute: loadFaqs, isLoading } = useAsyncAction(
     async () => {
@@ -58,19 +89,20 @@ export default function AdminFaqsPage() {
     if (isAdmin) void loadFaqs();
   }, [isAdmin, loadFaqs]);
 
-  const filtered = filterCategory === '전체'
+  const filtered = filters.category === '전체'
     ? faqs
-    : faqs.filter((f) => f.category === filterCategory);
+    : faqs.filter((faq) => faq.category === filters.category);
 
   const handleSave = async () => {
     if (!formData.question.trim() || !formData.answer.trim()) {
       toast.error('질문과 답변을 입력해주세요.');
       return;
     }
+
     try {
       if (editingId) {
         const updated = await adminFaqsApi.update(editingId, formData);
-        setFaqs((prev) => prev.map((f) => (f.id === editingId ? updated : f)));
+        setFaqs((prev) => prev.map((faq) => (faq.id === editingId ? updated : faq)));
         toast.success('FAQ가 수정되었습니다.');
       } else {
         const created = await adminFaqsApi.create(formData);
@@ -85,9 +117,10 @@ export default function AdminFaqsPage() {
 
   const handleDelete = async (id: number) => {
     if (!window.confirm('이 FAQ를 삭제하시겠습니까?')) return;
+
     try {
       await adminFaqsApi.remove(id);
-      setFaqs((prev) => prev.filter((f) => f.id !== id));
+      setFaqs((prev) => prev.filter((faq) => faq.id !== id));
       toast.success('FAQ가 삭제되었습니다.');
     } catch (err) {
       toast.error(handleApiError(err, 'FAQ 삭제에 실패했습니다.'));
@@ -98,8 +131,8 @@ export default function AdminFaqsPage() {
     return (
       <div className="space-y-4">
         <h1 className="typo-h1">FAQ 관리</h1>
-        {Array.from({ length: 5 }).map((_, i) => (
-          <SkeletonBox key={i} className="h-14 rounded-lg" />
+        {Array.from({ length: 5 }).map((_, index) => (
+          <SkeletonBox key={index} className="h-14 rounded-lg" />
         ))}
       </div>
     );
@@ -107,27 +140,21 @@ export default function AdminFaqsPage() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="typo-h1">FAQ 관리</h1>
-        <Button onClick={openCreate}>새 FAQ</Button>
-      </div>
+      <AdminPageHeader
+        title="FAQ 관리"
+        titleClassName="typo-h1"
+        action={<Button onClick={openCreate}>새 FAQ</Button>}
+      />
 
-      <div className="flex gap-2 flex-wrap">
-        {['전체', ...FAQ_CATEGORIES].map((cat) => (
-          <button
-            key={cat}
-            onClick={() => setFilterCategory(cat)}
-            className={cn(
-              'px-3 py-1.5 typo-body-sm rounded-md border transition-colors',
-              filterCategory === cat
-                ? 'bg-foreground text-background border-foreground'
-                : 'border-border text-muted-foreground hover:bg-muted',
-            )}
-          >
-            {cat}
-          </button>
-        ))}
-      </div>
+      <AdminFilterChips
+        items={FAQ_FILTERS}
+        value={filters.category}
+        onToggle={(value) => setFilter('category', value)}
+        ariaLabel="FAQ 카테고리 필터"
+        tone="inverted"
+        radius="md"
+        size="sm"
+      />
 
       <AdminTable
         columns={[
@@ -181,25 +208,25 @@ export default function AdminFaqsPage() {
             <label className="block typo-body-sm font-medium mb-1.5">카테고리</label>
             <select
               value={formData.category}
-              onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+              onChange={(event) => setFormData({ ...formData, category: event.target.value })}
               className="w-full border border-border rounded-md px-3 py-2.5 typo-body-sm focus:outline-none focus:ring-2 focus:ring-ring"
             >
-              {FAQ_CATEGORIES.map((cat) => (
-                <option key={cat} value={cat}>{cat}</option>
+              {FAQ_CATEGORIES.map((category) => (
+                <option key={category} value={category}>{category}</option>
               ))}
             </select>
           </div>
           <FormInput
             label="질문"
             value={formData.question}
-            onChange={(e) => setFormData({ ...formData, question: e.target.value })}
+            onChange={(event) => setFormData({ ...formData, question: event.target.value })}
             placeholder="자주 묻는 질문을 입력하세요"
           />
           <div>
             <label className="block typo-body-sm font-medium mb-1.5">답변</label>
             <textarea
               value={formData.answer}
-              onChange={(e) => setFormData({ ...formData, answer: e.target.value })}
+              onChange={(event) => setFormData({ ...formData, answer: event.target.value })}
               rows={5}
               placeholder="답변을 입력하세요"
               className="w-full border border-border rounded-md px-3 py-2.5 typo-body-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
@@ -209,13 +236,13 @@ export default function AdminFaqsPage() {
             label="정렬 순서"
             type="number"
             value={String(formData.sortOrder ?? 0)}
-            onChange={(e) => setFormData({ ...formData, sortOrder: Number(e.target.value) })}
+            onChange={(event) => setFormData({ ...formData, sortOrder: Number(event.target.value) })}
           />
           <label className="flex items-center gap-2 typo-body-sm">
             <input
               type="checkbox"
               checked={formData.isPublished ?? true}
-              onChange={(e) => setFormData({ ...formData, isPublished: e.target.checked })}
+              onChange={(event) => setFormData({ ...formData, isPublished: event.target.checked })}
               className="rounded border-border"
             />
             발행

--- a/src/app/[locale]/admin/inquiries/page.tsx
+++ b/src/app/[locale]/admin/inquiries/page.tsx
@@ -4,24 +4,36 @@ import React, { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
+import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
 import { adminInquiriesApi } from '@/lib/api';
 import type { Inquiry } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { AdminTable } from '@/components/shared/admin/AdminTable';
 import { InquiryStatusBadge } from '@/components/shared/admin/StatusBadge';
-import { cn } from '@/components/ui/utils';
+import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
+import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
 
-type StatusFilter = 'all' | 'pending' | 'answered';
+type InquiryStatusFilter = 'all' | 'pending' | 'answered';
+
+const STATUS_FILTERS = [
+  { label: '전체', value: 'all' },
+  { label: '미답변', value: 'pending' },
+  { label: '답변완료', value: 'answered' },
+] as const;
 
 export default function AdminInquiriesPage() {
   const { isAdmin } = useAdminGuard();
 
   const [inquiries, setInquiries] = useState<Inquiry[]>([]);
-  const [filter, setFilter] = useState<StatusFilter>('all');
   const [openId, setOpenId] = useState<number | null>(null);
   const [answerText, setAnswerText] = useState('');
   const [answering, setAnswering] = useState(false);
+  const { filters, setFilter } = useAdminListPage({
+    initialFilters: {
+      status: 'all' as InquiryStatusFilter,
+    },
+  });
 
   const { execute: loadInquiries, isLoading } = useAsyncAction(
     async () => {
@@ -35,19 +47,20 @@ export default function AdminInquiriesPage() {
     if (isAdmin) void loadInquiries();
   }, [isAdmin, loadInquiries]);
 
-  const filtered = filter === 'all'
+  const filtered = filters.status === 'all'
     ? inquiries
-    : inquiries.filter((i) => i.status === filter);
+    : inquiries.filter((inquiry) => inquiry.status === filters.status);
 
   const handleAnswer = async (id: number) => {
     if (!answerText.trim()) {
       toast.error('답변 내용을 입력해주세요.');
       return;
     }
+
     setAnswering(true);
     try {
       const updated = await adminInquiriesApi.answer(id, answerText.trim());
-      setInquiries((prev) => prev.map((i) => (i.id === id ? updated : i)));
+      setInquiries((prev) => prev.map((inquiry) => (inquiry.id === id ? updated : inquiry)));
       setAnswerText('');
       setOpenId(null);
       toast.success('답변이 등록되었습니다.');
@@ -62,42 +75,34 @@ export default function AdminInquiriesPage() {
     return (
       <div className="space-y-4">
         <h1 className="typo-h1">문의 관리</h1>
-        {Array.from({ length: 5 }).map((_, i) => (
-          <SkeletonBox key={i} className="h-14 rounded-lg" />
+        {Array.from({ length: 5 }).map((_, index) => (
+          <SkeletonBox key={index} className="h-14 rounded-lg" />
         ))}
       </div>
     );
   }
 
-  const pendingCount = inquiries.filter((i) => i.status === 'pending').length;
+  const pendingCount = inquiries.filter((inquiry) => inquiry.status === 'pending').length;
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="typo-h1">문의 관리</h1>
-        {pendingCount > 0 && (
-          <span className="text-sm font-medium text-red-600">
-            미답변 {pendingCount}건
-          </span>
-        )}
-      </div>
+      <AdminPageHeader
+        title="문의 관리"
+        titleClassName="typo-h1"
+        meta={pendingCount > 0 ? (
+          <span className="text-sm font-medium text-red-600">미답변 {pendingCount}건</span>
+        ) : undefined}
+      />
 
-      <div className="flex gap-2">
-        {(['all', 'pending', 'answered'] as StatusFilter[]).map((s) => (
-          <button
-            key={s}
-            onClick={() => setFilter(s)}
-            className={cn(
-              'px-3 py-1.5 text-sm rounded-lg border transition-colors',
-              filter === s
-                ? 'bg-foreground text-background border-foreground'
-                : 'border-input text-muted-foreground hover:bg-muted',
-            )}
-          >
-            {s === 'all' ? '전체' : s === 'pending' ? '미답변' : '답변완료'}
-          </button>
-        ))}
-      </div>
+      <AdminFilterChips
+        items={STATUS_FILTERS}
+        value={filters.status}
+        onToggle={(value) => setFilter('status', value as InquiryStatusFilter)}
+        ariaLabel="문의 상태 필터"
+        tone="inverted"
+        radius="md"
+        size="sm"
+      />
 
       {filtered.length === 0 ? (
         <p className="text-sm text-muted-foreground py-8 text-center">문의가 없습니다.</p>
@@ -147,7 +152,7 @@ export default function AdminInquiriesPage() {
                         <p className="text-xs font-semibold text-muted-foreground mb-1">답변</p>
                         <textarea
                           value={answerText}
-                          onChange={(e) => setAnswerText(e.target.value)}
+                          onChange={(event) => setAnswerText(event.target.value)}
                           rows={4}
                           placeholder="답변을 입력하세요..."
                           className="w-full border border-input rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring resize-none"

--- a/src/app/[locale]/admin/members/page.tsx
+++ b/src/app/[locale]/admin/members/page.tsx
@@ -3,23 +3,27 @@
 import { useEffect, useState } from 'react';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
+import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
 import { adminMembersApi } from '@/lib/api';
 import type { AdminMember } from '@/lib/api';
 import { AdminMembersTable } from '@/components/shared/admin/AdminMembersTable';
-import AdminPagination from '@/components/shared/admin/AdminPagination';
+import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
+import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
+import { AdminSearchForm } from '@/components/shared/admin/AdminSearchForm';
+import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
 
 const ROLE_FILTERS = [
   { label: '전체', value: '' },
   { label: '일반회원', value: 'user' },
   { label: '관리자', value: 'admin' },
   { label: '최고관리자', value: 'super_admin' },
-];
+] as const;
 
 const STATUS_FILTERS = [
   { label: '전체', value: '' },
   { label: '활성', value: 'true' },
   { label: '비활성', value: 'false' },
-];
+] as const;
 
 const PAGE_SIZE = 20;
 
@@ -27,11 +31,21 @@ export default function AdminMembersPage() {
   const { isAdmin } = useAdminGuard();
   const [members, setMembers] = useState<AdminMember[]>([]);
   const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
-  const [roleFilter, setRoleFilter] = useState('');
-  const [statusFilter, setStatusFilter] = useState('');
-  const [keyword, setKeyword] = useState('');
-  const [searchInput, setSearchInput] = useState('');
+  const {
+    page,
+    setPage,
+    keyword,
+    searchInput,
+    setSearchInput,
+    filters,
+    setFilter,
+    submitSearch,
+  } = useAdminListPage({
+    initialFilters: {
+      role: '',
+      status: '',
+    },
+  });
 
   const { execute: fetchMembers, isLoading: loading } = useAsyncAction(
     async () => {
@@ -39,8 +53,9 @@ export default function AdminMembersPage() {
         page,
         limit: PAGE_SIZE,
       };
-      if (roleFilter) params.role = roleFilter;
-      if (statusFilter) params.is_active = statusFilter;
+
+      if (filters.role) params.role = filters.role;
+      if (filters.status) params.is_active = filters.status;
       if (keyword) params.q = keyword;
 
       const res = await adminMembersApi.getList(params);
@@ -53,91 +68,54 @@ export default function AdminMembersPage() {
   useEffect(() => {
     if (isAdmin) void fetchMembers();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAdmin, page, roleFilter, statusFilter, keyword]);
-
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    setKeyword(searchInput);
-    setPage(1);
-  };
+  }, [isAdmin, page, filters.role, filters.status, keyword]);
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-8">
-      <h1 className="mb-6 text-2xl font-bold">회원 관리</h1>
+    <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
+      <AdminPageHeader title="회원 관리" />
 
-      {/* 역할 필터 */}
-      <div className="mb-4 flex flex-wrap gap-2">
-        {ROLE_FILTERS.map((f) => (
-          <button
-            key={f.value}
-            onClick={() => {
-              setRoleFilter(f.value);
-              setPage(1);
-            }}
-            className={`rounded-full px-3 py-1 text-sm ${
-              roleFilter === f.value
-                ? 'bg-primary text-primary-foreground'
-                : 'bg-secondary hover:bg-secondary/80'
-            }`}
-          >
-            {f.label}
-          </button>
-        ))}
-      </div>
+      <AdminFilterChips
+        items={ROLE_FILTERS}
+        value={filters.role}
+        onToggle={(value) => setFilter('role', value)}
+        ariaLabel="회원 역할 필터"
+        size="sm"
+      />
 
-      {/* 검색 & 상태 필터 */}
-      <div className="mb-4 flex flex-wrap items-end gap-4">
-        <form onSubmit={handleSearch} className="flex gap-2">
-          <input
-            type="text"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            placeholder="이메일, 이름 검색"
-            className="rounded-lg border bg-background px-3 py-2 text-sm"
-          />
-          <button
-            type="submit"
-            className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
-          >
-            검색
-          </button>
-        </form>
+      <div className="flex flex-wrap items-end gap-4">
+        <AdminSearchForm
+          value={searchInput}
+          onChange={setSearchInput}
+          onSubmit={submitSearch}
+          placeholder="이메일, 이름 검색"
+        />
 
         <div className="flex items-center gap-2">
           <span className="text-sm text-muted-foreground">상태:</span>
-          {STATUS_FILTERS.map((f) => (
-            <button
-              key={f.value}
-              onClick={() => {
-                setStatusFilter(f.value);
-                setPage(1);
-              }}
-              className={`rounded-full px-3 py-1 text-sm ${
-                statusFilter === f.value
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-secondary hover:bg-secondary/80'
-              }`}
-            >
-              {f.label}
-            </button>
-          ))}
+          <AdminFilterChips
+            items={STATUS_FILTERS}
+            value={filters.status}
+            onToggle={(value) => setFilter('status', value)}
+            ariaLabel="회원 상태 필터"
+            size="sm"
+          />
         </div>
       </div>
 
-      {/* 테이블 */}
-      {loading ? (
-        <p className="py-8 text-center text-muted-foreground">불러오는 중...</p>
-      ) : (
+      <PaginatedAdminTableShell
+        loading={loading}
+        loadingMessage="불러오는 중..."
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+      >
         <AdminMembersTable
           members={members}
           onRoleChange={() => void fetchMembers()}
         />
-      )}
-
-      {/* 페이지네이션 */}
-      <AdminPagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+      </PaginatedAdminTableShell>
     </div>
   );
 }

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -3,11 +3,15 @@
 import { useEffect, useState } from 'react';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
+import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
 import { adminOrdersApi } from '@/lib/api';
 import type { AdminOrder } from '@/lib/api';
 import { AdminOrdersTable } from '@/components/shared/admin/AdminOrdersTable';
 import { ShippingModal } from '@/components/shared/admin/ShippingModal';
-import AdminPagination from '@/components/shared/admin/AdminPagination';
+import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
+import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
+import { AdminSearchForm } from '@/components/shared/admin/AdminSearchForm';
+import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
 
 const STATUS_FILTERS = [
   { label: '전체', value: '' },
@@ -18,7 +22,7 @@ const STATUS_FILTERS = [
   { label: '배송완료', value: 'delivered' },
   { label: '주문취소', value: 'cancelled' },
   { label: '환불완료', value: 'refunded' },
-];
+] as const;
 
 const PAGE_SIZE = 20;
 
@@ -26,13 +30,23 @@ export default function AdminOrdersPage() {
   const { isAdmin } = useAdminGuard();
   const [orders, setOrders] = useState<AdminOrder[]>([]);
   const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
-  const [statusFilter, setStatusFilter] = useState('');
-  const [keyword, setKeyword] = useState('');
-  const [searchInput, setSearchInput] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
   const [shippingOrder, setShippingOrder] = useState<AdminOrder | null>(null);
+  const {
+    page,
+    setPage,
+    keyword,
+    searchInput,
+    setSearchInput,
+    filters,
+    setFilter,
+    submitSearch,
+  } = useAdminListPage({
+    initialFilters: {
+      status: '',
+      startDate: '',
+      endDate: '',
+    },
+  });
 
   const { execute: fetchOrders, isLoading: loading } = useAsyncAction(
     async () => {
@@ -40,10 +54,10 @@ export default function AdminOrdersPage() {
         page,
         limit: PAGE_SIZE,
       };
-      if (statusFilter) params.status = statusFilter;
+      if (filters.status) params.status = filters.status;
       if (keyword) params.keyword = keyword;
-      if (startDate) params.startDate = startDate;
-      if (endDate) params.endDate = endDate;
+      if (filters.startDate) params.startDate = filters.startDate;
+      if (filters.endDate) params.endDate = filters.endDate;
 
       const res = await adminOrdersApi.getList(params);
       setOrders(res.items);
@@ -55,13 +69,7 @@ export default function AdminOrdersPage() {
   useEffect(() => {
     if (isAdmin) void fetchOrders();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAdmin, page, statusFilter, keyword, startDate, endDate]);
-
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    setKeyword(searchInput);
-    setPage(1);
-  };
+  }, [isAdmin, page, filters.status, filters.startDate, filters.endDate, keyword]);
 
   const handleShippingSuccess = () => {
     setShippingOrder(null);
@@ -71,85 +79,56 @@ export default function AdminOrdersPage() {
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-8">
-      <h1 className="mb-6 text-2xl font-bold">주문 관리</h1>
+    <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
+      <AdminPageHeader title="주문 관리" />
 
-      {/* 필터 */}
-      <div className="mb-4 flex flex-wrap gap-2">
-        {STATUS_FILTERS.map((f) => (
-          <button
-            key={f.value}
-            onClick={() => {
-              setStatusFilter(f.value);
-              setPage(1);
-            }}
-            className={`rounded-full px-3 py-1 text-sm ${
-              statusFilter === f.value
-                ? 'bg-primary text-primary-foreground'
-                : 'bg-secondary hover:bg-secondary/80'
-            }`}
-          >
-            {f.label}
-          </button>
-        ))}
-      </div>
+      <AdminFilterChips
+        items={STATUS_FILTERS}
+        value={filters.status}
+        onToggle={(value) => setFilter('status', value)}
+        ariaLabel="주문 상태 필터"
+        size="sm"
+      />
 
-      {/* 검색 & 날짜 필터 */}
-      <div className="mb-4 flex flex-wrap items-end gap-4">
-        <form onSubmit={handleSearch} className="flex gap-2">
-          <input
-            type="text"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            placeholder="주문번호, 수령인, 이메일 검색"
-            className="rounded-lg border bg-background px-3 py-2 text-sm"
-          />
-          <button
-            type="submit"
-            className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
-          >
-            검색
-          </button>
-        </form>
+      <div className="flex flex-wrap items-end gap-4">
+        <AdminSearchForm
+          value={searchInput}
+          onChange={setSearchInput}
+          onSubmit={submitSearch}
+          placeholder="주문번호, 수령인, 이메일 검색"
+        />
 
         <div className="flex items-center gap-2">
           <input
             type="date"
-            value={startDate}
-            onChange={(e) => {
-              setStartDate(e.target.value);
-              setPage(1);
-            }}
+            value={filters.startDate}
+            onChange={(event) => setFilter('startDate', event.target.value)}
             className="rounded-lg border bg-background px-3 py-2 text-sm"
           />
           <span className="text-sm text-muted-foreground">~</span>
           <input
             type="date"
-            value={endDate}
-            onChange={(e) => {
-              setEndDate(e.target.value);
-              setPage(1);
-            }}
+            value={filters.endDate}
+            onChange={(event) => setFilter('endDate', event.target.value)}
             className="rounded-lg border bg-background px-3 py-2 text-sm"
           />
         </div>
       </div>
 
-      {/* 테이블 */}
-      {loading ? (
-        <p className="py-8 text-center text-muted-foreground">불러오는 중...</p>
-      ) : (
+      <PaginatedAdminTableShell
+        loading={loading}
+        loadingMessage="불러오는 중..."
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+      >
         <AdminOrdersTable
           orders={orders}
           onStatusChange={() => void fetchOrders()}
           onShippingRegister={(order) => setShippingOrder(order)}
         />
-      )}
+      </PaginatedAdminTableShell>
 
-      {/* 페이지네이션 */}
-      <AdminPagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
-
-      {/* 운송장 등록 모달 */}
       {shippingOrder && (
         <ShippingModal
           orderId={shippingOrder.id}

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -5,11 +5,14 @@ import Link from 'next/link';
 import { toast } from 'sonner';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
+import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
 import { adminProductsApi } from '@/lib/api';
 import type { Product } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
-import AdminPagination from '@/components/shared/admin/AdminPagination';
 import { ProductStatusBadge } from '@/components/shared/admin/StatusBadge';
+import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
+import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
+import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
 
 const STATUS_LABELS: Record<string, string> = {
   draft: '임시저장',
@@ -18,14 +21,25 @@ const STATUS_LABELS: Record<string, string> = {
   hidden: '숨김',
 };
 
+const STATUS_FILTERS = [
+  { label: '전체', value: '' },
+  { label: '판매중', value: 'active' },
+  { label: '임시저장', value: 'draft' },
+  { label: '품절', value: 'soldout' },
+  { label: '숨김', value: 'hidden' },
+] as const;
+
 const PAGE_SIZE = 20;
 
 export default function AdminProductsPage() {
   const { isAdmin } = useAdminGuard();
   const [products, setProducts] = useState<Product[]>([]);
   const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
-  const [statusFilter, setStatusFilter] = useState('');
+  const { page, setPage, filters, setFilter } = useAdminListPage({
+    initialFilters: {
+      status: '',
+    },
+  });
 
   const { execute: fetchProducts, isLoading: loading } = useAsyncAction(
     async () => {
@@ -33,7 +47,8 @@ export default function AdminProductsPage() {
         page,
         limit: PAGE_SIZE,
       };
-      if (statusFilter) params.status = statusFilter;
+      if (filters.status) params.status = filters.status;
+
       const res = await adminProductsApi.getList(params);
       setProducts(res.items);
       setTotal(res.total);
@@ -43,7 +58,8 @@ export default function AdminProductsPage() {
 
   useEffect(() => {
     if (isAdmin) void fetchProducts();
-  }, [isAdmin, page, statusFilter, fetchProducts]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin, page, filters.status]);
 
   const { execute: toggleStatus } = useAsyncAction(
     async (product: Product) => {
@@ -73,49 +89,36 @@ export default function AdminProductsPage() {
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-8">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">상품 관리</h1>
-        <Link
-          href="/admin/products/new"
-          className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
-        >
-          + 상품 등록
-        </Link>
-      </div>
-
-      {/* 필터 */}
-      <div className="mb-4 flex gap-2">
-        {[
-          { label: '전체', value: '' },
-          { label: '판매중', value: 'active' },
-          { label: '임시저장', value: 'draft' },
-          { label: '품절', value: 'soldout' },
-          { label: '숨김', value: 'hidden' },
-        ].map((f) => (
-          <button
-            key={f.value}
-            onClick={() => {
-              setStatusFilter(f.value);
-              setPage(1);
-            }}
-            className={`rounded-full px-3 py-1 text-sm ${
-              statusFilter === f.value
-                ? 'bg-primary text-primary-foreground'
-                : 'bg-secondary hover:bg-secondary/80'
-            }`}
+    <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
+      <AdminPageHeader
+        title="상품 관리"
+        action={(
+          <Link
+            href="/admin/products/new"
+            className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
           >
-            {f.label}
-          </button>
-        ))}
-      </div>
+            + 상품 등록
+          </Link>
+        )}
+      />
 
-      {/* 테이블 */}
-      {loading ? (
-        <p className="py-8 text-center text-muted-foreground">불러오는 중...</p>
-      ) : products.length === 0 ? (
-        <p className="py-8 text-center text-muted-foreground">상품이 없습니다.</p>
-      ) : (
+      <AdminFilterChips
+        items={STATUS_FILTERS}
+        value={filters.status}
+        onToggle={(value) => setFilter('status', value)}
+        ariaLabel="상품 상태 필터"
+        size="sm"
+      />
+
+      <PaginatedAdminTableShell
+        loading={loading}
+        loadingMessage="불러오는 중..."
+        isEmpty={products.length === 0}
+        emptyMessage="상품이 없습니다."
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+      >
         <div className="overflow-x-auto rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-secondary">
@@ -129,31 +132,31 @@ export default function AdminProductsPage() {
               </tr>
             </thead>
             <tbody className="divide-y">
-              {products.map((p) => (
-                <tr key={p.id} className="hover:bg-secondary/30">
-                  <td className="px-4 py-3 text-muted-foreground">{p.id}</td>
-                  <td className="px-4 py-3 font-medium">{p.name}</td>
-                  <td className="px-4 py-3">{formatCurrency(p.price)}</td>
+              {products.map((product) => (
+                <tr key={product.id} className="hover:bg-secondary/30">
+                  <td className="px-4 py-3 text-muted-foreground">{product.id}</td>
+                  <td className="px-4 py-3 font-medium">{product.name}</td>
+                  <td className="px-4 py-3">{formatCurrency(product.price)}</td>
                   <td className="px-4 py-3">
-                    <ProductStatusBadge status={p.status as 'active' | 'soldout' | 'draft' | 'hidden'} />
+                    <ProductStatusBadge status={product.status as 'active' | 'soldout' | 'draft' | 'hidden'} />
                   </td>
-                  <td className="px-4 py-3">{p.isFeatured ? '✓' : '-'}</td>
+                  <td className="px-4 py-3">{product.isFeatured ? '✓' : '-'}</td>
                   <td className="px-4 py-3 text-right">
                     <div className="flex justify-end gap-2">
                       <button
-                        onClick={() => void handleToggleStatus(p)}
+                        onClick={() => void handleToggleStatus(product)}
                         className="rounded border px-2 py-1 text-xs hover:bg-secondary"
                       >
-                        {p.status === 'active' ? '숨기기' : '노출'}
+                        {product.status === 'active' ? '숨기기' : '노출'}
                       </button>
                       <Link
-                        href={`/admin/products/${p.id}/edit`}
+                        href={`/admin/products/${product.id}/edit`}
                         className="rounded border px-2 py-1 text-xs hover:bg-secondary"
                       >
                         수정
                       </Link>
                       <button
-                        onClick={() => void handleDelete(p)}
+                        onClick={() => void handleDelete(product)}
                         className="rounded border border-destructive/30 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
                       >
                         삭제
@@ -165,10 +168,7 @@ export default function AdminProductsPage() {
             </tbody>
           </table>
         </div>
-      )}
-
-      {/* 페이지네이션 */}
-      <AdminPagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+      </PaginatedAdminTableShell>
     </div>
   );
 }

--- a/src/app/[locale]/archive/error.tsx
+++ b/src/app/[locale]/archive/error.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import ErrorFallback from '@/components/shared/ErrorFallback';
+
 export default function ErrorPage({
   error,
   reset,
@@ -7,21 +9,5 @@ export default function ErrorPage({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-
-  return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <div className="text-center max-w-md">
-        <div className="rounded-lg border border-red-200 bg-red-50 p-6 mb-6">
-          <p className="text-sm text-red-600 mb-2">데이터를 불러오지 못했습니다</p>
-          <p className="text-xs text-red-500/70">{error.message || '알 수 없는 오류가 발생했습니다.'}</p>
-        </div>
-        <button
-          onClick={reset}
-          className="inline-flex items-center gap-2 text-sm font-medium bg-foreground text-background rounded px-6 py-3 hover:opacity-80 transition-opacity"
-        >
-          다시 시도
-        </button>
-      </div>
-    </div>
-  );
+  return <ErrorFallback error={error} onRetry={reset} />;
 }

--- a/src/app/[locale]/collection/error.tsx
+++ b/src/app/[locale]/collection/error.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import ErrorFallback from '@/components/shared/ErrorFallback';
+
 export default function ErrorPage({
   error,
   reset,
@@ -7,21 +9,5 @@ export default function ErrorPage({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-
-  return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <div className="text-center max-w-md">
-        <div className="rounded-lg border border-red-200 bg-red-50 p-6 mb-6">
-          <p className="text-sm text-red-600 mb-2">데이터를 불러오지 못했습니다</p>
-          <p className="text-xs text-red-500/70">{error.message || '알 수 없는 오류가 발생했습니다.'}</p>
-        </div>
-        <button
-          onClick={reset}
-          className="inline-flex items-center gap-2 text-sm font-medium bg-foreground text-background rounded px-6 py-3 hover:opacity-80 transition-opacity"
-        >
-          다시 시도
-        </button>
-      </div>
-    </div>
-  );
+  return <ErrorFallback error={error} onRetry={reset} />;
 }

--- a/src/components/shared/admin/AdminFilterChips.tsx
+++ b/src/components/shared/admin/AdminFilterChips.tsx
@@ -1,0 +1,39 @@
+import SegmentedOptionGroup, { type SegmentedOptionItem } from '@/components/shared/ui/SegmentedOptionGroup';
+
+interface AdminFilterChipsProps<T extends string | number> {
+  items: readonly SegmentedOptionItem<T>[];
+  value: T | readonly T[] | null | undefined;
+  onToggle: (value: T) => void;
+  ariaLabel?: string;
+  className?: string;
+  itemClassName?: string;
+  size?: 'xs' | 'sm' | 'md';
+  radius?: 'full' | 'md';
+  tone?: 'primary' | 'inverted';
+}
+
+export function AdminFilterChips<T extends string | number>({
+  items,
+  value,
+  onToggle,
+  ariaLabel,
+  className,
+  itemClassName,
+  size,
+  radius,
+  tone,
+}: AdminFilterChipsProps<T>) {
+  return (
+    <SegmentedOptionGroup
+      items={items}
+      value={value}
+      onToggle={onToggle}
+      ariaLabel={ariaLabel}
+      className={className}
+      itemClassName={itemClassName}
+      size={size}
+      radius={radius}
+      tone={tone}
+    />
+  );
+}

--- a/src/components/shared/admin/AdminPageHeader.tsx
+++ b/src/components/shared/admin/AdminPageHeader.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/components/ui/utils';
+
+interface AdminPageHeaderProps {
+  title: string;
+  action?: ReactNode;
+  meta?: ReactNode;
+  className?: string;
+  titleClassName?: string;
+}
+
+export function AdminPageHeader({
+  title,
+  action,
+  meta,
+  className,
+  titleClassName,
+}: AdminPageHeaderProps) {
+  return (
+    <div className={cn('flex items-center justify-between gap-4', className)}>
+      <h1 className={cn('text-2xl font-bold', titleClassName)}>{title}</h1>
+      {meta ?? action}
+    </div>
+  );
+}

--- a/src/components/shared/admin/AdminSearchForm.tsx
+++ b/src/components/shared/admin/AdminSearchForm.tsx
@@ -1,0 +1,45 @@
+import type { FormEvent } from 'react';
+import { cn } from '@/components/ui/utils';
+
+interface AdminSearchFormProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  placeholder: string;
+  submitLabel?: string;
+  className?: string;
+  inputClassName?: string;
+  buttonClassName?: string;
+}
+
+export function AdminSearchForm({
+  value,
+  onChange,
+  onSubmit,
+  placeholder,
+  submitLabel = '검색',
+  className,
+  inputClassName,
+  buttonClassName,
+}: AdminSearchFormProps) {
+  return (
+    <form onSubmit={onSubmit} className={cn('flex gap-2', className)}>
+      <input
+        type="text"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className={cn('rounded-lg border bg-background px-3 py-2 text-sm', inputClassName)}
+      />
+      <button
+        type="submit"
+        className={cn(
+          'rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90',
+          buttonClassName,
+        )}
+      >
+        {submitLabel}
+      </button>
+    </form>
+  );
+}

--- a/src/components/shared/admin/PaginatedAdminTableShell.tsx
+++ b/src/components/shared/admin/PaginatedAdminTableShell.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+import AdminPagination from './AdminPagination';
+
+interface PaginatedAdminTableShellProps {
+  loading: boolean;
+  loadingMessage?: string;
+  isEmpty?: boolean;
+  emptyMessage?: string;
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  children: ReactNode;
+}
+
+export function PaginatedAdminTableShell({
+  loading,
+  loadingMessage = '불러오는 중...',
+  isEmpty = false,
+  emptyMessage = '데이터가 없습니다.',
+  currentPage,
+  totalPages,
+  onPageChange,
+  children,
+}: PaginatedAdminTableShellProps) {
+  return (
+    <>
+      {loading ? (
+        <p className="py-8 text-center text-muted-foreground">{loadingMessage}</p>
+      ) : isEmpty ? (
+        <p className="py-8 text-center text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        children
+      )}
+
+      {!loading && (
+        <AdminPagination currentPage={currentPage} totalPages={totalPages} onPageChange={onPageChange} />
+      )}
+    </>
+  );
+}

--- a/src/components/shared/blocks/JournalPreviewBlock.tsx
+++ b/src/components/shared/blocks/JournalPreviewBlock.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { journalsApi, type Journal, JournalCategory } from '@/lib/api';
 import { useScrollAnimation } from '@/components/shared/hooks/useScrollAnimation';
 import { useBlockData } from '@/components/shared/hooks/useBlockData';
+import JournalCard from '@/components/shared/journal/JournalCard';
+import { getJournalCategoryMessageKey } from '@/components/shared/journal/journalCategory';
 import { cn } from '@/components/ui/utils';
 
 interface JournalPreviewContent {
@@ -21,69 +22,15 @@ interface Props {
   content: JournalPreviewContent;
 }
 
-const CATEGORY_KEY_MAP: Record<JournalCategory, string> = {
-  [JournalCategory.CULTURE]: 'culture',
-  [JournalCategory.USAGE]: 'usage',
-  [JournalCategory.TABLE_SETTING]: 'tableSetting',
-  [JournalCategory.NEWS]: 'news',
-};
-
-function JournalCard({ journal, index }: { journal: Journal; index: number }) {
-  const tCat = useTranslations('journalCategories');
-  const imgSources = [
-    'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png',
-    'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png',
-    'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-3.png',
-  ];
-  const img = imgSources[index % imgSources.length];
-
-  return (
-    <Link
-      href={`/journal/${journal.slug}`}
-      className="group block bg-background overflow-hidden transition-shadow hover:shadow-lg"
-    >
-      <div className="relative h-48 bg-muted overflow-hidden">
-        {journal.coverImageUrl ? (
-          <Image
-            src={journal.coverImageUrl}
-            alt={journal.title}
-            fill
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          />
-        ) : (
-          <Image
-            src={img}
-            alt={journal.title}
-            fill
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          />
-        )}
-      </div>
-      <div className="p-5">
-        <div className="flex items-center gap-2 mb-2">
-          <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
-            {tCat(CATEGORY_KEY_MAP[journal.category])}
-          </span>
-          <span className="text-xs text-muted-foreground">·</span>
-          <span className="text-xs text-muted-foreground">{journal.readTime ?? ''}</span>
-        </div>
-        <h3 className="font-display text-lg text-foreground mb-1 group-hover:underline">
-          {journal.title}
-        </h3>
-        <p className="text-xs text-muted-foreground mb-3">{journal.subtitle ?? ''}</p>
-        <p className="text-sm text-muted-foreground leading-relaxed line-clamp-2">
-          {journal.summary ?? ''}
-        </p>
-        <time className="block mt-4 text-xs text-muted-foreground">{journal.date}</time>
-      </div>
-    </Link>
-  );
-}
+const PREVIEW_FALLBACK_IMAGES = [
+  'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png',
+  'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png',
+  'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-3.png',
+] as const;
 
 export default function JournalPreviewBlock({ content }: Props) {
   const tCommon = useTranslations('common');
+  const tCategory = useTranslations('journalCategories');
   const { title, limit = 6, category, more_href, prefetched_journals } = content;
   const { ref, visible } = useScrollAnimation<HTMLElement>();
 
@@ -101,8 +48,8 @@ export default function JournalPreviewBlock({ content }: Props) {
       <section className="py-16 md:py-24">
         {title && <h2 className="text-2xl font-medium mb-8">{title}</h2>}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {Array.from({ length: limit }).map((_, i) => (
-            <div key={i} className="rounded-lg overflow-hidden">
+          {Array.from({ length: limit }).map((_, index) => (
+            <div key={index} className="rounded-lg overflow-hidden">
               <div className="h-48 bg-muted animate-pulse" />
               <div className="p-5 space-y-2">
                 <div className="h-3 w-16 bg-muted rounded animate-pulse" />
@@ -138,16 +85,21 @@ export default function JournalPreviewBlock({ content }: Props) {
         </div>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {journals.map((journal, i) => (
+        {journals.map((journal, index) => (
           <div
             key={journal.id}
             className={cn(
               'transition-all duration-600 ease-out',
               visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5',
             )}
-            style={{ transitionDelay: visible ? `${i * 100}ms` : undefined }}
+            style={{ transitionDelay: visible ? `${index * 100}ms` : undefined }}
           >
-            <JournalCard journal={journal} index={i} />
+            <JournalCard
+              journal={journal}
+              fallbackImageUrl={PREVIEW_FALLBACK_IMAGES[index % PREVIEW_FALLBACK_IMAGES.length]}
+              categoryLabel={tCategory(getJournalCategoryMessageKey(journal.category))}
+              variant="preview"
+            />
           </div>
         ))}
       </div>

--- a/src/components/shared/filters/ClayTypeFilter.tsx
+++ b/src/components/shared/filters/ClayTypeFilter.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { cn } from '@/components/ui/utils';
 import type { Collection } from '@/lib/api';
+import SegmentedOptionGroup from '@/components/shared/ui/SegmentedOptionGroup';
 
 interface ClayTypeFilterProps {
   collections: Collection[];
@@ -12,35 +12,19 @@ interface ClayTypeFilterProps {
 
 export default function ClayTypeFilter({ collections, selected, onSelect }: ClayTypeFilterProps) {
   const tCommon = useTranslations('common');
+
   return (
-    <div className="flex flex-wrap gap-2">
-      <button
-        type="button"
-        onClick={() => onSelect(undefined)}
-        className={cn(
-          'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-          selected === undefined
-            ? 'border-primary bg-primary text-primary-foreground'
-            : 'border-border bg-background text-muted-foreground hover:border-primary hover:text-foreground',
-        )}
-      >
-        {tCommon('all')}
-      </button>
-      {collections.map((item) => (
-        <button
-          key={item.id}
-          type="button"
-          onClick={() => onSelect(selected === item.name ? undefined : item.name)}
-          className={cn(
-            'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-            selected === item.name
-              ? 'border-primary bg-primary text-primary-foreground'
-              : 'border-border bg-background text-muted-foreground hover:border-primary hover:text-foreground',
-          )}
-        >
-          {item.name}
-        </button>
-      ))}
-    </div>
+    <SegmentedOptionGroup
+      items={[
+        { label: tCommon('all'), value: '' },
+        ...collections.map((item) => ({ label: item.name, value: item.name })),
+      ]}
+      value={selected ?? ''}
+      onToggle={(value) => onSelect(value === selected ? undefined : value || undefined)}
+      ariaLabel="니료 필터"
+      size="xs"
+      radius="full"
+      tone="primary"
+    />
   );
 }

--- a/src/components/shared/filters/MobileFilterBar.tsx
+++ b/src/components/shared/filters/MobileFilterBar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { cn } from '@/components/ui/utils';
 import { useUrlModal } from '@/hooks/useUrlModal';
 import { buildAttrs, useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
+import SegmentedOptionGroup from '@/components/shared/ui/SegmentedOptionGroup';
 import PriceRangeFilter from './PriceRangeFilter';
 import TeapotShapeFilter from './TeapotShapeFilter';
 import type { Category, Collection } from '@/lib/api';
@@ -30,11 +30,19 @@ export default function MobileFilterBar({ categories, shapeCollections }: Mobile
   const selectedShape = attrs.get('teapot_shape');
 
   const rootCategories = categories.filter((category) => category.parentId === null);
+  const categoryItems = [
+    { label: tCommon('all'), value: -1 },
+    ...rootCategories.map((category) => ({
+      label: category.name,
+      value: Number(category.id),
+    })),
+  ];
 
   const isRootActive = (cat: Category): boolean => {
     if (categoryId === Number(cat.id)) return true;
     return (cat.children ?? []).some((child) => Number(child.id) === categoryId);
   };
+  const activeRootCategory = rootCategories.find(isRootActive);
 
   const handleCategorySelect = (id: number | undefined) => {
     updateQuery({ categoryId: id });
@@ -60,35 +68,17 @@ export default function MobileFilterBar({ categories, shapeCollections }: Mobile
   return (
     <div className="md:hidden">
       <div className="flex items-center gap-2 border-b border-border pb-3">
-        <div className="flex flex-1 gap-2 overflow-x-auto pb-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          <button
-            type="button"
-            onClick={() => handleCategorySelect(undefined)}
-            className={cn(
-              'shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-              categoryId === undefined
-                ? 'border-primary bg-primary text-primary-foreground'
-                : 'border-border bg-background text-muted-foreground',
-            )}
-          >
-            {tCommon('all')}
-          </button>
-          {rootCategories.map((cat) => (
-            <button
-              key={cat.id}
-              type="button"
-              onClick={() => handleCategorySelect(Number(cat.id))}
-              className={cn(
-                'shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
-                isRootActive(cat)
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border bg-background text-muted-foreground',
-              )}
-            >
-              {cat.name}
-            </button>
-          ))}
-        </div>
+        <SegmentedOptionGroup
+          items={categoryItems}
+          value={activeRootCategory ? Number(activeRootCategory.id) : -1}
+          onToggle={(value) => handleCategorySelect(value === -1 ? undefined : value)}
+          ariaLabel="카테고리 필터"
+          className="flex-1 flex-nowrap gap-2 overflow-x-auto pb-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          itemClassName="shrink-0"
+          size="xs"
+          radius="full"
+          tone="primary"
+        />
       </div>
 
       {filterOpen && (

--- a/src/components/shared/hooks/__tests__/useAdminListPage.test.tsx
+++ b/src/components/shared/hooks/__tests__/useAdminListPage.test.tsx
@@ -1,0 +1,42 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
+
+describe('useAdminListPage', () => {
+  it('resets page to 1 when a filter changes', () => {
+    const { result } = renderHook(() => useAdminListPage({
+      initialFilters: {
+        status: '',
+      },
+    }));
+
+    act(() => {
+      result.current.setPage(4);
+      result.current.setFilter('status', 'active');
+    });
+
+    expect(result.current.filters.status).toBe('active');
+    expect(result.current.page).toBe(1);
+  });
+
+  it('commits trimmed keyword on submit and resets page', () => {
+    const { result } = renderHook(() => useAdminListPage({
+      initialFilters: {
+        role: '',
+      },
+      initialKeyword: '',
+    }));
+
+    act(() => {
+      result.current.setPage(3);
+      result.current.setSearchInput('  admin@example.com  ');
+    });
+
+    act(() => {
+      result.current.submitSearch();
+    });
+
+    expect(result.current.keyword).toBe('admin@example.com');
+    expect(result.current.page).toBe(1);
+  });
+});

--- a/src/components/shared/hooks/useAdminListPage.ts
+++ b/src/components/shared/hooks/useAdminListPage.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback, useState, type FormEvent } from 'react';
+
+type FilterState = Record<string, string>;
+
+interface UseAdminListPageOptions<TFilters extends FilterState> {
+  initialFilters: TFilters;
+  initialPage?: number;
+  initialKeyword?: string;
+}
+
+export function useAdminListPage<TFilters extends FilterState>({
+  initialFilters,
+  initialPage = 1,
+  initialKeyword = '',
+}: UseAdminListPageOptions<TFilters>) {
+  const [page, setPage] = useState(initialPage);
+  const [keyword, setKeyword] = useState(initialKeyword);
+  const [searchInput, setSearchInput] = useState(initialKeyword);
+  const [filters, setFilters] = useState<TFilters>(initialFilters);
+
+  const setFilter = useCallback(<K extends keyof TFilters>(key: K, nextValue: TFilters[K]) => {
+    setFilters((prev) => ({ ...prev, [key]: nextValue }));
+    setPage(1);
+  }, []);
+
+  const submitSearch = useCallback((event?: FormEvent<HTMLFormElement>) => {
+    event?.preventDefault();
+    setKeyword(searchInput.trim());
+    setPage(1);
+  }, [searchInput]);
+
+  return {
+    page,
+    setPage,
+    keyword,
+    setKeyword,
+    searchInput,
+    setSearchInput,
+    filters,
+    setFilter,
+    submitSearch,
+  };
+}

--- a/src/components/shared/journal/JournalCard.tsx
+++ b/src/components/shared/journal/JournalCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import type { Journal } from '@/lib/api';
+import { cn } from '@/components/ui/utils';
+
+interface JournalCardProps {
+  journal: Journal;
+  fallbackImageUrl: string;
+  categoryLabel: string;
+  variant?: 'preview' | 'list';
+  excerptLines?: 2 | 3;
+}
+
+const TITLE_CLASS_MAP = {
+  preview: 'font-display text-lg text-foreground mb-1 group-hover:underline',
+  list: 'font-display typo-h3 text-foreground mb-1 group-hover:underline',
+} as const;
+
+const EXCERPT_CLASS_MAP = {
+  2: 'line-clamp-2',
+  3: 'line-clamp-3',
+} as const;
+
+export default function JournalCard({
+  journal,
+  fallbackImageUrl,
+  categoryLabel,
+  variant = 'list',
+  excerptLines = 2,
+}: JournalCardProps) {
+  const imageUrl = journal.coverImageUrl || fallbackImageUrl;
+
+  return (
+    <Link
+      href={`/journal/${journal.slug}`}
+      className="group block bg-background overflow-hidden transition-shadow hover:shadow-lg"
+    >
+      <div className="relative h-48 bg-muted overflow-hidden">
+        <Image
+          src={imageUrl}
+          alt={journal.title}
+          fill
+          className="object-cover transition-transform duration-300 group-hover:scale-105"
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+        />
+      </div>
+      <div className="p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+            {categoryLabel}
+          </span>
+          <span className="text-xs text-muted-foreground">·</span>
+          <span className="text-xs text-muted-foreground">{journal.readTime ?? ''}</span>
+        </div>
+        <h3 className={TITLE_CLASS_MAP[variant]}>{journal.title}</h3>
+        <p className="text-xs text-muted-foreground mb-3">{journal.subtitle ?? ''}</p>
+        <p className={cn('text-sm text-muted-foreground leading-relaxed', EXCERPT_CLASS_MAP[excerptLines])}>
+          {journal.summary ?? ''}
+        </p>
+        <time className="block mt-4 text-xs text-muted-foreground">{journal.date}</time>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/shared/journal/JournalListClient.tsx
+++ b/src/components/shared/journal/JournalListClient.tsx
@@ -1,108 +1,49 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { cn } from '@/components/ui/utils';
+import { useTranslations } from 'next-intl';
 import { TEAPOT_IMAGES } from '@/lib/teapot-images';
 import { journalsApi, type Journal, JournalCategory } from '@/lib/api';
+import { handleApiError } from '@/utils/error';
+import SegmentedOptionGroup from '@/components/shared/ui/SegmentedOptionGroup';
+import JournalCard from '@/components/shared/journal/JournalCard';
+import { getJournalCategoryMessageKey } from '@/components/shared/journal/journalCategory';
 
-const CATEGORY_LABELS: Record<JournalCategory, string> = {
-  [JournalCategory.CULTURE]: '다문화',
-  [JournalCategory.USAGE]: '사용법',
-  [JournalCategory.TABLE_SETTING]: '찻자리 세팅',
-  [JournalCategory.NEWS]: '소식',
-};
+const ALL_CATEGORY = 'ALL';
+type JournalCategoryFilter = JournalCategory | typeof ALL_CATEGORY;
 
 function CategoryFilter({
   selected,
   onSelect,
 }: {
-  selected: JournalCategory | null;
-  onSelect: (cat: JournalCategory | null) => void;
+  selected: JournalCategoryFilter;
+  onSelect: (category: JournalCategory | null) => void;
 }) {
-  return (
-    <div role="group" aria-label="카테고리 필터" className="flex flex-wrap gap-2 justify-center">
-      <button
-        onClick={() => onSelect(null)}
-        aria-pressed={selected === null}
-        className={cn(
-          'px-4 py-1.5 rounded-full text-sm font-medium transition-colors',
-          selected === null
-            ? 'bg-foreground text-background'
-            : 'bg-muted text-muted-foreground hover:text-foreground',
-        )}
-      >
-        전체
-      </button>
-      {Object.values(JournalCategory).map((cat) => (
-        <button
-          key={cat}
-          onClick={() => onSelect(cat)}
-          aria-pressed={selected === cat}
-          className={cn(
-            'px-4 py-1.5 rounded-full text-sm font-medium transition-colors',
-            selected === cat
-              ? 'bg-foreground text-background'
-              : 'bg-muted text-muted-foreground hover:text-foreground',
-          )}
-        >
-          {CATEGORY_LABELS[cat]}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function JournalCard({ journal, index }: { journal: Journal; index: number }) {
-  const img = TEAPOT_IMAGES[index % TEAPOT_IMAGES.length];
+  const tCommon = useTranslations('common');
+  const tCategory = useTranslations('journalCategories');
 
   return (
-    <Link
-      href={`/journal/${journal.slug}`}
-      className="group block bg-background overflow-hidden transition-shadow hover:shadow-lg"
-    >
-      <div className="relative h-48 bg-muted overflow-hidden">
-        {journal.coverImageUrl ? (
-          <Image
-            src={journal.coverImageUrl}
-            alt={journal.title}
-            fill
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          />
-        ) : (
-          <Image
-            src={img.src}
-            alt={journal.title}
-            fill
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          />
-        )}
-      </div>
-      <div className="p-5">
-        <div className="flex items-center gap-2 mb-2">
-          <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
-            {CATEGORY_LABELS[journal.category]}
-          </span>
-          <span className="text-xs text-muted-foreground">·</span>
-          <span className="text-xs text-muted-foreground">{journal.readTime ?? ''}</span>
-        </div>
-        <h3 className="font-display typo-h3 text-foreground mb-1 group-hover:underline">
-          {journal.title}
-        </h3>
-        <p className="text-xs text-muted-foreground mb-3">{journal.subtitle ?? ''}</p>
-        <p className="text-sm text-muted-foreground leading-relaxed line-clamp-2">
-          {journal.summary ?? ''}
-        </p>
-        <time className="block mt-4 text-xs text-muted-foreground">{journal.date}</time>
-      </div>
-    </Link>
+    <SegmentedOptionGroup
+      items={[
+        { label: tCommon('all'), value: ALL_CATEGORY },
+        ...Object.values(JournalCategory).map((category) => ({
+          label: tCategory(getJournalCategoryMessageKey(category)),
+          value: category,
+        })),
+      ]}
+      value={selected}
+      onToggle={(value) => onSelect(value === ALL_CATEGORY ? null : value)}
+      ariaLabel="카테고리 필터"
+      className="justify-center"
+      size="sm"
+      radius="full"
+      tone="inverted"
+    />
   );
 }
 
 export default function JournalListClient() {
+  const tCategory = useTranslations('journalCategories');
   const [journals, setJournals] = useState<Journal[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -114,17 +55,18 @@ export default function JournalListClient() {
         setLoading(true);
         const data = await journalsApi.getAll();
         setJournals(data);
-      } catch {
-        setError('저널 목록을 불러오지 못했습니다.');
+      } catch (err) {
+        setError(handleApiError(err, '저널 목록을 불러오지 못했습니다.'));
       } finally {
         setLoading(false);
       }
     }
+
     void loadJournals();
   }, []);
 
   const filtered = selectedCategory
-    ? journals.filter((j) => j.category === selectedCategory)
+    ? journals.filter((journal) => journal.category === selectedCategory)
     : journals;
 
   if (loading) {
@@ -142,7 +84,7 @@ export default function JournalListClient() {
   return (
     <>
       <div className="mb-12">
-        <CategoryFilter selected={selectedCategory} onSelect={setSelectedCategory} />
+        <CategoryFilter selected={selectedCategory ?? ALL_CATEGORY} onSelect={setSelectedCategory} />
       </div>
 
       {filtered.length === 0 ? (
@@ -151,8 +93,14 @@ export default function JournalListClient() {
         </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filtered.map((journal, i) => (
-            <JournalCard key={journal.id} journal={journal} index={i} />
+          {filtered.map((journal, index) => (
+            <JournalCard
+              key={journal.id}
+              journal={journal}
+              fallbackImageUrl={TEAPOT_IMAGES[index % TEAPOT_IMAGES.length].src}
+              categoryLabel={tCategory(getJournalCategoryMessageKey(journal.category))}
+              variant="list"
+            />
           ))}
         </div>
       )}

--- a/src/components/shared/journal/__tests__/JournalCard.test.tsx
+++ b/src/components/shared/journal/__tests__/JournalCard.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import JournalCard from '@/components/shared/journal/JournalCard';
+import { JournalCategory, type Journal } from '@/lib/api';
+
+const BASE_JOURNAL: Journal = {
+  id: 1,
+  slug: 'journal-test',
+  title: '저널 테스트',
+  subtitle: '부제목',
+  category: JournalCategory.CULTURE,
+  date: '2026-04-21',
+  readTime: '5분',
+  summary: '요약',
+  content: null,
+  coverImageUrl: null,
+  isPublished: true,
+  createdAt: '2026-04-21T00:00:00.000Z',
+  updatedAt: '2026-04-21T00:00:00.000Z',
+};
+
+describe('JournalCard', () => {
+  it('uses fallback image when cover image is missing', () => {
+    render(
+      <JournalCard
+        journal={BASE_JOURNAL}
+        fallbackImageUrl="https://example.com/fallback.jpg"
+        categoryLabel="다문화"
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: '저널 테스트' });
+    expect(image).toHaveAttribute('src', 'https://example.com/fallback.jpg');
+  });
+
+  it('prefers journal cover image when available', () => {
+    render(
+      <JournalCard
+        journal={{ ...BASE_JOURNAL, coverImageUrl: 'https://example.com/cover.jpg' }}
+        fallbackImageUrl="https://example.com/fallback.jpg"
+        categoryLabel="다문화"
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: '저널 테스트' });
+    expect(image).toHaveAttribute('src', 'https://example.com/cover.jpg');
+  });
+});

--- a/src/components/shared/journal/__tests__/journalCategory.test.ts
+++ b/src/components/shared/journal/__tests__/journalCategory.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { JournalCategory } from '@/lib/api';
+import { getJournalCategoryMessageKey } from '@/components/shared/journal/journalCategory';
+
+describe('getJournalCategoryMessageKey', () => {
+  it('maps every journal category to a translation key', () => {
+    expect(getJournalCategoryMessageKey(JournalCategory.CULTURE)).toBe('culture');
+    expect(getJournalCategoryMessageKey(JournalCategory.USAGE)).toBe('usage');
+    expect(getJournalCategoryMessageKey(JournalCategory.TABLE_SETTING)).toBe('tableSetting');
+    expect(getJournalCategoryMessageKey(JournalCategory.NEWS)).toBe('news');
+  });
+});

--- a/src/components/shared/journal/journalCategory.ts
+++ b/src/components/shared/journal/journalCategory.ts
@@ -1,0 +1,12 @@
+import { JournalCategory } from '@/lib/api';
+
+export const JOURNAL_CATEGORY_KEY_MAP: Record<JournalCategory, string> = {
+  [JournalCategory.CULTURE]: 'culture',
+  [JournalCategory.USAGE]: 'usage',
+  [JournalCategory.TABLE_SETTING]: 'tableSetting',
+  [JournalCategory.NEWS]: 'news',
+};
+
+export function getJournalCategoryMessageKey(category: JournalCategory): string {
+  return JOURNAL_CATEGORY_KEY_MAP[category];
+}

--- a/src/components/shared/ui/SegmentedOptionGroup.tsx
+++ b/src/components/shared/ui/SegmentedOptionGroup.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { cn } from '@/components/ui/utils';
+
+export interface SegmentedOptionItem<T extends string | number> {
+  label: string;
+  value: T;
+  disabled?: boolean;
+}
+
+interface SegmentedOptionGroupProps<T extends string | number> {
+  items: readonly SegmentedOptionItem<T>[];
+  value: T | readonly T[] | null | undefined;
+  onToggle: (value: T) => void;
+  ariaLabel?: string;
+  className?: string;
+  itemClassName?: string;
+  size?: 'xs' | 'sm' | 'md';
+  radius?: 'full' | 'md';
+  tone?: 'primary' | 'inverted';
+}
+
+const SIZE_CLASS_MAP = {
+  xs: 'px-3 py-1 text-xs',
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+} as const;
+
+const RADIUS_CLASS_MAP = {
+  full: 'rounded-full',
+  md: 'rounded-md',
+} as const;
+
+const TONE_CLASS_MAP = {
+  primary: {
+    active: 'border-primary bg-primary text-primary-foreground',
+    inactive: 'border-border bg-background text-muted-foreground hover:border-primary hover:text-foreground',
+  },
+  inverted: {
+    active: 'border-foreground bg-foreground text-background',
+    inactive: 'border-input text-muted-foreground hover:bg-muted',
+  },
+} as const;
+
+export default function SegmentedOptionGroup<T extends string | number>({
+  items,
+  value,
+  onToggle,
+  ariaLabel,
+  className,
+  itemClassName,
+  size = 'sm',
+  radius = 'full',
+  tone = 'primary',
+}: SegmentedOptionGroupProps<T>) {
+  const isMultiValue = Array.isArray(value);
+
+  return (
+    <div role="group" aria-label={ariaLabel} className={cn('flex flex-wrap gap-2', className)}>
+      {items.map((item) => {
+        const isActive = isMultiValue ? value.includes(item.value) : value === item.value;
+
+        return (
+          <button
+            key={String(item.value)}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onToggle(item.value)}
+            disabled={item.disabled}
+            className={cn(
+              'border font-medium transition-colors disabled:pointer-events-none disabled:opacity-50',
+              SIZE_CLASS_MAP[size],
+              RADIUS_CLASS_MAP[radius],
+              isActive ? TONE_CLASS_MAP[tone].active : TONE_CLASS_MAP[tone].inactive,
+              itemClassName,
+            )}
+          >
+            {item.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/shared/ui/__tests__/SegmentedOptionGroup.test.tsx
+++ b/src/components/shared/ui/__tests__/SegmentedOptionGroup.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import SegmentedOptionGroup from '@/components/shared/ui/SegmentedOptionGroup';
+
+describe('SegmentedOptionGroup', () => {
+  it('applies active state for single selection', () => {
+    render(
+      <SegmentedOptionGroup
+        items={[
+          { label: '전체', value: 'all' },
+          { label: '활성', value: 'active' },
+        ]}
+        value="active"
+        onToggle={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: '활성' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '전체' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('supports array values for multi selection', () => {
+    render(
+      <SegmentedOptionGroup
+        items={[
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+          { label: 'C', value: 'c' },
+        ]}
+        value={['a', 'c']}
+        onToggle={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'A' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'B' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'C' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('forwards clicked value via onToggle', async () => {
+    const onToggle = vi.fn();
+
+    render(
+      <SegmentedOptionGroup
+        items={[
+          { label: '전체', value: 'all' },
+          { label: '숨김', value: 'hidden' },
+        ]}
+        value="all"
+        onToggle={onToggle}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '숨김' }));
+
+    expect(onToggle).toHaveBeenCalledWith('hidden');
+  });
+});


### PR DESCRIPTION
## 요약
- admin 목록 페이지 공통 상태 훅(`useAdminListPage`)과 조합형 UI(`AdminPageHeader`, `AdminFilterChips`, `AdminSearchForm`, `PaginatedAdminTableShell`)를 도입해 members/orders/products/inquiries/faqs/collections 중복을 줄였습니다.
- 선택 칩 UI를 `SegmentedOptionGroup`으로 통합하고 admin/저널/상품 필터 화면에서 공통 사용하도록 변경했습니다.
- 저널 카드 렌더링을 `JournalCard`로 통합하고 카테고리 라벨 키 매핑을 `journalCategory` 유틸로 일원화했습니다.
- archive/collection route error 페이지를 `ErrorFallback` 기반으로 통일했습니다.
- 회귀 방지를 위해 공통 컴포넌트/훅/저널 유틸 테스트를 추가했습니다.

## 검증
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `bash scripts/start-local.sh`

## 이슈
Closes #589
Closes #590
Closes #591
Closes #592