### PR TITLE
test: #706 Auth 서비스 단위 테스트 보강

### DIFF
--- a/backend/src/modules/auth/__tests__/auth-audit.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth-audit.service.spec.ts
@@ -1,0 +1,194 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { User, UserRole } from '../../users/entities/user.entity';
+import { AuthAuditService } from '../services/auth-audit.service';
+import { AuditLogService } from '../../audit-logs/audit-log.service';
+import { AuditAction } from '../../audit-logs/entities/audit-log.entity';
+
+const mockAuditLogService = {
+  log: jest.fn(),
+};
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    email: 'test@example.com',
+    password: 'hashed-password',
+    name: '홍길동',
+    phone: null,
+    role: UserRole.USER,
+    tier: 'Bronze',
+    tierAccumulatedAmount: 0,
+    tierEvaluatedAt: null,
+    isActive: true,
+    isEmailVerified: true,
+    emailVerifiedAt: new Date(),
+    refreshToken: null,
+    failedLoginAttempts: 0,
+    lastFailedLoginAt: null,
+    lockedUntil: null,
+    deletionRequestedAt: null,
+    deletionScheduledAt: null,
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('AuthAuditService', () => {
+  let service: AuthAuditService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthAuditService,
+        { provide: AuditLogService, useValue: mockAuditLogService },
+      ],
+    }).compile();
+
+    service = module.get<AuthAuditService>(AuthAuditService);
+  });
+
+  describe('logUserNotFound', () => {
+    it('user_not_found 사유로 LOGIN_FAILURE 감사 로그를 기록한다', async () => {
+      await service.logUserNotFound('missing@example.com', '203.0.113.5', 'Mozilla/5.0');
+
+      expect(mockAuditLogService.log).toHaveBeenCalledWith({
+        actorId: 0,
+        actorRole: 'anonymous',
+        action: AuditAction.LOGIN_FAILURE,
+        resourceType: 'auth',
+        beforeJson: { email: 'missing@example.com' },
+        afterJson: { reason: 'user_not_found' },
+        ip: '203.0.113.5',
+        userAgent: 'Mozilla/5.0',
+      });
+    });
+
+    it('ip/userAgent가 undefined여도 null로 정규화하여 기록한다', async () => {
+      await service.logUserNotFound('missing@example.com');
+
+      expect(mockAuditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ip: null,
+          userAgent: null,
+        }),
+      );
+    });
+  });
+
+  describe('logLoginFailure', () => {
+    it('실패 사유와 시도 횟수를 afterJson에 포함하여 기록한다', async () => {
+      const user = makeUser({ id: 42, role: UserRole.USER });
+
+      await service.logLoginFailure(user, {
+        email: 'test@example.com',
+        reason: 'invalid_password',
+        attempts: 3,
+        ip: '198.51.100.1',
+        userAgent: 'curl/8.0',
+      });
+
+      expect(mockAuditLogService.log).toHaveBeenCalledWith({
+        actorId: 42,
+        actorRole: UserRole.USER,
+        action: AuditAction.LOGIN_FAILURE,
+        resourceType: 'auth',
+        beforeJson: { email: 'test@example.com' },
+        afterJson: { reason: 'invalid_password', attempts: 3 },
+        ip: '198.51.100.1',
+        userAgent: 'curl/8.0',
+      });
+    });
+
+    it('lockedUntil이 주어지면 ISO 문자열로 직렬화하여 기록한다 (브루트포스 임계값)', async () => {
+      const user = makeUser();
+      const lockedUntil = new Date('2030-01-01T00:00:00.000Z');
+
+      await service.logLoginFailure(user, {
+        email: user.email,
+        reason: 'account_locked_15m',
+        attempts: 5,
+        lockedUntil,
+        ip: null,
+        userAgent: null,
+      });
+
+      expect(mockAuditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          afterJson: {
+            reason: 'account_locked_15m',
+            attempts: 5,
+            lockedUntil: lockedUntil.toISOString(),
+          },
+        }),
+      );
+    });
+
+    it('attempts와 lockedUntil이 없으면 afterJson에서 누락한다', async () => {
+      const user = makeUser();
+
+      await service.logLoginFailure(user, {
+        email: user.email,
+        reason: 'invalid_password',
+      });
+
+      const callArg = mockAuditLogService.log.mock.calls[0][0];
+      expect(callArg.afterJson).toEqual({ reason: 'invalid_password' });
+      expect(callArg.afterJson).not.toHaveProperty('attempts');
+      expect(callArg.afterJson).not.toHaveProperty('lockedUntil');
+    });
+
+    it('관리자 계정의 실패도 actorRole=admin으로 기록한다', async () => {
+      const adminUser = makeUser({ id: 99, role: UserRole.ADMIN });
+
+      await service.logLoginFailure(adminUser, {
+        email: adminUser.email,
+        reason: 'invalid_password',
+        attempts: 1,
+      });
+
+      expect(mockAuditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: 99,
+          actorRole: UserRole.ADMIN,
+        }),
+      );
+    });
+  });
+
+  describe('logLoginSuccess', () => {
+    it('성공 시 LOGIN_SUCCESS 액션과 userId를 afterJson에 기록한다', async () => {
+      const user = makeUser({ id: 7, role: UserRole.USER });
+
+      await service.logLoginSuccess(user, 'test@example.com', '192.0.2.10', 'Chrome/120');
+
+      expect(mockAuditLogService.log).toHaveBeenCalledWith({
+        actorId: 7,
+        actorRole: UserRole.USER,
+        action: AuditAction.LOGIN_SUCCESS,
+        resourceType: 'auth',
+        beforeJson: { email: 'test@example.com' },
+        afterJson: { userId: 7 },
+        ip: '192.0.2.10',
+        userAgent: 'Chrome/120',
+      });
+    });
+
+    it('ip/userAgent 미제공 시 null로 정규화하여 기록한다', async () => {
+      const user = makeUser({ id: 7 });
+
+      await service.logLoginSuccess(user, user.email);
+
+      expect(mockAuditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.LOGIN_SUCCESS,
+          ip: null,
+          userAgent: null,
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/modules/auth/__tests__/token-issuer.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/token-issuer.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
-import { JwtService } from '@nestjs/jwt';
+import { JwtModule, JwtService } from '@nestjs/jwt';
 import { User, UserRole } from '../../users/entities/user.entity';
 import { TokenIssuerService } from '../services/token-issuer.service';
 import { AUTH_CONFIG, createAuthConfig } from '../../../config/auth.config';
@@ -11,10 +11,7 @@ const mockUserRepository = {
 };
 
 const mockJwtService = {
-  sign: jest
-    .fn()
-    .mockReturnValueOnce('access-token')
-    .mockReturnValueOnce('refresh-token'),
+  sign: jest.fn(),
 };
 
 function makeUser(overrides: Partial<User> = {}): User {
@@ -44,7 +41,7 @@ function makeUser(overrides: Partial<User> = {}): User {
   };
 }
 
-describe('TokenIssuerService', () => {
+describe('TokenIssuerService (mocked JwtService)', () => {
   let service: TokenIssuerService;
 
   beforeEach(async () => {
@@ -105,6 +102,36 @@ describe('TokenIssuerService', () => {
     );
   });
 
+  it('access token에는 jti가 포함되고 refresh token 호출에는 별도 jti가 없다', () => {
+    const user = makeUser();
+
+    service.issueTokens(user);
+
+    const accessPayload = mockJwtService.sign.mock.calls[0][0];
+    expect(accessPayload).toHaveProperty('jti');
+    expect(typeof accessPayload.jti).toBe('string');
+    expect(accessPayload.jti.length).toBeGreaterThan(0);
+
+    const refreshPayload = mockJwtService.sign.mock.calls[1][0];
+    expect(refreshPayload).not.toHaveProperty('jti');
+  });
+
+  it('refresh token 발급 시 refreshSecret/refreshExpiresIn을 옵션으로 전달한다', () => {
+    const user = makeUser();
+
+    service.issueTokens(user);
+
+    expect(mockJwtService.sign).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Object),
+      expect.objectContaining({
+        secret: 'refresh-secret',
+        expiresIn: '7d',
+        algorithm: 'HS256',
+      }),
+    );
+  });
+
   it('refresh token은 해시해서 DB에 저장한다', async () => {
     const user = makeUser();
 
@@ -123,5 +150,141 @@ describe('TokenIssuerService', () => {
 
     const updatedPayload = mockUserRepository.update.mock.calls[0][1] as { refreshToken: string };
     expect(await bcrypt.compare('refresh-token', updatedPayload.refreshToken)).toBe(true);
+    // 평문 저장 금지 회귀 테스트
+    expect(updatedPayload.refreshToken).not.toBe('refresh-token');
+  });
+});
+
+describe('TokenIssuerService (real JwtService — sign/verify, TTL, signature)', () => {
+  let service: TokenIssuerService;
+  let accessJwtService: JwtService;
+  let refreshJwtService: JwtService;
+
+  const ACCESS_SECRET = 'access-secret-for-tests';
+  const REFRESH_SECRET = 'refresh-secret-for-tests';
+  const ACCESS_TTL = '1h';
+  const REFRESH_TTL = '7d';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        JwtModule.register({
+          secret: ACCESS_SECRET,
+          signOptions: { expiresIn: ACCESS_TTL, algorithm: 'HS256' },
+        }),
+      ],
+      providers: [
+        TokenIssuerService,
+        { provide: getRepositoryToken(User), useValue: { update: jest.fn() } },
+        {
+          provide: AUTH_CONFIG,
+          useValue: createAuthConfig({
+            NODE_ENV: 'development',
+            JWT_SECRET: ACCESS_SECRET,
+            JWT_PRIVATE_KEY: 'private-key',
+            JWT_PUBLIC_KEY: 'public-key',
+            FRONTEND_URL: 'https://frontend.test',
+            JWT_REFRESH_SECRET: REFRESH_SECRET,
+            JWT_REFRESH_EXPIRES_IN: REFRESH_TTL,
+          }),
+        },
+      ],
+    }).compile();
+
+    service = module.get<TokenIssuerService>(TokenIssuerService);
+    accessJwtService = module.get<JwtService>(JwtService);
+    // refresh verification 도구 (다른 secret 사용)
+    refreshJwtService = new JwtService({});
+  });
+
+  it('access token은 JWT_SECRET으로 서명되고 sub/email/role/tokenType/jti를 포함한다', () => {
+    const user = makeUser({ id: 42, email: 'real@example.com', role: UserRole.USER });
+
+    const { accessToken } = service.issueTokens(user);
+
+    const decoded = accessJwtService.verify<Record<string, unknown>>(accessToken, {
+      secret: ACCESS_SECRET,
+    });
+    expect(decoded.sub).toBe(42);
+    expect(decoded.email).toBe('real@example.com');
+    expect(decoded.role).toBe(UserRole.USER);
+    expect(decoded.tokenType).toBe('access');
+    expect(typeof decoded.jti).toBe('string');
+  });
+
+  it('access token은 약 1시간(JWT_EXPIRES_IN 기본값) 후 만료되도록 exp가 설정된다', () => {
+    const user = makeUser();
+    const beforeIssue = Math.floor(Date.now() / 1000);
+
+    const { accessToken } = service.issueTokens(user);
+
+    const decoded = accessJwtService.verify<{ iat: number; exp: number }>(accessToken, {
+      secret: ACCESS_SECRET,
+    });
+    // 1h = 3600s, 약간의 클럭 슬라이드 허용 (±5초)
+    expect(decoded.exp - decoded.iat).toBe(3600);
+    expect(decoded.iat).toBeGreaterThanOrEqual(beforeIssue);
+    expect(decoded.exp).toBeGreaterThan(beforeIssue);
+  });
+
+  it('refresh token은 JWT_REFRESH_SECRET으로 서명되며 access secret으로는 검증 실패한다', () => {
+    const user = makeUser();
+
+    const { refreshToken } = service.issueTokens(user);
+
+    // refresh secret으로 검증 → 성공
+    const decoded = refreshJwtService.verify<Record<string, unknown>>(refreshToken, {
+      secret: REFRESH_SECRET,
+    });
+    expect(decoded.tokenType).toBe('refresh');
+    expect(decoded.sub).toBe(user.id);
+
+    // 잘못된 secret(access secret)으로 검증 → 거부
+    expect(() =>
+      refreshJwtService.verify(refreshToken, { secret: ACCESS_SECRET }),
+    ).toThrow();
+  });
+
+  it('refresh token은 7일 TTL을 가진다', () => {
+    const user = makeUser();
+
+    const { refreshToken } = service.issueTokens(user);
+
+    const decoded = refreshJwtService.verify<{ iat: number; exp: number }>(refreshToken, {
+      secret: REFRESH_SECRET,
+    });
+    // 7d = 7 * 24 * 60 * 60 = 604800s
+    expect(decoded.exp - decoded.iat).toBe(7 * 24 * 60 * 60);
+  });
+
+  it('변조된(잘못된 서명) access token은 검증을 거부한다', () => {
+    const user = makeUser();
+
+    const { accessToken } = service.issueTokens(user);
+
+    // payload는 그대로 두고 마지막 서명 부분만 변조
+    const parts = accessToken.split('.');
+    expect(parts).toHaveLength(3);
+    const tamperedToken = `${parts[0]}.${parts[1]}.${parts[2].slice(0, -2)}xx`;
+
+    expect(() =>
+      accessJwtService.verify(tamperedToken, { secret: ACCESS_SECRET }),
+    ).toThrow();
+  });
+
+  it('동일 사용자에게 발급된 access token들은 서로 다른 jti를 가진다 (회전/추적용)', () => {
+    const user = makeUser();
+
+    const first = service.issueTokens(user);
+    const second = service.issueTokens(user);
+
+    const firstDecoded = accessJwtService.verify<{ jti: string }>(first.accessToken, {
+      secret: ACCESS_SECRET,
+    });
+    const secondDecoded = accessJwtService.verify<{ jti: string }>(second.accessToken, {
+      secret: ACCESS_SECRET,
+    });
+
+    expect(firstDecoded.jti).not.toBe(secondDecoded.jti);
   });
 });


### PR DESCRIPTION
## 요약
P0 Auth 서비스 단위 테스트 누락분 보강. 본 코드는 변경하지 않고 spec만 추가/확장.

## 변경 사항
### 신규
- `backend/src/modules/auth/__tests__/auth-audit.service.spec.ts` (8 테스트)
  - `logUserNotFound`: anonymous actor, user_not_found 사유, ip/userAgent null 정규화
  - `logLoginFailure`: invalid_password 사유 + attempts, lockedUntil ISO 직렬화 (브루트포스 임계값 컨텍스트), 옵셔널 필드 누락 처리, admin actorRole 보존
  - `logLoginSuccess`: LOGIN_SUCCESS 액션 + userId afterJson, ip/userAgent null 정규화

### 보강
- `backend/src/modules/auth/__tests__/token-issuer.service.spec.ts` (4→10 테스트)
  - 기존 mocked `JwtService` 시나리오 유지 + 평문 저장 회귀 테스트 추가
  - **실제 `JwtModule`** 기반 신규 describe 블록 추가:
    - access token 서명 검증(`JWT_SECRET`) 및 sub/email/role/tokenType/jti 필드 확인
    - access token TTL(1h) 정확성
    - refresh token `JWT_REFRESH_SECRET` 분리 서명, access secret으로 검증 시 거부
    - refresh token TTL(7d) 정확성
    - 변조된(잘못된 서명) access token 검증 거부
    - 동일 사용자 발급 access token jti 유일성

## 이슈에서 다룬 시나리오 매핑
| 이슈 항목 | 커버 위치 |
|---|---|
| 로그인 성공/실패 감사 (ip/device/userAgent) | `auth-audit.service.spec.ts` |
| 비정상 접근 패턴 / 브루트포스 임계값 | 기존 `auth-login-policy.service.spec.ts` (5/10/15회) + `auth-audit`의 lockedUntil 직렬화 |
| access/refresh JWT 페이로드 | `token-issuer.service.spec.ts` (mocked + 실제 JwtModule) |
| 만료 TTL | 신규 실제 JwtModule 시나리오 (access 1h, refresh 7d) |
| 잘못된 서명 거부 | 신규 실제 JwtModule 시나리오 (변조 토큰 + 잘못된 secret) |
| Refresh token 회전 시 이전 토큰 무효화 | 기존 `auth.service.spec.ts > refresh` 5개 테스트 |
| OAuth 신규 가입 vs 기존 연동 | 기존 `oauth.service.spec.ts` |
| password_reset_tokens 1회용 | 기존 `auth.service.spec.ts > resetPassword` (used 토큰 재사용 거부) |

## 검증
- `npm run lint` → 통과 (warnings 0)
- `npm run build` → 통과
- `npm test` → 73 suites / **710 passed**, 0 failed
- 새 spec 단독 실행: auth-audit 8/8, token-issuer 10/10

## 본 코드 결함
없음. 기존 `AuthAuditService`/`TokenIssuerService`는 사양대로 동작하며, 추가 테스트는 회귀 가드 역할만 수행.

Closes #706