### PR TITLE
refactor: #687 backend DTO 중복 제거

### DIFF
--- a/backend/src/modules/archives/dto/archive.dto.ts
+++ b/backend/src/modules/archives/dto/archive.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsString, IsOptional, IsBoolean, IsNumber, IsArray } from 'class-validator';
 
 export class CreateNiloTypeDto {
@@ -42,53 +42,7 @@ export class CreateNiloTypeDto {
   isActive?: boolean;
 }
 
-export class UpdateNiloTypeDto {
-  @ApiProperty({ example: 'Jin', description: 'nilo type 이름 (영문)', required: false })
-  @IsOptional()
-  @IsString()
-  name?: string;
-
-  @ApiProperty({ example: '진', description: 'nilo type 이름 (한국어)', required: false })
-  @IsOptional()
-  @IsString()
-  nameKo?: string;
-
-  @ApiProperty({ example: '#8B4513', description: 'nilo type 색상', required: false })
-  @IsOptional()
-  @IsString()
-  color?: string;
-
-  @ApiProperty({ example: 'Jeju', description: '산지', required: false })
-  @IsOptional()
-  @IsString()
-  region?: string;
-
-  @ApiProperty({ example: 'Traditional hand-made process', description: '설명', required: false })
-  @IsOptional()
-  @IsString()
-  description?: string;
-
-  @ApiProperty({ example: ['smooth', 'sweet', ' floral'], description: '특징 목록', required: false })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  characteristics?: string[];
-
-  @ApiProperty({ example: '/products?nilo=jin', description: '관련 상품 URL', required: false })
-  @IsOptional()
-  @IsString()
-  productUrl?: string;
-
-  @ApiProperty({ example: 1, description: '정렬 순서', required: false })
-  @IsOptional()
-  @IsNumber()
-  sortOrder?: number;
-
-  @ApiProperty({ example: true, description: '활성 상태', required: false })
-  @IsOptional()
-  @IsBoolean()
-  isActive?: boolean;
-}
+export class UpdateNiloTypeDto extends PartialType(CreateNiloTypeDto) {}
 
 export class CreateProcessStepDto {
   @ApiProperty({ example: 1, description: '공정 단계' })
@@ -108,27 +62,7 @@ export class CreateProcessStepDto {
   detail!: string;
 }
 
-export class UpdateProcessStepDto {
-  @ApiProperty({ example: 1, description: '공정 단계', required: false })
-  @IsOptional()
-  @IsNumber()
-  step?: number;
-
-  @ApiProperty({ example: '잎采摘', description: '공정 제목', required: false })
-  @IsOptional()
-  @IsString()
-  title?: string;
-
-  @ApiProperty({ example: '수확 철에 맞춰 신선한 잎을采摘합니다', description: '공정 설명', required: false })
-  @IsOptional()
-  @IsString()
-  description?: string;
-
-  @ApiProperty({ example: '春季의 아침에 손으로 신선한 찻잎을采摘합니다...', description: '공정 상세 내용', required: false })
-  @IsOptional()
-  @IsString()
-  detail?: string;
-}
+export class UpdateProcessStepDto extends PartialType(CreateProcessStepDto) {}
 
 export class CreateArtistDto {
   @ApiProperty({ example: 'Kim Young-ha', description: '아티스트 이름' })
@@ -171,49 +105,4 @@ export class CreateArtistDto {
   isActive?: boolean;
 }
 
-export class UpdateArtistDto {
-  @ApiProperty({ example: 'Kim Young-ha', description: '아티스트 이름', required: false })
-  @IsOptional()
-  @IsString()
-  name?: string;
-
-  @ApiProperty({ example: 'Master Tea Maker', description: '아티스트 칭호', required: false })
-  @IsOptional()
-  @IsString()
-  title?: string;
-
-  @ApiProperty({ example: 'Jeju', description: '지역', required: false })
-  @IsOptional()
-  @IsString()
-  region?: string;
-
-  @ApiProperty({ example: '30 years of tea making experience...', description: '아티스트 이야기', required: false })
-  @IsOptional()
-  @IsString()
-  story?: string;
-
-  @ApiProperty({ example: 'Green Tea', description: '전문 분야', required: false })
-  @IsOptional()
-  @IsString()
-  specialty?: string;
-
-  @ApiProperty({ example: 'https://example.com/artist.jpg', description: '아티스트 이미지 URL', required: false })
-  @IsOptional()
-  @IsString()
-  imageUrl?: string;
-
-  @ApiProperty({ example: '/products?artist=kim-young-ha', description: '관련 상품 URL', required: false })
-  @IsOptional()
-  @IsString()
-  productUrl?: string;
-
-  @ApiProperty({ example: 1, description: '정렬 순서', required: false })
-  @IsOptional()
-  @IsNumber()
-  sortOrder?: number;
-
-  @ApiProperty({ example: true, description: '활성 상태', required: false })
-  @IsOptional()
-  @IsBoolean()
-  isActive?: boolean;
-}
+export class UpdateArtistDto extends PartialType(CreateArtistDto) {}

--- a/backend/src/modules/collections/dto/collection.dto.ts
+++ b/backend/src/modules/collections/dto/collection.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsEnum, IsOptional, IsString, IsBoolean, IsNumber } from 'class-validator';
 import { CollectionType } from '../entities/collection.entity';
 
@@ -46,49 +46,4 @@ export class CreateCollectionDto {
   isActive?: boolean;
 }
 
-export class UpdateCollectionDto {
-  @ApiProperty({ example: 'clay', enum: ['clay', 'shape'], description: '컬렉션 유형', required: false })
-  @IsOptional()
-  @IsEnum(CollectionType)
-  type?: CollectionType;
-
-  @ApiProperty({ example: 'Summer Collection', description: '컬렉션 이름', required: false })
-  @IsOptional()
-  @IsString()
-  name?: string;
-
-  @ApiProperty({ example: '여름 컬렉션', description: '컬렉션 이름 (한국어)', required: false })
-  @IsOptional()
-  @IsString()
-  nameKo?: string;
-
-  @ApiProperty({ example: '#FF6B6B', description: '컬렉션 색상', required: false })
-  @IsOptional()
-  @IsString()
-  color?: string;
-
-  @ApiProperty({ example: 'Discover our summer teas', description: '컬렉션 설명', required: false })
-  @IsOptional()
-  @IsString()
-  description?: string;
-
-  @ApiProperty({ example: 'https://example.com/collection.jpg', description: '컬렉션 이미지 URL', required: false })
-  @IsOptional()
-  @IsString()
-  imageUrl?: string;
-
-  @ApiProperty({ example: '/products?collection=summer', description: '상품 목록 URL', required: false })
-  @IsOptional()
-  @IsString()
-  productUrl?: string;
-
-  @ApiProperty({ example: 1, description: '정렬 순서', required: false })
-  @IsOptional()
-  @IsNumber()
-  sortOrder?: number;
-
-  @ApiProperty({ example: true, description: '활성 상태', required: false })
-  @IsOptional()
-  @IsBoolean()
-  isActive?: boolean;
-}
+export class UpdateCollectionDto extends PartialType(CreateCollectionDto) {}

--- a/backend/src/modules/journal/dto/journal.dto.ts
+++ b/backend/src/modules/journal/dto/journal.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsString, IsOptional, IsBoolean, IsEnum } from 'class-validator';
 import { JournalCategory } from '../entities/journal-entry.entity';
 
@@ -50,54 +50,4 @@ export class CreateJournalDto {
   isPublished?: boolean;
 }
 
-export class UpdateJournalDto {
-  @ApiProperty({ example: 'junzi-tea-culture', description: 'URL 슬러그', required: false })
-  @IsOptional()
-  @IsString()
-  slug?: string;
-
-  @ApiProperty({ example: '중국차 도자기 문화', description: '제목', required: false })
-  @IsOptional()
-  @IsString()
-  title?: string;
-
-  @ApiProperty({ example: '따뜻한 차 한 잔의 철학', description: '부제목', required: false })
-  @IsOptional()
-  @IsString()
-  subtitle?: string;
-
-  @ApiProperty({ example: 'CULTURE', description: '카테고리', enum: JournalCategory, required: false })
-  @IsOptional()
-  @IsEnum(JournalCategory)
-  category?: JournalCategory;
-
-  @ApiProperty({ example: '2024-01-15', description: '게시 날짜', required: false })
-  @IsOptional()
-  @IsString()
-  date?: string;
-
-  @ApiProperty({ example: '5분', description: '읽는 시간', required: false })
-  @IsOptional()
-  @IsString()
-  readTime?: string;
-
-  @ApiProperty({ example: '중국 차 도자기는 수천 년의 역사를 가지고 있습니다...', description: '요약', required: false })
-  @IsOptional()
-  @IsString()
-  summary?: string;
-
-  @ApiProperty({ example: ['첫 번째 단락...', '두 번째 단락...'], description: '본문 내용 (JSON 배열)', required: false })
-  @IsOptional()
-  @IsString()
-  content?: string;
-
-  @ApiProperty({ example: 'https://example.com/image.jpg', description: '커버 이미지 URL', required: false })
-  @IsOptional()
-  @IsString()
-  coverImageUrl?: string;
-
-  @ApiProperty({ example: true, description: '공개 여부', required: false })
-  @IsOptional()
-  @IsBoolean()
-  isPublished?: boolean;
-}
+export class UpdateJournalDto extends PartialType(CreateJournalDto) {}

--- a/backend/src/modules/upload/upload.service.ts
+++ b/backend/src/modules/upload/upload.service.ts
@@ -50,20 +50,16 @@ export class UploadService {
   }
 
   uploadImage(file: Express.Multer.File): Promise<UploadedFile> {
-    return this.uploadWithPipeline(file, (filename, buffer, mimetype) =>
-      this.adapter.save(filename, buffer, mimetype),
-    );
+    return this.uploadWithPipeline(file, 'save');
   }
 
   uploadCategoryImage(file: Express.Multer.File): Promise<UploadedFile> {
-    return this.uploadWithPipeline(file, (filename, buffer, mimetype) =>
-      this.adapter.saveCategoryImage(filename, buffer, mimetype),
-    );
+    return this.uploadWithPipeline(file, 'saveCategoryImage');
   }
 
   private async uploadWithPipeline(
     file: Express.Multer.File,
-    save: (filename: string, buffer: Buffer, mimetype: string) => Promise<UploadedFile>,
+    saveMethod: 'save' | 'saveCategoryImage',
   ): Promise<UploadedFile> {
     this.validateFile(file);
 
@@ -79,7 +75,7 @@ export class UploadService {
       })
       .toBuffer();
 
-    return save(filename, resized, file.mimetype);
+    return this.adapter[saveMethod](filename, resized, file.mimetype);
   }
 
   private validateFile(file: Express.Multer.File): void {


### PR DESCRIPTION
## 요약

jscpd hotspot으로 지목된 backend DTO/서비스 중복을 정리한다.

## 변경 사항

- `journal/dto/journal.dto.ts`: `UpdateJournalDto`를 `PartialType(CreateJournalDto)`로 전환
- `collections/dto/collection.dto.ts`: `UpdateCollectionDto`를 `PartialType(CreateCollectionDto)`로 전환
- `archives/dto/archive.dto.ts`: `UpdateNiloTypeDto`, `UpdateProcessStepDto`, `UpdateArtistDto` 모두 `PartialType`로 전환
- `upload/upload.service.ts`: `uploadImage` / `uploadCategoryImage` 두 퍼블릭 메서드의 arrow-wrapper 중복을 메서드 키 문자열로 통합

diffstat: `4 files changed, 12 insertions(+), 222 deletions(-)` — 210 라인 감소.

## 유지된 동작

- `PartialType`(from `@nestjs/swagger`)이 `@IsString`/`@IsNumber`/`@IsBoolean`/`@IsEnum`/`@IsArray`와 `@ApiProperty` 메타를 자동으로 `required: false`로 상속 → validator/Swagger/serialization 동작 동일
- 컨트롤러(`@Body() dto: Update*Dto`), 서비스(`Object.assign`, `repository.create(dto)`) 사용부 변경 없음
- `upload.service`의 퍼블릭 API (`uploadImage`, `uploadCategoryImage`) 시그니처/리턴 동일, `StorageAdapter` 인터페이스 변경 없음
- API 응답 포맷 변경 없음

## 비목표 (의도적으로 안 함)

- journal/collections/archives 간 Base*Dto 추출 — 공통 필드(`sortOrder`, `isActive`)만 일부 겹치고 업무 도메인이 달라 과도한 추상화가 됨 → KISS로 유지
- DB 스키마/마이그레이션 변경 없음

## 검증

- `cd backend && npm run lint` — exit 0
- `cd backend && npm run build` — exit 0
- `cd backend && npm run test` — Test Suites 72 passed, Tests 692 passed

Closes #687