### PR TITLE
fix: #675 #676 마이그레이션 식별자와 브랜드 표기를 안정화

### DIFF
--- a/backend/src/database/migrations/1775500000001-UpdateThemeColorsOkhwadang.ts
+++ b/backend/src/database/migrations/1775500000001-UpdateThemeColorsOkhwadang.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class UpdateThemeColorsOkhwandang1775500000000 implements MigrationInterface {
-  name = 'UpdateThemeColorsOkhwandang1775500000000';
+export class UpdateThemeColorsOkhwadang1775500000001 implements MigrationInterface {
+  name = 'UpdateThemeColorsOkhwadang1775500000001';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/backend/src/database/migrations/1776000000001-UnifyCardAndBackgroundColor.ts
+++ b/backend/src/database/migrations/1776000000001-UnifyCardAndBackgroundColor.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class UnifyCardAndBackgroundColor1776000000000 implements MigrationInterface {
-  name = 'UnifyCardAndBackgroundColor1776000000000';
+export class UnifyCardAndBackgroundColor1776000000001 implements MigrationInterface {
+  name = 'UnifyCardAndBackgroundColor1776000000001';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     // color_card를 color_background와 동일하게 통일 (#FDFCF9)

--- a/backend/src/database/migrations/1776800000000-SeedEnglishValues.ts
+++ b/backend/src/database/migrations/1776800000000-SeedEnglishValues.ts
@@ -10,7 +10,7 @@ export class SeedEnglishValues1776800000000 implements MigrationInterface {
       UPDATE \`promotions\` SET \`title_en\` = 'Spring Collection — New Jooni Teapots', \`description_en\` = 'New Fuchun Jooni (Zhuni) teapots at special prices. Limited quantities of Jooni Seosiho, Juxingho, and Sebyo. May close early when stock runs out.' WHERE \`id\` = 1
     `);
     await query(`
-      UPDATE \`promotions\` SET \`title_en\` = 'Beginner Set 14% Time Sale', \`description_en\` = 'Okhwandang beginner tea set at special price. 280,000 won → 240,000 won (40,000 won discount). Complete set with teapot + dáwǎn + dábàn + chá dōujù.' WHERE \`id\` = 2
+      UPDATE \`promotions\` SET \`title_en\` = 'Beginner Set 14% Time Sale', \`description_en\` = 'Okhwadang beginner tea set at special price. 280,000 won → 240,000 won (40,000 won discount). Complete set with teapot + dáwǎn + dábàn + chá dōujù.' WHERE \`id\` = 2
     `);
     await query(`
       UPDATE \`promotions\` SET \`title_en\` = 'Boischa Intro Event', \`description_en\` = 'Purchase Daek 7572 aged shucha and get bamboo tea set (5 items). Includes chaceol, chachim, chahyeop, charu, chachim.' WHERE \`id\` = 3

--- a/backend/src/database/migrations/1778400000001-CreatePasswordResetTokensTable.ts
+++ b/backend/src/database/migrations/1778400000001-CreatePasswordResetTokensTable.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreatePasswordResetTokensTable1778400000000 implements MigrationInterface {
-  name = 'CreatePasswordResetTokensTable1778400000000';
+export class CreatePasswordResetTokensTable1778400000001 implements MigrationInterface {
+  name = 'CreatePasswordResetTokensTable1778400000001';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/backend/src/database/migrations/1782500000001-CreateRecentlyViewedProductsTable.ts
+++ b/backend/src/database/migrations/1782500000001-CreateRecentlyViewedProductsTable.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateRecentlyViewedProductsTable1782500000000 implements MigrationInterface {
-  name = 'CreateRecentlyViewedProductsTable1782500000000';
+export class CreateRecentlyViewedProductsTable1782500000001 implements MigrationInterface {
+  name = 'CreateRecentlyViewedProductsTable1782500000001';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`


### PR DESCRIPTION
## 요약
- 브랜드 오타가 들어간 migration/class/name 식별자를 `Okhwadang`으로 바로잡았습니다.
- 동일 timestamp를 공유하던 migration 4쌍 중 두 번째 파일들을 `+1ms`로 재명명해 적용 순서를 결정적으로 만들었습니다.
- 시드 영문 카피의 `Okhwandang` 오타를 `Okhwadang`으로 수정했습니다.

## 검증
- `npm run build`
- `npm run test:run`
- `cd backend && npm run build`
- `cd backend && npm run test`
- `cd backend && npm run test:e2e` (mysql-test + temporary JWT keypair)

## 이슈
Closes #675
Closes #676
