### PR TITLE
test: #708 어댑터/공통 유틸 단위 테스트 보강

### DIFF
--- a/backend/src/common/utils/__tests__/ownership.util.spec.ts
+++ b/backend/src/common/utils/__tests__/ownership.util.spec.ts
@@ -1,0 +1,37 @@
+import { ForbiddenException } from '@nestjs/common';
+import { assertOwnership } from '../ownership.util';
+
+describe('assertOwnership', () => {
+  it('동일한 number 비교 시 통과', () => {
+    expect(() => assertOwnership(1, 1)).not.toThrow();
+  });
+
+  it('동일한 string 비교 시 통과 (TypeORM BigInt 반환 케이스)', () => {
+    expect(() => assertOwnership('123', '123')).not.toThrow();
+  });
+
+  it('string과 number 혼합 비교 시 Number() 변환으로 통과', () => {
+    expect(() => assertOwnership('42', 42)).not.toThrow();
+    expect(() => assertOwnership(42, '42')).not.toThrow();
+  });
+
+  it('큰 BigInt-like string도 동일하면 통과', () => {
+    expect(() => assertOwnership('9007199254740991', 9007199254740991)).not.toThrow();
+  });
+
+  it('userId가 다르면 ForbiddenException 발생', () => {
+    expect(() => assertOwnership(1, 2)).toThrow(ForbiddenException);
+  });
+
+  it('기본 메시지는 "접근 권한이 없습니다."', () => {
+    expect(() => assertOwnership(1, 2)).toThrow('접근 권한이 없습니다.');
+  });
+
+  it('커스텀 메시지를 전달할 수 있음', () => {
+    expect(() => assertOwnership(1, 2, '주문 소유자가 아닙니다.')).toThrow('주문 소유자가 아닙니다.');
+  });
+
+  it('string vs number 다른 값일 때도 ForbiddenException', () => {
+    expect(() => assertOwnership('1', 2)).toThrow(ForbiddenException);
+  });
+});

--- a/backend/src/common/utils/__tests__/reorder.util.spec.ts
+++ b/backend/src/common/utils/__tests__/reorder.util.spec.ts
@@ -1,0 +1,83 @@
+import { Repository } from 'typeorm';
+import { reorderEntities } from '../reorder.util';
+
+interface TestEntity {
+  id: number;
+  sortOrder: number;
+}
+
+describe('reorderEntities', () => {
+  it('각 항목에 대해 repo.update 호출 (기본 sortField=sortOrder)', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const repo = { update } as unknown as Repository<TestEntity>;
+
+    await reorderEntities(repo, [
+      { id: 1, sortOrder: 10 },
+      { id: 2, sortOrder: 20 },
+      { id: 3, sortOrder: 30 },
+    ]);
+
+    expect(update).toHaveBeenCalledTimes(3);
+    expect(update).toHaveBeenCalledWith(1, { sortOrder: 10 });
+    expect(update).toHaveBeenCalledWith(2, { sortOrder: 20 });
+    expect(update).toHaveBeenCalledWith(3, { sortOrder: 30 });
+  });
+
+  it('커스텀 sortField 사용 시 해당 컬럼명으로 update', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const repo = { update } as unknown as Repository<TestEntity>;
+
+    await reorderEntities(repo, [{ id: 1, sortOrder: 5 }], 'displayOrder');
+
+    expect(update).toHaveBeenCalledWith(1, { displayOrder: 5 });
+  });
+
+  it('Promise.all 병렬 실행 — 한 항목이 늦어도 나머지는 동시 진행', async () => {
+    const order: number[] = [];
+    const update = jest.fn().mockImplementation(async (id: number) => {
+      if (id === 1) {
+        await new Promise((r) => setTimeout(r, 30));
+      }
+      order.push(id);
+    });
+    const repo = { update } as unknown as Repository<TestEntity>;
+
+    await reorderEntities(repo, [
+      { id: 1, sortOrder: 10 },
+      { id: 2, sortOrder: 20 },
+      { id: 3, sortOrder: 30 },
+    ]);
+
+    // 순차 for-of await였다면 [1,2,3]. Promise.all이라 [2,3,1]
+    expect(order[0]).not.toBe(1);
+    expect(order).toContain(1);
+    expect(order).toContain(2);
+    expect(order).toContain(3);
+  });
+
+  it('빈 배열 입력 시 update 호출 없음', async () => {
+    const update = jest.fn();
+    const repo = { update } as unknown as Repository<TestEntity>;
+
+    await reorderEntities(repo, []);
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('하나라도 update 실패 시 reject', async () => {
+    const update = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('DB error'))
+      .mockResolvedValueOnce(undefined);
+    const repo = { update } as unknown as Repository<TestEntity>;
+
+    await expect(
+      reorderEntities(repo, [
+        { id: 1, sortOrder: 1 },
+        { id: 2, sortOrder: 2 },
+        { id: 3, sortOrder: 3 },
+      ]),
+    ).rejects.toThrow('DB error');
+  });
+});

