### PR TITLE
perf: #699 #700 #701 #702 백엔드 배치 처리와 공유 타입 정리

### DIFF
--- a/backend/src/common/decorators/current-user.decorator.ts
+++ b/backend/src/common/decorators/current-user.decorator.ts
@@ -1,7 +1,8 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { RequestWithAuthUser } from '../interfaces/auth-user.interface';
 
 export const CurrentUser = createParamDecorator(
   (_data: unknown, ctx: ExecutionContext) => {
-    return ctx.switchToHttp().getRequest<{ user: unknown }>().user;
+    return ctx.switchToHttp().getRequest<RequestWithAuthUser>().user;
   },
 );

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY } from '../decorators/roles.decorator';
+import { RequestWithAuthUser } from '../interfaces/auth-user.interface';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -13,7 +14,7 @@ export class RolesGuard implements CanActivate {
     ]);
     if (!requiredRoles || requiredRoles.length === 0) return true;
 
-    const { user } = context.switchToHttp().getRequest<{ user?: { role: string } }>();
+    const { user } = context.switchToHttp().getRequest<RequestWithAuthUser>();
     if (!user) return false;
     // super_admin has all privileges
     if (user.role === 'super_admin') return true;

--- a/backend/src/common/interfaces/auth-user.interface.ts
+++ b/backend/src/common/interfaces/auth-user.interface.ts
@@ -1,0 +1,16 @@
+import { UserRole } from '../../modules/users/entities/user.entity';
+
+export interface AuthUser {
+  id: number;
+  email: string;
+  role: UserRole;
+  jti?: string;
+}
+
+export interface RequestWithAuthUser {
+  user?: AuthUser;
+}
+
+export interface AuthenticatedRequestWithAuthUser {
+  user: AuthUser;
+}

