### PR TITLE
fix: #672 #673 #674 공개 엔드포인트 보안 하드닝

### DIFF
--- a/backend/src/__tests__/query-limit-validation.spec.ts
+++ b/backend/src/__tests__/query-limit-validation.spec.ts
@@ -1,0 +1,22 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ReviewQueryDto } from '../modules/reviews/dto/review-query.dto';
+import { AdminOrderQueryDto } from '../modules/admin/dto/admin-order-query.dto';
+import { AdminMembersQueryDto } from '../modules/admin/dto/admin-members-query.dto';
+
+describe('query DTO limit validation', () => {
+  it.each([
+    ['ReviewQueryDto', ReviewQueryDto],
+    ['AdminOrderQueryDto', AdminOrderQueryDto],
+    ['AdminMembersQueryDto', AdminMembersQueryDto],
+  ])('%s rejects limit values above 100', async (_name, DtoClass) => {
+    const dto = plainToInstance(DtoClass, { limit: 101 });
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.property).toBe('limit');
+    expect(errors[0]?.constraints).toMatchObject({
+      max: 'limit은 100 이하여야 합니다.',
+    });
+  });
+});

--- a/backend/src/common/guards/user-aware-throttler.guard.spec.ts
+++ b/backend/src/common/guards/user-aware-throttler.guard.spec.ts
@@ -3,11 +3,17 @@ import { UserAwareThrottlerGuard } from './user-aware-throttler.guard';
 
 describe('UserAwareThrottlerGuard', () => {
   let guard: UserAwareThrottlerGuard;
+  const originalJwtSecret = process.env.JWT_SECRET;
   const call = (req: unknown) =>
     (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req);
 
   beforeEach(() => {
     guard = Object.create(UserAwareThrottlerGuard.prototype) as UserAwareThrottlerGuard;
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  afterEach(() => {
+    process.env.JWT_SECRET = originalJwtSecret;
   });
 
   describe('getTracker — post-JwtAuthGuard request.user', () => {
@@ -21,8 +27,8 @@ describe('UserAwareThrottlerGuard', () => {
   });
 
   describe('getTracker — cookie accessToken fallback (runs before JwtAuthGuard)', () => {
-    it('decodes sub from accessToken cookie when request.user is missing', async () => {
-      const token = jwt.sign({ sub: 99, role: 'user' }, 'dev-secret');
+    it('uses sub from a verified accessToken cookie when request.user is missing', async () => {
+      const token = jwt.sign({ sub: 99, role: 'user' }, 'test-secret');
       await expect(
         call({ user: undefined, ip: '10.0.0.1', cookies: { accessToken: token } }),
       ).resolves.toBe('user:99');
@@ -41,17 +47,33 @@ describe('UserAwareThrottlerGuard', () => {
     });
 
     it('falls back to ip when cookie token lacks sub', async () => {
-      const token = jwt.sign({ foo: 'bar' }, 'dev-secret');
+      const token = jwt.sign({ foo: 'bar' }, 'test-secret');
       await expect(
         call({ user: undefined, ip: '203.0.113.7', cookies: { accessToken: token } }),
       ).resolves.toBe('ip:203.0.113.7');
     });
 
     it('ignores refresh token (tokenType=refresh) to avoid mixing buckets', async () => {
-      const token = jwt.sign({ sub: 5, tokenType: 'refresh' }, 'dev-secret');
+      const token = jwt.sign({ sub: 5, tokenType: 'refresh' }, 'test-secret');
       await expect(
         call({ user: undefined, ip: '203.0.113.8', cookies: { accessToken: token } }),
       ).resolves.toBe('ip:203.0.113.8');
+    });
+
+    it('falls back to ip when cookie token signature is invalid', async () => {
+      const token = jwt.sign({ sub: 'spoofed-user' }, 'wrong-secret');
+      await expect(
+        call({ user: undefined, ip: '203.0.113.9', cookies: { accessToken: token } }),
+      ).resolves.toBe('ip:203.0.113.9');
+    });
+
+    it('falls back to ip when JWT_SECRET is missing', async () => {
+      delete process.env.JWT_SECRET;
+      const token = jwt.sign({ sub: 77 }, 'test-secret');
+
+      await expect(
+        call({ user: undefined, ip: '203.0.113.10', cookies: { accessToken: token } }),
+      ).resolves.toBe('ip:203.0.113.10');
     });
   });
 

--- a/backend/src/common/guards/user-aware-throttler.guard.ts
+++ b/backend/src/common/guards/user-aware-throttler.guard.ts
@@ -8,10 +8,8 @@ import * as jwt from 'jsonwebtoken';
  * 트래커 키를 분리한다.
  *
  * APP_GUARD 순서상 ThrottlerGuard 가 JwtAuthGuard 보다 먼저 실행되므로
- * req.user 는 아직 비어있다. accessToken 쿠키가 있으면 직접 디코드해
- * 트래커 키로만 사용한다 (verify 는 JwtAuthGuard 가 담당). 토큰이
- * 위조되어도 트래커 버킷 분리는 악영향이 없고, 실제 인증은 뒤의
- * JwtAuthGuard 에서 거부된다.
+ * req.user 는 아직 비어있다. accessToken 쿠키가 있으면 서명 검증 후
+ * sub 를 트래커 키로만 사용한다. 검증에 실패하면 ip 버킷으로 폴백한다.
  */
 @Injectable()
 export class UserAwareThrottlerGuard extends ThrottlerGuard {
@@ -48,7 +46,10 @@ export class UserAwareThrottlerGuard extends ThrottlerGuard {
 
   private decodeSub(token: string): number | string | undefined {
     try {
-      const payload = jwt.decode(token);
+      const secret = process.env.JWT_SECRET?.trim();
+      if (!secret) return undefined;
+
+      const payload = jwt.verify(token, secret);
       if (!payload || typeof payload !== 'object') return undefined;
       // refresh 토큰은 tracker 버킷을 access 와 섞지 않도록 거부
       if ((payload as { tokenType?: string }).tokenType === 'refresh') return undefined;

--- a/backend/src/common/interceptors/audit-log.interceptor.spec.ts
+++ b/backend/src/common/interceptors/audit-log.interceptor.spec.ts
@@ -44,7 +44,7 @@ describe('AuditLogInterceptor', () => {
           params: { id: '123' },
           ip: '192.168.1.1',
           headers: { 'user-agent': 'Mozilla/5.0' },
-          connection: { remoteAddress: '192.168.1.1' },
+          socket: { remoteAddress: '192.168.1.1' },
         }),
       }),
       getHandler: () => ({}),
@@ -118,7 +118,7 @@ describe('AuditLogInterceptor', () => {
     });
   });
 
-  it('should extract ip from x-forwarded-for header', (done) => {
+  it('should prefer request.ip over x-forwarded-for header', (done) => {
     mockReflector.get.mockReturnValue({
       action: AuditAction.LOGIN_FAILURE,
       resourceType: 'auth',
@@ -133,7 +133,7 @@ describe('AuditLogInterceptor', () => {
         'user-agent': 'Test Agent',
       },
       ip: '127.0.0.1',
-      connection: { remoteAddress: '192.168.1.1' },
+      socket: { remoteAddress: '192.168.1.1' },
     };
 
     const context = {
@@ -151,7 +151,47 @@ describe('AuditLogInterceptor', () => {
       next: () => {
         expect(auditLogService.log).toHaveBeenCalledWith(
           expect.objectContaining({
-            ip: '10.0.0.1',
+            ip: '127.0.0.1',
+          }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('should fall back to socket remoteAddress when request.ip is missing', (done) => {
+    mockReflector.get.mockReturnValue({
+      action: AuditAction.LOGIN_FAILURE,
+      resourceType: 'auth',
+    });
+
+    const reqWithoutIp = {
+      user: { id: 0, role: 'anonymous' },
+      body: { email: 'test@example.com' },
+      params: {},
+      headers: {
+        'x-forwarded-for': '10.0.0.1, 192.168.1.1',
+        'user-agent': 'Test Agent',
+      },
+      socket: { remoteAddress: '192.168.1.1' },
+    };
+
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => reqWithoutIp,
+      }),
+      getHandler: () => ({}),
+      getParamTypes: () => [],
+    } as unknown as ExecutionContext;
+
+    const handler = createMockCallHandler(null);
+    auditLogService.log.mockResolvedValue({ id: 1 } as never);
+
+    interceptor.intercept(context, handler).subscribe({
+      next: () => {
+        expect(auditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ip: '192.168.1.1',
           }),
         );
         done();

--- a/backend/src/common/interceptors/audit-log.interceptor.ts
+++ b/backend/src/common/interceptors/audit-log.interceptor.ts
@@ -53,16 +53,13 @@ export class AuditLogInterceptor implements NestInterceptor {
         params?: Record<string, string>;
         ip?: string;
         headers?: Record<string, string | string[] | undefined>;
-        connection?: { remoteAddress?: string };
+        socket?: { remoteAddress?: string };
       }>();
       const user = request.user;
       const actorId = user?.id ?? 0;
       const actorRole = user?.role ?? 'anonymous';
 
-      const xForwardedFor = request.headers?.['x-forwarded-for'];
-      const ip = typeof xForwardedFor === 'string'
-        ? xForwardedFor.split(',')[0].trim()
-        : request.ip ?? request.connection?.remoteAddress ?? null;
+      const ip = request.ip ?? request.socket?.remoteAddress ?? null;
       const userAgent = request.headers?.['user-agent'] ?? null;
 
       const resourceId = request.params?.id ? parseInt(request.params.id, 10) || null : null;

--- a/backend/src/common/utils/pagination.util.spec.ts
+++ b/backend/src/common/utils/pagination.util.spec.ts
@@ -1,0 +1,16 @@
+import { paginate } from './pagination.util';
+
+describe('paginate', () => {
+  it('clamps limit to 100 before applying skip/take', async () => {
+    const getManyAndCount = jest.fn().mockResolvedValue([[], 0] as const);
+    const take = jest.fn().mockReturnValue({ getManyAndCount });
+    const skip = jest.fn().mockReturnValue({ take });
+    const qb = { skip } as never;
+
+    const result = await paginate(qb, { page: 2, limit: 1000 });
+
+    expect(skip).toHaveBeenCalledWith(100);
+    expect(take).toHaveBeenCalledWith(100);
+    expect(result).toEqual({ items: [], total: 0, page: 2, limit: 100 });
+  });
+});

--- a/backend/src/common/utils/pagination.util.ts
+++ b/backend/src/common/utils/pagination.util.ts
@@ -16,7 +16,7 @@ export async function paginate<T extends ObjectLiteral>(
   pagination: { page?: number; limit?: number },
 ): Promise<PaginatedResult<T>> {
   const page = pagination.page ?? 1;
-  const limit = pagination.limit ?? 20;
+  const limit = Math.min(Math.max(1, pagination.limit ?? 20), 100);
 
   const [items, total] = await qb
     .skip((page - 1) * limit)

--- a/backend/src/modules/admin/dto/admin-members-query.dto.ts
+++ b/backend/src/modules/admin/dto/admin-members-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsInt, Min, IsIn, IsBoolean } from 'class-validator';
+import { IsOptional, IsString, IsInt, Max, Min, IsIn, IsBoolean } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 
 export class AdminMembersQueryDto {
@@ -36,5 +36,6 @@ export class AdminMembersQueryDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
+  @Max(100, { message: 'limit은 100 이하여야 합니다.' })
   limit?: number = 20;
 }

--- a/backend/src/modules/admin/dto/admin-order-query.dto.ts
+++ b/backend/src/modules/admin/dto/admin-order-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsInt, Min, IsIn } from 'class-validator';
+import { IsOptional, IsString, IsInt, Max, Min, IsIn } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class AdminOrderQueryDto {
@@ -36,5 +36,6 @@ export class AdminOrderQueryDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
+  @Max(100, { message: 'limit은 100 이하여야 합니다.' })
   limit?: number = 20;
 }

--- a/backend/src/modules/reviews/dto/review-query.dto.ts
+++ b/backend/src/modules/reviews/dto/review-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsInt, IsIn, Min } from 'class-validator';
+import { IsOptional, IsInt, IsIn, Max, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class ReviewQueryDto {
@@ -26,5 +26,6 @@ export class ReviewQueryDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
+  @Max(100, { message: 'limit은 100 이하여야 합니다.' })
   limit?: number;
 }

--- a/src/components/__tests__/CartItemRow.test.tsx
+++ b/src/components/__tests__/CartItemRow.test.tsx
@@ -46,9 +46,9 @@ describe('CartItemRow', () => {
       />,
     );
     expect(screen.getByText('테스트 상품')).toBeInTheDocument();
-    expect(screen.getByText('₩15,000')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('₩30,000')).toBeInTheDocument();
+    expect(screen.getAllByText('₩15,000')).toHaveLength(1);
+    expect(screen.getAllByText('2')).toHaveLength(2);
+    expect(screen.getAllByText('₩30,000')).toHaveLength(2);
   });
 
   it('renders option text when option is provided', () => {
@@ -93,7 +93,7 @@ describe('CartItemRow', () => {
         onRemove={vi.fn()}
       />,
     );
-    await user.click(screen.getByRole('button', { name: '수량 증가' }));
+    await user.click(screen.getAllByRole('button', { name: '수량 증가' })[0]);
     expect(onQuantityChange).toHaveBeenCalledWith(1, 3);
   });
 
@@ -110,7 +110,7 @@ describe('CartItemRow', () => {
         onRemove={vi.fn()}
       />,
     );
-    const decreaseBtn = screen.getByRole('button', { name: '수량 감소' });
+    const decreaseBtn = screen.getAllByRole('button', { name: '수량 감소' })[0];
     expect(decreaseBtn).toBeDisabled();
     await user.click(decreaseBtn);
     expect(onQuantityChange).not.toHaveBeenCalled();
@@ -128,7 +128,7 @@ describe('CartItemRow', () => {
         onRemove={onRemove}
       />,
     );
-    await user.click(screen.getByRole('button', { name: '테스트 상품 삭제' }));
+    await user.click(screen.getAllByRole('button', { name: '테스트 상품 삭제' })[0]);
     expect(onRemove).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## 요약
- paginate 공통 유틸과 관련 DTO 3곳에 limit 상한(100)을 추가해 과도한 조회를 차단했습니다.
- UserAwareThrottlerGuard 가 서명 검증된 accessToken 에서만 sub 를 읽도록 바꿔 위조 JWT 기반 rate-limit 우회를 막았습니다.
- AuditLogInterceptor 가 X-Forwarded-For 를 직접 파싱하지 않고 Express trust-proxy 결과(req.ip)를 사용하도록 수정했습니다.
- 전체 검증을 막던 기존 CartItemRow 테스트 중복 쿼리를 반응형 구조에 맞게 안정화했습니다.

## 검증
- `npm run build`
- `npm run test:run`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd backend && npm run test`
- `npx tsc --noEmit --project backend/tsconfig.json`

## 이슈
Closes #672
Closes #673
Closes #674
