### PR TITLE
상품상세 문의 탭을 실제 문의 플로우로 전환

### DIFF
--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -86,6 +86,7 @@ export default function CheckoutPage({
     confirming_payment: t('steps.confirming_payment'),
     success: t('steps.success'),
   };
+  const loadAddressErrorMessage = t('loadAddressError');
 
   const fillFormFromAddress = (addr: UserAddress) => {
     setForm({
@@ -139,12 +140,12 @@ export default function CheckoutPage({
         }
       })
       .catch(() => {
-        toast.error(t('loadAddressError'));
+        toast.error(loadAddressErrorMessage);
       })
       .finally(() => {
         setAddressLoading(false);
       });
-  }, [isAuthenticated, isLoading, t]);
+  }, [isAuthenticated, isLoading, loadAddressErrorMessage]);
 
   const handleAddressSelect = (id: number | 'manual') => {
     setSelectedAddressId(id);

--- a/src/components/__tests__/ProductTabs.test.tsx
+++ b/src/components/__tests__/ProductTabs.test.tsx
@@ -1,13 +1,79 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import ProductTabs from '@/components/shared/products/ProductTabs'
 
-vi.mock('isomorphic-dompurify', () => ({
+vi.mock('dompurify', () => ({
   default: { sanitize: (html: string) => html },
 }))
 
+const mockUseAuth = vi.fn(() => ({
+  isAuthenticated: false,
+}))
+
+const mockGetList = vi.fn()
+const mockCreate = vi.fn()
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  inquiriesApi: {
+    getList: (...args: unknown[]) => mockGetList(...args),
+    create: (...args: unknown[]) => mockCreate(...args),
+  },
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/ko/products/1',
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const translations: Record<string, string> = {
+  'tabs.details': '상세정보',
+  'tabs.reviews': '리뷰',
+  'tabs.inquiry': '문의',
+  'tabs.comingSoon': '준비 중입니다.',
+  'tabs.inquiryPanel.loginRequiredTitle': '로그인이 필요합니다.',
+  'tabs.inquiryPanel.loginRequiredDescription': '문의를 작성하려면 로그인해주세요.',
+  'tabs.inquiryPanel.loginAction': '로그인하기',
+  'tabs.inquiryPanel.listTitle': '내 문의 내역',
+  'tabs.inquiryPanel.loading': '문의 내역을 불러오는 중입니다.',
+  'tabs.inquiryPanel.empty': '등록된 문의가 없습니다.',
+  'tabs.inquiryPanel.titleLabel': '제목',
+  'tabs.inquiryPanel.titlePlaceholder': '문의 제목을 입력해주세요',
+  'tabs.inquiryPanel.contentLabel': '내용',
+  'tabs.inquiryPanel.contentPlaceholder': '문의 내용을 입력해주세요',
+  'tabs.inquiryPanel.submit': '문의 등록',
+  'tabs.inquiryPanel.submitting': '등록 중...',
+  'tabs.inquiryPanel.statusPending': '접수',
+  'tabs.inquiryPanel.statusAnswered': '답변완료',
+  'tabs.inquiryPanel.answerLabel': '답변',
+}
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string | number>) => {
+    const template = translations[key] ?? key
+    if (!values) return template
+    return Object.entries(values).reduce(
+      (acc, [k, v]) => acc.replace(`{${k}}`, String(v)),
+      template,
+    )
+  },
+}))
+
 describe('ProductTabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue({ isAuthenticated: false })
+    mockGetList.mockResolvedValue({ data: [] })
+    mockCreate.mockResolvedValue({ id: 1 })
+  })
+
   it('default tab shows description content', () => {
     render(<ProductTabs description="<p>상품 상세 내용입니다.</p>" descriptionImages={[]} />)
     expect(screen.getByText('상세정보')).toBeInTheDocument()
@@ -22,10 +88,50 @@ describe('ProductTabs', () => {
     expect(screen.getByText('준비 중입니다.')).toBeInTheDocument()
   })
 
-  it('clicking 문의 tab shows 준비 중입니다', async () => {
+  it('clicking 문의 tab shows login call-to-action when user is not authenticated', async () => {
     const user = userEvent.setup()
     render(<ProductTabs description={null} descriptionImages={[]} />)
     await user.click(screen.getByRole('button', { name: '문의' }))
-    expect(screen.getByText('준비 중입니다.')).toBeInTheDocument()
+    expect(screen.getByText('로그인이 필요합니다.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '로그인하기' })).toHaveAttribute(
+      'href',
+      '/login?redirect=%2Fko%2Fproducts%2F1',
+    )
+  })
+
+  it('loads inquiries and submits new inquiry when user is authenticated', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({ isAuthenticated: true })
+    mockGetList.mockResolvedValue({
+      data: [
+        {
+          id: 22,
+          type: '상품',
+          title: '기존 문의',
+          content: '내용',
+          status: 'pending',
+          answer: null,
+          answeredAt: null,
+          createdAt: '2026-04-21T10:00:00.000Z',
+        },
+      ],
+    })
+
+    render(<ProductTabs description={null} descriptionImages={[]} productId={1} />)
+    await user.click(screen.getByRole('button', { name: '문의' }))
+
+    expect(await screen.findByText('내 문의 내역')).toBeInTheDocument()
+    expect(await screen.findByText('기존 문의')).toBeInTheDocument()
+    expect(mockGetList).toHaveBeenCalled()
+
+    await user.type(screen.getByLabelText('제목'), '추가 문의')
+    await user.type(screen.getByLabelText('내용'), '문의 내용')
+    await user.click(screen.getByRole('button', { name: '문의 등록' }))
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      type: '상품',
+      title: '추가 문의',
+      content: '문의 내용',
+    })
   })
 })