--- a/backend/src/common/utils/__tests__/repository.util.spec.ts
+++ b/backend/src/common/utils/__tests__/repository.util.spec.ts
@@ -1,0 +1,56 @@
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { findOrThrow } from '../repository.util';
+
+interface TestEntity {
+  id: number;
+  name: string;
+}
+
+describe('findOrThrow', () => {
+  it('엔티티가 존재하면 반환', async () => {
+    const entity: TestEntity = { id: 1, name: 'foo' };
+    const repo = {
+      findOne: jest.fn().mockResolvedValue(entity),
+    } as unknown as Repository<TestEntity>;
+
+    const result = await findOrThrow(repo, { id: 1 }, '없음');
+
+    expect(result).toBe(entity);
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it('엔티티가 null이면 NotFoundException 발생', async () => {
+    const repo = {
+      findOne: jest.fn().mockResolvedValue(null),
+    } as unknown as Repository<TestEntity>;
+
+    await expect(findOrThrow(repo, { id: 999 }, '엔티티 없음')).rejects.toThrow(NotFoundException);
+    await expect(findOrThrow(repo, { id: 999 }, '엔티티 없음')).rejects.toThrow('엔티티 없음');
+  });
+
+  it('relations 옵션 전달 시 findOne 인자에 포함', async () => {
+    const entity: TestEntity = { id: 1, name: 'foo' };
+    const repo = {
+      findOne: jest.fn().mockResolvedValue(entity),
+    } as unknown as Repository<TestEntity>;
+
+    await findOrThrow(repo, { id: 1 }, '없음', ['user', 'product']);
+
+    expect(repo.findOne).toHaveBeenCalledWith({
+      where: { id: 1 },
+      relations: ['user', 'product'],
+    });
+  });
+
+  it('relations 미전달 시 findOne 인자에 relations 키 없음', async () => {
+    const entity: TestEntity = { id: 1, name: 'foo' };
+    const findOne = jest.fn().mockResolvedValue(entity);
+    const repo = { findOne } as unknown as Repository<TestEntity>;
+
+    await findOrThrow(repo, { id: 1 }, '없음');
+
+    expect(findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+    expect(findOne.mock.calls[0][0]).not.toHaveProperty('relations');
+  });
+});

--- a/backend/src/common/utils/__tests__/tree.util.spec.ts
+++ b/backend/src/common/utils/__tests__/tree.util.spec.ts
@@ -1,0 +1,117 @@
+import { buildTree } from '../tree.util';
+
+interface Category {
+  id: number;
+  parentId: number | null;
+  name: string;
+}
+
+describe('buildTree', () => {
+  it('parentId가 null인 항목들은 루트로 분류', () => {
+    const items: Category[] = [
+      { id: 1, parentId: null, name: 'A' },
+      { id: 2, parentId: null, name: 'B' },
+    ];
+
+    const result = buildTree(items);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].children).toEqual([]);
+    expect(result[1].children).toEqual([]);
+  });
+
+  it('parent-child 관계를 children 배열로 구성', () => {
+    const items: Category[] = [
+      { id: 1, parentId: null, name: '루트' },
+      { id: 2, parentId: 1, name: '자식1' },
+      { id: 3, parentId: 1, name: '자식2' },
+    ];
+
+    const result = buildTree(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+    expect(result[0].children).toHaveLength(2);
+    expect(result[0].children.map((c) => c.id).sort()).toEqual([2, 3]);
+  });
+
+  it('다단계 계층 구조 (손자까지)', () => {
+    const items: Category[] = [
+      { id: 1, parentId: null, name: '루트' },
+      { id: 2, parentId: 1, name: '자식' },
+      { id: 3, parentId: 2, name: '손자' },
+    ];
+
+    const result = buildTree(items);
+
+    expect(result).toHaveLength(1);
+    const child = result[0].children[0] as Category & { children: Category[] };
+    expect(child.id).toBe(2);
+    expect(child.children).toHaveLength(1);
+    expect((child.children[0] as Category).id).toBe(3);
+  });
+
+  it('parentId가 존재하지 않는 항목은 루트로 분류 (orphan)', () => {
+    const items: Category[] = [
+      { id: 1, parentId: null, name: '루트' },
+      { id: 2, parentId: 999, name: 'orphan' },
+    ];
+
+    const result = buildTree(items);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.id).sort()).toEqual([1, 2]);
+  });
+
+  it('빈 배열 입력 시 빈 배열 반환', () => {
+    expect(buildTree<Category>([])).toEqual([]);
+  });
+
+  it('id/parentId가 string이어도 Number() 변환 후 매칭 (BigInt-like)', () => {
+    interface StrCategory {
+      id: string;
+      parentId: string | null;
+      name: string;
+    }
+    const items: StrCategory[] = [
+      { id: '1', parentId: null, name: 'A' },
+      { id: '2', parentId: '1', name: 'B' },
+    ];
+
+    const result = buildTree(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children[0].id).toBe('2');
+  });
+
+  it('커스텀 idKey/parentKey 지원', () => {
+    interface CustomNode {
+      pk: number;
+      parent: number | null;
+      label: string;
+    }
+    const items: CustomNode[] = [
+      { pk: 1, parent: null, label: 'root' },
+      { pk: 2, parent: 1, label: 'child' },
+    ];
+
+    const result = buildTree(items, 'pk', 'parent');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children[0].pk).toBe(2);
+  });
+
+  it('원본 객체를 mutate하지 않음 (스프레드 복사)', () => {
+    const items: Category[] = [
+      { id: 1, parentId: null, name: '루트' },
+      { id: 2, parentId: 1, name: '자식' },
+    ];
+
+    buildTree(items);
+
+    expect(items[0]).not.toHaveProperty('children');
+    expect(items[1]).not.toHaveProperty('children');
+  });
+});

