### PR TITLE
design: #642 상품 카드 정보 우선순위 재정렬

### DIFF
--- a/src/components/shared/common/PriceDisplay.tsx
+++ b/src/components/shared/common/PriceDisplay.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from 'next-intl';
+import { cn } from '@/components/ui/utils';
 import { calcDiscount, formatCurrency, type Locale } from '@/utils/currency';
 
 interface PriceDisplayProps {
@@ -6,33 +7,39 @@ interface PriceDisplayProps {
   salePrice: number | null;
   size?: 'sm' | 'md' | 'lg';
   locale?: Locale;
+  className?: string;
 }
 
-export default function PriceDisplay({ price, salePrice, size = 'sm', locale = 'ko' }: PriceDisplayProps) {
+export default function PriceDisplay({
+  price,
+  salePrice,
+  size = 'sm',
+  locale = 'ko',
+  className,
+}: PriceDisplayProps) {
   const t = useTranslations('product');
-  const discountClass = size === 'lg' ? 'text-sm font-bold' : 'text-xs font-bold';
-  const priceClass = size === 'lg' ? 'text-2xl font-bold' : 'text-sm font-bold';
-  const originalClass = size === 'lg' ? 'text-sm' : 'text-xs';
+  const priceClass = size === 'lg' ? 'typo-price-lg' : 'typo-price';
+  const isOnSale = salePrice !== null && salePrice < price;
 
-  if (salePrice !== null && salePrice < price) {
+  if (isOnSale) {
     return (
-      <div className="min-h-[2.75rem] flex flex-col justify-center">
-        <div className="flex items-baseline gap-1.5 flex-wrap leading-none">
-          <span className={`${priceClass} text-foreground`}>{formatCurrency(salePrice, locale)}</span>
-          <span className={`${discountClass} text-destructive`}>
+      <div className={cn('flex flex-col gap-0.5', className)}>
+        <span className="typo-price-original">{formatCurrency(price, locale)}</span>
+        <div className="flex items-baseline gap-1.5">
+          <span className={cn(priceClass, 'text-foreground')}>
+            {formatCurrency(salePrice, locale)}
+          </span>
+          <span className="typo-price-discount text-destructive">
             {t('discountOff', { percent: calcDiscount(price, salePrice) })}
           </span>
         </div>
-        <span className={`${originalClass} text-muted-foreground line-through leading-none`}>
-          {formatCurrency(price, locale)}
-        </span>
       </div>
     );
   }
 
   return (
-    <div className="min-h-[2.75rem] flex flex-col justify-center items-start">
-      <span className={`${priceClass} text-foreground`}>{formatCurrency(price, locale)}</span>
+    <div className={cn('flex flex-col', className)}>
+      <span className={cn(priceClass, 'text-foreground')}>{formatCurrency(price, locale)}</span>
     </div>
   );
 }

--- a/src/components/shared/products/ProductCard.tsx
+++ b/src/components/shared/products/ProductCard.tsx
@@ -158,7 +158,6 @@ function ProductCard({
       <div className="mt-3 flex flex-1 flex-col gap-1.5">
         {/* 1순위: 상품명 */}
         <p className="typo-title line-clamp-2 text-foreground min-h-[2.75rem]">{name}</p>
-        <hr className="border-border" />
 
         {/* 2순위: 가격 */}
         <PriceDisplay price={price} salePrice={salePrice} locale={locale} />

--- a/src/components/shared/products/ProductCard.tsx
+++ b/src/components/shared/products/ProductCard.tsx
@@ -70,6 +70,7 @@ function ProductCard({
   const thumbnail = images[0]?.url;
   const isSoldout = status === 'soldout';
   const clayTagClass = categoryName ? getClayTagClass(categoryName) : null;
+  const hasRating = rating !== undefined && reviewCount !== undefined && reviewCount > 0;
 
   const { addItem } = useCart();
   const { isWishlisted, loading: isWishlistLoading, toggle: handleToggleWishlist } = useWishlistToggle(id);
@@ -93,7 +94,7 @@ function ProductCard({
         isSoldout && 'opacity-60',
       )}
     >
-      {/* ── 이미지 영역 ── */}
+      {/* ── 이미지 영역 — 오버레이 액션은 hover 시에만 노출 ── */}
       <div className="relative aspect-square overflow-hidden bg-secondary rounded-md">
         {thumbnail ? (
           <Image
@@ -117,12 +118,17 @@ function ProductCard({
         )}
 
         {categoryName && (
-          <span className={cn('absolute left-2 bottom-2 z-10 px-2 py-0.5 rounded-sm tag-clay', clayTagClass ?? 'tag-generic')}>
+          <span
+            className={cn(
+              'absolute left-2 bottom-2 z-10 px-2 py-0.5 rounded-sm tag-clay',
+              clayTagClass ?? 'tag-generic',
+            )}
+          >
             {categoryName}
           </span>
         )}
 
-        {/* 찜하기 버튼 — 우상단 */}
+        {/* 찜하기 — 모바일: 항상 노출 / 데스크톱: hover 또는 찜한 상태에서만 */}
         <button
           type="button"
           aria-label={isWishlisted ? tWishlist('toggleOff') : tWishlist('toggleOn')}
@@ -131,52 +137,62 @@ function ProductCard({
             handleToggleWishlist(e);
           }}
           disabled={isWishlistLoading}
-          className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-background/60 backdrop-blur-sm disabled:cursor-not-allowed transition-colors hover:bg-background/80"
+          className={cn(
+            'absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-full',
+            'bg-background/70 backdrop-blur-sm transition-opacity hover:bg-background/90',
+            'disabled:cursor-not-allowed',
+            'opacity-100 md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100',
+            isWishlisted && 'md:opacity-100',
+          )}
         >
           <Heart
             className={cn(
-              'h-3.5 w-3.5 transition-colors',
-              isWishlisted ? 'fill-foreground text-foreground' : 'text-foreground/60',
+              'h-4 w-4 transition-colors',
+              isWishlisted ? 'fill-foreground text-foreground' : 'text-foreground/70',
             )}
           />
         </button>
       </div>
 
-      {/* ── 정보 영역 — 공방 도면 스타일 ── */}
-      <div className="mt-2.5 flex flex-1 flex-col gap-1">
-        <p className="typo-title line-clamp-2 leading-snug min-h-10 shrink-0">{name}</p>
+      {/* ── 정보 영역 — 상품명 > 가격 > 메타 위계 ── */}
+      <div className="mt-3 flex flex-1 flex-col gap-1.5">
+        {/* 1순위: 상품명 */}
+        <p className="typo-title line-clamp-2 text-foreground min-h-[2.75rem]">{name}</p>
 
-        {/* 리뷰 */}
-        <div className="flex items-center gap-1.5 h-4 shrink-0">
-          {rating !== undefined && (
-            <>
+        {/* 2순위: 가격 */}
+        <PriceDisplay price={price} salePrice={salePrice} locale={locale} />
+
+        {/* 3순위: 리뷰·설명 — 낮은 대비로 보조 */}
+        <div className="mt-0.5 flex flex-col gap-1">
+          {hasRating && (
+            <div className="flex items-center gap-1.5">
               <StarRating rating={rating} size="sm" interactive={false} />
-              <span className="font-mono text-xs leading-none text-muted-foreground">{rating.toFixed(1)}</span>
-              {reviewCount !== undefined && reviewCount > 0 && (
-                <span className="font-mono text-xs text-muted-foreground leading-none">({reviewCount})</span>
-              )}
-            </>
+              <span className="font-mono text-xs leading-none text-muted-foreground">
+                {rating.toFixed(1)}
+              </span>
+              <span className="font-mono text-xs leading-none text-muted-foreground">
+                ({reviewCount})
+              </span>
+            </div>
+          )}
+
+          {shortDescription && (
+            <p className="line-clamp-1 text-xs text-muted-foreground leading-relaxed">
+              {shortDescription}
+            </p>
           )}
         </div>
 
-        {shortDescription && (
-          <p className="line-clamp-2 text-xs text-muted-foreground leading-relaxed">{shortDescription}</p>
-        )}
-
-        {/* 구분선 */}
-        <div className="pt-2 mt-auto">
-          <hr className="border-border" />
-        </div>
-
-        <PriceDisplay price={price} salePrice={salePrice} locale={locale} />
-
+        {/* 장바구니 담기 — 메타 아래 고정, hover 시 foreground 대비 강화 */}
         {!isSoldout && (
           <button
             type="button"
             onClick={handleAddToCart}
             disabled={isCartLoading}
             className={cn(
-              'flex w-full items-center justify-center gap-2 border border-border py-2 text-xs font-medium text-foreground transition-colors hover:bg-foreground hover:text-background disabled:cursor-not-allowed shrink-0 font-mono tracking-wide',
+              'mt-auto flex w-full items-center justify-center gap-2 border border-border py-2',
+              'typo-button text-foreground transition-colors',
+              'hover:bg-foreground hover:text-background disabled:cursor-not-allowed',
             )}
           >
             <ShoppingCart className="h-3.5 w-3.5" />

--- a/src/components/shared/products/ProductCard.tsx
+++ b/src/components/shared/products/ProductCard.tsx
@@ -158,6 +158,7 @@ function ProductCard({
       <div className="mt-3 flex flex-1 flex-col gap-1.5">
         {/* 1순위: 상품명 */}
         <p className="typo-title line-clamp-2 text-foreground min-h-[2.75rem]">{name}</p>
+        <hr className="border-border" />
 
         {/* 2순위: 가격 */}
         <PriceDisplay price={price} salePrice={salePrice} locale={locale} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -190,6 +190,38 @@
   line-height: var(--line-height-compact);
 }
 
+/* ── 가격 타이포 토큰 — 상품 카드/상세에서 공통 사용 ── */
+@utility typo-price {
+  font-size: 1.0625rem;
+  line-height: 1.15;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  font-family: var(--font-body);
+}
+
+@utility typo-price-lg {
+  font-size: 1.5rem;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  font-family: var(--font-body);
+}
+
+@utility typo-price-original {
+  font-size: 0.75rem;
+  line-height: 1.1;
+  font-weight: 400;
+  color: var(--color-muted-foreground);
+  text-decoration: line-through;
+}
+
+@utility typo-price-discount {
+  font-size: 0.75rem;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
 /* ── Base styles ───────────────────────────────────────────────── */
 body {
   font-family: var(--font-body);


### PR DESCRIPTION
## 변경 사항

상품 카드의 시각적 위계를 개선하여 사용자가 핵심 정보를 더 빠르게 파악할 수 있도록 합니다.

### 정보 우선순위 재정렬
- **1순위**: 상품명 (`typo-title`, 최소 높이 보장)
- **2순위**: 가격 (`typo-price*` 토큰 — 세일 시 원가 위, 할인가+% 아래)
- **3순위**: 리뷰 평점 · 짧은 설명 (muted 대비, 보조 정보)

### PriceDisplay 리팩터링
- `typo-price`, `typo-price-lg`, `typo-price-original`, `typo-price-discount` 4개 전용 토큰 추가 (`globals.css`)
- 세일가 레이아웃: 원가(취소선) → 세일가 + 할인율(%) 순으로 변경
- `className` prop 추가로 외부 커스터마이징 지원

### ProductCard 개선
- 위시리스트 버튼: 모바일 항상 노출 / 데스크톱 hover or 찜 상태에서만 노출
- 장바구니 버튼: 정보 영역 하단 고정, `mt-auto`로 카드 높이 무관하게 정렬
- 리뷰 행: `reviewCount > 0`일 때만 렌더 (`hasRating` 가드)
- 불필요한 `<hr>` 구분선 제거

Closes #642