### PR TITLE
feat: #635 #636 #637 #638 관리자 이미지/번들 최적화

### DIFF
--- a/docs/performance/bundle-monitoring.md
+++ b/docs/performance/bundle-monitoring.md
@@ -1,0 +1,32 @@
+# 번들 모니터링 가이드
+
+## 점검 명령어
+
+```bash
+npm run audit:bundle-imports
+npm run build:analyze
+```
+
+## 자동 점검 범위 (`audit:bundle-imports`)
+
+- `react-markdown` static import 금지 검사
+- `@stripe/stripe-js` static import 금지 검사
+- `lucide-react` wildcard import(`import * as`) 금지 검사
+- lucide 아이콘 import 10개 이상 파일 목록 출력
+
+## 2026-04-21 기준 결과
+
+- `react-markdown` static import: 없음
+- `@stripe/stripe-js` static import: 없음
+- `lucide-react` wildcard import: 없음
+- 아이콘 10개 이상 import 파일:
+  - `src/components/shared/admin/page-editor/BlockPalette.tsx` (10)
+  - `src/components/Header.tsx` (10)
+
+## 번들 분석 참고
+
+- 분석 리포트 출력 경로:
+  - `.next/analyze/client.html`
+  - `.next/analyze/nodejs.html`
+  - `.next/analyze/edge.html`
+- `@stripe/stripe-js`는 `static/chunks/4511.*.js` 비초기(async) 청크로 분리됨

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from 'next';
+import createBundleAnalyzer from '@next/bundle-analyzer';
 import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
+const withBundleAnalyzer = createBundleAnalyzer({
+  enabled: process.env.ANALYZE === 'true',
+});
 
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: false,
@@ -16,6 +20,8 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'gdimg.gmarket.co.kr' },
       { protocol: 'https', hostname: 'cdn-optimized.imweb.me' },
       { protocol: 'https', hostname: '*.cloudfront.net' },
+      { protocol: 'http', hostname: 'localhost' },
+      { protocol: 'http', hostname: '127.0.0.1' },
     ],
   },
   async rewrites() {
@@ -45,4 +51,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withNextIntl(nextConfig);
+export default withBundleAnalyzer(withNextIntl(nextConfig));

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@next/bundle-analyzer": "^15.3.3",
         "@tailwindcss/postcss": "^4.1.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
@@ -633,6 +634,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -2066,6 +2077,16 @@
         "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-15.5.15.tgz",
+      "integrity": "sha512-Y9XFxAGfk7E9Se1WYmmZWhznfWFVugsroZy+gD7qv8vZmHSIlI0izLESz3yRXJ8FPTuDSdIqP1Azw1u88gDx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.14",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
@@ -2581,6 +2602,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
@@ -5022,6 +5050,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -5670,6 +5711,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5987,6 +6038,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6145,6 +6203,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.322",
@@ -7332,6 +7397,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8001,6 +8082,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -10081,6 +10172,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10478,6 +10579,16 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -11543,6 +11654,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/sonner": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
@@ -12060,6 +12186,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -12793,6 +12929,56 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "next dev --turbopack -p 5173",
     "build": "next build",
+    "build:analyze": "ANALYZE=true npm run build",
     "start": "next start",
+    "audit:bundle-imports": "bash scripts/audit-bundle-imports.sh",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -49,6 +51,7 @@
     "tailwind-merge": "^3.0.2"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^15.3.3",
     "@eslint/js": "^9.39.4",
     "@tailwindcss/postcss": "^4.1.1",
     "@testing-library/jest-dom": "^6.6.3",

--- a/scripts/audit-bundle-imports.sh
+++ b/scripts/audit-bundle-imports.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "== React Markdown static import 검사 =="
+if rg -n "^[[:space:]]*import .*['\"]react-markdown['\"]" src; then
+  echo "❌ static react-markdown import 발견"
+  exit 1
+else
+  echo "✅ static react-markdown import 없음"
+fi
+
+echo
+echo "== Stripe SDK static import 검사 =="
+if rg -n "^[[:space:]]*import .*['\"]@stripe/stripe-js['\"]" src; then
+  echo "❌ static @stripe/stripe-js import 발견"
+  exit 1
+else
+  echo "✅ static @stripe/stripe-js import 없음"
+fi
+
+echo
+echo "== Lucide wildcard import 검사 =="
+if rg -n "^[[:space:]]*import \\* as .*['\"]lucide-react['\"]" src; then
+  echo "❌ wildcard lucide-react import 발견"
+  exit 1
+else
+  echo "✅ wildcard lucide-react import 없음"
+fi
+
+echo
+echo "== lucide-react import 상위 파일(참고용) =="
+python3 - <<'PY'
+import pathlib
+import re
+
+root = pathlib.Path("src")
+pattern = re.compile(r"^\s*import\s*\{([^}]+)\}\s*from\s*['\"]lucide-react['\"]")
+rows = []
+for path in root.rglob("*.ts*"):
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        continue
+    total = 0
+    for line in text.splitlines():
+        m = pattern.match(line)
+        if not m:
+            continue
+        names = [n.strip() for n in m.group(1).split(",") if n.strip()]
+        total += len(names)
+    if total >= 10:
+        rows.append((total, str(path)))
+
+for count, path in sorted(rows, reverse=True)[:10]:
+    print(f"{count:>2} {path}")
+if not rows:
+    print("(10개 이상 import 파일 없음)")
+PY

--- a/src/app/[locale]/admin/archives/page.tsx
+++ b/src/app/[locale]/admin/archives/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useMemo } from 'react';
+import Image from 'next/image';
 import { toast } from 'sonner';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