--- a/src/components/__tests__/ProfileForm.test.tsx
+++ b/src/components/__tests__/ProfileForm.test.tsx
@@ -5,6 +5,28 @@ import ProfilePage from '@/app/[locale]/my/profile/page';
 import { AuthContext } from '@/contexts/AuthContext';
 import type { AuthContextValue } from '@/contexts/AuthContext';
 
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace: string) => (key: string) => {
+    const dict: Record<string, Record<string, string>> = {
+      myPage: { title: '마이페이지' },
+      profile: {
+        title: '회원정보',
+        email: '이메일',
+        emailReadOnly: '이메일은 변경할 수 없습니다.',
+        name: '이름',
+        phone: '전화번호',
+        save: '저장하기',
+        saving: '저장 중...',
+        updateSuccess: '회원정보가 수정되었습니다.',
+        updateError: '회원정보 수정에 실패했습니다.',
+        'validation.nameRequired': '이름은 필수입니다.',
+        'validation.phoneInvalid': '전화번호 형식이 올바르지 않습니다.',
+      },
+    };
+    return dict[namespace]?.[key] ?? key;
+  },
+}));
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: vi.fn() }),
 }));

--- a/src/components/shared/products/ProductDetailClient.tsx
+++ b/src/components/shared/products/ProductDetailClient.tsx
@@ -364,7 +364,12 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
 
       {/* Tabs */}
       <div className="layout-container p-0">
-        <ProductTabs description={product.description} descriptionImages={descriptionImages} productId={Number(product.id)} />
+        <ProductTabs
+          description={product.description}
+          descriptionImages={descriptionImages}
+          productId={Number(product.id)}
+          locale={locale}
+        />
       </div>
 
       {/* Mobile fixed bottom action bar — sits above MobileBottomNav (z-50, ~56px tall) */}

--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -1,23 +1,81 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { toast } from 'sonner'
+import { inquiriesApi } from '@/lib/api'
+import type { Inquiry, ProductDetailImage } from '@/lib/api'
+import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction'
+import { useAuth } from '@/contexts/AuthContext'
 import { cn } from '@/components/ui/utils'
 import ReviewsTab from '@/components/shared/reviews/ReviewsTab'
-import type { ProductDetailImage } from '@/lib/api'
 
 interface ProductTabsProps {
   description: string | null
   descriptionImages: ProductDetailImage[]
   productId?: number
+  locale?: string
 }
 
