### PR TITLE
[design] 643~650 공통 디자인 규칙 정비 + Cart/Checkout 핵심 흐름 개선

### DIFF
--- a/docs/architecture/FRONTEND_DESIGN_RULES_643_650.md
+++ b/docs/architecture/FRONTEND_DESIGN_RULES_643_650.md
@@ -1,0 +1,42 @@
+# Frontend Design Rules (Issues #643 ~ #650)
+
+## 1) Spacing / Grid Rhythm (#643)
+- 페이지 래퍼: `layout-container`, `layout-page`
+- 섹션 리듬: `layout-section`, `layout-stack-md`
+- 본문 가독 폭: `text-readable`
+- 홈/상품리스트/상품상세/장바구니/체크아웃에 동일 토큰 적용
+
+## 2) CTA Hierarchy (#644)
+- 버튼 체계: `primary(default) / secondary / ghost / destructive / outline`
+- 최소 터치 높이 44px 이상(`min-h-11`)
+- Primary CTA는 단계별 핵심 행동(주문/결제)에만 사용
+
+## 3) Cart / Checkout Visual Hierarchy (#645)
+- 요약 카드에서 최종 금액(`typo-h2`)을 최상위로 강조
+- 배송비 임계 배너 + 진행 바를 요약 영역에 공통 적용
+- 모바일 장바구니/체크아웃 하단 Sticky CTA 적용
+
+## 4) Admin Information Design (#646)
+- 관리자 표면/헤더/row 밀도 토큰:
+  - `admin-surface`
+  - `admin-table-head`
+  - `admin-row`, `admin-row-compact`
+- `StatusBadge`는 상태 점(dot)+색+경계선 조합으로 통일
+
+## 5) A11y Baseline (#647)
+- 전역 `prefers-reduced-motion` 대응 추가
+- 버튼 최소 터치 타깃 및 시각 포커스 링 유지
+
+## 6) Commerce Conversion Patterns (#648)
+- 장바구니/체크아웃에 무료배송 임계 진행 패턴 통일
+- 주문 흐름(배송 → 결제 → 완료) 스텝 표시 추가
+
+## 7) Performance-Oriented Design (#649)
+- Hero 이미지에 `fetchPriority="high"` 적용
+- Hero 높이 arbitrary value 제거, 토큰 클래스 사용
+
+## 8) Mobile Interaction Standard (#650)
+- 모바일 하단 고정 CTA:
+  - PDP(기존 유지)
+  - Cart/Checkout(신규 적용)
+- 하단 네비게이션 표시 여부(`MobileNavContext`)에 맞춰 offset 조정

