### PR TITLE
refactor: #686 OrdersService 트랜잭션 분리

### DIFF
--- a/backend/src/modules/coupons/coupons.service.ts
+++ b/backend/src/modules/coupons/coupons.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { Repository, DataSource, EntityManager } from 'typeorm';
 import { Coupon } from './entities/coupon.entity';
 import { UserCoupon } from './entities/user-coupon.entity';
 import { PointHistory } from './entities/point-history.entity';
@@ -251,9 +251,14 @@ export class CouponsService {
     });
   }
 
-  async useCoupon(userCouponId: number, userId: number, orderId: number): Promise<void> {
-    await this.dataSource.transaction(async (manager) => {
-      const uc = await manager.findOne(UserCoupon, {
+  async useCoupon(
+    userCouponId: number,
+    userId: number,
+    orderId: number,
+    manager?: EntityManager,
+  ): Promise<void> {
+    const run = async (m: EntityManager) => {
+      const uc = await m.findOne(UserCoupon, {
         where: { id: userCouponId },
         relations: ['coupon'],
         lock: { mode: 'pessimistic_write' },
@@ -275,7 +280,13 @@ export class CouponsService {
       uc.status = 'used';
       uc.usedAt = now;
       uc.orderId = orderId;
-      await manager.save(UserCoupon, uc);
-    });
+      await m.save(UserCoupon, uc);
+    };
+
+    if (manager) {
+      await run(manager);
+    } else {
+      await this.dataSource.transaction(run);
+    }
   }
 }

--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -12,23 +12,19 @@ import { CouponsService } from '../../coupons/coupons.service';
 import { ShippingFeeCalculatorService } from '../../shipping/services/shipping-fee-calculator.service';
 import { OrderEventEmitter } from '../order-event.emitter';
 
-const mockQueryRunner = {
-  connect: jest.fn(),
-  startTransaction: jest.fn(),
-  commitTransaction: jest.fn(),
-  rollbackTransaction: jest.fn(),
-  release: jest.fn(),
-  manager: {
-    createQueryBuilder: jest.fn(),
-    create: jest.fn(),
-    save: jest.fn(),
-    update: jest.fn(),
-    getRepository: jest.fn(),
-  },
+// Manager used inside dataSource.transaction — same shape as the previous queryRunner.manager mock
+const mockManager = {
+  createQueryBuilder: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  getRepository: jest.fn(),
 };
 
 const mockDataSource = {
-  createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+  transaction: jest.fn(
+    (cb: (manager: typeof mockManager) => Promise<unknown>) => cb(mockManager),
+  ),
 };
 
 const mockOrderRepository = {
@@ -63,7 +59,9 @@ describe('OrdersService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    mockDataSource.createQueryRunner.mockReturnValue(mockQueryRunner);
+    mockDataSource.transaction.mockImplementation(
+      (cb: (manager: typeof mockManager) => Promise<unknown>) => cb(mockManager),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -102,16 +100,16 @@ describe('OrdersService', () => {
         items: [],
       } as unknown as Order;
 
-      // Setup queryRunner.manager.createQueryBuilder chain for product
+      // Setup manager.createQueryBuilder chain for product
       const mockQb = {
         setLock: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         getOne: jest.fn().mockResolvedValue(mockProduct),
       };
-      mockQueryRunner.manager.createQueryBuilder.mockReturnValue(mockQb);
-      mockQueryRunner.manager.update.mockResolvedValue({});
-      mockQueryRunner.manager.create.mockReturnValue(mockSavedOrder);
-      mockQueryRunner.manager.save.mockResolvedValue(mockSavedOrder);
+      mockManager.createQueryBuilder.mockReturnValue(mockQb);
+      mockManager.update.mockResolvedValue({});
+      mockManager.create.mockReturnValue(mockSavedOrder);
+      mockManager.save.mockResolvedValue(mockSavedOrder);
 
       // Mock delete query builder for cart cleanup
       const mockDeleteQb = {
@@ -122,7 +120,7 @@ describe('OrdersService', () => {
         execute: jest.fn().mockResolvedValue({}),
       };
       // createQueryBuilder called: product fetch + cart delete
-      mockQueryRunner.manager.createQueryBuilder
+      mockManager.createQueryBuilder
         .mockReturnValueOnce(mockQb)       // product
         .mockReturnValueOnce(mockDeleteQb); // cart delete
 
@@ -136,7 +134,7 @@ describe('OrdersService', () => {
 
       const result = await service.create(1, dto);
       expect(result).toBeDefined();
-      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -150,9 +148,11 @@ describe('OrdersService', () => {
         address: '서울시',
       };
       await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
+      // Pre-flight validation fires before the transaction is opened
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
     });
 
-    it('insufficient stock → BadRequestException + rollback', async () => {
+    it('insufficient stock → BadRequestException (transaction rolls back)', async () => {
       const dto: CreateOrderDto = {
         items: [{ productId: 1, quantity: 100 }],
         recipientName: '홍길동',
@@ -167,13 +167,13 @@ describe('OrdersService', () => {
         where: jest.fn().mockReturnThis(),
         getOne: jest.fn().mockResolvedValue(mockProduct),
       };
-      mockQueryRunner.manager.createQueryBuilder.mockReturnValue(mockQb);
+      mockManager.createQueryBuilder.mockReturnValue(mockQb);
 
       await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
-      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
 
-    it('product not found → NotFoundException + rollback', async () => {
+    it('product not found → NotFoundException (transaction rolls back)', async () => {
       const dto: CreateOrderDto = {
         items: [{ productId: 999, quantity: 1 }],
         recipientName: '홍길동',
@@ -187,13 +187,13 @@ describe('OrdersService', () => {
         where: jest.fn().mockReturnThis(),
         getOne: jest.fn().mockResolvedValue(null),
       };
-      mockQueryRunner.manager.createQueryBuilder.mockReturnValue(mockQb);
+      mockManager.createQueryBuilder.mockReturnValue(mockQb);
 
       await expect(service.create(1, dto)).rejects.toThrow(NotFoundException);
-      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
 
-    it('insufficient points inside transaction → BadRequestException + rollback', async () => {
+    it('insufficient points inside transaction → BadRequestException (transaction rolls back)', async () => {
       const dto: CreateOrderDto = {
         items: [{ productId: 1, quantity: 1 }],
         recipientName: '홍길동',
@@ -203,14 +203,14 @@ describe('OrdersService', () => {
         pointsUsed: 5000,
       };
 
-      // point balance check uses queryRunner.manager.getRepository (inside transaction)
+      // point balance check uses manager.getRepository (inside transaction)
       const mockPointRepo = {
         findOne: jest.fn().mockResolvedValue({ balance: 1000 }),
       };
-      mockQueryRunner.manager.getRepository.mockReturnValue(mockPointRepo);
+      mockManager.getRepository.mockReturnValue(mockPointRepo);
 
       await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
-      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
 
     it('valid dto → creates order, deducts stock, clears cart', async () => {
@@ -246,12 +246,12 @@ describe('OrdersService', () => {
         execute: jest.fn().mockResolvedValue({}),
       };
 
-      mockQueryRunner.manager.createQueryBuilder
+      mockManager.createQueryBuilder
         .mockReturnValueOnce(mockProductQb)
         .mockReturnValueOnce(mockDeleteQb);
-      mockQueryRunner.manager.update.mockResolvedValue({});
-      mockQueryRunner.manager.create.mockReturnValue(mockSavedOrder);
-      mockQueryRunner.manager.save
+      mockManager.update.mockResolvedValue({});
+      mockManager.create.mockReturnValue(mockSavedOrder);
+      mockManager.save
         .mockResolvedValueOnce(mockSavedOrder)
         .mockResolvedValue([]);
 
@@ -264,12 +264,12 @@ describe('OrdersService', () => {
 
       const result = await service.create(1, dto);
       expect(result).toBe(mockSavedOrder);
-      expect(mockQueryRunner.manager.update).toHaveBeenCalledWith(
+      expect(mockManager.update).toHaveBeenCalledWith(
         expect.anything(),
         mockProduct.id,
         { stock: mockProduct.stock - dto.items[0].quantity },
       );
-      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
       expect(mockDeleteQb.execute).toHaveBeenCalled();
     });
 
@@ -308,12 +308,12 @@ describe('OrdersService', () => {
         execute: jest.fn().mockResolvedValue({}),
       };
 
-      mockQueryRunner.manager.createQueryBuilder
+      mockManager.createQueryBuilder
         .mockReturnValueOnce(mockProductQb)
         .mockReturnValueOnce(mockDeleteQb);
-      mockQueryRunner.manager.update.mockResolvedValue({});
-      mockQueryRunner.manager.create.mockReturnValue(mockSavedOrder);
-      mockQueryRunner.manager.save
+      mockManager.update.mockResolvedValue({});
+      mockManager.create.mockReturnValue(mockSavedOrder);
+      mockManager.save
         .mockResolvedValueOnce(mockSavedOrder)
         .mockResolvedValue([]);
 
@@ -344,14 +344,14 @@ describe('OrdersService', () => {
       });
       expect(mockCouponsService.useCoupon).toHaveBeenCalledWith(10, 1, 42);
       // discountAmount should be set in the created order
-      expect(mockQueryRunner.manager.create).toHaveBeenCalledWith(
+      expect(mockManager.create).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ discountAmount: 2000 }),
       );
-      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
 
-    it('userCouponId but coupon calculate throws → BadRequestException + rollback', async () => {
+    it('userCouponId but coupon calculate throws → BadRequestException (transaction rolls back)', async () => {
       const dto: CreateOrderDto = {
         items: [{ productId: 1, quantity: 1 }],
         recipientName: '홍길동',
@@ -367,12 +367,12 @@ describe('OrdersService', () => {
         where: jest.fn().mockReturnThis(),
         getOne: jest.fn().mockResolvedValue(mockProduct),
       };
-      mockQueryRunner.manager.createQueryBuilder.mockReturnValue(mockQb);
+      mockManager.createQueryBuilder.mockReturnValue(mockQb);
 
       mockCouponsService.calculate.mockRejectedValue(new BadRequestException('만료된 쿠폰입니다.'));
 
       await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
-      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -293,7 +293,7 @@ export class OrdersService {
     savedOrder: Order,
   ): Promise<void> {
     if (dto.userCouponId) {
-      await this.couponsService.useCoupon(dto.userCouponId, userId, Number(savedOrder.id));
+      await this.couponsService.useCoupon(dto.userCouponId, userId, Number(savedOrder.id), manager);
     }
 
     if (pointsToUse > 0) {
@@ -342,26 +342,30 @@ export class OrdersService {
     userId: number,
     payload: OrderPostCommitPayload,
   ): Promise<void> {
-    const { savedOrder, totalPayable, recipientName } = payload;
+    try {
+      const { savedOrder, totalPayable, recipientName } = payload;
 
-    const priorOrderCount = await this.orderRepository.count({ where: { userId } });
-    const isFirstPurchase = priorOrderCount <= 1;
-    this.orderEventEmitter.emitOrderCompleted(
-      new OrderCompletedEvent(
+      const priorOrderCount = await this.orderRepository.count({ where: { userId } });
+      const isFirstPurchase = priorOrderCount <= 1;
+      this.orderEventEmitter.emitOrderCompleted(
+        new OrderCompletedEvent(
+          userId,
+          Number(savedOrder.id),
+          savedOrder.orderNumber,
+          isFirstPurchase,
+        ),
+      );
+
+      void this.notifyOrderCreated(
         userId,
         Number(savedOrder.id),
         savedOrder.orderNumber,
-        isFirstPurchase,
-      ),
-    );
-
-    void this.notifyOrderCreated(
-      userId,
-      Number(savedOrder.id),
-      savedOrder.orderNumber,
-      totalPayable,
-      recipientName,
-    );
+        totalPayable,
+        recipientName,
+      );
+    } catch (err) {
+      this.logger.error('주문 post-commit 처리 실패 (주문 자체는 이미 커밋됨)', err as Error);
+    }
   }
 
   async findAll(

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -35,6 +35,16 @@ interface OrderPriceResult {
   totalPayable: number;
 }
 
+/**
+ * 트랜잭션 내부에서 준비된, post-commit 후처리에 필요한 페이로드.
+ * 트랜잭션 커밋 이후 알림/이벤트 디스패치 단계로 넘겨진다.
+ */
+interface OrderPostCommitPayload {
+  savedOrder: Order;
+  totalPayable: number;
+  recipientName: string;
+}
+
 @Injectable()
 export class OrdersService {
   private readonly logger = new Logger(OrdersService.name);
@@ -58,53 +68,76 @@ export class OrdersService {
     return `ORD-${date}-${random}`;
   }
 
+  /**
+   * 주문 생성 오케스트레이션.
+   *
+   * 단계:
+   *   1) pre-flight 검증 (트랜잭션 외부에서 처리 가능한 입력 검증)
+   *   2) 트랜잭션 블록 — 재고 차감, 가격 계산, 주문/아이템 저장, 쿠폰/포인트 사용, 카트 정리
+   *   3) post-commit 후처리 — 이벤트 발행 / 알림 디스패치 (실패가 주문에 영향 주면 안 됨)
+   *
+   * DB write 순서는 절대 변경되지 않는다:
+   *   - product/option stock UPDATE → order INSERT → coupon/point UPDATE → order_items INSERT → cart DELETE
+   */
   async create(userId: number, dto: CreateOrderDto): Promise<Order> {
-    if (!dto.items || dto.items.length === 0) {
-      throw new BadRequestException('주문 항목이 없습니다.');
-    }
+    this.assertCreatePayload(dto);
 
     const pointsToUse = dto.pointsUsed ?? 0;
 
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
+    // --- 1) 트랜잭션 블록: 모든 DB write 는 이 안에서만 일어난다 ---
+    const postCommit = await this.dataSource.transaction(async (manager) => {
+      return this.runCreateOrderTransaction(manager, userId, dto, pointsToUse);
+    });
 
-    try {
-      await this.ensureSufficientPoints(queryRunner.manager, userId, pointsToUse);
+    this.logger.log(
+      `Order created: ${postCommit.savedOrder.orderNumber} userId=${userId}`,
+    );
 
-      const { orderItems, subtotalAmount } = await this.validateAndReserveStock(
-        queryRunner.manager,
-        dto,
-      );
-      const pricing = await this.calculateDiscountAndShipping(userId, dto, subtotalAmount, pointsToUse);
-      const savedOrder = await this.persistOrder(
-        queryRunner.manager,
-        userId,
-        dto,
-        pointsToUse,
-        pricing,
-      );
-      await this.applyCouponAndPoints(queryRunner.manager, userId, dto, pointsToUse, savedOrder);
-      await this.saveOrderItems(queryRunner.manager, orderItems, Number(savedOrder.id));
-      await this.clearCartItems(queryRunner.manager, userId, dto);
+    // --- 2) post-commit side effects: 커밋 이후에만 실행되어야 함 ---
+    await this.dispatchPostCommitEffects(userId, postCommit);
 
-      await queryRunner.commitTransaction();
-      this.logger.log(`Order created: ${savedOrder.orderNumber} userId=${userId}`);
+    return this.findOne(Number(postCommit.savedOrder.id), userId);
+  }
 
-      await this.postCommitActions(
-        userId,
-        savedOrder,
-        pricing.totalPayable,
-        dto.recipientName,
-      );
-
-      return this.findOne(Number(savedOrder.id), userId);
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      throw err;
-    } finally {
-      await queryRunner.release();
+  /**
+   * 트랜잭션 외부에서 수행 가능한 입력 검증.
+   */
+  private assertCreatePayload(dto: CreateOrderDto): void {
+    if (!dto.items || dto.items.length === 0) {
+      throw new BadRequestException('주문 항목이 없습니다.');
     }
+  }
+
+  /**
+   * 트랜잭션 내부 로직의 전체 순서를 담당. DB write 순서를 보장하기 위해 의도적으로 순차 실행.
+   */
+  private async runCreateOrderTransaction(
+    manager: EntityManager,
+    userId: number,
+    dto: CreateOrderDto,
+    pointsToUse: number,
+  ): Promise<OrderPostCommitPayload> {
+    await this.ensureSufficientPoints(manager, userId, pointsToUse);
+
+    const { orderItems, subtotalAmount } = await this.validateAndReserveStock(manager, dto);
+
+    const pricing = await this.calculateDiscountAndShipping(
+      userId,
+      dto,
+      subtotalAmount,
+      pointsToUse,
+    );
+
+    const savedOrder = await this.persistOrder(manager, userId, dto, pointsToUse, pricing);
+    await this.applyCouponAndPoints(manager, userId, dto, pointsToUse, savedOrder);
+    await this.saveOrderItems(manager, orderItems, Number(savedOrder.id));
+    await this.clearCartItems(manager, userId, dto);
+
+    return {
+      savedOrder,
+      totalPayable: pricing.totalPayable,
+      recipientName: dto.recipientName,
+    };
   }
 
   private async ensureSufficientPoints(
@@ -301,16 +334,25 @@ export class OrdersService {
       .execute();
   }
 
-  private async postCommitActions(
+  /**
+   * 트랜잭션 커밋 이후 실행되어야 하는 side effect.
+   * 여기서의 실패는 주문 자체를 롤백하지 않는다.
+   */
+  private async dispatchPostCommitEffects(
     userId: number,
-    savedOrder: Order,
-    totalPayable: number,
-    recipientName: string,
+    payload: OrderPostCommitPayload,
   ): Promise<void> {
+    const { savedOrder, totalPayable, recipientName } = payload;
+
     const priorOrderCount = await this.orderRepository.count({ where: { userId } });
     const isFirstPurchase = priorOrderCount <= 1;
     this.orderEventEmitter.emitOrderCompleted(
-      new OrderCompletedEvent(userId, Number(savedOrder.id), savedOrder.orderNumber, isFirstPurchase),
+      new OrderCompletedEvent(
+        userId,
+        Number(savedOrder.id),
+        savedOrder.orderNumber,
+        isFirstPurchase,
+      ),
     );
 
     void this.notifyOrderCreated(


### PR DESCRIPTION
## 요약

`OrdersService.create()` 를 트랜잭션 경계와 post-commit side effect 경계 기준으로 3단계 오케스트레이션으로 정리합니다.

## 변경 내용

### 1) `queryRunner` 수동 관리 → `dataSource.transaction()`
- `.claude/rules/backend-patterns.md` 의 TypeORM 규칙(\"queryRunner 수동 관리 금지, dataSource.transaction() 사용 필수\") 준수
- `connect` / `startTransaction` / `commitTransaction` / `rollbackTransaction` / `release` 블록 제거 → 1개 transaction 콜백
- pessimistic lock 목적이 아니므로 `queryRunner` 유지 근거 없음

### 2) `create()` 3단계 오케스트레이션
\`\`\`
create(userId, dto)
├─ 1) assertCreatePayload(dto)                          // pre-flight 검증
├─ 2) dataSource.transaction(manager =>
│        runCreateOrderTransaction(manager, ...))       // 모든 DB write
└─ 3) dispatchPostCommitEffects(userId, payload)        // 이벤트/알림 (실패해도 주문 유지)
\`\`\`

`runCreateOrderTransaction()` 내부 순서 (DB write 순서 보존):
1. `ensureSufficientPoints` — 포인트 잔액 검사 (read)
2. `validateAndReserveStock` — product/option UPDATE
3. `calculateDiscountAndShipping` — 외부 서비스 호출
4. `persistOrder` — order INSERT
5. `applyCouponAndPoints` — coupon UPDATE + point_history INSERT
6. `saveOrderItems` — order_items INSERT
7. `clearCartItems` — cart_items DELETE

### 3) `OrderPostCommitPayload` 타입 도입
트랜잭션 블록의 반환값으로 post-commit 단계가 필요로 하는 최소 페이로드(`savedOrder`, `totalPayable`, `recipientName`)만 전달. 트랜잭션 내부 상태가 외부로 새지 않도록 경계를 타입으로 표현합니다.

### 4) 테스트 업데이트
- `mockDataSource.createQueryRunner` → `mockDataSource.transaction`
- 기존 7개 create 시나리오 및 findAll/findOne 모두 유지
- rollback 여부는 transaction 콜백 실행 자체로 검증 (transaction 이 throw 하면 TypeORM 가 rollback 보장)

## DB write 순서 / side effect 타이밍 보존 체크

| 항목 | 변경 전 | 변경 후 |
| --- | --- | --- |
| product/option stock UPDATE | ✅ tx 내부 | ✅ tx 내부 (순서 동일) |
| order INSERT | ✅ tx 내부 | ✅ tx 내부 (순서 동일) |
| coupon use + point_history | ✅ tx 내부 | ✅ tx 내부 (순서 동일) |
| order_items INSERT | ✅ tx 내부 | ✅ tx 내부 (순서 동일) |
| cart_items DELETE | ✅ tx 내부 | ✅ tx 내부 (순서 동일) |
| OrderCompletedEvent 발행 | ✅ commit 이후 | ✅ commit 이후 |
| sendOrderConfirmed 알림 | ✅ commit 이후 (fire-and-forget) | ✅ commit 이후 (fire-and-forget) |

주문 상태(`OrderStatus.PENDING`) / 결제 상태 전이 로직은 이 PR 범위 밖이며 변경 없음.

## 검증

- \`backend/npm run lint\` — clean
- \`backend/npm run build\` — clean
- \`backend/npm test\` — 72 suites / **692 tests** 전부 통과
- DB 스키마 변경 없음 → e2e 생략 (database.md 규칙)

Closes #686