-const TABS = ['상세정보', '리뷰', '문의'] as const
+const TABS = ['details', 'reviews', 'inquiry'] as const
 type Tab = (typeof TABS)[number]
+const INQUIRY_TYPE_PRODUCT = '상품'
 
-export default function ProductTabs({ description, descriptionImages, productId }: ProductTabsProps) {
-  const [activeTab, setActiveTab] = useState<Tab>('상세정보')
+export default function ProductTabs({ description, descriptionImages, productId, locale = 'ko' }: ProductTabsProps) {
+  const t = useTranslations('product')
+  const pathname = usePathname()
+  const { isAuthenticated } = useAuth()
+  const [activeTab, setActiveTab] = useState<Tab>('details')
   const [sanitized, setSanitized] = useState('')
+  const [inquiries, setInquiries] = useState<Inquiry[]>([])
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+
+  const tabLabels = useMemo(
+    () => ({
+      details: t('tabs.details'),
+      reviews: t('tabs.reviews'),
+      inquiry: t('tabs.inquiry'),
+    }),
+    [t],
+  )
+
+  const loginHref = useMemo(() => {
+    if (!pathname) return '/login'
+    return `/login?redirect=${encodeURIComponent(pathname)}`
+  }, [pathname])
+
+  const { execute: loadInquiries, isLoading: isLoadingInquiries } = useAsyncAction(
+    async () => {
+      const response = await inquiriesApi.getList()
+      const items = Array.isArray(response) ? response : response.data
+      const filtered = items
+        .filter((inquiry) => inquiry.type === INQUIRY_TYPE_PRODUCT)
+        .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
+      setInquiries(filtered)
+    },
+    { errorMessage: t('tabs.inquiryPanel.loadError') },
+  )
+
+  const { execute: submitInquiry, isLoading: isSubmitting } = useAsyncAction(
+    async () => {
+      const trimmedTitle = title.trim()
+      const trimmedContent = content.trim()
+
+      await inquiriesApi.create({
+        type: INQUIRY_TYPE_PRODUCT,
+        title: trimmedTitle,
+        content: trimmedContent,
+      })
+      setTitle('')
+      setContent('')
+      await loadInquiries(undefined)
+    },
+    { successMessage: t('tabs.inquiryPanel.submitSuccess'), errorMessage: t('tabs.inquiryPanel.submitError') },
+  )
 
   useEffect(() => {
     import('dompurify').then((mod) => {
@@ -27,6 +85,19 @@ export default function ProductTabs({ description, descriptionImages, productId 
       }))
     })
   }, [description])
+
+  useEffect(() => {
+    if (activeTab !== 'inquiry' || !isAuthenticated) return
+    void loadInquiries(undefined)
+  }, [activeTab, isAuthenticated, loadInquiries])
+
+  const handleInquirySubmit = () => {
+    if (!title.trim() || !content.trim()) {
+      toast.error(t('tabs.inquiryPanel.validation'))
+      return
+    }
+    void submitInquiry(undefined)
+  }
 
   return (
     <div className="mt-8">
@@ -43,12 +114,12 @@ export default function ProductTabs({ description, descriptionImages, productId 
                 : 'text-muted-foreground hover:text-foreground',
             )}
           >
-            {tab}
+            {tabLabels[tab]}
           </button>
         ))}
       </div>
       <div className="py-6">
