### PR TITLE
refactor: #684 NavigationEditor 책임 분리

### DIFF
--- a/src/components/shared/admin/NavigationEditor.tsx
+++ b/src/components/shared/admin/NavigationEditor.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { useFormModal } from '@/components/shared/hooks/useFormModal';
 import { useAdminDndSensors } from '@/components/shared/hooks/useDndSensors';
 import {
   DndContext,
@@ -11,409 +10,22 @@ import {
 import {
   SortableContext,
   verticalListSortingStrategy,
-  useSortable,
   arrayMove,
 } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Pencil, Trash2, Plus, Eye, EyeOff, ExternalLink, ChevronRight, X } from 'lucide-react';
+import { Plus, Eye } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import type { NavigationItem } from '@/lib/api';
+import { GROUP_INFO, type NavGroup } from './navigation/navigationGroups';
+import { flattenItems } from './navigation/flattenItems';
+import NavigationPreview from './navigation/NavigationPreview';
+import SortableNavigationRow from './navigation/SortableNavigationRow';
+import NavigationFormModal, { type NavigationFormData } from './navigation/NavigationFormModal';
 
-// --- 그룹별 설명 ---
-const GROUP_INFO: Record<'gnb' | 'sidebar' | 'footer', { label: string; desc: string; preview: string }> = {
-  gnb: {
-    label: 'GNB (상단 메뉴)',
-    desc: '쇼핑몰 상단 헤더에 항상 표시되는 주요 메뉴입니다. 방문자가 가장 먼저 보는 내비게이션으로, 상품목록·이벤트·브랜드 소개 등 핵심 페이지로 연결합니다.',
-    preview: '홈  |  상품목록  |  이벤트  |  브랜드',
-  },
-  sidebar: {
-    label: '사이드바 메뉴',
-    desc: '모바일 햄버거 메뉴 또는 PC 좌측 사이드바에 표시되는 메뉴입니다. GNB보다 많은 항목을 담을 수 있으며, 카테고리·마이페이지·고객센터 등 보조 링크에 활용합니다.',
-    preview: '≡  홈 / 상품목록 / 마이페이지 / 고객센터',
-  },
-  footer: {
-    label: '푸터 메뉴',
-    desc: '페이지 최하단 푸터 영역에 표시되는 링크 모음입니다. 이용약관·개인정보처리방침·회사소개 등 법적 안내 및 부가 정보 링크를 배치합니다.',
-    preview: '이용약관  개인정보처리방침  고객센터  회사소개',
-  },
-};
-
-// --- GNB 미리보기용 Dropdown 아이템 ---
-function GNBDropdownPreviewItem({ item }: { item: NavigationItem }) {
-  const [isHovered, setIsHovered] = useState(false);
-  const activeChildren = item.children.filter((c: NavigationItem) => c.is_active);
-  const hasActiveChildren = activeChildren.length > 0;
-
-  return (
-    <div
-      className="relative"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <span className="flex items-center gap-1 px-3 py-1 text-slate-200 hover:text-white text-xs cursor-default transition-colors duration-200">
-        {item.label}
-        {hasActiveChildren && (
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 10 10"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            className={cn('transition-transform duration-300', isHovered && 'rotate-180')}
-          >
-            <path d="M2.5 4.5L5 7L7.5 4.5" />
-          </svg>
-        )}
-      </span>
-      {hasActiveChildren && isHovered && (
-        <div className="absolute left-1/2 -translate-x-1/2 top-full mt-2 min-w-36 rounded-lg border border-slate-600 bg-slate-800 shadow-xl py-1 z-10 animate-accordion-down">
-          {activeChildren.map((child: NavigationItem) => (
-            <span key={child.id} className="flex items-center gap-2 px-4 py-2 text-xs text-slate-300 hover:text-white hover:bg-slate-700/50 transition-all duration-200 cursor-default border-l-2 border-transparent hover:border-slate-400/50">
-              <span className="text-slate-500">└</span>
-              {child.label}
-            </span>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// --- 미리보기 컴포넌트 ---
-function NavigationPreview({
-  group,
-  items,
-}: {
-  group: 'gnb' | 'sidebar' | 'footer';
-  items: NavigationItem[];
-}) {
-  const activeItems = items.filter((i) => i.is_active);
-
-  if (group === 'gnb') {
-    return (
-      <div className="rounded-lg border bg-slate-900 px-4 py-3">
-        <div className="flex items-center gap-1 text-sm text-white">
-          <span className="mr-4 font-bold text-white">로고</span>
-          {activeItems.length === 0 ? (
-            <span className="text-xs text-slate-400">(메뉴 없음)</span>
-          ) : (
-            activeItems.map((item) => (
-              <GNBDropdownPreviewItem key={item.id} item={item} />
-            ))
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  if (group === 'sidebar') {
-    return (
-      <div className="rounded-lg border bg-white shadow-md w-48 py-2 text-sm">
-        {activeItems.length === 0 ? (
-          <p className="px-4 py-2 text-xs text-muted-foreground">(메뉴 없음)</p>
-        ) : (
-          activeItems.map((item) => (
-            <div key={item.id}>
-              <div className="flex items-center justify-between px-4 py-1.5 hover:bg-muted text-foreground text-xs">
-                <span>{item.label}</span>
-                {item.children.filter(c => c.is_active).length > 0 && (
-                  <ChevronRight className="h-3 w-3 text-muted-foreground" />
-                )}
-              </div>
-              {item.children.filter(c => c.is_active).map(child => (
-                <div key={child.id} className="px-8 py-1 text-xs text-muted-foreground hover:bg-muted">
-                  {child.label}
-                </div>
-              ))}
-            </div>
-          ))
-        )}
-      </div>
-    );
-  }
-
-  // footer
-  return (
-    <div className="rounded-lg border bg-slate-800 px-6 py-4">
-      <div className="flex flex-wrap gap-4 text-xs text-slate-300">
-        {activeItems.length === 0 ? (
-          <span className="text-slate-500">(메뉴 없음)</span>
-        ) : (
-          activeItems.map((item) => (
-            <span key={item.id} className="hover:text-white flex items-center gap-0.5">
-              {item.label}
-              <ExternalLink className="h-2.5 w-2.5" />
-            </span>
-          ))
-        )}
-      </div>
-    </div>
-  );
-}
-
-// --- SortableItem ---
-interface SortableItemProps {
-  item: NavigationItem;
-  depth: number;
-  onEdit: (item: NavigationItem) => void;
-  onDelete: (item: NavigationItem) => void;
-  onToggleActive: (item: NavigationItem) => void;
-}
-
-function SortableItem({ item, depth, onEdit, onDelete, onToggleActive }: SortableItemProps) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: item.id });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
-
-  return (
-    <div ref={setNodeRef} style={style} {...attributes}>
-      <div
-        className={cn(
-          'flex items-center gap-3 rounded-md border bg-background px-3 py-2 mb-1',
-          isDragging && 'opacity-50',
-          !item.is_active && 'opacity-50 bg-muted/30',
-        )}
-        style={{ marginLeft: depth * 24 }}
-      >
-        {depth > 0 && (
-          <span className="text-xs text-muted-foreground">└</span>
-        )}
-        <button
-          type="button"
-          {...listeners}
-          title="드래그하여 순서 변경"
-          className="cursor-grab text-muted-foreground hover:text-foreground"
-          aria-label="드래그하여 순서 변경"
-        >
-          <GripVertical className="h-4 w-4" />
-        </button>
-
-        <div className="flex flex-1 flex-col min-w-0">
-          <span className={cn('text-sm font-medium truncate', !item.is_active && 'line-through text-muted-foreground')}>
-            {item.label}
-          </span>
-          <span className="text-xs text-muted-foreground truncate">{item.url}</span>
-        </div>
-
-        {item.children.length > 0 && (
-          <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-            하위 {item.children.length}
-          </span>
-        )}
-
-        <button
-          type="button"
-          onClick={() => onToggleActive(item)}
-          title={item.is_active ? '클릭하면 이 메뉴가 숨겨집니다 (비활성화)' : '클릭하면 이 메뉴가 표시됩니다 (활성화)'}
-          className={cn('shrink-0', item.is_active ? 'text-green-600 hover:text-muted-foreground' : 'text-muted-foreground hover:text-green-600')}
-          aria-label={item.is_active ? '비활성화' : '활성화'}
-        >
-          {item.is_active ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
-        </button>
-        <button
-          type="button"
-          onClick={() => onEdit(item)}
-          title="메뉴 이름·URL·상위 메뉴 수정"
-          className="shrink-0 text-muted-foreground hover:text-foreground"
-          aria-label="수정"
-        >
-          <Pencil className="h-4 w-4" />
-        </button>
-        <button
-          type="button"
-          onClick={() => onDelete(item)}
-          title="메뉴 삭제 (하위 메뉴도 함께 삭제됩니다)"
-          className="shrink-0 text-muted-foreground hover:text-destructive"
-          aria-label="삭제"
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
-      </div>
-      {item.children.length > 0 && (
-        <div>
-          {item.children.map((child) => (
-            <SortableItem
-              key={child.id}
-              item={child}
-              depth={depth + 1}
-              onEdit={onEdit}
-              onDelete={onDelete}
-              onToggleActive={onToggleActive}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// --- Form Modal ---
-interface NavigationFormModalProps {
-  open: boolean;
-  onClose: () => void;
-  onSubmit: (data: {
-    label: string;
-    url: string;
-    group: 'gnb' | 'sidebar' | 'footer';
-    parent_id: number | null;
-    is_active: boolean;
-  }) => Promise<void>;
-  initial: NavigationItem | null;
-  group: 'gnb' | 'sidebar' | 'footer';
-  flatItems: NavigationItem[];
-}
-
-function NavigationFormModal({ open, onClose, onSubmit, initial, group, flatItems }: NavigationFormModalProps) {
-  const defaults = { label: '', url: '', group, parent_id: null as number | null, is_active: true };
-  const modalInitial = initial
-    ? { label: initial.label, url: initial.url, group, parent_id: initial.parent_id, is_active: initial.is_active }
-    : null;
-  const { formData, setFormData, loading, handleSubmit } = useFormModal(defaults, modalInitial, open);
-
-  if (!open) return null;
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="relative w-full max-w-md rounded-lg bg-background p-6 shadow-lg">
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="닫기"
-          className="absolute right-4 top-4 text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <X className="h-5 w-5" />
-        </button>
-        <h2 className="mb-1 text-lg font-semibold">
-          {initial ? '메뉴 수정' : '새 메뉴 추가'}
-        </h2>
-        <p className="mb-4 text-xs text-muted-foreground">
-          {GROUP_INFO[group].label}에 표시될 메뉴를 {initial ? '수정' : '추가'}합니다.
-        </p>
-
-        <form onSubmit={(e) => handleSubmit(e, onSubmit, onClose)} className="space-y-4">
-          <div>
-            <label htmlFor="nav-label" className="mb-1 block text-sm font-medium">
-              메뉴명 <span className="text-destructive">*</span>
-            </label>
-            <input
-              id="nav-label"
-              type="text"
-              value={formData.label}
-              onChange={(e) => setFormData({ ...formData, label: e.target.value })}
-              required
-              maxLength={100}
-              placeholder="예: 상품목록, 이벤트, 고객센터"
-              className="w-full rounded-md border border-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-            <p className="mt-1 text-xs text-muted-foreground">쇼핑몰 메뉴에 표시될 이름입니다.</p>
-          </div>
-
-          <div>
-            <label htmlFor="nav-url" className="mb-1 block text-sm font-medium">
-              URL (링크 주소) <span className="text-destructive">*</span>
-            </label>
-            <input
-              id="nav-url"
-              type="text"
-              value={formData.url}
-              onChange={(e) => setFormData({ ...formData, url: e.target.value })}
-              required
-              maxLength={500}
-              placeholder="예: /products, /event, https://외부링크.com"
-              className="w-full rounded-md border border-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-            <p className="mt-1 text-xs text-muted-foreground">
-              내부 페이지는 <b>/products</b> 형태로, 외부 사이트는 <b>https://</b>로 시작하는 전체 주소를 입력하세요.
-            </p>
-          </div>
-
-          <div>
-            <label htmlFor="nav-parent" className="mb-1 block text-sm font-medium">
-              상위 메뉴
-            </label>
-            <select
-              id="nav-parent"
-              value={formData.parent_id ?? ''}
-              onChange={(e) => setFormData({ ...formData, parent_id: e.target.value ? Number(e.target.value) : null })}
-              className="w-full rounded-md border border-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            >
-              <option value="">없음 (최상위 메뉴)</option>
-              {flatItems
-                .filter((i) => initial === null || i.id !== initial.id)
-                .map((i) => (
-                  <option key={i.id} value={i.id}>
-                    {i.label}
-                  </option>
-                ))}
-            </select>
-            <p className="mt-1 text-xs text-muted-foreground">
-              상위 메뉴를 선택하면 해당 메뉴의 <b>하위(드롭다운) 메뉴</b>로 등록됩니다. 최상위 메뉴로 만들려면 &quot;없음&quot;을 선택하세요.
-            </p>
-          </div>
-
-          <div className="rounded-md border bg-muted/40 px-3 py-2.5">
-            <div className="flex items-center gap-2">
-              <input
-                id="nav-active"
-                type="checkbox"
-                checked={formData.is_active}
-                onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
-                className="h-4 w-4 rounded border-input"
-              />
-              <label htmlFor="nav-active" className="text-sm font-medium">
-                활성화 (쇼핑몰에 표시)
-              </label>
-            </div>
-            <p className="mt-1 text-xs text-muted-foreground pl-6">
-              체크 해제 시 메뉴가 쇼핑몰에서 숨겨집니다. 임시로 숨길 때 사용하세요.
-            </p>
-          </div>
-
-          <div className="flex justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border px-4 py-2 text-sm hover:bg-muted"
-            >
-              취소
-            </button>
-            <button
-              type="submit"
-              disabled={loading}
-              className="rounded-md bg-foreground px-4 py-2 text-sm text-background hover:opacity-90 disabled:opacity-50"
-            >
-              {loading ? '저장 중...' : '저장'}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-// --- NavigationEditor ---
 interface NavigationEditorProps {
-  group: 'gnb' | 'sidebar' | 'footer';
+  group: NavGroup;
   items: NavigationItem[];
   onReload: () => Promise<void>;
-  onCreate: (data: {
-    label: string;
-    url: string;
-    group: 'gnb' | 'sidebar' | 'footer';
-    parent_id: number | null;
-    is_active: boolean;
-  }) => Promise<void>;
+  onCreate: (data: NavigationFormData) => Promise<void>;
   onUpdate: (id: number, data: {
     label?: string;
     url?: string;
@@ -422,17 +34,6 @@ interface NavigationEditorProps {
   }) => Promise<void>;
   onDelete: (id: number) => Promise<void>;
   onReorder: (orders: Array<{ id: number; sort_order: number }>) => Promise<void>;
-}
-
-function flattenItems(items: NavigationItem[]): NavigationItem[] {
-  const result: NavigationItem[] = [];
-  for (const item of items) {
-    result.push(item);
-    if (item.children.length > 0) {
-      result.push(...flattenItems(item.children));
-    }
-  }
-  return result;
 }
 
 export default function NavigationEditor({
@@ -497,13 +98,7 @@ export default function NavigationEditor({
     await onReload();
   };
 
-  const handleSubmit = async (data: {
-    label: string;
-    url: string;
-    group: 'gnb' | 'sidebar' | 'footer';
-    parent_id: number | null;
-    is_active: boolean;
-  }) => {
+  const handleSubmit = async (data: NavigationFormData) => {
     if (editTarget) {
       await onUpdate(Number(editTarget.id), {
         label: data.label,
@@ -581,7 +176,7 @@ export default function NavigationEditor({
         >
           <SortableContext items={rootIds} strategy={verticalListSortingStrategy}>
             {items.map((item) => (
-              <SortableItem
+              <SortableNavigationRow
                 key={item.id}
                 item={item}
                 depth={0}

--- a/src/components/shared/admin/navigation/NavigationFormModal.tsx
+++ b/src/components/shared/admin/navigation/NavigationFormModal.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useFormModal } from '@/components/shared/hooks/useFormModal';
+import type { NavigationItem } from '@/lib/api';
+import { GROUP_INFO, type NavGroup } from './navigationGroups';
+
+export interface NavigationFormData {
+  label: string;
+  url: string;
+  group: NavGroup;
+  parent_id: number | null;
+  is_active: boolean;
+}
+
+interface NavigationFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: NavigationFormData) => Promise<void>;
+  initial: NavigationItem | null;
+  group: NavGroup;
+  flatItems: NavigationItem[];
+}
+
+export default function NavigationFormModal({
+  open,
+  onClose,
+  onSubmit,
+  initial,
+  group,
+  flatItems,
+}: NavigationFormModalProps) {
+  const defaults: NavigationFormData = {
+    label: '',
+    url: '',
+    group,
+    parent_id: null,
+    is_active: true,
+  };
+  const modalInitial: NavigationFormData | null = initial
+    ? { label: initial.label, url: initial.url, group, parent_id: initial.parent_id, is_active: initial.is_active }
+    : null;
+  const { formData, setFormData, loading, handleSubmit } = useFormModal(defaults, modalInitial, open);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="relative w-full max-w-md rounded-lg bg-background p-6 shadow-lg">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="닫기"
+          className="absolute right-4 top-4 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <X className="h-5 w-5" />
+        </button>
+        <h2 className="mb-1 text-lg font-semibold">
+          {initial ? '메뉴 수정' : '새 메뉴 추가'}
+        </h2>
+        <p className="mb-4 text-xs text-muted-foreground">
+          {GROUP_INFO[group].label}에 표시될 메뉴를 {initial ? '수정' : '추가'}합니다.
+        </p>
+
+        <form onSubmit={(e) => handleSubmit(e, onSubmit, onClose)} className="space-y-4">
+          <div>
+            <label htmlFor="nav-label" className="mb-1 block text-sm font-medium">
+              메뉴명 <span className="text-destructive">*</span>
+            </label>
+            <input
+              id="nav-label"
+              type="text"
+              value={formData.label}
+              onChange={(e) => setFormData({ ...formData, label: e.target.value })}
+              required
+              maxLength={100}
+              placeholder="예: 상품목록, 이벤트, 고객센터"
+              className="w-full rounded-md border border-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">쇼핑몰 메뉴에 표시될 이름입니다.</p>
+          </div>
+
+          <div>
+            <label htmlFor="nav-url" className="mb-1 block text-sm font-medium">
+              URL (링크 주소) <span className="text-destructive">*</span>
+            </label>
+            <input
+              id="nav-url"
+              type="text"
+              value={formData.url}
+              onChange={(e) => setFormData({ ...formData, url: e.target.value })}
+              required
+              maxLength={500}
+              placeholder="예: /products, /event, https://외부링크.com"
+              className="w-full rounded-md border border-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              내부 페이지는 <b>/products</b> 형태로, 외부 사이트는 <b>https://</b>로 시작하는 전체 주소를 입력하세요.
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="nav-parent" className="mb-1 block text-sm font-medium">
+              상위 메뉴
+            </label>
+            <select
+              id="nav-parent"
+              value={formData.parent_id ?? ''}
+              onChange={(e) => setFormData({ ...formData, parent_id: e.target.value ? Number(e.target.value) : null })}
+              className="w-full rounded-md border border-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">없음 (최상위 메뉴)</option>
+              {flatItems
+                .filter((i) => initial === null || i.id !== initial.id)
+                .map((i) => (
+                  <option key={i.id} value={i.id}>
+                    {i.label}
+                  </option>
+                ))}
+            </select>
+            <p className="mt-1 text-xs text-muted-foreground">
+              상위 메뉴를 선택하면 해당 메뉴의 <b>하위(드롭다운) 메뉴</b>로 등록됩니다. 최상위 메뉴로 만들려면 &quot;없음&quot;을 선택하세요.
+            </p>
+          </div>
+
+          <div className="rounded-md border bg-muted/40 px-3 py-2.5">
+            <div className="flex items-center gap-2">
+              <input
+                id="nav-active"
+                type="checkbox"
+                checked={formData.is_active}
+                onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
+                className="h-4 w-4 rounded border-input"
+              />
+              <label htmlFor="nav-active" className="text-sm font-medium">
+                활성화 (쇼핑몰에 표시)
+              </label>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground pl-6">
+              체크 해제 시 메뉴가 쇼핑몰에서 숨겨집니다. 임시로 숨길 때 사용하세요.
+            </p>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border px-4 py-2 text-sm hover:bg-muted"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded-md bg-foreground px-4 py-2 text-sm text-background hover:opacity-90 disabled:opacity-50"
+            >
+              {loading ? '저장 중...' : '저장'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/admin/navigation/NavigationPreview.tsx
+++ b/src/components/shared/admin/navigation/NavigationPreview.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronRight, ExternalLink } from 'lucide-react';
+import { cn } from '@/components/ui/utils';
+import type { NavigationItem } from '@/lib/api';
+import type { NavGroup } from './navigationGroups';
+
+// GNB 미리보기의 단일 최상위 항목 — hover 시 드롭다운 펼침.
+function GNBDropdownPreviewItem({ item }: { item: NavigationItem }) {
+  const [isHovered, setIsHovered] = useState(false);
+  const activeChildren = item.children.filter((c: NavigationItem) => c.is_active);
+  const hasActiveChildren = activeChildren.length > 0;
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <span className="flex items-center gap-1 px-3 py-1 text-slate-200 hover:text-white text-xs cursor-default transition-colors duration-200">
+        {item.label}
+        {hasActiveChildren && (
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className={cn('transition-transform duration-300', isHovered && 'rotate-180')}
+          >
+            <path d="M2.5 4.5L5 7L7.5 4.5" />
+          </svg>
+        )}
+      </span>
+      {hasActiveChildren && isHovered && (
+        <div className="absolute left-1/2 -translate-x-1/2 top-full mt-2 min-w-36 rounded-lg border border-slate-600 bg-slate-800 shadow-xl py-1 z-10 animate-accordion-down">
+          {activeChildren.map((child: NavigationItem) => (
+            <span key={child.id} className="flex items-center gap-2 px-4 py-2 text-xs text-slate-300 hover:text-white hover:bg-slate-700/50 transition-all duration-200 cursor-default border-l-2 border-transparent hover:border-slate-400/50">
+              <span className="text-slate-500">└</span>
+              {child.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface NavigationPreviewProps {
+  group: NavGroup;
+  items: NavigationItem[];
+}
+
+// 그룹별(쇼핑몰 상단/사이드바/푸터) 실제 렌더 모습을 근사한 미리보기.
+export default function NavigationPreview({ group, items }: NavigationPreviewProps) {
+  const activeItems = items.filter((i) => i.is_active);
+
+  if (group === 'gnb') {
+    return (
+      <div className="rounded-lg border bg-slate-900 px-4 py-3">
+        <div className="flex items-center gap-1 text-sm text-white">
+          <span className="mr-4 font-bold text-white">로고</span>
+          {activeItems.length === 0 ? (
+            <span className="text-xs text-slate-400">(메뉴 없음)</span>
+          ) : (
+            activeItems.map((item) => (
+              <GNBDropdownPreviewItem key={item.id} item={item} />
+            ))
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (group === 'sidebar') {
+    return (
+      <div className="rounded-lg border bg-white shadow-md w-48 py-2 text-sm">
+        {activeItems.length === 0 ? (
+          <p className="px-4 py-2 text-xs text-muted-foreground">(메뉴 없음)</p>
+        ) : (
+          activeItems.map((item) => (
+            <div key={item.id}>
+              <div className="flex items-center justify-between px-4 py-1.5 hover:bg-muted text-foreground text-xs">
+                <span>{item.label}</span>
+                {item.children.filter(c => c.is_active).length > 0 && (
+                  <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                )}
+              </div>
+              {item.children.filter(c => c.is_active).map(child => (
+                <div key={child.id} className="px-8 py-1 text-xs text-muted-foreground hover:bg-muted">
+                  {child.label}
+                </div>
+              ))}
+            </div>
+          ))
+        )}
+      </div>
+    );
+  }
+
+  // footer
+  return (
+    <div className="rounded-lg border bg-slate-800 px-6 py-4">
+      <div className="flex flex-wrap gap-4 text-xs text-slate-300">
+        {activeItems.length === 0 ? (
+          <span className="text-slate-500">(메뉴 없음)</span>
+        ) : (
+          activeItems.map((item) => (
+            <span key={item.id} className="hover:text-white flex items-center gap-0.5">
+              {item.label}
+              <ExternalLink className="h-2.5 w-2.5" />
+            </span>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/admin/navigation/SortableNavigationRow.tsx
+++ b/src/components/shared/admin/navigation/SortableNavigationRow.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, Pencil, Trash2, Eye, EyeOff } from 'lucide-react';
+import { cn } from '@/components/ui/utils';
+import type { NavigationItem } from '@/lib/api';
+
+interface SortableNavigationRowProps {
+  item: NavigationItem;
+  depth: number;
+  onEdit: (item: NavigationItem) => void;
+  onDelete: (item: NavigationItem) => void;
+  onToggleActive: (item: NavigationItem) => void;
+}
+
+// 드래그 가능한 단일 행 + 자식 재귀 렌더. depth>0 은 non-sortable (루트 순서만 DnD 대상).
+export default function SortableNavigationRow({
+  item,
+  depth,
+  onEdit,
+  onDelete,
+  onToggleActive,
+}: SortableNavigationRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes}>
+      <div
+        className={cn(
+          'flex items-center gap-3 rounded-md border bg-background px-3 py-2 mb-1',
+          isDragging && 'opacity-50',
+          !item.is_active && 'opacity-50 bg-muted/30',
+        )}
+        style={{ marginLeft: depth * 24 }}
+      >
+        {depth > 0 && (
+          <span className="text-xs text-muted-foreground">└</span>
+        )}
+        <button
+          type="button"
+          {...listeners}
+          title="드래그하여 순서 변경"
+          className="cursor-grab text-muted-foreground hover:text-foreground"
+          aria-label="드래그하여 순서 변경"
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+
+        <div className="flex flex-1 flex-col min-w-0">
+          <span className={cn('text-sm font-medium truncate', !item.is_active && 'line-through text-muted-foreground')}>
+            {item.label}
+          </span>
+          <span className="text-xs text-muted-foreground truncate">{item.url}</span>
+        </div>
+
+        {item.children.length > 0 && (
+          <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+            하위 {item.children.length}
+          </span>
+        )}
+
+        <button
+          type="button"
+          onClick={() => onToggleActive(item)}
+          title={item.is_active ? '클릭하면 이 메뉴가 숨겨집니다 (비활성화)' : '클릭하면 이 메뉴가 표시됩니다 (활성화)'}
+          className={cn('shrink-0', item.is_active ? 'text-green-600 hover:text-muted-foreground' : 'text-muted-foreground hover:text-green-600')}
+          aria-label={item.is_active ? '비활성화' : '활성화'}
+        >
+          {item.is_active ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+        </button>
+        <button
+          type="button"
+          onClick={() => onEdit(item)}
+          title="메뉴 이름·URL·상위 메뉴 수정"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          aria-label="수정"
+        >
+          <Pencil className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(item)}
+          title="메뉴 삭제 (하위 메뉴도 함께 삭제됩니다)"
+          className="shrink-0 text-muted-foreground hover:text-destructive"
+          aria-label="삭제"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+      {item.children.length > 0 && (
+        <div>
+          {item.children.map((child) => (
+            <SortableNavigationRow
+              key={child.id}
+              item={child}
+              depth={depth + 1}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onToggleActive={onToggleActive}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/admin/navigation/flattenItems.ts
+++ b/src/components/shared/admin/navigation/flattenItems.ts
@@ -1,0 +1,13 @@
+import type { NavigationItem } from '@/lib/api';
+
+// 트리 구조의 네비게이션을 평탄화한다. 폼 모달의 상위 메뉴 선택지/카운트 계산 용도.
+export function flattenItems(items: NavigationItem[]): NavigationItem[] {
+  const result: NavigationItem[] = [];
+  for (const item of items) {
+    result.push(item);
+    if (item.children.length > 0) {
+      result.push(...flattenItems(item.children));
+    }
+  }
+  return result;
+}

--- a/src/components/shared/admin/navigation/navigationGroups.ts
+++ b/src/components/shared/admin/navigation/navigationGroups.ts
@@ -1,0 +1,26 @@
+export type NavGroup = 'gnb' | 'sidebar' | 'footer';
+
+export interface NavGroupInfo {
+  label: string;
+  desc: string;
+  preview: string;
+}
+
+// 각 네비게이션 그룹 설명. 에디터 상단 안내·폼 모달 안내에 공용으로 사용.
+export const GROUP_INFO: Record<NavGroup, NavGroupInfo> = {
+  gnb: {
+    label: 'GNB (상단 메뉴)',
+    desc: '쇼핑몰 상단 헤더에 항상 표시되는 주요 메뉴입니다. 방문자가 가장 먼저 보는 내비게이션으로, 상품목록·이벤트·브랜드 소개 등 핵심 페이지로 연결합니다.',
+    preview: '홈  |  상품목록  |  이벤트  |  브랜드',
+  },
+  sidebar: {
+    label: '사이드바 메뉴',
+    desc: '모바일 햄버거 메뉴 또는 PC 좌측 사이드바에 표시되는 메뉴입니다. GNB보다 많은 항목을 담을 수 있으며, 카테고리·마이페이지·고객센터 등 보조 링크에 활용합니다.',
+    preview: '≡  홈 / 상품목록 / 마이페이지 / 고객센터',
+  },
+  footer: {
+    label: '푸터 메뉴',
+    desc: '페이지 최하단 푸터 영역에 표시되는 링크 모음입니다. 이용약관·개인정보처리방침·회사소개 등 법적 안내 및 부가 정보 링크를 배치합니다.',
+    preview: '이용약관  개인정보처리방침  고객센터  회사소개',
+  },
+};


### PR DESCRIPTION
## Summary
- Closes #684
- `NavigationEditor.tsx` (607 lines) 를 editor shell / tree / row / preview / 상수 파일로 분리
- sortable tree recursion, preview, action bar, group description 상수의 경계 분리
- drag/edit/toggle/delete 동작 및 접근성 유지

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run