@@ -96,8 +97,13 @@ function SortableArtistRow({ item, onEdit, onDelete }: SortableArtistRowProps) {
       </td>
       <td className="py-3 px-4">
         {item.imageUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={item.imageUrl} alt={item.name} className="w-10 h-10 rounded object-cover" />
+          <Image
+            src={item.imageUrl}
+            alt={item.name}
+            width={40}
+            height={40}
+            className="h-10 w-10 rounded object-cover"
+          />
         ) : (
           <div className="w-10 h-10 rounded bg-muted flex items-center justify-center text-muted-foreground">
             {item.name.slice(0, 1)}
@@ -678,8 +684,13 @@ export default function AdminArchivesPage() {
                   <>
                     <td className="py-3 px-4">
                       {(activeItem as Artist).imageUrl ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={(activeItem as Artist).imageUrl!} alt="" className="w-10 h-10 rounded object-cover" />
+                        <Image
+                          src={(activeItem as Artist).imageUrl!}
+                          alt={(activeItem as Artist).name}
+                          width={40}
+                          height={40}
+                          className="h-10 w-10 rounded object-cover"
+                        />
                       ) : (
                         <div className="w-10 h-10 rounded bg-muted flex items-center justify-center">{(activeItem as Artist).name.slice(0, 1)}</div>
                       )}

--- a/src/app/[locale]/admin/collections/page.tsx
+++ b/src/app/[locale]/admin/collections/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useMemo } from 'react';
+import Image from 'next/image';
 import { toast } from 'sonner';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
@@ -116,8 +117,13 @@ function SortableCollectionRow({ collection, onEdit, onDelete }: SortableCollect
       </td>
       <td className="py-3 px-4">
         {collection.imageUrl && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={collection.imageUrl} alt="" className="w-10 h-10 rounded object-cover" />
+          <Image
+            src={collection.imageUrl}
+            alt={collection.name}
+            width={40}
+            height={40}
+            className="h-10 w-10 rounded object-cover"
+          />
         )}
       </td>
       <td className="py-3 px-4 text-sm">

--- a/src/app/[locale]/admin/journal/page.tsx
+++ b/src/app/[locale]/admin/journal/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useMemo } from 'react';
+import Image from 'next/image';
 import { toast } from 'sonner';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
@@ -73,8 +74,13 @@ function JournalRow({
     <tr className="border-b border-border hover:bg-muted/50 transition-colors">
       <td className="py-3 px-4">
         {journal.coverImageUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={journal.coverImageUrl} alt="" className="w-12 h-12 rounded object-cover" />
+          <Image
+            src={journal.coverImageUrl}
+            alt={journal.title}
+            width={48}
+            height={48}
+            className="h-12 w-12 rounded object-cover"
+          />
         ) : (
           <div className="w-12 h-12 rounded bg-muted" />
         )}

--- a/src/components/shared/admin/page-editor/PreviewBlock.tsx
+++ b/src/components/shared/admin/page-editor/PreviewBlock.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import type { DraftBlock } from '@/components/shared/admin/page-editor/SortableBlockItem';
 
 // --- Preview block renderers ---
@@ -10,8 +11,13 @@ function PreviewHeroBanner({ content }: { content: Record<string, unknown> }) {
   return (
     <div className="relative flex min-h-48 items-center justify-center overflow-hidden rounded-lg bg-gray-200">
       {imageUrl && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={imageUrl} alt="" className="absolute inset-0 h-full w-full object-cover" />
+        <Image
+          src={imageUrl}
+          alt={title || '히어로 배너 이미지'}
+          fill
+          sizes="(max-width: 1024px) 100vw, 640px"
+          className="object-cover"
+        />
       )}
       <div className="relative z-10 text-center">
         {title && <h2 className="text-2xl font-bold drop-shadow">{title}</h2>}
@@ -93,8 +99,13 @@ function PreviewPromotionBanner({ content }: { content: Record<string, unknown> 
   return (
     <div className="relative flex min-h-32 items-center justify-between overflow-hidden rounded-lg bg-orange-50 px-6">
       {imageUrl && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={imageUrl} alt="" className="absolute inset-0 h-full w-full object-cover opacity-30" />
+        <Image
+          src={imageUrl}
+          alt={title || '프로모션 배너 이미지'}
+          fill
+          sizes="(max-width: 1024px) 100vw, 640px"
+          className="object-cover opacity-30"
+        />
       )}
       <div className="relative z-10">
         {title && <h3 className="text-lg font-bold text-orange-900">{title}</h3>}


### PR DESCRIPTION
## 작업 요약
- 관리자 archives/collections/journal 및 페이지 에디터 PreviewBlock의 이미지 태그를 next/image로 교체
- next.config.ts에 @next/bundle-analyzer 연동 및 ANALYZE=true 토글 추가
- 로컬 관리자 이미지 경로 대응을 위해 images.remotePatterns에 localhost/127.0.0.1 추가
- scripts/audit-bundle-imports.sh + npm run audit:bundle-imports로 react-markdown/stripe/lucide import 회귀 점검 자동화
- docs/performance/bundle-monitoring.md에 실행 절차와 기준 결과 기록

## 검증
- npm run audit:bundle-imports
- ANALYZE=true npm run build
- npm run build && npm run test:run
- cd backend && npm run build && npm run test
- bash scripts/start-local.sh

## 메모
- react-markdown static import 없음 확인
- @stripe/stripe-js는 비초기(async) 청크로 분리된 상태 유지 확인
- review:graph는 로컬 code-review-graph 미설치로 실행 불가

Closes #635
Closes #636
Closes #637
Closes #638