-        {activeTab === '상세정보' && (
+        {activeTab === 'details' && (
           <div className="flex flex-col gap-6">
             {descriptionImages.length > 0 && (
               <div className="flex flex-col gap-0">
@@ -60,7 +131,7 @@ export default function ProductTabs({ description, descriptionImages, productId 
                   >
                     <Image
                       src={image.url}
-                      alt={image.alt ?? `상세정보 이미지 ${index + 1}`}
+                      alt={image.alt ?? t('tabs.detailsImageAlt', { index: index + 1 })}
                       fill
                       sizes="(max-width: 768px) 100vw, 600px"
                       className="object-cover"
@@ -76,14 +147,107 @@ export default function ProductTabs({ description, descriptionImages, productId 
             />
           </div>
         )}
-        {activeTab === '리뷰' && productId && (
+        {activeTab === 'reviews' && productId && (
           <ReviewsTab productId={productId} />
         )}
-        {activeTab === '리뷰' && !productId && (
-          <p className="text-sm text-muted-foreground">준비 중입니다.</p>
+        {activeTab === 'reviews' && !productId && (
+          <p className="text-sm text-muted-foreground">{t('tabs.comingSoon')}</p>
         )}
-        {activeTab === '문의' && (
-          <p className="text-sm text-muted-foreground">준비 중입니다.</p>
+        {activeTab === 'inquiry' && (
+          <div className="space-y-5">
+            {!isAuthenticated ? (
+              <div className="rounded-lg border border-border bg-muted/30 p-5">
+                <p className="text-base font-semibold text-foreground">{t('tabs.inquiryPanel.loginRequiredTitle')}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{t('tabs.inquiryPanel.loginRequiredDescription')}</p>
+                <Link
+                  href={loginHref}
+                  className="mt-4 inline-flex items-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+                >
+                  {t('tabs.inquiryPanel.loginAction')}
+                </Link>
+              </div>
+            ) : (
+              <>
+                <form
+                  className="space-y-3 rounded-lg border border-border bg-card p-4"
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    handleInquirySubmit()
+                  }}
+                >
+                  <div>
+                    <label htmlFor="inquiry-title" className="mb-1 block text-sm font-medium text-foreground">
+                      {t('tabs.inquiryPanel.titleLabel')}
+                    </label>
+                    <input
+                      id="inquiry-title"
+                      value={title}
+                      maxLength={255}
+                      onChange={(e) => setTitle(e.target.value)}
+                      placeholder={t('tabs.inquiryPanel.titlePlaceholder')}
+                      className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="inquiry-content" className="mb-1 block text-sm font-medium text-foreground">
+                      {t('tabs.inquiryPanel.contentLabel')}
+                    </label>
+                    <textarea
+                      id="inquiry-content"
+                      value={content}
+                      rows={4}
+                      onChange={(e) => setContent(e.target.value)}
+                      placeholder={t('tabs.inquiryPanel.contentPlaceholder')}
+                      className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </div>
+                  <div className="flex justify-end">
+                    <button
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {isSubmitting ? t('tabs.inquiryPanel.submitting') : t('tabs.inquiryPanel.submit')}
+                    </button>
+                  </div>
+                </form>
+
+                <div className="space-y-2">
+                  <p className="text-sm font-semibold text-foreground">{t('tabs.inquiryPanel.listTitle')}</p>
+                  {isLoadingInquiries ? (
+                    <p className="text-sm text-muted-foreground">{t('tabs.inquiryPanel.loading')}</p>
+                  ) : inquiries.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">{t('tabs.inquiryPanel.empty')}</p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {inquiries.map((inquiry) => (
+                        <li key={inquiry.id} className="rounded-lg border border-border bg-muted/20 p-3">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <p className="text-sm font-medium text-foreground">{inquiry.title}</p>
+                            <span className="text-xs text-muted-foreground">
+                              {new Date(inquiry.createdAt).toLocaleDateString(locale)}
+                            </span>
+                          </div>
+                          <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">{inquiry.content}</p>
+                          <p className="mt-2 text-xs font-semibold text-foreground">
+                            {inquiry.status === 'answered'
+                              ? t('tabs.inquiryPanel.statusAnswered')
+                              : t('tabs.inquiryPanel.statusPending')}
+                          </p>
+                          {inquiry.answer && (
+                            <div className="mt-2 rounded-md border border-border bg-card p-2">
+                              <p className="text-xs font-semibold text-foreground">{t('tabs.inquiryPanel.answerLabel')}</p>
+                              <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">{inquiry.answer}</p>
+                            </div>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -171,12 +171,34 @@
     "noProducts": "No products found",
     "noProductsDescription": "No products are listed yet.",
     "noSearchResults": "No results found for \"{query}\".",
-    "tabs": {
-      "details": "Details",
-      "reviews": "Reviews",
-      "inquiry": "Inquiry",
-      "comingSoon": "Coming soon."
-    },
+  "tabs": {
+    "details": "Details",
+    "reviews": "Reviews",
+    "inquiry": "Inquiry",
+    "comingSoon": "Coming soon.",
+    "detailsImageAlt": "Detail image {index}",
+    "inquiryPanel": {
+      "loginRequiredTitle": "Login required.",
+      "loginRequiredDescription": "Please log in to submit an inquiry.",
+      "loginAction": "Go to login",
+      "titleLabel": "Title",
+      "titlePlaceholder": "Enter the inquiry title",
+      "contentLabel": "Content",
+      "contentPlaceholder": "Please describe your inquiry",
+      "submit": "Submit inquiry",
+      "submitting": "Submitting...",
+      "submitSuccess": "Your inquiry has been submitted.",
+      "submitError": "Failed to submit inquiry.",
+      "validation": "Please enter both title and content.",
+      "listTitle": "My inquiries",
+      "loading": "Loading inquiries...",
+      "empty": "No inquiries yet.",
+      "loadError": "Failed to load inquiries.",
+      "statusAnswered": "Answered",
+      "statusPending": "Received",
+      "answerLabel": "Answer"
+    }
+  },
     "sort": {
       "label": "Sort by",
       "latest": "Newest",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -171,12 +171,34 @@
     "noProducts": "상품이 없습니다",
     "noProductsDescription": "등록된 상품이 없습니다.",
     "noSearchResults": "\"{query}\"에 대한 검색 결과가 없습니다.",
-    "tabs": {
-      "details": "상세정보",
-      "reviews": "리뷰",
-      "inquiry": "문의",
-      "comingSoon": "준비 중입니다."
-    },
+  "tabs": {
+    "details": "상세정보",
+    "reviews": "리뷰",
+    "inquiry": "문의",
+    "comingSoon": "준비 중입니다.",
+    "detailsImageAlt": "상세정보 이미지 {index}",
+    "inquiryPanel": {
+      "loginRequiredTitle": "로그인이 필요합니다.",
+      "loginRequiredDescription": "문의를 작성하려면 로그인해주세요.",
+      "loginAction": "로그인하기",
+      "titleLabel": "제목",
+      "titlePlaceholder": "문의 제목을 입력해주세요",
+      "contentLabel": "내용",
+      "contentPlaceholder": "문의 내용을 입력해주세요",
+      "submit": "문의 등록",
+      "submitting": "등록 중...",
+      "submitSuccess": "문의가 접수되었습니다.",
+      "submitError": "문의 등록에 실패했습니다.",
+      "validation": "제목과 내용을 입력해주세요.",
+      "listTitle": "내 문의 내역",
+      "loading": "문의 내역을 불러오는 중입니다.",
+      "empty": "등록된 문의가 없습니다.",
+      "loadError": "문의 내역을 불러오지 못했습니다.",
+      "statusAnswered": "답변완료",
+      "statusPending": "접수",
+      "answerLabel": "답변"
+    }
+  },
     "sort": {
       "label": "정렬 기준",
       "latest": "최신순",


### PR DESCRIPTION
## 요약
- 상품상세 `문의` 탭의 `준비 중` 플레이스홀더를 실제 문의 UI로 교체
- 비로그인 상태에서는 로그인 유도 메시지 + 로그인 링크 제공
- 로그인 상태에서는 문의 작성 폼 + 내 상품 문의 목록(로딩/빈 상태/상태값/답변) 제공
- 문의 탭 관련 문구를 `next-intl` 키로 이동(ko/en 동시 반영)

## 변경 파일
- `src/components/shared/products/ProductTabs.tsx`
- `src/components/shared/products/ProductDetailClient.tsx`
- `src/components/__tests__/ProductTabs.test.tsx`
- `src/i18n/messages/ko.json`
- `src/i18n/messages/en.json`

## 검증
- `npx vitest run src/components/__tests__/ProductTabs.test.tsx`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `bash scripts/start-local.sh`

## 이슈
- Closes #669