--- a/src/app/[locale]/(routes)/page.tsx
+++ b/src/app/[locale]/(routes)/page.tsx
@@ -62,7 +62,7 @@ export default async function Home({
   return (
     <div>
       {heroBlocks.length > 0 && <BlockRenderer blocks={heroBlocks} />}
-      <div className="mx-auto max-w-7xl px-4 mt-8">
+      <div className="layout-container layout-section">
         <BlockRenderer blocks={restBlocks} />
       </div>
     </div>

--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -1,19 +1,25 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { useCart } from '@/contexts/CartContext';
 import { useAuth } from '@/contexts/AuthContext';
+import { useMobileNav } from '@/contexts/MobileNavContext';
+import { Button } from '@/components/ui/button';
 import EmptyState from '@/components/shared/EmptyState';
 import CartItemRow from '@/components/shared/cart/CartItemRow';
 import { formatCurrency } from '@/utils/currency';
 import { FREE_SHIPPING_THRESHOLD, SHIPPING_FEE } from '@/constants/shipping';
 import { SESSION_KEYS } from '@/constants/storage';
 import { SkeletonBox } from '@/components/ui/Skeleton';
+import { cn } from '@/components/ui/utils';
 
 export default function CartPage() {
+  const t = useTranslations('cart');
   const router = useRouter();
+  const { isVisible: isNavVisible } = useMobileNav();
   const { isAuthenticated } = useAuth();
   const { items, isLoading, updateQuantity, removeItem } = useCart();
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
@@ -27,6 +33,12 @@ export default function CartPage() {
         .reduce((sum, item) => sum + item.subtotal, 0),
     [items, selectedIds],
   );
+
+  const selectedShippingFee =
+    selectedTotal >= FREE_SHIPPING_THRESHOLD || selectedTotal === 0 ? 0 : SHIPPING_FEE;
+  const grandTotal = selectedTotal + selectedShippingFee;
+  const remainingForFreeShipping = Math.max(FREE_SHIPPING_THRESHOLD - selectedTotal, 0);
+  const freeShippingProgress = Math.min((selectedTotal / FREE_SHIPPING_THRESHOLD) * 100, 100);
 
   const handleSelectAll = (checked: boolean) => {
     setSelectedIds(checked ? new Set(items.map((i) => i.id)) : new Set());
@@ -52,7 +64,7 @@ export default function CartPage() {
 
   const handleOrder = () => {
     if (selectedIds.size === 0) {
-      toast.warning('주문할 상품을 선택해주세요.');
+      toast.warning(t('selectItemsToOrder'));
       return;
     }
     const selectedItems = items.filter((item) => selectedIds.has(item.id));
@@ -62,11 +74,11 @@ export default function CartPage() {
 
   if (!isAuthenticated) {
     return (
-      <div className="mx-auto max-w-7xl px-4 py-12">
+      <div className="layout-container layout-page">
         <EmptyState
-          title="로그인이 필요합니다"
-          description="장바구니를 이용하려면 로그인해주세요."
-          action={{ label: '로그인', onClick: () => router.push('/login') }}
+          title={t('requireLogin')}
+          description={t('requireLoginDescription')}
+          action={{ label: t('loginAction'), onClick: () => router.push('/login') }}
         />
       </div>
     );
@@ -74,9 +86,9 @@ export default function CartPage() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-7xl px-4 py-12">
+      <div className="layout-container layout-page">
         <div className="grid gap-4 lg:grid-cols-3">
-          <div className="lg:col-span-2 space-y-4">
+          <div className="space-y-4 lg:col-span-2">
             {[1, 2, 3].map((i) => (
               <SkeletonBox key={i} height="h-24" />
             ))}
@@ -89,88 +101,107 @@ export default function CartPage() {
 
   if (items.length === 0) {
     return (
-      <div className="mx-auto max-w-7xl px-4 py-12">
+      <div className="layout-container layout-page">
         <EmptyState
-          title="장바구니가 비었습니다"
-          description="마음에 드는 상품을 장바구니에 담아보세요."
-          action={{ label: '쇼핑 계속하기', onClick: () => router.push('/products') }}
+          title={t('empty')}
+          description={t('emptyDescription')}
+          action={{ label: t('continueShopping'), onClick: () => router.push('/products') }}
         />
       </div>
     );
   }
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-8">
-      <h1 className="mb-6 typo-h1">장바구니</h1>
+    <div className="layout-container layout-page pb-24 md:pb-8">
+      <h1 className="typo-h1">{t('title')}</h1>
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        {/* Item list */}
+      <div className="mt-6 grid gap-6 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <div className="mb-3 flex items-center justify-between border-b pb-3">
-            <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="checkbox"
                 checked={allSelected}
                 onChange={(e) => handleSelectAll(e.target.checked)}
-                aria-label="전체 선택"
+                aria-label={t('selectAll')}
                 className="h-4 w-4 rounded border-input accent-foreground"
               />
-              전체 선택 ({selectedIds.size}/{items.length})
+              {t('selectAll')} ({selectedIds.size}/{items.length})
             </label>
           </div>
 
-          <div>
-            {items.map((item) => (
-              <CartItemRow
-                key={item.id}
-                item={item}
-                selected={selectedIds.has(item.id)}
-                onSelect={handleSelect}
-                onQuantityChange={updateQuantity}
-                onRemove={handleRemove}
-              />
-            ))}
-          </div>
+          {items.map((item) => (
+            <CartItemRow
+              key={item.id}
+              item={item}
+              selected={selectedIds.has(item.id)}
+              onSelect={handleSelect}
+              onQuantityChange={updateQuantity}
+              onRemove={handleRemove}
+            />
+          ))}
         </div>
 
-        {/* Summary */}
-        <div className="h-fit rounded-lg border p-6 space-y-4 lg:sticky lg:top-24">
-          <h2 className="font-semibold text-lg">주문 요약</h2>
+        <aside className="hidden h-fit rounded-lg border p-6 lg:sticky lg:top-24 lg:block">
+          <h2 className="typo-h3">{t('orderSummary')}</h2>
 
-          <div className="space-y-2 text-sm">
+          <div className="mt-4 space-y-2 text-sm">
             <div className="flex justify-between">
-              <span className="text-muted-foreground">선택 상품</span>
-              <span>{selectedIds.size}개</span>
+              <span className="text-muted-foreground">{t('selectedItems')}</span>
+              <span>{selectedIds.size}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-muted-foreground">상품 금액</span>
+              <span className="text-muted-foreground">{t('productAmount')}</span>
               <span>{formatCurrency(selectedTotal)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-muted-foreground">배송비</span>
-              <span>{selectedTotal >= FREE_SHIPPING_THRESHOLD ? '무료' : formatCurrency(SHIPPING_FEE)}</span>
+              <span className="text-muted-foreground">{t('shippingFee')}</span>
+              <span>{selectedShippingFee === 0 ? t('freeShipping') : formatCurrency(selectedShippingFee)}</span>
             </div>
           </div>
 
-          <div className="border-t pt-4">
-            <div className="flex justify-between font-bold">
-              <span>합계</span>
-              <span>
-                {formatCurrency(
-                  selectedTotal +
-                  (selectedTotal >= FREE_SHIPPING_THRESHOLD || selectedTotal === 0 ? 0 : SHIPPING_FEE)
-                )}
-              </span>
+          <div className="mt-4 rounded-md border border-border bg-muted/30 p-3">
+            <p className="text-xs text-muted-foreground">
+              {remainingForFreeShipping === 0
+                ? t('freeShippingUnlocked')
+                : t('freeShippingRemaining', { amount: formatCurrency(remainingForFreeShipping) })}
+            </p>
+            <div className="mt-2 h-1.5 w-full rounded-full bg-background">
+              <div
+                className="h-full rounded-full bg-primary transition-[width] duration-300"
+                style={{ width: `${freeShippingProgress}%` }}
+                aria-hidden
+              />
             </div>
           </div>
 
-          <button
-            type="button"
-            onClick={handleOrder}
-            className="w-full rounded-md bg-foreground py-3 text-sm font-semibold text-background hover:opacity-90 transition-opacity disabled:opacity-40"
-          >
-            선택 상품 주문하기
-          </button>
+          <div className="mt-4 border-t pt-4">
+            <div className="flex items-end justify-between">
+              <span className="typo-title">{t('total')}</span>
+              <span className="typo-h2">{formatCurrency(grandTotal)}</span>
+            </div>
+          </div>
+
+          <Button type="button" className="mt-4 w-full" onClick={handleOrder}>
+            {t('orderSelected')}
+          </Button>
+        </aside>
+      </div>
+
+      <div
+        className={cn(
+          'fixed left-0 right-0 z-50 border-t bg-background p-4 md:hidden',
+          isNavVisible ? 'bottom-14' : 'bottom-0',
+        )}
+      >
+        <div className="layout-container p-0">
+          <div className="mb-2 flex items-end justify-between">
+            <p className="text-xs text-muted-foreground">{t('total')}</p>
+            <p className="typo-title">{formatCurrency(grandTotal)}</p>
+          </div>
+          <Button type="button" className="w-full" onClick={handleOrder}>
+            {t('orderSelected')}
+          </Button>
         </div>
       </div>
     </div>

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { useState, useEffect, use, useRef } from 'react';
+import { use, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
 import { useCart } from '@/contexts/CartContext';
+import { useMobileNav } from '@/contexts/MobileNavContext';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/components/ui/utils';
 import type { CartItem, PreparePaymentResponse, UserAddress } from '@/lib/api';
 import { usersApi } from '@/lib/api';
 import { FREE_SHIPPING_THRESHOLD, SHIPPING_FEE } from '@/constants/shipping';
@@ -14,24 +18,15 @@ import PaymentGateway, { type PaymentGatewayHandle } from '@/components/shared/c
 import { AddressSelectorSection } from '@/components/shared/checkout/AddressSelectorSection';
 import { OrderSummarySection } from '@/components/shared/checkout/OrderSummarySection';
 import {
-  ShippingFormSection,
-  PhoneInputSection,
-  ZipcodeInputSection,
-  AddressInputSection,
   AddressDetailInputSection,
+  AddressInputSection,
   MemoInputSection,
+  PhoneInputSection,
+  ShippingFormSection,
+  ZipcodeInputSection,
 } from '@/components/shared/checkout/ShippingFormSection';
 import { useCheckout, type PaymentStep } from '@/components/shared/hooks/useCheckout';
-
-// Re-exported for type usage
-
-const STEP_LABELS: Record<PaymentStep, string> = {
-  idle: '결제하기',
-  creating_order: '주문 생성 중...',
-  preparing_payment: '결제 준비 중...',
-  confirming_payment: '결제 확인 중...',
-  success: '완료',
-};
+import { formatCurrency } from '@/utils/currency';
 
 export interface ShippingForm {
   recipientName: string;
@@ -55,7 +50,9 @@ export default function CheckoutPage({
   params: Promise<{ locale: Locale }>;
 }) {
   const { locale } = use(params);
+  const t = useTranslations('checkout');
   const router = useRouter();
+  const { isVisible: isNavVisible } = useMobileNav();
   const { isAuthenticated, isLoading } = useAuth();
   const { refetch } = useCart();
 
@@ -63,7 +60,7 @@ export default function CheckoutPage({
   const [step, setStep] = useState<PaymentStep>('idle');
   const [prepareResult, setPrepareResult] = useState<PreparePaymentResponse | null>(null);
   const [currentOrderId, setCurrentOrderId] = useState<number | null>(null);
-  const [currentOrderNumber, setCurrentOrderNumber] = useState<string>('');
+  const [currentOrderNumber, setCurrentOrderNumber] = useState('');
   const [form, setForm] = useState<ShippingForm>({
     recipientName: '',
     recipientPhone: '',
@@ -81,6 +78,14 @@ export default function CheckoutPage({
   const totalAmount = checkoutItems.reduce((sum, item) => sum + item.subtotal, 0);
   const shippingFee = totalAmount >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_FEE;
   const grandTotal = totalAmount + shippingFee;
+
+  const stepLabels: Record<PaymentStep, string> = {
+    idle: t('steps.idle'),
+    creating_order: t('steps.creating_order'),
+    preparing_payment: t('steps.preparing_payment'),
+    confirming_payment: t('steps.confirming_payment'),
+    success: t('steps.success'),
+  };
 
   const fillFormFromAddress = (addr: UserAddress) => {
     setForm({
@@ -120,7 +125,8 @@ export default function CheckoutPage({
     if (isLoading || !isAuthenticated) return;
 
     setAddressLoading(true);
-    usersApi.getAddresses()
+    usersApi
+      .getAddresses()
       .then((result) => {
         setAddresses(result);
         const defaultAddr = result.find((a) => a.isDefault);
@@ -133,7 +139,7 @@ export default function CheckoutPage({
         }
       })
       .catch(() => {
-        toast.error('저장된 주소를 불러오는데 실패했습니다.');
+        toast.error(t('loadAddressError'));
       })
       .finally(() => {
         setAddressLoading(false);
@@ -179,69 +185,97 @@ export default function CheckoutPage({
   }
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-8">
-      <h1 className="mb-6 typo-h1">주문 / 결제</h1>
+    <div className="layout-container layout-page pb-24 md:pb-8">
+      <h1 className="typo-h1">{t('title')}</h1>
 
-      <form onSubmit={handleSubmit}>
+      <ol className="mt-4 flex items-center gap-2 rounded-md border border-border bg-muted/20 px-3 py-2 text-xs text-muted-foreground md:max-w-xl">
+        <li className="rounded-full bg-primary px-2.5 py-1 text-primary-foreground">{t('flow.shipping')}</li>
+        <span aria-hidden>→</span>
+        <li className="rounded-full bg-secondary px-2.5 py-1 text-secondary-foreground">{t('flow.payment')}</li>
+        <span aria-hidden>→</span>
+        <li className="rounded-full bg-secondary px-2.5 py-1 text-secondary-foreground">{t('flow.complete')}</li>
+      </ol>
+
+      <form id="checkout-form" onSubmit={handleSubmit} className="mt-6">
         <div className="grid gap-6 lg:grid-cols-3">
-          <div className="lg:col-span-2 space-y-6">
-            <section className="rounded-lg border p-6 space-y-4">
-              <h2 className="typo-h3">배송 정보</h2>
+          <div className="layout-stack-md lg:col-span-2">
+            <section className="rounded-lg border p-6">
+              <h2 className="typo-h3">{t('shippingInfo')}</h2>
 
-              <AddressSelectorSection
-                addresses={addresses}
-                selectedAddressId={selectedAddressId}
-                addressLoading={addressLoading}
-                onSelect={handleAddressSelect}
-                locale={locale}
-              />
-
-              <ShippingFormSection form={form} errors={errors} onChange={handleChange} />
-              <PhoneInputSection form={form} errors={errors} onChange={handleChange} />
-              <ZipcodeInputSection form={form} errors={errors} onChange={handleChange} />
-              <AddressInputSection form={form} errors={errors} onChange={handleChange} />
-              <AddressDetailInputSection form={form} onChange={handleChange} />
-              <MemoInputSection form={form} onChange={handleChange} />
-            </section>
-
-            <section className="rounded-lg border p-6 space-y-4">
-              <h2 className="typo-h3">결제 수단</h2>
-              {prepareResult ? (
-                <PaymentGateway
-                  ref={paymentRef}
-                  prepareResult={prepareResult}
-                  orderId={currentOrderId!}
-                  orderNumber={currentOrderNumber}
-                  amount={grandTotal}
+              <div className="mt-4 layout-stack-md">
+                <AddressSelectorSection
+                  addresses={addresses}
+                  selectedAddressId={selectedAddressId}
+                  addressLoading={addressLoading}
+                  onSelect={handleAddressSelect}
                   locale={locale}
-                  onError={handlePaymentError}
                 />
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  주문 정보 입력 후 결제 수단이 표시됩니다.
-                </p>
-              )}
+
+                <ShippingFormSection form={form} errors={errors} onChange={handleChange} />
+                <PhoneInputSection form={form} errors={errors} onChange={handleChange} />
+                <ZipcodeInputSection form={form} errors={errors} onChange={handleChange} />
+                <AddressInputSection form={form} errors={errors} onChange={handleChange} />
+                <AddressDetailInputSection form={form} onChange={handleChange} />
+                <MemoInputSection form={form} onChange={handleChange} />
+              </div>
             </section>
 
-            <section className="rounded-lg border p-6 space-y-2 opacity-50">
-              <h2 className="typo-h3">쿠폰 / 적립금</h2>
-              <p className="text-sm text-muted-foreground">쿠폰/적립금 적용은 추후 지원 예정입니다.</p>
+            <section className="rounded-lg border p-6">
+              <h2 className="typo-h3">{t('paymentMethod')}</h2>
+              <div className="mt-4">
+                {prepareResult ? (
+                  <PaymentGateway
+                    ref={paymentRef}
+                    prepareResult={prepareResult}
+                    orderId={currentOrderId!}
+                    orderNumber={currentOrderNumber}
+                    amount={grandTotal}
+                    locale={locale}
+                    onError={handlePaymentError}
+                  />
+                ) : (
+                  <p className="text-sm text-muted-foreground">{t('paymentMethodHint')}</p>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-lg border p-6 opacity-70">
+              <h2 className="typo-h3">{t('couponPoints')}</h2>
+              <p className="mt-2 text-sm text-muted-foreground">{t('couponPointsComingSoon')}</p>
             </section>
           </div>
 
-          <div className="space-y-4">
+          <div className="layout-stack-md">
             <OrderSummarySection checkoutItems={checkoutItems} locale={locale} />
-
-            <button
-              type="submit"
-              disabled={step !== 'idle'}
-              className="w-full rounded-md bg-foreground py-3 typo-button text-background hover:opacity-90 transition-opacity disabled:opacity-40"
-            >
-              {STEP_LABELS[step]}
-            </button>
+            <div className="hidden rounded-lg border border-border p-4 lg:block">
+              <div className="mb-2 flex items-end justify-between">
+                <span className="text-sm text-muted-foreground">{t('total')}</span>
+                <span className="typo-h2">{formatCurrency(grandTotal, locale)}</span>
+              </div>
+              <Button type="submit" disabled={step !== 'idle'} className="w-full">
+                {stepLabels[step]}
+              </Button>
+            </div>
           </div>
         </div>
       </form>
+
+      <div
+        className={cn(
+          'fixed left-0 right-0 z-50 border-t bg-background p-4 md:hidden',
+          isNavVisible ? 'bottom-14' : 'bottom-0',
+        )}
+      >
+        <div className="layout-container p-0">
+          <div className="mb-2 flex items-end justify-between">
+            <span className="text-xs text-muted-foreground">{t('total')}</span>
+            <span className="typo-title">{formatCurrency(grandTotal, locale)}</span>
+          </div>
+          <Button type="submit" form="checkout-form" className="w-full" disabled={step !== 'idle'}>
+            {stepLabels[step]}
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -81,7 +81,7 @@ export default async function ProductsPage({ params, searchParams }: ProductsPag
     : null;
 
   return (
-    <div className="mx-auto max-w-7xl px-4">
+    <div className="layout-container layout-page">
       <Breadcrumb category={selectedCategory} />
 
       {selectedCategory && (

--- a/src/components/__tests__/CartPage.test.tsx
+++ b/src/components/__tests__/CartPage.test.tsx
@@ -5,6 +5,32 @@ import CartPage from '@/app/[locale]/cart/page';
 import type { CartItem } from '@/lib/api';
 import { toast } from 'sonner';
 
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string | number>) => {
+    const dict: Record<string, string> = {
+      title: '장바구니',
+      empty: '장바구니가 비었습니다',
+      emptyDescription: '마음에 드는 상품을 장바구니에 담아보세요.',
+      requireLogin: '로그인이 필요합니다',
+      requireLoginDescription: '장바구니를 이용하려면 로그인해주세요.',
+      loginAction: '로그인',
+      continueShopping: '쇼핑 계속하기',
+      selectAll: '전체 선택',
+      orderSummary: '주문 요약',
+      selectedItems: '선택 상품',
+      productAmount: '상품 금액',
+      shippingFee: '배송비',
+      total: '합계',
+      orderSelected: '선택 상품 주문하기',
+      selectItemsToOrder: '주문할 상품을 선택해주세요.',
+      freeShipping: '무료',
+      freeShippingUnlocked: '무료배송이 적용되었습니다.',
+      freeShippingRemaining: `${values?.amount ?? ''} 더 담으면 무료배송`,
+    };
+    return dict[key] ?? key;
+  },
+}));
+
 // ---- next/navigation ----
 const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -33,6 +59,10 @@ vi.mock('@/contexts/CartContext', () => ({
   useCart: () => mockUseCart(),
   CartContext: {},
   CartProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/contexts/MobileNavContext', () => ({
+  useMobileNav: () => ({ isVisible: false }),
 }));
 
 // ---- next/image ----
@@ -144,7 +174,7 @@ describe('CartPage', () => {
     mockUseCart.mockReturnValue({ ...defaultCart, items: [cartItem1] });
 
     render(<CartPage />);
-    await user.click(screen.getByRole('button', { name: '선택 상품 주문하기' }));
+    await user.click(screen.getAllByRole('button', { name: '선택 상품 주문하기' })[0]);
 
     expect(toast.warning).toHaveBeenCalledWith('주문할 상품을 선택해주세요.');
   });

--- a/src/components/__tests__/CheckoutPage.test.tsx
+++ b/src/components/__tests__/CheckoutPage.test.tsx
@@ -8,6 +8,47 @@ import type { CartItem, UserAddress } from '@/lib/api';
 
 const makeParams = () => Promise.resolve({ locale: 'ko' as const });
 
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const dict: Record<string, string> = {
+      title: '주문 / 결제',
+      shippingInfo: '배송 정보',
+      loadingAddresses: '주소 불러오는 중...',
+      noSavedAddress: '저장된 배송지가 없습니다.',
+      addAddress: '배송지 추가',
+      manualEntry: '직접 입력',
+      recipientName: '받는 분 이름',
+      phone: '연락처',
+      zipcode: '우편번호',
+      address: '주소',
+      addressDetail: '상세 주소',
+      shippingMemo: '배송 메모',
+      paymentMethod: '결제 수단',
+      paymentMethodHint: '주문 정보 입력 후 결제 수단이 표시됩니다.',
+      couponPoints: '쿠폰 / 적립금',
+      couponPointsComingSoon: '쿠폰/적립금 적용은 추후 지원 예정입니다.',
+      orderItems: '주문 상품',
+      productAmount: '상품 금액',
+      shippingFee: '배송비',
+      total: '합계',
+      pay: '결제하기',
+      loadAddressError: '저장된 주소를 불러오는데 실패했습니다.',
+      freeShipping: '무료',
+      freeShippingUnlocked: '무료배송이 적용되었습니다.',
+      freeShippingRemaining: '무료배송 임계',
+      'flow.shipping': '배송 정보',
+      'flow.payment': '결제 수단',
+      'flow.complete': '결제 완료',
+      'steps.idle': '결제하기',
+      'steps.creating_order': '주문 생성 중...',
+      'steps.preparing_payment': '결제 준비 중...',
+      'steps.confirming_payment': '결제 확인 중...',
+      'steps.success': '완료',
+    };
+    return dict[key] ?? key;
+  },
+}));
+
 // ---- next/navigation ----
 const mockReplace = vi.fn();
 const mockPush = vi.fn();
@@ -38,6 +79,10 @@ vi.mock('@/contexts/CartContext', () => ({
   }),
   CartContext: {},
   CartProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/contexts/MobileNavContext', () => ({
+  useMobileNav: () => ({ isVisible: false }),
 }));
 
 // ---- i18n/routing ----
@@ -112,7 +157,7 @@ describe('CheckoutPage', () => {
     await user.type(screen.getByLabelText(/연락처/), '01012345678');
     await user.type(screen.getByLabelText(/우편번호/), '12345');
     await user.type(screen.getByLabelText(/^주소/), '서울시 강남구');
-    await user.click(screen.getByRole('button', { name: '결제하기' }));
+    await user.click(screen.getAllByRole('button', { name: '결제하기' })[0]);
 
     await waitFor(() => {
       expect(ordersApi.create).not.toHaveBeenCalled();
@@ -146,7 +191,7 @@ describe('CheckoutPage', () => {
     await user.type(screen.getByLabelText(/연락처/), '010-1234-5678');
     await user.type(screen.getByLabelText(/우편번호/), '12345');
     await user.type(screen.getByLabelText(/^주소/), '서울시 강남구');
-    await user.click(screen.getByRole('button', { name: '결제하기' }));
+    await user.click(screen.getAllByRole('button', { name: '결제하기' })[0]);
 
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith('/ko/order/complete?orderId=1&orderNumber=ORD-001');

--- a/src/components/shared/admin/AdminTable.tsx
+++ b/src/components/shared/admin/AdminTable.tsx
@@ -8,22 +8,32 @@ interface AdminTableProps {
   children: React.ReactNode;
   emptyMessage?: string;
   isEmpty?: boolean;
+  density?: 'regular' | 'compact';
 }
 
-export function AdminTable({ columns, children, emptyMessage = '데이터가 없습니다.', isEmpty }: AdminTableProps) {
+export function AdminTable({
+  columns,
+  children,
+  emptyMessage = '데이터가 없습니다.',
+  isEmpty,
+  density = 'regular',
+}: AdminTableProps) {
   return (
-    <div className="rounded-lg border border-border overflow-hidden">
+    <div className="admin-surface overflow-hidden">
       <table className="w-full">
-        <thead className="bg-muted/50">
-          <tr className="text-left text-xs text-muted-foreground uppercase">
+        <thead className="admin-table-head">
+          <tr className="text-left text-xs text-muted-foreground uppercase tracking-wide">
             {columns.map((col, i) => (
-              <th key={i} className={`py-3 px-4${col.width ? ` ${col.width}` : ''}`}>
+              <th
+                key={i}
+                className={`${density === 'compact' ? 'admin-row-compact' : 'admin-row'} border-b border-border px-4 py-3${col.width ? ` ${col.width}` : ''}`}
+              >
                 {col.label}
               </th>
             ))}
           </tr>
         </thead>
-        <tbody>
+        <tbody className="divide-y divide-border">
           {isEmpty ? (
             <tr>
               <td colSpan={columns.length} className="py-8 text-center text-sm text-muted-foreground">

--- a/src/components/shared/admin/StatusBadge.tsx
+++ b/src/components/shared/admin/StatusBadge.tsx
@@ -2,14 +2,14 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/components/ui/utils';
 
 const statusBadgeVariants = cva(
-  'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold',
+  'inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold',
   {
     variants: {
       color: {
-        green: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
-        red: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
-        yellow: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
-        secondary: 'bg-secondary text-muted-foreground',
+        green: 'border-emerald-200 bg-emerald-100/70 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200',
+        red: 'border-red-200 bg-red-100/70 text-red-800 dark:border-red-700 dark:bg-red-900/40 dark:text-red-200',
+        yellow: 'border-amber-200 bg-amber-100/70 text-amber-800 dark:border-amber-700 dark:bg-amber-900/40 dark:text-amber-200',
+        secondary: 'border-border bg-muted/70 text-muted-foreground',
       },
     },
     defaultVariants: {
@@ -26,9 +26,11 @@ interface ActiveStatusBadgeProps extends VariantProps<typeof statusBadgeVariants
 }
 
 export function StatusBadge({ isActive, className }: ActiveStatusBadgeProps) {
+  const active = isActive;
   return (
-    <span className={cn(statusBadgeVariants({ color: isActive ? 'green' : 'red' }), className)}>
-      {isActive ? '활성' : '비활성'}
+    <span className={cn(statusBadgeVariants({ color: active ? 'green' : 'red' }), className)}>
+      <span aria-hidden className={cn('h-1.5 w-1.5 rounded-full', active ? 'bg-emerald-600' : 'bg-red-600')} />
+      {active ? '활성' : '비활성'}
     </span>
   );
 }
@@ -61,6 +63,16 @@ export function ProductStatusBadge({ status, className }: ProductStatusBadgeProp
   const label = PRODUCT_STATUS_LABELS[status] ?? status;
   return (
     <span className={cn(statusBadgeVariants({ color }), className)}>
+      <span
+        aria-hidden
+        className={cn(
+          'h-1.5 w-1.5 rounded-full',
+          color === 'green' && 'bg-emerald-600',
+          color === 'red' && 'bg-red-600',
+          color === 'yellow' && 'bg-amber-600',
+          color === 'secondary' && 'bg-muted-foreground/70',
+        )}
+      />
       {label}
     </span>
   );
@@ -82,6 +94,7 @@ export function InquiryStatusBadge({ status, context = 'admin', className }: Inq
   const pendingLabel = context === 'my' ? '접수' : '미답변';
   return (
     <span className={cn(statusBadgeVariants({ color: isAnswered ? 'green' : 'yellow' }), className)}>
+      <span aria-hidden className={cn('h-1.5 w-1.5 rounded-full', isAnswered ? 'bg-emerald-600' : 'bg-amber-600')} />
       {isAnswered ? '답변완료' : pendingLabel}
     </span>
   );

--- a/src/components/shared/blocks/HeroBannerBlock.tsx
+++ b/src/components/shared/blocks/HeroBannerBlock.tsx
@@ -62,7 +62,7 @@ function SliderHero({ slides, description, sectionRef }: SliderHeroProps) {
               key={slideIndex}
               className={cn(
                 'relative min-w-full flex items-center justify-center overflow-hidden',
-                'h-[40svh] min-h-[25rem] md:h-[680px]',
+                'h-size-hero-sm min-h-size-hero-min md:h-size-hero-md',
               )}
               style={{ backgroundColor: slide.bg_color ?? '#2A2520' }}
             >
@@ -76,6 +76,7 @@ function SliderHero({ slides, description, sectionRef }: SliderHeroProps) {
                     slideIndex === selectedIndex && !slide.image_url.toLowerCase().endsWith('.gif') && 'animate-kenburns',
                   )}
                   priority={slideIndex === 0}
+                  fetchPriority={slideIndex === 0 ? 'high' : 'auto'}
                   sizes="100vw"
                   unoptimized={slide.image_url.toLowerCase().endsWith('.gif')}
                 />
@@ -240,7 +241,7 @@ export default function HeroBannerBlock({ content }: Props) {
 
   return (
     <ScrollLogoProvider value={scrollLogoContextValue}>
-      <section ref={sectionRef} className="relative flex h-[40svh] min-h-[25rem] md:h-[680px] items-center justify-center overflow-hidden bg-neutral-900">
+      <section ref={sectionRef} className="relative flex h-size-hero-sm min-h-size-hero-min md:h-size-hero-md items-center justify-center overflow-hidden bg-neutral-900">
         {image_url && (
           <Image
             src={image_url}
@@ -248,6 +249,7 @@ export default function HeroBannerBlock({ content }: Props) {
             fill
             className={cn('object-cover object-center', !image_url.toLowerCase().endsWith('.gif') && 'animate-kenburns')}
             priority
+            fetchPriority="high"
             sizes="100vw"
             unoptimized={image_url.toLowerCase().endsWith('.gif')}
           />

--- a/src/components/shared/checkout/OrderSummarySection.tsx
+++ b/src/components/shared/checkout/OrderSummarySection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import type { CartItem } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import type { Locale } from '@/i18n/routing';
@@ -10,50 +11,64 @@ interface OrderSummarySectionProps {
   locale: Locale;
 }
 
-export function OrderSummarySection({
-  checkoutItems,
-  locale,
-}: OrderSummarySectionProps) {
+export function OrderSummarySection({ checkoutItems, locale }: OrderSummarySectionProps) {
+  const t = useTranslations('checkout');
   const totalAmount = checkoutItems.reduce((sum, item) => sum + item.subtotal, 0);
   const shippingFee = totalAmount >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_FEE;
   const grandTotal = totalAmount + shippingFee;
+  const remainingForFreeShipping = Math.max(FREE_SHIPPING_THRESHOLD - totalAmount, 0);
+  const freeShippingProgress = Math.min((totalAmount / FREE_SHIPPING_THRESHOLD) * 100, 100);
 
   return (
-    <section className="rounded-lg border p-6 space-y-4 lg:sticky lg:top-24">
-      <h2 className="typo-h3">주문 상품</h2>
+    <section className="rounded-lg border p-6 lg:sticky lg:top-24">
+      <h2 className="typo-h3">{t('orderItems')}</h2>
 
-      <ul className="divide-y text-sm">
+      <ul className="mt-4 divide-y text-sm">
         {checkoutItems.map((item) => (
-          <li key={item.id} className="py-3 space-y-0.5">
+          <li key={item.id} className="space-y-0.5 py-3">
             <p className="font-medium">{item.product.name}</p>
             {item.option && (
-              <p className="text-muted-foreground text-xs">
+              <p className="text-xs text-muted-foreground">
                 {item.option.name}: {item.option.value}
               </p>
             )}
             <p className="text-muted-foreground">
-              {formatCurrency(item.unitPrice, locale)} × {item.quantity}개 ={' '}
-              {formatCurrency(item.subtotal, locale)}
+              {formatCurrency(item.unitPrice, locale)} × {item.quantity} = {formatCurrency(item.subtotal, locale)}
             </p>
           </li>
         ))}
       </ul>
 
-      <div className="border-t pt-4 space-y-2 text-sm">
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">상품 금액</span>
-          <span>{formatCurrency(totalAmount, locale)}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">배송비</span>
-          <span>{shippingFee === 0 ? '무료' : formatCurrency(shippingFee, locale)}</span>
+      <div className="mt-4 rounded-md border border-border bg-muted/30 p-3">
+        <p className="text-xs text-muted-foreground">
+          {remainingForFreeShipping === 0
+            ? t('freeShippingUnlocked')
+            : t('freeShippingRemaining', { amount: formatCurrency(remainingForFreeShipping, locale) })}
+        </p>
+        <div className="mt-2 h-1.5 w-full rounded-full bg-background">
+          <div
+            className="h-full rounded-full bg-primary transition-[width] duration-300"
+            style={{ width: `${freeShippingProgress}%` }}
+            aria-hidden
+          />
         </div>
       </div>
 
-      <div className="border-t pt-4">
-        <div className="flex justify-between typo-h3">
-          <span>합계</span>
-          <span>{formatCurrency(grandTotal, locale)}</span>
+      <div className="mt-4 border-t pt-4 text-sm">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">{t('productAmount')}</span>
+          <span>{formatCurrency(totalAmount, locale)}</span>
+        </div>
+        <div className="mt-2 flex justify-between">
+          <span className="text-muted-foreground">{t('shippingFee')}</span>
+          <span>{shippingFee === 0 ? t('freeShipping') : formatCurrency(shippingFee, locale)}</span>
+        </div>
+      </div>
+
+      <div className="mt-4 border-t pt-4">
+        <div className="flex items-end justify-between">
+          <span className="typo-title">{t('total')}</span>
+          <span className="typo-h2">{formatCurrency(grandTotal, locale)}</span>
         </div>
       </div>
     </section>

--- a/src/components/shared/products/ProductDetailClient.tsx
+++ b/src/components/shared/products/ProductDetailClient.tsx
@@ -170,7 +170,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
   }, [product.options.length, selectedOptionId, buyNow, t, focusOptionSection])
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-8 pb-24 md:pb-8">
+    <div className="layout-container layout-page pb-24 md:pb-8">
       {/* 갤러리 + 정보 영역 */}
       <div className="grid grid-cols-1 gap-8 md:grid-cols-[1.2fr_1fr]">
         {/* Left: Image gallery */}
@@ -363,7 +363,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
       </div>
 
       {/* Tabs */}
-      <div className="mx-auto max-w-7xl px-4">
+      <div className="layout-container p-0">
         <ProductTabs description={product.description} descriptionImages={descriptionImages} productId={Number(product.id)} />
       </div>
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,22 +4,23 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/components/ui/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex min-h-11 items-center justify-center whitespace-nowrap rounded-md text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/92',
+        primary: 'bg-primary text-primary-foreground hover:bg-primary/92',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/92',
+        outline: 'border border-input bg-background hover:border-foreground/20 hover:bg-accent hover:text-accent-foreground',
+        secondary: 'border border-border bg-secondary text-secondary-foreground hover:bg-secondary/70',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        default: 'h-11 px-4 py-2',
+        sm: 'h-10 rounded-md px-3',
+        lg: 'h-12 rounded-md px-8',
+        icon: 'h-11 w-11',
       },
     },
     defaultVariants: {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -220,7 +220,12 @@
     "orderSelected": "Order Selected Items",
     "selectItemsToOrder": "Please select items to order.",
     "noImage": "No image",
-    "removeItem": "Remove {name}"
+    "removeItem": "Remove {name}",
+    "loginAction": "Log in",
+    "continueShopping": "Continue shopping",
+    "freeShipping": "Free",
+    "freeShippingUnlocked": "Free shipping is now applied.",
+    "freeShippingRemaining": "Add {amount} more for free shipping"
   },
   "checkout": {
     "title": "Order / Payment",
@@ -263,7 +268,16 @@
       "phoneInvalid": "Please enter a valid phone number. (e.g. 010-1234-5678)",
       "zipcodeInvalid": "ZIP code must be 5 digits.",
       "addressRequired": "Please enter your address."
-    }
+    },
+    "flow": {
+      "shipping": "Shipping info",
+      "payment": "Payment",
+      "complete": "Done"
+    },
+    "paymentMethodHint": "Payment methods appear after shipping info is complete.",
+    "freeShipping": "Free",
+    "freeShippingUnlocked": "Free shipping is now applied.",
+    "freeShippingRemaining": "Add {amount} more for free shipping"
   },
   "order": {
     "orderHistory": "Order History",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -220,7 +220,12 @@
     "orderSelected": "선택 상품 주문하기",
     "selectItemsToOrder": "주문할 상품을 선택해주세요.",
     "noImage": "No image",
-    "removeItem": "{name} 삭제"
+    "removeItem": "{name} 삭제",
+    "loginAction": "로그인",
+    "continueShopping": "쇼핑 계속하기",
+    "freeShipping": "무료",
+    "freeShippingUnlocked": "무료배송이 적용되었습니다.",
+    "freeShippingRemaining": "{amount} 더 담으면 무료배송"
   },
   "checkout": {
     "title": "주문 / 결제",
@@ -263,7 +268,16 @@
       "phoneInvalid": "올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)",
       "zipcodeInvalid": "우편번호는 5자리 숫자로 입력해주세요.",
       "addressRequired": "주소를 입력해주세요."
-    }
+    },
+    "flow": {
+      "shipping": "배송 정보",
+      "payment": "결제 수단",
+      "complete": "결제 완료"
+    },
+    "paymentMethodHint": "주문 정보 입력 후 결제 수단이 표시됩니다.",
+    "freeShipping": "무료",
+    "freeShippingUnlocked": "무료배송이 적용되었습니다.",
+    "freeShippingRemaining": "{amount} 더 담으면 무료배송"
   },
   "order": {
     "orderHistory": "주문 내역",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -94,6 +94,19 @@
   --radius-md: var(--db-radius-md, 0.25rem);
   --radius-lg: var(--db-radius-lg, 0.5rem);
 
+  /* ── Layout rhythm tokens ── */
+  --layout-max-width: 80rem; /* 1280px */
+  --layout-page-y: 2rem;
+  --layout-section-y: 1.5rem;
+  --layout-grid-gap: 1.5rem;
+  --layout-text-max: 42rem;
+
+  /* ── Admin density / contrast tokens ── */
+  --admin-header-bg: color-mix(in srgb, var(--color-muted) 55%, var(--color-background));
+  --admin-row-hover: color-mix(in srgb, var(--color-muted) 40%, transparent);
+  --admin-row-height: 2.875rem;
+  --admin-row-height-compact: 2.5rem;
+
   /* ── 타이포그래피 — 폰트 패밀리 (3종) ── */
   --font-display: 'Noto Serif KR', 'Georgia', serif;
   --font-body: 'Pretendard', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;
@@ -121,7 +134,55 @@
     --font-size-heading-3: 1.25rem;  /* 20px desktop */
     --font-size-title: 1.125rem;     /* 18px desktop */
     --font-size-heading-0: 3rem;     /* 48px desktop - hero only */
+    --layout-page-y: 2.5rem;
+    --layout-section-y: 2rem;
+    --layout-grid-gap: 2rem;
   }
+}
+
+/* ── Layout utilities ──────────────────────────────────────────── */
+@utility layout-container {
+  width: 100%;
+  max-width: var(--layout-max-width);
+  margin-inline: auto;
+  padding-inline: 1rem;
+}
+
+@utility layout-page {
+  padding-block: var(--layout-page-y);
+}
+
+@utility layout-section {
+  padding-block: var(--layout-section-y);
+}
+
+@utility layout-stack-md {
+  display: flex;
+  flex-direction: column;
+  gap: var(--layout-grid-gap);
+}
+
+@utility text-readable {
+  max-width: var(--layout-text-max);
+}
+
+/* ── Admin utilities ───────────────────────────────────────────── */
+@utility admin-surface {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-card);
+}
+
+@utility admin-table-head {
+  background: var(--admin-header-bg);
+}
+
+@utility admin-row {
+  min-height: var(--admin-row-height);
+}
+
+@utility admin-row-compact {
+  min-height: var(--admin-row-height-compact);
 }
 
 /* ── Typography utility classes ────────────────────────────────── */
@@ -317,6 +378,21 @@ h3 {
 .animate-fade-in-up {
   opacity: 0;
   animation: fadeInUp 0.7s ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* ── Lightbox animation ──────────────────────────────────────────── */


### PR DESCRIPTION
## 요약
- 전역 spacing/grid/admin 토큰 및 유틸리티를 정비해 레이아웃 리듬을 통일했습니다.
- Button variant(Primary/Secondary/Destructive) 계층을 강화하고 터치 타깃 기준(min-h-11)을 적용했습니다.
- Cart/Checkout에 무료배송 임계 진행바, 모바일 sticky CTA, 결제 단계 흐름 표시를 추가했습니다.
- AdminTable/StatusBadge의 대비·밀도 규칙을 통일했습니다.
- Hero 높이 arbitrary class를 토큰 기반 클래스로 치환하고 우선 로딩 힌트를 보강했습니다.
- 변경 규칙 문서를 docs/architecture/FRONTEND_DESIGN_RULES_643_650.md로 추가했습니다.

## 검증
- npm run build
- npm run test:run
- cd backend && npm run build && npm run test
- bash scripts/start-local.sh

## 참고
- 스키마/마이그레이션 변경이 없어 cd backend && npm run test:e2e는 생략했습니다.

Closes #643
Closes #644
Closes #645
Closes #646
Closes #647
Closes #648
Closes #649
Closes #650