--- a/backend/src/modules/notification/adapters/__tests__/resend.adapter.spec.ts
+++ b/backend/src/modules/notification/adapters/__tests__/resend.adapter.spec.ts
@@ -1,0 +1,122 @@
+import { ResendEmailAdapter } from '../resend.adapter';
+import { NotificationConfig } from '../../../../config/notification.config';
+
+describe('ResendEmailAdapter', () => {
+  const baseConfig: NotificationConfig = {
+    nodeEnv: 'test',
+    provider: 'resend',
+    resend: {
+      apiKey: 'test-key',
+      fromAddress: 'noreply@example.com',
+    },
+  };
+
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch' as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('send()', () => {
+    it('정상 응답 시 messageId/provider 반환', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'msg-123' }),
+      } as Response);
+
+      const adapter = new ResendEmailAdapter(baseConfig);
+      const result = await adapter.send({
+        to: 'user@example.com',
+        subject: 'Hi',
+        html: '<p>Hi</p>',
+      });
+
+      expect(result).toEqual({ messageId: 'msg-123', provider: 'resend' });
+    });
+
+    it('Resend API 호출 시 올바른 URL/헤더/바디', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'msg-1' }),
+      } as Response);
+
+      const adapter = new ResendEmailAdapter(baseConfig);
+      await adapter.send({
+        to: 'user@example.com',
+        subject: '제목',
+        html: '<p>본문</p>',
+        text: '본문',
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.resend.com/emails',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer test-key',
+          }),
+        }),
+      );
+
+      const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({
+        from: 'noreply@example.com',
+        to: 'user@example.com',
+        subject: '제목',
+        html: '<p>본문</p>',
+        text: '본문',
+      });
+    });
+
+    it('id가 누락되면 messageId는 빈 문자열', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+
+      const adapter = new ResendEmailAdapter(baseConfig);
+      const result = await adapter.send({ to: 'a@b.com', subject: 's', html: 'h' });
+
+      expect(result.messageId).toBe('');
+    });
+
+    it('apiKey 미설정 시 send() 호출하면 에러', async () => {
+      const adapter = new ResendEmailAdapter({
+        ...baseConfig,
+        resend: { ...baseConfig.resend, apiKey: '' },
+      });
+
+      await expect(
+        adapter.send({ to: 'a@b.com', subject: 's', html: 'h' }),
+      ).rejects.toThrow('RESEND_API_KEY is not configured.');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('non-2xx 응답 시 status/body 포함된 에러', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 422,
+        text: async () => 'Invalid recipient',
+      } as Response);
+
+      const adapter = new ResendEmailAdapter(baseConfig);
+      await expect(
+        adapter.send({ to: 'bad@example.com', subject: 's', html: 'h' }),
+      ).rejects.toThrow('Resend API error: 422 Invalid recipient');
+    });
+
+    it('네트워크 오류는 그대로 throw', async () => {
+      fetchSpy.mockRejectedValue(new Error('ECONNRESET'));
+
+      const adapter = new ResendEmailAdapter(baseConfig);
+      await expect(
+        adapter.send({ to: 'a@b.com', subject: 's', html: 'h' }),
+      ).rejects.toThrow('ECONNRESET');
+    });
+  });
+});

