### PR TITLE
fix: password_reset_tokens FK 추가 idempotent 처리 (배포 실패 핫픽스)

### DIFF
--- a/backend/src/database/migrations/1778400000001-CreatePasswordResetTokensTable.ts
+++ b/backend/src/database/migrations/1778400000001-CreatePasswordResetTokensTable.ts
@@ -7,15 +7,34 @@ export class CreatePasswordResetTokensTable1778400000001 implements MigrationInt
     await queryRunner.query(
       `CREATE TABLE IF NOT EXISTS \`password_reset_tokens\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`user_id\` bigint NOT NULL, \`token_hash\` varchar(64) NOT NULL, \`expires_at\` datetime NOT NULL, \`used_at\` datetime NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), UNIQUE INDEX \`IDX_password_reset_tokens_token_hash\` (\`token_hash\`), INDEX \`IDX_password_reset_tokens_user_id\` (\`user_id\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
     );
-    await queryRunner.query(
-      `ALTER TABLE \`password_reset_tokens\` ADD CONSTRAINT \`FK_password_reset_tokens_user_id\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
-    );
+
+    const existingFk = await queryRunner.query(`
+      SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'password_reset_tokens'
+        AND CONSTRAINT_NAME = 'FK_password_reset_tokens_user_id'
+        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    `);
+    if ((existingFk as unknown[]).length === 0) {
+      await queryRunner.query(
+        `ALTER TABLE \`password_reset_tokens\` ADD CONSTRAINT \`FK_password_reset_tokens_user_id\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+      );
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE \`password_reset_tokens\` DROP FOREIGN KEY \`FK_password_reset_tokens_user_id\``,
-    );
+    const existingFk = await queryRunner.query(`
+      SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'password_reset_tokens'
+        AND CONSTRAINT_NAME = 'FK_password_reset_tokens_user_id'
+        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    `);
+    if ((existingFk as unknown[]).length > 0) {
+      await queryRunner.query(
+        `ALTER TABLE \`password_reset_tokens\` DROP FOREIGN KEY \`FK_password_reset_tokens_user_id\``,
+      );
+    }
     await queryRunner.query(
       `DROP INDEX \`IDX_password_reset_tokens_user_id\` ON \`password_reset_tokens\``,
     );


### PR DESCRIPTION
## 배경

`deploy.yml` 의 `migration:run` 단계가 다음 에러로 백엔드 배포 실패:

\`\`\`
Migration "CreatePasswordResetTokensTable1778400000001" failed,
error: Duplicate foreign key constraint name 'FK_password_reset_tokens_user_id'
code: 'ER_FK_DUP_NAME'
\`\`\`

테이블 자체는 `CREATE TABLE IF NOT EXISTS` 였으나, FK 추가가 조건 없이 실행되어
재시도/부분실패 후 재실행 시 중복 에러로 전체 배포 파이프라인이 멈춤.

이번 ship 사이클에서 PR #695, #697 머지 시 배포가 모두 실패했지만 프로덕션은 이전 성공 배포(uptime 100k+초)로 정상 가동 중. 다음 백엔드 배포부터 정상화 위해 핫픽스 필요.

## 변경

- `INFORMATION_SCHEMA.TABLE_CONSTRAINTS` 사전 조회로 FK 존재 여부 확인 후에만 ADD CONSTRAINT 실행
- down 마이그레이션도 동일 패턴으로 보강
- `AddRefundsTable` 등 기존 마이그레이션이 사용하던 패턴과 동일

## Test plan
- [x] backend `npm run lint`
- [x] backend `npm run build`
- [x] backend `npm run test:e2e`

## 관련
- 관측 실패: PR #695, #697 머지 후 `Deploy Backend` 워크플로우