--- a/backend/src/database/migrations/1783100000000-AddProductReviewStats.ts
+++ b/backend/src/database/migrations/1783100000000-AddProductReviewStats.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductReviewStats1783100000000 implements MigrationInterface {
+  name = 'AddProductReviewStats1783100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`products\`
+       ADD \`review_count\` int UNSIGNED NOT NULL DEFAULT 0,
+       ADD \`avg_rating\` decimal(3,2) NOT NULL DEFAULT '0.00'`,
+    );
+    await queryRunner.query('CREATE INDEX `IDX_products_review_count` ON `products` (`review_count`)');
+    await queryRunner.query('CREATE INDEX `IDX_products_avg_rating` ON `products` (`avg_rating`)');
+    await queryRunner.query(
+      `UPDATE \`products\` p
+       LEFT JOIN (
+         SELECT \`product_id\`, COUNT(*) AS \`review_count\`, COALESCE(AVG(\`rating\`), 0) AS \`avg_rating\`
+         FROM \`reviews\`
+         WHERE \`is_visible\` = 1
+         GROUP BY \`product_id\`
+       ) rs ON rs.\`product_id\` = p.\`id\`
+       SET p.\`review_count\` = COALESCE(rs.\`review_count\`, 0),
+           p.\`avg_rating\` = COALESCE(rs.\`avg_rating\`, 0)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX `IDX_products_avg_rating` ON `products`');
+    await queryRunner.query('DROP INDEX `IDX_products_review_count` ON `products`');
+    await queryRunner.query(
+      'ALTER TABLE `products` DROP COLUMN `avg_rating`, DROP COLUMN `review_count`',
+    );
+  }
+}

--- a/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
@@ -8,6 +8,7 @@ import { Payment, PaymentStatus } from '../../payments/entities/payment.entity';
 import { Shipping } from '../../payments/entities/shipping.entity';
 import { PaymentsService } from '../../payments/payments.service';
 import { MembershipService } from '../../membership/membership.service';
+import { PointsService } from '../../points/points.service';
 
 function createMockRepository() {
   const transactionManager = {
@@ -54,6 +55,7 @@ describe('AdminOrdersService', () => {
   let paymentsService: jest.Mocked<PaymentsService>;
   let dataSource: jest.Mocked<DataSource>;
   let mockManager: ReturnType<typeof createMockManager>;
+  let pointsService: jest.Mocked<PointsService>;
 
   beforeEach(async () => {
     orderRepo = createMockRepository();
@@ -63,6 +65,9 @@ describe('AdminOrdersService', () => {
     paymentsService = {
       cancelAdmin: jest.fn(),
     } as unknown as jest.Mocked<PaymentsService>;
+    pointsService = {
+      getRunningBalanceInTx: jest.fn().mockResolvedValue(0),
+    } as unknown as jest.Mocked<PointsService>;
     dataSource = {
       transaction: jest.fn().mockImplementation((cb: (manager: unknown) => Promise<unknown>) => cb(mockManager)),
     } as unknown as jest.Mocked<DataSource>;
@@ -76,6 +81,7 @@ describe('AdminOrdersService', () => {
         { provide: PaymentsService, useValue: paymentsService },
         { provide: DataSource, useValue: dataSource },
         { provide: MembershipService, useValue: { incrementAccumulatedAmount: jest.fn().mockResolvedValue(undefined) } },
+        { provide: PointsService, useValue: pointsService },
       ],
     }).compile();
 

--- a/backend/src/modules/admin/admin-members.controller.ts
+++ b/backend/src/modules/admin/admin-members.controller.ts
@@ -25,10 +25,7 @@ import { AdminMembersQueryDto } from './dto/admin-members-query.dto';
 import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import { UserRole } from '../users/entities/user.entity';
 import { AuditAction } from '../audit-logs/entities/audit-log.entity';
-
-interface RequestWithUser {
-  user: { id: number; email: string; role: string };
-}
+import { AuthenticatedRequestWithAuthUser } from '../../common/interfaces/auth-user.interface';
 
 @ApiTags('관리자 - 회원')
 @Controller('admin')
@@ -63,7 +60,7 @@ export class AdminMembersController {
   updateRole(
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateMemberRoleDto,
-    @Request() req: RequestWithUser,
+    @Request() req: AuthenticatedRequestWithAuthUser,
   ) {
     return this.adminMembersService.updateRole(
       id,

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -13,6 +13,7 @@ import { ProductOption } from '../products/entities/product-option.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { PaymentsService } from '../payments/payments.service';
 import { MembershipService } from '../membership/membership.service';
+import { PointsService } from '../points/points.service';
 import { AdminOrderQueryDto } from './dto/admin-order-query.dto';
 import { RegisterShippingDto } from './dto/register-shipping.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
@@ -33,6 +34,7 @@ export class AdminOrdersService {
     private readonly paymentsService: PaymentsService,
     private readonly dataSource: DataSource,
     private readonly membershipService: MembershipService,
+    private readonly pointsService: PointsService,
   ) {}
 
   async findAll(query: AdminOrderQueryDto): Promise<PaginatedResult<Order>> {
@@ -138,11 +140,10 @@ export class AdminOrdersService {
       return;
     }
 
-    const latest = await manager.findOne(PointHistory, {
-      where: { userId: order.userId },
-      order: { createdAt: 'DESC', id: 'DESC' },
-    });
-    const currentBalance = latest?.balance ?? 0;
+    const currentBalance = await this.pointsService.getRunningBalanceInTx(
+      manager,
+      order.userId,
+    );
     const restoredBalance = currentBalance + order.pointsUsed;
 
     await manager.save(PointHistory, {

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -18,6 +18,7 @@ import { Product } from '../products/entities/product.entity';
 import { PaymentsModule } from '../payments/payments.module';
 import { AuditLogModule } from '../audit-logs/audit-log.module';
 import { MembershipModule } from '../membership/membership.module';
+import { PointsModule } from '../points/points.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { MembershipModule } from '../membership/membership.module';
     PaymentsModule,
     AuditLogModule,
     MembershipModule,
+    PointsModule,
   ],
   controllers: [AdminController, AdminDashboardController, AdminOrdersController, AdminMembersController, AdminExportController],
   providers: [AdminService, AdminDashboardService, AdminOrdersService, AdminMembersService, AdminExportService],

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -31,13 +31,7 @@ import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { SkipThrottle, Throttle } from '@nestjs/throttler';
 import { JwtService } from '@nestjs/jwt';
 import { AUTH_CONFIG, AuthConfig } from '../../config/auth.config';
-
-interface JwtUser {
-  id: number;
-  email: string;
-  role: string;
-  jti?: string;
-}
+import { AuthUser } from '../../common/interfaces/auth-user.interface';
 
 const ACCESS_TOKEN_MAX_AGE = 60 * 60 * 1000;
 const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
@@ -171,7 +165,7 @@ export class AuthController {
   @ApiOperation({ summary: '프로필 조회', description: '현재 로그인한 사용자의 프로필 정보를 조회합니다.' })
   @ApiResponse({ status: 200, description: '프로필 정보' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  getProfile(@CurrentUser() user: JwtUser) {
+  getProfile(@CurrentUser() user: AuthUser) {
     return this.authService.getProfile(user.id);
   }
 
@@ -181,7 +175,7 @@ export class AuthController {
   @ApiOperation({ summary: '현재 사용자 조회', description: '현재 로그인한 사용자의 정보를 반환합니다. (profile과 동일)' })
   @ApiResponse({ status: 200, description: '사용자 정보' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  getMe(@CurrentUser() user: JwtUser) {
+  getMe(@CurrentUser() user: AuthUser) {
     return this.authService.getProfile(user.id);
   }
 
@@ -205,7 +199,7 @@ export class AuthController {
   @ApiOperation({ summary: '로그아웃', description: '현재 세션을 종료하고 토큰을 무효화합니다. 인증 쿠키가 삭제됩니다.' })
   @ApiResponse({ status: 204, description: '로그아웃 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  async logout(@CurrentUser() user: JwtUser, @Res({ passthrough: true }) res: Response, @Req() req: Request) {
+  async logout(@CurrentUser() user: AuthUser, @Res({ passthrough: true }) res: Response, @Req() req: Request) {
     const rawAccessToken = (req.cookies as Record<string, string | undefined>)?.accessToken ?? '';
     if (rawAccessToken) {
       const decoded = this.jwtService.decode(rawAccessToken) as { jti?: string; exp?: number } | null;
@@ -227,7 +221,7 @@ export class AuthController {
   @ApiOperation({ summary: '모든 기기 로그아웃', description: '해당 사용자의 모든 토큰을 무효화합니다. 모든 기기에서 로그아웃됩니다.' })
   @ApiResponse({ status: 204, description: '모든 기기 로그아웃 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  async logoutAll(@CurrentUser() user: JwtUser, @Res({ passthrough: true }) res: Response) {
+  async logoutAll(@CurrentUser() user: AuthUser, @Res({ passthrough: true }) res: Response) {
     await this.authService.logoutAll(user.id);
     clearAuthCookies(res, this.authConfig.cookie.secure);
   }
@@ -267,7 +261,7 @@ export class AuthController {
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 404, description: '연결된 OAuth 계정을 찾을 수 없습니다.' })
   async disconnectOAuth(
-    @CurrentUser() user: JwtUser,
+    @CurrentUser() user: AuthUser,
     @Param('provider', new ParseEnumPipe(OAuthProvider)) provider: OAuthProvider,
   ): Promise<void> {
     await this.oauthService.disconnect(user.id, provider);

--- a/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -1,7 +1,7 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { JwtStrategy } from './jwt.strategy';
-import { User } from '../../users/entities/user.entity';
+import { User, UserRole } from '../../users/entities/user.entity';
 import { TokenBlacklistService } from '../token-blacklist.service';
 import { createAuthConfig } from '../../../config/auth.config';
 
@@ -17,6 +17,12 @@ const mockTokenBlacklistService = {
 
 describe('JwtStrategy', () => {
   let strategy: JwtStrategy;
+  const activeUser = {
+    id: 1,
+    email: 'test@test.com',
+    role: UserRole.USER,
+    isActive: true,
+  } as User;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -36,7 +42,7 @@ describe('JwtStrategy', () => {
 
   describe('validate()', () => {
     it('should return user object for valid access token payload without tokenType', async () => {
-      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockUserRepository.findOne.mockResolvedValue(activeUser);
       mockTokenBlacklistService.isBlacklisted.mockResolvedValue(false);
       const payload = { sub: 1, email: 'test@test.com', role: 'user' };
       const result = await strategy.validate(payload);
@@ -44,7 +50,7 @@ describe('JwtStrategy', () => {
     });
 
     it('should return user object for payload with tokenType: access', async () => {
-      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockUserRepository.findOne.mockResolvedValue(activeUser);
       mockTokenBlacklistService.isBlacklisted.mockResolvedValue(false);
       const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access' };
       const result = await strategy.validate(payload);
@@ -89,14 +95,14 @@ describe('JwtStrategy', () => {
     });
 
     it('should not check blacklist when jti is absent', async () => {
-      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockUserRepository.findOne.mockResolvedValue(activeUser);
       const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access' };
       await strategy.validate(payload);
       expect(mockTokenBlacklistService.isBlacklisted).not.toHaveBeenCalled();
     });
 
     it('should check blacklist and return user with jti when token is not blacklisted', async () => {
-      mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: true } as User);
+      mockUserRepository.findOne.mockResolvedValue(activeUser);
       mockTokenBlacklistService.isBlacklisted.mockResolvedValue(false);
       const payload = { sub: 1, email: 'test@test.com', role: 'user', tokenType: 'access', jti: 'valid-jti' };
       const result = await strategy.validate(payload);

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -7,6 +7,7 @@ import type { Request } from 'express';
 import { User } from '../../users/entities/user.entity';
 import { TokenBlacklistService } from '../token-blacklist.service';
 import { AUTH_CONFIG, AuthConfig } from '../../../config/auth.config';
+import { AuthUser } from '../../../common/interfaces/auth-user.interface';
 
 export interface JwtPayload {
   sub: number;
@@ -46,7 +47,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: JwtPayload) {
+  async validate(payload: JwtPayload): Promise<AuthUser> {
     if (payload.tokenType === 'refresh') {
       throw new UnauthorizedException('Refresh tokens cannot be used for API access');
     }
@@ -64,6 +65,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('비활성화된 계정입니다.');
     }
 
-    return { id: payload.sub, email: payload.email, role: payload.role, jti: payload.jti };
+    return { id: payload.sub, email: user.email, role: user.role, jti: payload.jti };
   }
 }

--- a/backend/src/modules/cart/cart.controller.ts
+++ b/backend/src/modules/cart/cart.controller.ts
@@ -25,12 +25,7 @@ import { AddToCartDto } from './dto/add-to-cart.dto';
 import { UpdateCartQuantityDto } from './dto/update-cart-quantity.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
-
-interface AuthUser {
-  id: number;
-  email: string;
-  role: string;
-}
+import { AuthUser } from '../../common/interfaces/auth-user.interface';
 
 @ApiTags('장바구니')
 @Controller('cart')

--- a/backend/src/modules/coupons/__tests__/coupon-rules.service.spec.ts
+++ b/backend/src/modules/coupons/__tests__/coupon-rules.service.spec.ts
@@ -40,6 +40,7 @@ describe('CouponRulesService', () => {
 
   const mockCouponsService = {
     issueCoupon: jest.fn(),
+    issueCouponsForUser: jest.fn(),
   };
 
   const mockMembershipEvents = {
@@ -189,19 +190,22 @@ describe('CouponRulesService', () => {
     it('issues coupons for all matching active rules', async () => {
       const rules = [makeCouponRule({ couponTemplateId: 10 }), makeCouponRule({ id: 2, couponTemplateId: 20 })];
       mockCouponRuleRepo.find.mockResolvedValue(rules);
-      mockCouponsService.issueCoupon.mockResolvedValue({});
+      mockCouponsService.issueCouponsForUser.mockResolvedValue([
+        { couponId: 10, issued: true },
+        { couponId: 20, issued: true },
+      ]);
 
       await service.applyRulesForUser(CouponRuleTrigger.SIGNUP, 42);
 
-      expect(mockCouponsService.issueCoupon).toHaveBeenCalledTimes(2);
-      expect(mockCouponsService.issueCoupon).toHaveBeenCalledWith({ userId: 42, couponId: 10 });
-      expect(mockCouponsService.issueCoupon).toHaveBeenCalledWith({ userId: 42, couponId: 20 });
+      expect(mockCouponsService.issueCouponsForUser).toHaveBeenCalledWith(42, [10, 20]);
     });
 
     it('skips duplicate coupon issue errors silently', async () => {
       const rules = [makeCouponRule()];
       mockCouponRuleRepo.find.mockResolvedValue(rules);
-      mockCouponsService.issueCoupon.mockRejectedValue(new Error('이미 발급된 쿠폰입니다.'));
+      mockCouponsService.issueCouponsForUser.mockResolvedValue([
+        { couponId: 10, issued: false, reason: '이미 발급된 쿠폰입니다.' },
+      ]);
 
       await expect(service.applyRulesForUser(CouponRuleTrigger.SIGNUP, 42)).resolves.not.toThrow();
     });
@@ -209,7 +213,7 @@ describe('CouponRulesService', () => {
     it('does nothing if no active rules', async () => {
       mockCouponRuleRepo.find.mockResolvedValue([]);
       await service.applyRulesForUser(CouponRuleTrigger.SIGNUP, 42);
-      expect(mockCouponsService.issueCoupon).not.toHaveBeenCalled();
+      expect(mockCouponsService.issueCouponsForUser).not.toHaveBeenCalled();
     });
   });
 
@@ -220,11 +224,11 @@ describe('CouponRulesService', () => {
         conditionsJson: { minTier: 'Silver' },
       });
       mockCouponRuleRepo.find.mockResolvedValue([rule]);
-      mockCouponsService.issueCoupon.mockResolvedValue({});
+      mockCouponsService.issueCouponsForUser.mockResolvedValue([{ couponId: 10, issued: true }]);
 
       await service.applyRulesForUser(CouponRuleTrigger.TIER_UP, 1, { newTier: 'Gold' });
 
-      expect(mockCouponsService.issueCoupon).toHaveBeenCalled();
+      expect(mockCouponsService.issueCouponsForUser).toHaveBeenCalled();
     });
 
     it('tier_up rule with minTier condition skips when newTier < minTier', async () => {
@@ -236,17 +240,17 @@ describe('CouponRulesService', () => {
 
       await service.applyRulesForUser(CouponRuleTrigger.TIER_UP, 1, { newTier: 'Silver' });
 
-      expect(mockCouponsService.issueCoupon).not.toHaveBeenCalled();
+      expect(mockCouponsService.issueCouponsForUser).not.toHaveBeenCalled();
     });
 
     it('rule with null conditionsJson always matches', async () => {
       const rule = makeCouponRule({ conditionsJson: null });
       mockCouponRuleRepo.find.mockResolvedValue([rule]);
-      mockCouponsService.issueCoupon.mockResolvedValue({});
+      mockCouponsService.issueCouponsForUser.mockResolvedValue([{ couponId: 10, issued: true }]);
 
       await service.applyRulesForUser(CouponRuleTrigger.SIGNUP, 1);
 
-      expect(mockCouponsService.issueCoupon).toHaveBeenCalled();
+      expect(mockCouponsService.issueCouponsForUser).toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/coupons/coupon-rules.service.ts
+++ b/backend/src/modules/coupons/coupon-rules.service.ts
@@ -17,6 +17,8 @@ import { OrderEventEmitter } from '../orders/order-event.emitter';
 import { User } from '../users/entities/user.entity';
 import { SchedulerLockService } from '../../common/services/scheduler-lock.service';
 
+const BIRTHDAY_COUPON_USER_BATCH_SIZE = 20;
+
 @Injectable()
 export class CouponRulesService implements OnModuleInit {
   private readonly logger = new Logger(CouponRulesService.name);
@@ -71,23 +73,11 @@ export class CouponRulesService implements OnModuleInit {
       where: { trigger, active: true },
     });
 
-    for (const rule of rules) {
-      if (!this.matchesConditions(rule, context)) {
-        continue;
-      }
+    const matchingCouponIds = rules
+      .filter((rule) => this.matchesConditions(rule, context))
+      .map((rule) => Number(rule.couponTemplateId));
 
-      try {
-        await this.couponsService.issueCoupon({ userId, couponId: Number(rule.couponTemplateId) });
-        this.logger.log(
-          `[${trigger}] Issued couponTemplateId=${rule.couponTemplateId} to userId=${userId}`,
-        );
-      } catch (err) {
-        // BadRequestException for duplicate issues is expected — skip silently
-        this.logger.debug(
-          `[${trigger}] Skipped couponTemplateId=${rule.couponTemplateId} for userId=${userId}: ${String(err)}`,
-        );
-      }
-    }
+    await this.issueCouponsForUser(trigger, userId, matchingCouponIds);
   }
 
   private matchesConditions(rule: CouponRule, context: Record<string, unknown>): boolean {
@@ -139,17 +129,14 @@ export class CouponRulesService implements OnModuleInit {
         `[cron:birthday-coupons] Processing ${birthdayUsers.length} users with birthday on ${month}/${day}`,
       );
 
-      for (const { id: userId } of birthdayUsers) {
-        for (const rule of rules) {
-          try {
-            await this.couponsService.issueCoupon({ userId, couponId: Number(rule.couponTemplateId) });
-            this.logger.log(`[cron:birthday-coupons] Issued couponTemplateId=${rule.couponTemplateId} to userId=${userId}`);
-          } catch (err) {
-            this.logger.debug(
-              `[cron:birthday-coupons] Skipped couponTemplateId=${rule.couponTemplateId} for userId=${userId}: ${String(err)}`,
-            );
-          }
-        }
+      const couponIds = rules.map((rule) => Number(rule.couponTemplateId));
+      for (let index = 0; index < birthdayUsers.length; index += BIRTHDAY_COUPON_USER_BATCH_SIZE) {
+        const chunk = birthdayUsers.slice(index, index + BIRTHDAY_COUPON_USER_BATCH_SIZE);
+        await Promise.allSettled(
+          chunk.map(({ id: userId }) =>
+            this.issueCouponsForUser('cron:birthday-coupons', userId, couponIds),
+          ),
+        );
       }
 
       this.logger.log(`[cron:birthday-coupons] Completed for ${birthdayUsers.length} users`);
@@ -201,5 +188,28 @@ export class CouponRulesService implements OnModuleInit {
     await this.couponRuleRepo.remove(rule);
     this.logger.log(`CouponRule deleted: id=${id}`);
     return { message: '삭제되었습니다.' };
+  }
+
+  private async issueCouponsForUser(
+    trigger: string,
+    userId: number,
+    couponIds: number[],
+  ): Promise<void> {
+    if (couponIds.length === 0) {
+      return;
+    }
+
+    const results = await this.couponsService.issueCouponsForUser(userId, couponIds);
+    for (const result of results) {
+      if (result.issued) {
+        this.logger.log(
+          `[${trigger}] Issued couponTemplateId=${result.couponId} to userId=${userId}`,
+        );
+      } else {
+        this.logger.debug(
+          `[${trigger}] Skipped couponTemplateId=${result.couponId} for userId=${userId}: ${result.reason ?? 'unknown error'}`,
+        );
+      }
+    }
   }
 }

--- a/backend/src/modules/coupons/coupons.controller.ts
+++ b/backend/src/modules/coupons/coupons.controller.ts
@@ -20,11 +20,7 @@ import { CalculateDiscountDto } from './dto/calculate-discount.dto';
 import { CreateCouponDto } from './dto/create-coupon.dto';
 import { IssueCouponDto } from './dto/issue-coupon.dto';
 import { Roles } from '../../common/decorators/roles.decorator';
-
-interface JwtUser {
-  id: number;
-  role: string;
-}
+import { AuthenticatedRequestWithAuthUser } from '../../common/interfaces/auth-user.interface';
 
 @ApiTags('쿠폰')
 @Controller('coupons')
@@ -38,7 +34,7 @@ export class CouponsController {
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiQuery({ name: 'status', required: false, type: String, description: '쿠폰 상태 (available/used/expired)' })
   findAll(
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
     @Query('status') status?: string,
   ) {
     return this.couponsService.findAll(req.user.id, status);
@@ -51,7 +47,7 @@ export class CouponsController {
   @ApiResponse({ status: 200, description: '할인 금액 계산 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   calculate(
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
     @Body() dto: CalculateDiscountDto,
   ) {
     return this.couponsService.calculate(req.user.id, dto);
@@ -62,7 +58,7 @@ export class CouponsController {
   @ApiOperation({ summary: '쿠폰 포인트 조회', description: '현재 사용자의 쿠폰 포인트를 조회합니다.' })
   @ApiResponse({ status: 200, description: '쿠폰 포인트 조회 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  getPoints(@Request() req: { user: JwtUser }) {
+  getPoints(@Request() req: AuthenticatedRequestWithAuthUser) {
     return this.couponsService.getPoints(req.user.id);
   }
 }

--- a/backend/src/modules/coupons/coupons.service.ts
+++ b/backend/src/modules/coupons/coupons.service.ts
@@ -59,6 +59,12 @@ export interface PointHistoryItem {
   createdAt: Date;
 }
 
+export interface IssueCouponBatchResult {
+  couponId: number;
+  issued: boolean;
+  reason?: string;
+}
+
 export interface PointsResponse {
   balance: number;
   history: PointHistoryItem[];
@@ -216,39 +222,68 @@ export class CouponsService {
   }
 
   async issueCoupon(dto: IssueCouponDto): Promise<UserCoupon> {
-    return await this.dataSource.transaction(async (manager) => {
-      const coupon = await manager.findOne(Coupon, {
-        where: { id: dto.couponId },
-        lock: { mode: 'pessimistic_write' },
-      });
-
-      if (!coupon) {
-        throw new NotFoundException('쿠폰을 찾을 수 없습니다.');
-      }
-      if (!coupon.isActive) {
-        throw new BadRequestException('비활성화된 쿠폰입니다.');
-      }
-      if (coupon.totalQuantity != null && coupon.issuedCount >= coupon.totalQuantity) {
-        throw new BadRequestException('발급 수량이 소진된 쿠폰입니다.');
-      }
-
-      const existing = await manager.findOne(UserCoupon, {
-        where: { userId: dto.userId, couponId: dto.couponId },
-      });
-      if (existing) {
-        throw new BadRequestException('이미 발급된 쿠폰입니다.');
-      }
-
-      const uc = manager.create(UserCoupon, {
-        userId: dto.userId,
-        couponId: dto.couponId,
-        status: 'available',
-      });
-      const saved = await manager.save(UserCoupon, uc);
-      await manager.increment(Coupon, { id: dto.couponId }, 'issuedCount', 1);
-      this.logger.log(`Coupon issued: couponId=${dto.couponId}, userId=${dto.userId}`);
-      return saved;
+    return this.dataSource.transaction(async (manager) => {
+      return this.issueCouponInTx(manager, dto);
     });
+  }
+
+  async issueCouponsForUser(
+    userId: number,
+    couponIds: number[],
+  ): Promise<IssueCouponBatchResult[]> {
+    return this.dataSource.transaction(async (manager) => {
+      const results: IssueCouponBatchResult[] = [];
+      for (const couponId of couponIds) {
+        try {
+          await this.issueCouponInTx(manager, { userId, couponId });
+          results.push({ couponId, issued: true });
+        } catch (err) {
+          results.push({
+            couponId,
+            issued: false,
+            reason: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      return results;
+    });
+  }
+
+  private async issueCouponInTx(
+    manager: EntityManager,
+    dto: IssueCouponDto,
+  ): Promise<UserCoupon> {
+    const coupon = await manager.findOne(Coupon, {
+      where: { id: dto.couponId },
+      lock: { mode: 'pessimistic_write' },
+    });
+
+    if (!coupon) {
+      throw new NotFoundException('쿠폰을 찾을 수 없습니다.');
+    }
+    if (!coupon.isActive) {
+      throw new BadRequestException('비활성화된 쿠폰입니다.');
+    }
+    if (coupon.totalQuantity != null && coupon.issuedCount >= coupon.totalQuantity) {
+      throw new BadRequestException('발급 수량이 소진된 쿠폰입니다.');
+    }
+
+    const existing = await manager.findOne(UserCoupon, {
+      where: { userId: dto.userId, couponId: dto.couponId },
+    });
+    if (existing) {
+      throw new BadRequestException('이미 발급된 쿠폰입니다.');
+    }
+
+    const uc = manager.create(UserCoupon, {
+      userId: dto.userId,
+      couponId: dto.couponId,
+      status: 'available',
+    });
+    const saved = await manager.save(UserCoupon, uc);
+    await manager.increment(Coupon, { id: dto.couponId }, 'issuedCount', 1);
+    this.logger.log(`Coupon issued: couponId=${dto.couponId}, userId=${dto.userId}`);
+    return saved;
   }
 
   async useCoupon(

--- a/backend/src/modules/inquiries/inquiries.controller.ts
+++ b/backend/src/modules/inquiries/inquiries.controller.ts
@@ -20,11 +20,7 @@ import { CreateInquiryDto } from './dto/create-inquiry.dto';
 import { AnswerInquiryDto } from './dto/answer-inquiry.dto';
 import { AdminInquiryQueryDto } from './dto/admin-inquiry-query.dto';
 import { Roles } from '../../common/decorators/roles.decorator';
-
-interface JwtUser {
-  id: number;
-  role: string;
-}
+import { AuthenticatedRequestWithAuthUser } from '../../common/interfaces/auth-user.interface';
 
 @ApiTags('1:1 문의')
 @Controller('inquiries')
@@ -36,7 +32,7 @@ export class InquiriesController {
   @ApiOperation({ summary: '내 문의 목록 조회', description: '현재 사용자의 1:1 문의 목록을 조회합니다.' })
   @ApiResponse({ status: 200, description: '문의 목록 조회 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  findAll(@Request() req: { user: JwtUser }) {
+  findAll(@Request() req: AuthenticatedRequestWithAuthUser) {
     return this.inquiriesService.findAllByUser(req.user.id);
   }
 
@@ -45,7 +41,7 @@ export class InquiriesController {
   @ApiOperation({ summary: '1:1 문의 생성', description: '새로운 1:1 문의를 생성합니다.' })
   @ApiResponse({ status: 201, description: '문의 생성 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  create(@Request() req: { user: JwtUser }, @Body() dto: CreateInquiryDto) {
+  create(@Request() req: AuthenticatedRequestWithAuthUser, @Body() dto: CreateInquiryDto) {
     return this.inquiriesService.create(req.user.id, dto);
   }
 
@@ -59,7 +55,7 @@ export class InquiriesController {
   @ApiParam({ name: 'id', type: Number, description: '문의 ID' })
   findOne(
     @Param('id', ParseIntPipe) id: number,
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
   ) {
     return this.inquiriesService.findOne(id, req.user.id);
   }

--- a/backend/src/modules/membership/__tests__/membership.service.spec.ts
+++ b/backend/src/modules/membership/__tests__/membership.service.spec.ts
@@ -176,7 +176,10 @@ describe('MembershipService', () => {
 
       await service.evaluateAllUserTiers();
 
-      expect(mockUserRepo.update).toHaveBeenCalledWith(1, expect.objectContaining({ tier: 'Silver' }));
+      expect(mockUserRepo.update).toHaveBeenCalledWith(
+        { id: expect.any(Object) },
+        expect.objectContaining({ tier: 'Silver' }),
+      );
       expect(mockEventEmitter.emitTierUpgraded).toHaveBeenCalledWith(
         expect.objectContaining({ userId: 1, previousTier: 'Bronze', newTier: 'Silver' }),
       );
@@ -193,6 +196,10 @@ describe('MembershipService', () => {
       await service.evaluateAllUserTiers();
 
       expect(mockEventEmitter.emitTierUpgraded).not.toHaveBeenCalled();
+      expect(mockUserRepo.update).toHaveBeenCalledWith(
+        { id: expect.any(Object) },
+        expect.objectContaining({ tierEvaluatedAt: expect.any(Date) }),
+      );
     });
 
     it('should do nothing when no tiers configured', async () => {

--- a/backend/src/modules/membership/membership.controller.ts
+++ b/backend/src/modules/membership/membership.controller.ts
@@ -2,12 +2,7 @@ import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiCookieAuth } from '@nestjs/swagger';
 import { MembershipService } from './membership.service';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
-
-interface AuthUser {
-  id: number;
-  email: string;
-  role: string;
-}
+import { AuthUser } from '../../common/interfaces/auth-user.interface';
 
 @ApiTags('사용자 - 회원 등급')
 @Controller('users')

--- a/backend/src/modules/membership/membership.service.ts
+++ b/backend/src/modules/membership/membership.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { MembershipTier } from './entities/membership-tier.entity';
 import { User } from '../users/entities/user.entity';
 import { CreateMembershipTierDto } from './dto/create-membership-tier.dto';
@@ -21,6 +21,8 @@ export interface UserTierInfo {
   nextTier: MembershipTier | null;
   amountToNextTier: number | null;
 }
+
+const USER_TIER_BATCH_SIZE = 500;
 
 @Injectable()
 export class MembershipService {
@@ -125,10 +127,22 @@ export class MembershipService {
       return;
     }
 
-    const users = await this.userRepo.find({ where: { isActive: true } });
+    const users = await this.userRepo.find({
+      select: {
+        id: true,
+        tier: true,
+        tierAccumulatedAmount: true,
+        isActive: true,
+      },
+      where: { isActive: true },
+    });
     this.logger.log(`[membership:cron] Evaluating tiers for ${users.length} users`);
 
     let upgradedCount = 0;
+    const evaluatedAt = new Date();
+    const unchangedUserIds: number[] = [];
+    const tierUpdates = new Map<string, number[]>();
+    const upgradeEvents: TierUpgradedEvent[] = [];
 
     for (const user of users) {
       const accumulated = Number(user.tierAccumulatedAmount);
@@ -139,10 +153,11 @@ export class MembershipService {
       const previousTier = user.tier;
 
       if (appropriateTier.name !== previousTier) {
-        await this.userRepo.update(user.id, {
-          tier: appropriateTier.name,
-          tierEvaluatedAt: new Date(),
-        });
+        const bucket =
+          tierUpdates.get(appropriateTier.name) ??
+          [];
+        bucket.push(user.id);
+        tierUpdates.set(appropriateTier.name, bucket);
 
         // Determine if this is an upgrade (new tier has higher minAmount than previous)
         const previousTierData = tiers.find((t) => t.name === previousTier);
@@ -151,7 +166,7 @@ export class MembershipService {
           Number(newTierData.minAmount) > Number(previousTierData?.minAmount ?? 0);
 
         if (isUpgrade) {
-          this.membershipEvents.emitTierUpgraded(
+          upgradeEvents.push(
             new TierUpgradedEvent(Number(user.id), previousTier, appropriateTier.name),
           );
           upgradedCount++;
@@ -160,10 +175,31 @@ export class MembershipService {
           );
         }
       } else {
-        await this.userRepo.update(user.id, { tierEvaluatedAt: new Date() });
+        unchangedUserIds.push(user.id);
       }
     }
 
+    await this.updateUsersInChunks(unchangedUserIds, { tierEvaluatedAt: evaluatedAt });
+    for (const [tier, userIds] of tierUpdates) {
+      await this.updateUsersInChunks(userIds, { tier, tierEvaluatedAt: evaluatedAt });
+    }
+
+    for (const event of upgradeEvents) {
+      this.membershipEvents.emitTierUpgraded(event);
+    }
+
     this.logger.log(`[membership:cron] Evaluation complete. Upgraded: ${upgradedCount}/${users.length}`);
+  }
+
+  private async updateUsersInChunks(
+    userIds: number[],
+    values: Partial<Pick<User, 'tier' | 'tierEvaluatedAt'>>,
+  ): Promise<void> {
+    for (let index = 0; index < userIds.length; index += USER_TIER_BATCH_SIZE) {
+      const chunk = userIds.slice(index, index + USER_TIER_BATCH_SIZE);
+      if (chunk.length > 0) {
+        await this.userRepo.update({ id: In(chunk) }, values);
+      }
+    }
   }
 }

--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -34,6 +34,7 @@ const mockOrderRepository = {
 
 const mockPointsService = {
   getUserPointBalance: jest.fn(),
+  getRunningBalanceInTx: jest.fn(),
 };
 
 const mockCouponsService = {
@@ -208,6 +209,12 @@ describe('OrdersService', () => {
         findOne: jest.fn().mockResolvedValue({ balance: 1000 }),
       };
       mockManager.getRepository.mockReturnValue(mockPointRepo);
+      mockPointsService.getRunningBalanceInTx.mockResolvedValue(1000);
+      mockManager.createQueryBuilder.mockReturnValue({
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({ id: 1, price: 10000, salePrice: null, stock: 5 }),
+      });
 
       await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
       expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);

--- a/backend/src/modules/orders/orders.controller.ts
+++ b/backend/src/modules/orders/orders.controller.ts
@@ -12,12 +12,7 @@ import {
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
-
-interface AuthUser {
-  id: number;
-  email: string;
-  role: string;
-}
+import { AuthUser } from '../../common/interfaces/auth-user.interface';
 
 @ApiTags('주문')
 @Controller('orders')

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -9,7 +9,6 @@ import { OrderItem } from './entities/order-item.entity';
 import { Product } from '../products/entities/product.entity';
 import { ProductOption } from '../products/entities/product-option.entity';
 import { CartItem } from '../cart/entities/cart-item.entity';
-import { PointHistory } from '../coupons/entities/point-history.entity';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
@@ -147,11 +146,7 @@ export class OrdersService {
   ): Promise<void> {
     if (pointsToUse <= 0) return;
 
-    const latest = await manager.getRepository(PointHistory).findOne({
-      where: { userId },
-      order: { createdAt: 'DESC', id: 'DESC' },
-    });
-    const balance = latest ? latest.balance : 0;
+    const balance = await this.pointsService.getRunningBalanceInTx(manager, userId);
     if (pointsToUse > balance) {
       throw new BadRequestException('적립금이 부족합니다.');
     }

--- a/backend/src/modules/points/__tests__/points.service.spec.ts
+++ b/backend/src/modules/points/__tests__/points.service.spec.ts
@@ -102,6 +102,34 @@ describe('PointsService', () => {
     });
   });
 
+  describe('getRunningBalanceInTx', () => {
+    it('should return latest running balance', async () => {
+      mockEntityManager.findOne.mockResolvedValue({ balance: 2500 });
+
+      const balance = await service.getRunningBalanceInTx(
+        mockEntityManager as unknown as EntityManager,
+        1,
+      );
+
+      expect(balance).toBe(2500);
+      expect(mockEntityManager.findOne).toHaveBeenCalledWith(PointHistory, {
+        where: { userId: 1 },
+        order: { createdAt: 'DESC', id: 'DESC' },
+      });
+    });
+
+    it('should return 0 when latest running balance does not exist', async () => {
+      mockEntityManager.findOne.mockResolvedValue(null);
+
+      const balance = await service.getRunningBalanceInTx(
+        mockEntityManager as unknown as EntityManager,
+        1,
+      );
+
+      expect(balance).toBe(0);
+    });
+  });
+
   describe('deductFifo', () => {
     it('should create a spend record with correct balance and return new balance', async () => {
       mockEntityManager.findOne.mockResolvedValue({ balance: 5000 });

--- a/backend/src/modules/points/points.service.ts
+++ b/backend/src/modules/points/points.service.ts
@@ -56,6 +56,18 @@ export class PointsService {
     return parseInt(result?.total ?? '0', 10);
   }
 
+  async getRunningBalanceInTx(
+    manager: EntityManager,
+    userId: number,
+  ): Promise<number> {
+    const latestEntry = await manager.findOne(PointHistory, {
+      where: { userId },
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+
+    return latestEntry ? latestEntry.balance : 0;
+  }
+
   /**
    * Deducts `amount` points using FIFO (earliest-expiring earn entries consumed first).
    * Creates a single 'spend' PointHistory record within the provided transaction manager.
@@ -72,12 +84,7 @@ export class PointsService {
     description: string,
     orderId: number | null = null,
   ): Promise<number> {
-    // Get the latest running balance
-    const latestEntry = await manager.findOne(PointHistory, {
-      where: { userId },
-      order: { createdAt: 'DESC', id: 'DESC' },
-    });
-    const currentBalance = latestEntry?.balance ?? 0;
+    const currentBalance = await this.getRunningBalanceInTx(manager, userId);
     const newBalance = currentBalance - amount;
 
     await manager.save(PointHistory, {

--- a/backend/src/modules/products/__tests__/products.search.spec.ts
+++ b/backend/src/modules/products/__tests__/products.search.spec.ts
@@ -28,6 +28,7 @@ function makeFulltextError(): QueryFailedError {
 
 const mockSelect = jest.fn().mockReturnThis();
 const mockOrderBy = jest.fn().mockReturnThis();
+const mockAddOrderBy = jest.fn().mockReturnThis();
 const mockAndWhere = jest.fn().mockReturnThis();
 const mockSkip = jest.fn().mockReturnThis();
 const mockTake = jest.fn().mockReturnThis();
@@ -45,6 +46,7 @@ const mockQueryBuilder = {
   andWhere: mockAndWhere,
   where: mockWhere,
   orderBy: mockOrderBy,
+  addOrderBy: mockAddOrderBy,
   skip: mockSkip,
   take: mockTake,
   limit: mockLimit,

--- a/backend/src/modules/products/__tests__/products.service.spec.ts
+++ b/backend/src/modules/products/__tests__/products.service.spec.ts
@@ -17,6 +17,7 @@ import { CacheService } from '../../cache/cache.service';
 import { RestockAlertsService } from '../../restock-alerts/restock-alerts.service';
 
 const mockOrderBy = jest.fn().mockReturnThis();
+const mockAddOrderBy = jest.fn().mockReturnThis();
 const mockAndWhere = jest.fn().mockReturnThis();
 const mockSkip = jest.fn().mockReturnThis();
 const mockTake = jest.fn().mockReturnThis();
@@ -32,6 +33,7 @@ const mockQueryBuilder = {
   andWhere: mockAndWhere,
   where: mockWhere,
   orderBy: mockOrderBy,
+  addOrderBy: mockAddOrderBy,
   skip: mockSkip,
   take: mockTake,
   getManyAndCount: mockGetManyAndCount,

--- a/backend/src/modules/products/entities/product.entity.ts
+++ b/backend/src/modules/products/entities/product.entity.ts
@@ -27,6 +27,8 @@ export enum ProductStatus {
 @Index(['categoryId'])
 @Index(['status'])
 @Index(['isFeatured'])
+@Index(['reviewCount'])
+@Index(['avgRating'])
 export class Product {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id!: number;
@@ -97,6 +99,12 @@ export class Product {
 
   @Column({ name: 'view_count', default: 0 })
   viewCount!: number;
+
+  @Column({ name: 'review_count', type: 'int', unsigned: true, default: 0 })
+  reviewCount!: number;
+
+  @Column({ name: 'avg_rating', type: 'decimal', precision: 3, scale: 2, default: 0 })
+  avgRating!: number;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/backend/src/modules/products/product-query.service.ts
+++ b/backend/src/modules/products/product-query.service.ts
@@ -385,8 +385,13 @@ export class ProductQueryService {
         qb.orderBy('product.viewCount', 'DESC');
         break;
       case ProductSort.REVIEW_COUNT:
+        qb.orderBy('product.reviewCount', 'DESC')
+          .addOrderBy('product.createdAt', 'DESC');
+        break;
       case ProductSort.RATING:
-        qb.orderBy('product.createdAt', 'DESC');
+        qb.orderBy('product.avgRating', 'DESC')
+          .addOrderBy('product.reviewCount', 'DESC')
+          .addOrderBy('product.createdAt', 'DESC');
         break;
       default:
         qb.orderBy('product.createdAt', 'DESC');
@@ -408,15 +413,7 @@ export class ProductQueryService {
     const statsMap = await this.getReviewStats(
       localizedItems.map((product) => Number(product.id)),
     );
-    let itemsWithStats = this.applyReviewStats(localizedItems, statsMap);
-
-    if (sort === ProductSort.REVIEW_COUNT) {
-      itemsWithStats = itemsWithStats.sort(
-        (left, right) => right.reviewCount - left.reviewCount,
-      );
-    } else if (sort === ProductSort.RATING) {
-      itemsWithStats = itemsWithStats.sort((left, right) => right.rating - left.rating);
-    }
+    const itemsWithStats = this.applyReviewStats(localizedItems, statsMap);
 
     const result = { ...paged, items: itemsWithStats };
     if (cacheKey) {

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -28,13 +28,10 @@ import { BulkProductsDto } from './dto/bulk-products.dto';
 import { Public } from '../../common/decorators/public.decorator';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { RequestWithAuthUser } from '../../common/interfaces/auth-user.interface';
 import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
 import { CreateRestockAlertDto } from '../restock-alerts/dto/create-restock-alert.dto';
 import { RecentlyViewedService } from './recently-viewed.service';
-
-interface RequestWithUser {
-  user?: { id: number; email: string; role: string };
-}
 
 @ApiTags('상품')
 @Controller('products')
@@ -53,7 +50,7 @@ export class ProductsController {
   @ApiQuery({ name: 'limit', required: false, type: Number, description: '페이지당 개수' })
   @ApiQuery({ name: 'categoryId', required: false, type: Number, description: '카테고리 ID' })
   @ApiQuery({ name: 'search', required: false, type: String, description: '검색어' })
-  findAll(@Query() query: QueryProductsDto, @Request() req: RequestWithUser) {
+  findAll(@Query() query: QueryProductsDto, @Request() req: RequestWithAuthUser) {
     const isAdmin = req.user?.role === 'admin';
     return this.productsService.findAll(query, isAdmin);
   }
@@ -73,7 +70,7 @@ export class ProductsController {
   @ApiOperation({ summary: '상품 벌크 조회', description: '여러 상품 ID로 상품 목록을 한 번에 조회합니다.' })
   @ApiResponse({ status: 200, description: '상품 목록 조회 성공' })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
-  bulkLookup(@Body() dto: BulkProductsDto, @Request() req: RequestWithUser) {
+  bulkLookup(@Body() dto: BulkProductsDto, @Request() req: RequestWithAuthUser) {
     const isAdmin = req.user?.role === 'admin';
     return this.productsService.findBulk(dto.ids, isAdmin);
   }
@@ -88,7 +85,7 @@ export class ProductsController {
   async findOne(
     @Param('id', ParseIntPipe) id: number,
     @Query('locale') locale: string | undefined,
-    @Request() req: RequestWithUser,
+    @Request() req: RequestWithAuthUser,
   ) {
     const isAdmin = req.user?.role === 'admin';
     const result = await this.productsService.findOne(id, isAdmin, locale);
@@ -122,7 +119,7 @@ export class ProductsController {
   @ApiResponse({ status: 404, description: '상품 또는 옵션을 찾을 수 없음' })
   subscribeRestockAlert(
     @Param('id', ParseIntPipe) id: number,
-    @CurrentUser() user: RequestWithUser['user'],
+    @CurrentUser() user: RequestWithAuthUser['user'],
     @Body() dto: CreateRestockAlertDto,
   ) {
     return this.restockAlertsService.createAlert(user!.id, id, dto);

--- a/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
@@ -8,6 +8,7 @@ import { OrderItem } from '../../orders/entities/order-item.entity';
 import { PointHistory } from '../../coupons/entities/point-history.entity';
 import { SettingsService } from '../../settings/settings.service';
 import { OrderStatus } from '../../orders/entities/order.entity';
+import { PointsService } from '../../points/points.service';
 
 describe('ReviewsService', () => {
   let service: ReviewsService;
@@ -54,6 +55,10 @@ describe('ReviewsService', () => {
     getNumber: jest.fn(),
   };
 
+  const mockPointsService = {
+    getRunningBalanceInTx: jest.fn(),
+  };
+
   // Manager used inside dataSource.transaction
   const mockManager = {
     createQueryBuilder: jest.fn(),
@@ -61,6 +66,7 @@ describe('ReviewsService', () => {
     create: jest.fn(),
     save: jest.fn(),
     remove: jest.fn(),
+    query: jest.fn(),
   };
 
   const mockDataSource = {
@@ -76,11 +82,18 @@ describe('ReviewsService', () => {
         { provide: getRepositoryToken(PointHistory), useValue: mockPointHistoryRepo },
         { provide: SettingsService, useValue: mockSettingsService },
         { provide: DataSource, useValue: mockDataSource },
+        { provide: PointsService, useValue: mockPointsService },
       ],
     }).compile();
 
     service = module.get<ReviewsService>(ReviewsService);
     jest.clearAllMocks();
+    mockManager.findOne.mockReset();
+    mockManager.create.mockReset();
+    mockManager.save.mockReset();
+    mockManager.remove.mockReset();
+    mockManager.query.mockReset();
+    mockPointsService.getRunningBalanceInTx.mockResolvedValue(0);
 
     // Default settings: reward=100, bonus=0
     mockSettingsService.getNumber.mockImplementation((key: string, def: number) => {
@@ -291,8 +304,7 @@ describe('ReviewsService', () => {
       };
       mockManager.findOne
         .mockResolvedValueOnce(earnEntry) // earn entry
-        .mockResolvedValueOnce(null)      // no existing revoke
-        .mockResolvedValueOnce(null);     // current balance (no prior history)
+        .mockResolvedValueOnce(null);     // no existing revoke
       mockManager.create.mockImplementation((_entity: unknown, data: unknown) => data);
       mockManager.save.mockResolvedValue({});
       mockManager.remove.mockResolvedValue(undefined);
@@ -321,7 +333,6 @@ describe('ReviewsService', () => {
       };
       mockManager.findOne
         .mockResolvedValueOnce(earnEntry)
-        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null);
       mockManager.create.mockImplementation((_entity: unknown, data: unknown) => data);
       mockManager.save.mockResolvedValue({});

--- a/backend/src/modules/reviews/reviews.controller.ts
+++ b/backend/src/modules/reviews/reviews.controller.ts
@@ -30,12 +30,8 @@ import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { ReviewQueryDto } from './dto/review-query.dto';
 import { Public } from '../../common/decorators/public.decorator';
+import { AuthenticatedRequestWithAuthUser } from '../../common/interfaces/auth-user.interface';
 import { UploadService } from '../upload/upload.service';
-
-interface JwtUser {
-  id: number;
-  role: string;
-}
 
 const REVIEW_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const REVIEW_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
@@ -65,7 +61,7 @@ export class ReviewsController {
   @ApiResponse({ status: 201, description: '후기 생성 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   create(
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
     @Body() dto: CreateReviewDto,
   ) {
     return this.reviewsService.create(req.user.id, dto);
@@ -116,7 +112,7 @@ export class ReviewsController {
   @ApiParam({ name: 'id', type: Number, description: '후기 ID' })
   update(
     @Param('id', ParseIntPipe) id: number,
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
     @Body() dto: UpdateReviewDto,
   ) {
     return this.reviewsService.update(id, req.user.id, dto);
@@ -132,7 +128,7 @@ export class ReviewsController {
   @ApiParam({ name: 'id', type: Number, description: '후기 ID' })
   remove(
     @Param('id', ParseIntPipe) id: number,
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
   ) {
     return this.reviewsService.remove(id, req.user.id, req.user.role);
   }

--- a/backend/src/modules/reviews/reviews.module.ts
+++ b/backend/src/modules/reviews/reviews.module.ts
@@ -7,12 +7,14 @@ import { ReviewsController } from './reviews.controller';
 import { ReviewsService } from './reviews.service';
 import { UploadModule } from '../upload/upload.module';
 import { SettingsModule } from '../settings/settings.module';
+import { PointsModule } from '../points/points.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Review, OrderItem, PointHistory]),
     UploadModule,
     SettingsModule,
+    PointsModule,
   ],
   controllers: [ReviewsController],
   providers: [ReviewsService],

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -18,7 +18,7 @@ import { findOrThrow } from '../../common/utils/repository.util';
 import { paginate } from '../../common/utils/pagination.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { SettingsService } from '../settings/settings.service';
-import { addOneYear } from '../points/points.service';
+import { PointsService, addOneYear } from '../points/points.service';
 
 const REVIEW_POINT_REWARD_KEY = 'review_point_reward';
 const PHOTO_REVIEW_BONUS_KEY = 'photo_review_bonus';
@@ -63,6 +63,7 @@ export class ReviewsService {
     private readonly pointHistoryRepo: Repository<PointHistory>,
     private readonly settingsService: SettingsService,
     private readonly dataSource: DataSource,
+    private readonly pointsService: PointsService,
   ) {}
 
   private maskUserName(name: string): string {
@@ -206,7 +207,7 @@ export class ReviewsService {
       const earnAmount = reward + (isPhotoReview ? bonus : 0);
 
       if (earnAmount > 0) {
-        const currentBalance = await this.getBalanceInTx(manager, userId);
+        const currentBalance = await this.pointsService.getRunningBalanceInTx(manager, userId);
         const newBalance = currentBalance + earnAmount;
 
         const pointEntry = manager.create(PointHistory, {
@@ -223,6 +224,7 @@ export class ReviewsService {
         await manager.save(PointHistory, pointEntry);
       }
 
+      await this.refreshProductReviewStats(manager, dto.productId);
       return saved;
     });
 
@@ -244,6 +246,9 @@ export class ReviewsService {
     if (dto.imageUrls !== undefined) review.imageUrls = dto.imageUrls ?? null;
 
     const saved = await this.reviewRepo.save(review);
+    await this.dataSource.transaction((manager) =>
+      this.refreshProductReviewStats(manager, Number(saved.productId)),
+    );
     return this.toResponse(saved);
   }
 
@@ -277,7 +282,10 @@ export class ReviewsService {
         });
 
         if (!alreadyRevoked) {
-          const currentBalance = await this.getBalanceInTx(manager, Number(review.userId));
+          const currentBalance = await this.pointsService.getRunningBalanceInTx(
+            manager,
+            Number(review.userId),
+          );
           const newBalance = currentBalance - earnEntry.amount;
 
           const revokeEntry = manager.create(PointHistory, {
@@ -296,19 +304,28 @@ export class ReviewsService {
       }
 
       await manager.remove(Review, review);
+      await this.refreshProductReviewStats(manager, Number(review.productId));
     });
 
     this.logger.log(`Review deleted: id=${id}, by userId=${userId}`);
   }
 
-  private async getBalanceInTx(
+  private async refreshProductReviewStats(
     manager: EntityManager,
-    userId: number,
-  ): Promise<number> {
-    const latest = await manager.findOne(PointHistory, {
-      where: { userId },
-      order: { createdAt: 'DESC', id: 'DESC' },
-    });
-    return latest ? latest.balance : 0;
+    productId: number,
+  ): Promise<void> {
+    await manager.query(
+      `UPDATE products p
+       LEFT JOIN (
+         SELECT product_id, COUNT(*) AS review_count, COALESCE(AVG(rating), 0) AS avg_rating
+         FROM reviews
+         WHERE product_id = ? AND is_visible = 1
+         GROUP BY product_id
+       ) rs ON rs.product_id = p.id
+       SET p.review_count = COALESCE(rs.review_count, 0),
+           p.avg_rating = COALESCE(rs.avg_rating, 0)
+       WHERE p.id = ?`,
+      [productId, productId],
+    );
   }
 }

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -15,14 +15,9 @@ import { CreateAddressDto } from './dto/create-address.dto';
 import { UpdateAddressDto } from './dto/update-address.dto';
 import { RequestAccountDeletionDto } from './dto/request-account-deletion.dto';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { AuthUser } from '../../common/interfaces/auth-user.interface';
 import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
 import { RecentlyViewedService } from '../products/recently-viewed.service';
-
-interface AuthUser {
-  id: number;
-  email: string;
-  role: string;
-}
 
 @ApiTags('사용자')
 @Controller('users')

--- a/backend/src/modules/wishlist/wishlist.controller.ts
+++ b/backend/src/modules/wishlist/wishlist.controller.ts
@@ -21,11 +21,7 @@ import {
 } from '@nestjs/swagger';
 import { WishlistService } from './wishlist.service';
 import { CreateWishlistDto } from './dto/create-wishlist.dto';
-
-interface JwtUser {
-  id: number;
-  role: string;
-}
+import { AuthenticatedRequestWithAuthUser } from '../../common/interfaces/auth-user.interface';
 
 @ApiTags('위시리스트')
 @Controller('wishlist')
@@ -37,7 +33,7 @@ export class WishlistController {
   @ApiOperation({ summary: '위시리스트 목록 조회', description: '현재 사용자의 위시리스트 목록을 조회합니다.' })
   @ApiResponse({ status: 200, description: '위시리스트 목록 조회 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  findAll(@Request() req: { user: JwtUser }) {
+  findAll(@Request() req: AuthenticatedRequestWithAuthUser) {
     return this.wishlistService.findAll(req.user.id);
   }
 
@@ -48,7 +44,7 @@ export class WishlistController {
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiQuery({ name: 'productId', type: Number, description: '상품 ID' })
   check(
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
     @Query('productId', ParseIntPipe) productId: number,
   ) {
     return this.wishlistService.check(req.user.id, productId);
@@ -60,7 +56,7 @@ export class WishlistController {
   @ApiResponse({ status: 201, description: '위시리스트에 상품 추가 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   create(
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
     @Body() dto: CreateWishlistDto,
   ) {
     return this.wishlistService.create(req.user.id, dto);
@@ -76,7 +72,7 @@ export class WishlistController {
   @ApiParam({ name: 'id', type: Number, description: '위시리스트 ID' })
   remove(
     @Param('id', ParseIntPipe) id: number,
-    @Request() req: { user: JwtUser },
+    @Request() req: AuthenticatedRequestWithAuthUser,
   ) {
     return this.wishlistService.remove(id, req.user.id);
   }


### PR DESCRIPTION
## 요약
- Closes #699
- Closes #700
- Closes #701
- Closes #702
- 멤버십 등급 cron을 등급별/청크별 일괄 UPDATE로 바꿔 사용자별 sequential UPDATE를 제거했습니다.
- 쿠폰 규칙/생일 쿠폰 발급을 사용자별 단일 트랜잭션 + 20명 단위 병렬 처리로 바꿔 user×rule 트랜잭션 폭증을 줄였습니다.
- products.review_count / products.avg_rating materialized 컬럼과 인덱스, backfill migration을 추가하고 상품 정렬을 SQL ORDER BY로 이동했습니다.
- PointHistory 최신 running balance 조회와 AuthUser/Request 타입을 공용화했습니다.

## 벤치마크/효과
- evaluateAllUserTiers: 기존 활성 사용자 N명 기준 N회 UPDATE → 변경 후 tier 그룹 수 + unchanged 청크 수 UPDATE. 기본 청크 500 기준 1000명/4등급이면 최대 약 6회 UPDATE 수준입니다.
- birthday coupons: 기존 birthdayUsers×rules 개별 트랜잭션 → 변경 후 birthdayUsers 개별 트랜잭션이며 사용자 배치는 20명씩 병렬 실행합니다.
- review_count/rating 정렬: 페이지 조회 후 in-memory reorder 제거, review_count/avg_rating 인덱스 기반 ORDER BY LIMIT로 전역 정렬 prefix가 유지됩니다.

## 검증
- cd backend && npm run build && npm run test -- --runInBand
- bash scripts/test.sh e2e
- npm run build && npm run test:run

## 남은 리스크
- 운영 DB 실제 데이터량 기준 EXPLAIN/latency는 아직 측정하지 않았습니다.
- 리뷰 통계 materialized 컬럼은 리뷰 생성/수정/삭제 경로에서 갱신하므로, 향후 리뷰 visibility를 직접 변경하는 경로가 추가되면 동일 갱신이 필요합니다.