--- a/backend/src/modules/notification/adapters/__tests__/ses.adapter.spec.ts
+++ b/backend/src/modules/notification/adapters/__tests__/ses.adapter.spec.ts
@@ -1,0 +1,23 @@
+import { SesEmailAdapter } from '../ses.adapter';
+
+describe('SesEmailAdapter', () => {
+  it('생성 시점에는 throw하지 않음 (DI 안전)', () => {
+    expect(() => new SesEmailAdapter()).not.toThrow();
+  });
+
+  it('send() 호출 시 stub 에러 발생 (구현 미완료)', async () => {
+    const adapter = new SesEmailAdapter();
+
+    await expect(
+      adapter.send({ to: 'user@example.com', subject: '제목', html: '<p>본문</p>' }),
+    ).rejects.toThrow('SesEmailAdapter is not implemented.');
+  });
+
+  it('text 본문 포함 메시지에도 동일하게 stub 에러', async () => {
+    const adapter = new SesEmailAdapter();
+
+    await expect(
+      adapter.send({ to: 'a@b.com', subject: 's', html: 'h', text: 't' }),
+    ).rejects.toThrow(/SesEmailAdapter is not implemented/);
+  });
+});

--- a/backend/src/modules/shipping/adapters/__tests__/cj-shipping.adapter.spec.ts
+++ b/backend/src/modules/shipping/adapters/__tests__/cj-shipping.adapter.spec.ts
@@ -1,0 +1,160 @@
+import { BadRequestException } from '@nestjs/common';
+import axios, { AxiosError } from 'axios';
+import { CjShippingAdapter } from '../cj-shipping.adapter';
+
+jest.mock('axios');
+
+const mockedAxiosGet = axios.get as jest.MockedFunction<typeof axios.get>;
+
+describe('CjShippingAdapter', () => {
+  let adapter: CjShippingAdapter;
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    adapter = new CjShippingAdapter();
+    jest.clearAllMocks();
+    process.env.CJ_TRACKING_API_URL = 'https://example.com/tracking';
+    process.env.CJ_TRACKING_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  describe('registerTrackingNumber()', () => {
+    it('CJ는 별도 등록 절차 없이 no-op로 성공', async () => {
+      await expect(adapter.registerTrackingNumber('order-1', 'TRACK-123')).resolves.toBeUndefined();
+      expect(mockedAxiosGet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getTrackingStatus()', () => {
+    it('정상 응답 시 trackingNumber/status/steps 매핑', async () => {
+      mockedAxiosGet.mockResolvedValue({
+        data: {
+          status: 'in transit',
+          estimatedDelivery: '2026-04-30',
+          steps: [
+            { status: 'shipped', description: '출고', timestamp: '2026-04-25T10:00:00Z' },
+            { status: 'in_transit', description: '이동중', timestamp: '2026-04-26T10:00:00Z' },
+          ],
+        },
+      });
+
+      const result = await adapter.getTrackingStatus('TRK-1', 'cj');
+
+      expect(result.trackingNumber).toBe('TRK-1');
+      expect(result.status).toBe('in_transit');
+      expect(result.estimatedDelivery).toBe('2026-04-30');
+      expect(result.steps).toHaveLength(2);
+      expect(mockedAxiosGet).toHaveBeenCalledWith(
+        'https://example.com/tracking',
+        expect.objectContaining({
+          params: { trackingNumber: 'TRK-1' },
+          headers: { Authorization: 'Bearer test-api-key' },
+          timeout: 5000,
+        }),
+      );
+    });
+
+    it('status에 "deliver" 포함 시 delivered로 매핑', async () => {
+      mockedAxiosGet.mockResolvedValue({
+        data: { status: 'Delivered', steps: [] },
+      });
+
+      const result = await adapter.getTrackingStatus('TRK-2', 'cj');
+
+      expect(result.status).toBe('delivered');
+    });
+
+    it('status에 "move" 포함 시 in_transit로 매핑', async () => {
+      mockedAxiosGet.mockResolvedValue({
+        data: { status: 'On the move', steps: [] },
+      });
+
+      const result = await adapter.getTrackingStatus('TRK-3', 'cj');
+
+      expect(result.status).toBe('in_transit');
+    });
+
+    it('알 수 없는 status는 shipped로 fallback', async () => {
+      mockedAxiosGet.mockResolvedValue({
+        data: { status: 'unknown-state', steps: [] },
+      });
+
+      const result = await adapter.getTrackingStatus('TRK-4', 'cj');
+
+      expect(result.status).toBe('shipped');
+    });
+
+    it('steps의 누락 필드는 기본값으로 채움', async () => {
+      mockedAxiosGet.mockResolvedValue({
+        data: {
+          status: 'shipped',
+          steps: [{}],
+        },
+      });
+
+      const result = await adapter.getTrackingStatus('TRK-5', 'cj');
+
+      expect(result.steps[0].status).toBe('in_transit');
+      expect(result.steps[0].description).toBe('');
+      expect(typeof result.steps[0].timestamp).toBe('string');
+    });
+
+    it('steps 누락 시 빈 배열 반환', async () => {
+      mockedAxiosGet.mockResolvedValue({
+        data: { status: 'shipped' },
+      });
+
+      const result = await adapter.getTrackingStatus('TRK-6', 'cj');
+
+      expect(result.steps).toEqual([]);
+    });
+
+    it('환경변수 CJ_TRACKING_API_URL 누락 시 BadRequestException', async () => {
+      delete process.env.CJ_TRACKING_API_URL;
+
+      await expect(adapter.getTrackingStatus('TRK-7', 'cj')).rejects.toThrow(BadRequestException);
+      await expect(adapter.getTrackingStatus('TRK-7', 'cj')).rejects.toThrow(
+        'CJ 택배 API 연동 설정이 누락되었습니다.',
+      );
+      expect(mockedAxiosGet).not.toHaveBeenCalled();
+    });
+
+    it('환경변수 CJ_TRACKING_API_KEY 누락 시 BadRequestException', async () => {
+      delete process.env.CJ_TRACKING_API_KEY;
+
+      await expect(adapter.getTrackingStatus('TRK-8', 'cj')).rejects.toThrow(BadRequestException);
+    });
+
+    it('429 응답 시 요청 한도 초과 메시지로 BadRequestException', async () => {
+      const err = new AxiosError('rate limited');
+      err.response = { status: 429 } as AxiosError['response'];
+      mockedAxiosGet.mockRejectedValue(err);
+
+      await expect(adapter.getTrackingStatus('TRK-9', 'cj')).rejects.toThrow(
+        'CJ API 요청 한도를 초과했습니다.',
+      );
+    });
+
+    it('네트워크 오류 시 일반 실패 메시지로 BadRequestException', async () => {
+      mockedAxiosGet.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(adapter.getTrackingStatus('TRK-10', 'cj')).rejects.toThrow(BadRequestException);
+      await expect(adapter.getTrackingStatus('TRK-10', 'cj')).rejects.toThrow(
+        'CJ 배송 추적 조회에 실패했습니다.',
+      );
+    });
+
+    it('429 외 AxiosError 응답 코드는 일반 실패 메시지로 처리', async () => {
+      const err = new AxiosError('server error');
+      err.response = { status: 500 } as AxiosError['response'];
+      mockedAxiosGet.mockRejectedValue(err);
+
+      await expect(adapter.getTrackingStatus('TRK-11', 'cj')).rejects.toThrow(
+        'CJ 배송 추적 조회에 실패했습니다.',
+      );
+    });
+  });
+});

--- a/backend/src/modules/shipping/adapters/__tests__/mock-shipping.adapter.spec.ts
+++ b/backend/src/modules/shipping/adapters/__tests__/mock-shipping.adapter.spec.ts
@@ -1,0 +1,57 @@
+import { MockShippingAdapter } from '../mock-shipping.adapter';
+
+describe('MockShippingAdapter', () => {
+  let adapter: MockShippingAdapter;
+
+  beforeEach(() => {
+    adapter = new MockShippingAdapter();
+  });
+
+  describe('registerTrackingNumber()', () => {
+    it('Mock은 no-op로 성공', async () => {
+      await expect(adapter.registerTrackingNumber('order-1', 'TRACK-1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getTrackingStatus()', () => {
+    it('전달받은 trackingNumber 그대로 반환', async () => {
+      const result = await adapter.getTrackingStatus('MOCK-123', 'mock');
+
+      expect(result.trackingNumber).toBe('MOCK-123');
+    });
+
+    it('status는 in_transit으로 시뮬레이션', async () => {
+      const result = await adapter.getTrackingStatus('MOCK-124', 'mock');
+
+      expect(result.status).toBe('in_transit');
+    });
+
+    it('shipped + in_transit 두 단계의 steps 시뮬레이션', async () => {
+      const result = await adapter.getTrackingStatus('MOCK-125', 'mock');
+
+      expect(result.steps).toHaveLength(2);
+      expect(result.steps[0].status).toBe('shipped');
+      expect(result.steps[0].description).toBe('발송 완료');
+      expect(result.steps[1].status).toBe('in_transit');
+      expect(result.steps[1].description).toBe('배송 중');
+    });
+
+    it('각 step의 timestamp는 ISO 8601 문자열', async () => {
+      const result = await adapter.getTrackingStatus('MOCK-126', 'mock');
+
+      for (const step of result.steps) {
+        expect(typeof step.timestamp).toBe('string');
+        expect(() => new Date(step.timestamp).toISOString()).not.toThrow();
+      }
+    });
+
+    it('carrier 인자에 무관하게 동일 시뮬레이션 반환', async () => {
+      const cj = await adapter.getTrackingStatus('TRK', 'cj');
+      const hanjin = await adapter.getTrackingStatus('TRK', 'hanjin');
+
+      expect(cj.trackingNumber).toBe(hanjin.trackingNumber);
+      expect(cj.status).toBe(hanjin.status);
+      expect(cj.steps).toHaveLength(hanjin.steps.length);
+    });
+  });
+});

--- a/backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts
+++ b/backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts
@@ -1,0 +1,142 @@
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
+import { S3StorageAdapter } from '../s3.adapter';
+import { StorageConfig } from '../../../../config/storage.config';
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const send = jest.fn();
+  return {
+    __esModule: true,
+    S3Client: jest.fn().mockImplementation(() => ({ send })),
+    PutObjectCommand: jest.fn().mockImplementation((input: unknown) => ({ __type: 'put', input })),
+    DeleteObjectCommand: jest.fn().mockImplementation((input: unknown) => ({ __type: 'delete', input })),
+    __mockSend: send,
+  };
+});
+
+const s3Module = jest.requireMock('@aws-sdk/client-s3') as {
+  __mockSend: jest.Mock;
+};
+
+const baseConfig: StorageConfig = {
+  provider: 's3',
+  s3: {
+    bucket: 'test-bucket',
+    region: 'ap-northeast-2',
+    cdnUrl: null,
+    accessKeyId: 'AKIA-test',
+    secretAccessKey: 'secret-test',
+  },
+};
+
+describe('S3StorageAdapter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    s3Module.__mockSend.mockResolvedValue({});
+  });
+
+  describe('생성자', () => {
+    it('S3Client가 region/credentials와 함께 초기화됨', () => {
+      new S3StorageAdapter(baseConfig);
+
+      expect(S3Client).toHaveBeenCalledWith({
+        region: 'ap-northeast-2',
+        credentials: {
+          accessKeyId: 'AKIA-test',
+          secretAccessKey: 'secret-test',
+        },
+      });
+    });
+  });
+
+  describe('save()', () => {
+    it('products/ 폴더에 PutObjectCommand 전송', async () => {
+      const adapter = new S3StorageAdapter(baseConfig);
+      const buffer = Buffer.from('image-data');
+
+      const result = await adapter.save('photo.jpg', buffer, 'image/jpeg');
+
+      expect(PutObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: 'products/photo.jpg',
+        Body: buffer,
+        ContentType: 'image/jpeg',
+        ACL: 'public-read',
+      });
+      expect(s3Module.__mockSend).toHaveBeenCalledTimes(1);
+      expect(result.filename).toBe('products/photo.jpg');
+    });
+
+    it('cdnUrl 미설정 시 S3 직접 URL 반환', async () => {
+      const adapter = new S3StorageAdapter(baseConfig);
+      const result = await adapter.save('photo.jpg', Buffer.from(''), 'image/jpeg');
+
+      expect(result.url).toBe(
+        'https://test-bucket.s3.ap-northeast-2.amazonaws.com/products/photo.jpg',
+      );
+    });
+
+    it('cdnUrl 설정 시 CDN URL 반환', async () => {
+      const adapter = new S3StorageAdapter({
+        ...baseConfig,
+        s3: { ...baseConfig.s3, cdnUrl: 'https://cdn.example.com' },
+      });
+
+      const result = await adapter.save('photo.jpg', Buffer.from(''), 'image/jpeg');
+
+      expect(result.url).toBe('https://cdn.example.com/products/photo.jpg');
+    });
+
+    it('S3 전송 실패 시 reject', async () => {
+      s3Module.__mockSend.mockRejectedValueOnce(new Error('S3 unreachable'));
+      const adapter = new S3StorageAdapter(baseConfig);
+
+      await expect(
+        adapter.save('photo.jpg', Buffer.from(''), 'image/jpeg'),
+      ).rejects.toThrow('S3 unreachable');
+    });
+  });
+
+  describe('saveCategoryImage()', () => {
+    it('categories/ 폴더에 저장', async () => {
+      const adapter = new S3StorageAdapter(baseConfig);
+
+      const result = await adapter.saveCategoryImage('cat.png', Buffer.from(''), 'image/png');
+
+      expect(PutObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Key: 'categories/cat.png',
+          Bucket: 'test-bucket',
+          ContentType: 'image/png',
+          ACL: 'public-read',
+        }),
+      );
+      expect(result.filename).toBe('categories/cat.png');
+      expect(result.url).toContain('categories/cat.png');
+    });
+  });
+
+  describe('delete()', () => {
+    it('주어진 key로 DeleteObjectCommand 전송', async () => {
+      const adapter = new S3StorageAdapter(baseConfig);
+
+      await adapter.delete('products/photo.jpg');
+
+      expect(DeleteObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: 'products/photo.jpg',
+      });
+      expect(s3Module.__mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('S3 삭제 실패 시 reject', async () => {
+      s3Module.__mockSend.mockRejectedValueOnce(new Error('Access denied'));
+      const adapter = new S3StorageAdapter(baseConfig);
+
+      await expect(adapter.delete('products/x.jpg')).rejects.toThrow('Access denied');
+    });
+  });
+});


### PR DESCRIPTION
## 요약
P2 audit 이슈 #708 — 결합 지점 어댑터(`adapters/*`)와 공통 유틸(`common/utils/*`)의 단위 테스트 누락 보강.

본 코드는 수정하지 않았고, 외부 API 호출은 모두 mock 처리(jest.mock)하여 실제 네트워크 호출 없음.

## 추가된 spec 파일 (9개)

### 어댑터 (5개)
- `backend/src/modules/shipping/adapters/__tests__/cj-shipping.adapter.spec.ts` — 송장 조회 정상/429/네트워크 오류, status 매핑(deliver/move/fallback), env 누락 BadRequest
- `backend/src/modules/shipping/adapters/__tests__/mock-shipping.adapter.spec.ts` — 시뮬레이션(2-step), carrier 무관성
- `backend/src/modules/notification/adapters/__tests__/resend.adapter.spec.ts` — fetch 호출 검증, apiKey 누락, non-2xx, 네트워크 오류
- `backend/src/modules/notification/adapters/__tests__/ses.adapter.spec.ts` — stub 에러 검증 (DI 안전)
- `backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts` — Put/Delete 명령, products/categories 폴더, cdnUrl on/off

### 공통 유틸 (4개)
- `backend/src/common/utils/__tests__/ownership.util.spec.ts` — BigInt string ↔ number 비교, 커스텀 메시지, ForbiddenException
- `backend/src/common/utils/__tests__/repository.util.spec.ts` — findOrThrow 정상/null/relations 옵션
- `backend/src/common/utils/__tests__/reorder.util.spec.ts` — Promise.all 병렬 검증(순서 비결정성), 커스텀 sortField, 빈 배열, 실패 전파
- `backend/src/common/utils/__tests__/tree.util.spec.ts` — parent/child/orphan, 다단계, BigInt-like string id, 커스텀 키, 원본 mutate 안 함

(이슈 본문의 `pagination.util.spec.ts` / `locale.util.spec.ts` 는 이미 존재 → 스킵.)

## 검증
- `npm run lint` — 0 errors
- `npm run build` — success
- `npm test` — **754 passed / 754 total** (81 suites). 새 spec 60건 모두 PASS.

## 비고
- 이슈 본문의 "S3 서명 URL" — 현재 `S3StorageAdapter`에 presigner 메서드가 없어 해당 항목은 테스트 대상이 없음(스킵).
- `SesEmailAdapter` 는 stub 상태이므로 send() 가 throw 한다는 사실만 검증.

Closes #708