### PR TITLE
test: #704 결제 서비스 단위 테스트 보강

### DIFF
--- a/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
@@ -1,0 +1,434 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { PaymentConfirmationService } from './payment-confirmation.service';
+import {
+  Payment,
+  PaymentGatewayType,
+  PaymentMethod,
+  PaymentStatus,
+} from '../entities/payment.entity';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { Shipping, ShippingStatus } from '../entities/shipping.entity';
+import { PaymentGateway } from '../interfaces/payment-gateway.interface';
+
+const makeOrder = (overrides: Partial<Order> = {}): Order =>
+  ({
+    id: 1,
+    userId: 10,
+    orderNumber: 'ORD-20240101-ABCD1',
+    status: OrderStatus.PENDING,
+    totalAmount: 30000,
+    recipientName: '홍길동',
+    ...overrides,
+  } as unknown as Order);
+
+const makePayment = (overrides: Partial<Payment> = {}): Payment =>
+  ({
+    id: 100,
+    orderId: 1,
+    amount: 30000,
+    status: PaymentStatus.PENDING,
+    method: PaymentMethod.MOCK,
+    gateway: PaymentGatewayType.MOCK,
+    paymentKey: null,
+    order: makeOrder(),
+    ...overrides,
+  } as unknown as Payment);
+
+const makeTransactionManager = (overrides: Record<string, jest.Mock> = {}) => ({
+  update: jest.fn().mockResolvedValue({}),
+  findOne: jest.fn().mockResolvedValue(null),
+  save: jest.fn().mockResolvedValue({}),
+  create: jest
+    .fn()
+    .mockImplementation((_entity: unknown, data: unknown) => data),
+  ...overrides,
+});
+
+const makeDataSource = (manager = makeTransactionManager()) => ({
+  transaction: jest.fn(
+    async (
+      fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>,
+    ) => fn(manager),
+  ),
+  _manager: manager,
+});
+
+interface BuildArgs {
+  paymentRepo?: Partial<{
+    findOne: jest.Mock;
+    update: jest.Mock;
+  }>;
+  orderRepo?: Partial<{ findOne: jest.Mock; update: jest.Mock }>;
+  shippingRepo?: Partial<{ findOne: jest.Mock }>;
+  dataSource?: ReturnType<typeof makeDataSource>;
+  gateway?: Partial<PaymentGateway>;
+  resolveGateway?: jest.Mock;
+  notifyDispatch?: jest.Mock;
+  notificationSend?: jest.Mock;
+}
+
+const buildService = (args: BuildArgs = {}) => {
+  const paymentRepo = {
+    findOne: jest.fn(),
+    update: jest.fn().mockResolvedValue({}),
+    ...args.paymentRepo,
+  };
+  const orderRepo = {
+    findOne: jest.fn(),
+    update: jest.fn().mockResolvedValue({}),
+    ...args.orderRepo,
+  };
+  const shippingRepo = {
+    findOne: jest.fn(),
+    ...args.shippingRepo,
+  };
+  const dataSource = args.dataSource ?? makeDataSource();
+  const gateway: PaymentGateway = {
+    prepare: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    partialCancel: jest.fn(),
+    verifyWebhook: jest.fn(),
+    ...args.gateway,
+  } as PaymentGateway;
+  const resolveGatewayByType = args.resolveGateway ?? jest.fn(() => gateway);
+  const notificationDispatch =
+    args.notifyDispatch ?? jest.fn().mockResolvedValue(undefined);
+  const notificationSend =
+    args.notificationSend ?? jest.fn().mockResolvedValue(undefined);
+
+  const service = new PaymentConfirmationService({
+    paymentRepository: paymentRepo as never,
+    orderRepository: orderRepo as never,
+    shippingRepository: shippingRepo as never,
+    dataSource: dataSource as never,
+    notificationService: {
+      sendPaymentConfirmed: notificationSend,
+    } as never,
+    notificationDispatchHelper: {
+      dispatch: notificationDispatch,
+    } as never,
+    resolveGatewayByType,
+    logger: new Logger('PaymentConfirmationService.spec'),
+    defaultCarrier: 'mock',
+  });
+
+  return {
+    service,
+    paymentRepo,
+    orderRepo,
+    shippingRepo,
+    dataSource,
+    gateway,
+    resolveGatewayByType,
+    notificationDispatch,
+    notificationSend,
+  };
+};
+
+describe('PaymentConfirmationService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('confirm() — 정상 흐름', () => {
+    it('PENDING 결제를 CONFIRMED 로 전환하고 paidAt 을 기록한다', async () => {
+      const payment = makePayment();
+      const { service, paymentRepo, dataSource, gateway } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+      (gateway.confirm as jest.Mock).mockResolvedValue({
+        paymentKey: 'pay_abc',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: { mock: true },
+      });
+
+      const before = Date.now();
+      const result = await service.confirm(
+        { orderId: 1, paymentKey: 'pay_abc', amount: 30000 },
+        10,
+      );
+      const after = Date.now();
+
+      expect(result.status).toBe(PaymentStatus.CONFIRMED);
+      expect(result.method).toBe('mock');
+      expect(result.amount).toBe(30000);
+      expect(result.paidAt).toBeInstanceOf(Date);
+      const paidAt = result.paidAt.getTime();
+      expect(paidAt).toBeGreaterThanOrEqual(before);
+      expect(paidAt).toBeLessThanOrEqual(after);
+
+      // 트랜잭션 내에서 payment 업데이트 시 paidAt 이 함께 기록되었는지 확인
+      const manager = dataSource._manager;
+      expect(manager.update).toHaveBeenCalledWith(
+        Payment,
+        payment.id,
+        expect.objectContaining({
+          status: PaymentStatus.CONFIRMED,
+          paymentKey: 'pay_abc',
+          paidAt: expect.any(Date),
+        }),
+      );
+      expect(paymentRepo.findOne).toHaveBeenCalledWith({
+        where: { orderId: 1 },
+        relations: ['order'],
+      });
+    });
+
+    it('order 를 PAID 로 갱신하고 신규 shipping 을 생성한다', async () => {
+      const payment = makePayment();
+      const { service, dataSource, gateway } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+      (gateway.confirm as jest.Mock).mockResolvedValue({
+        paymentKey: 'pay_abc',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: { mock: true },
+      });
+
+      await service.confirm(
+        { orderId: 1, paymentKey: 'pay_abc', amount: 30000 },
+        10,
+      );
+
+      const manager = dataSource._manager;
+      expect(manager.update).toHaveBeenCalledWith(Order, 1, {
+        status: OrderStatus.PAID,
+      });
+      expect(manager.save).toHaveBeenCalledWith(
+        Shipping,
+        expect.objectContaining({
+          orderId: 1,
+          carrier: 'mock',
+          status: ShippingStatus.PAYMENT_CONFIRMED,
+        }),
+      );
+    });
+
+    it('shipping 이 이미 존재하면 새로 생성하지 않는다', async () => {
+      const payment = makePayment();
+      const existingShipping = { id: 5, orderId: 1 } as Shipping;
+      const manager = makeTransactionManager({
+        findOne: jest.fn().mockResolvedValue(existingShipping),
+      });
+      const dataSource = makeDataSource(manager);
+      const { service, gateway } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+        dataSource,
+      });
+      (gateway.confirm as jest.Mock).mockResolvedValue({
+        paymentKey: 'pay_abc',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: { mock: true },
+      });
+
+      await service.confirm(
+        { orderId: 1, paymentKey: 'pay_abc', amount: 30000 },
+        10,
+      );
+
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirm() — 권한/상태 검증', () => {
+    it('결제 정보가 없으면 NotFoundException', async () => {
+      const { service } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(null) },
+      });
+
+      await expect(
+        service.confirm({ orderId: 999, paymentKey: 'pk', amount: 1000 }, 10),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('타인 주문 → ForbiddenException', async () => {
+      const payment = makePayment({
+        order: makeOrder({ userId: 99 }),
+      });
+      const { service } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('이미 CONFIRMED → ConflictException (이중 결제 방지)', async () => {
+      const payment = makePayment({ status: PaymentStatus.CONFIRMED });
+      const { service, gateway } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
+      ).rejects.toThrow(ConflictException);
+      expect(gateway.confirm).not.toHaveBeenCalled();
+    });
+
+    it('PENDING 외 상태 (FAILED) → BadRequestException', async () => {
+      const payment = makePayment({ status: PaymentStatus.FAILED });
+      const { service } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('REFUNDED 상태 → BadRequestException (환불 후 재결제 거부)', async () => {
+      const payment = makePayment({ status: PaymentStatus.REFUNDED });
+      const { service, gateway } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
+      ).rejects.toThrow(BadRequestException);
+      expect(gateway.confirm).not.toHaveBeenCalled();
+    });
+
+    it('amount 가 주문 totalAmount 와 불일치 → BadRequestException', async () => {
+      const payment = makePayment();
+      const { service, gateway } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pk', amount: 99999 }, 10),
+      ).rejects.toThrow(BadRequestException);
+      expect(gateway.confirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirm() — 게이트웨이 분기/실패', () => {
+    it('payment.gateway 값으로 어댑터를 라우팅한다 (TOSS)', async () => {
+      const payment = makePayment({ gateway: PaymentGatewayType.TOSS });
+      const tossGateway: PaymentGateway = {
+        prepare: jest.fn(),
+        confirm: jest.fn().mockResolvedValue({
+          paymentKey: 'pay_toss',
+          method: 'card',
+          amount: 30000,
+          status: 'confirmed',
+          rawResponse: { toss: true },
+        }),
+        cancel: jest.fn(),
+        partialCancel: jest.fn(),
+        verifyWebhook: jest.fn(),
+      };
+      const resolveGateway = jest.fn(() => tossGateway);
+
+      const { service } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+        resolveGateway,
+      });
+
+      await service.confirm(
+        { orderId: 1, paymentKey: 'pay_toss', amount: 30000 },
+        10,
+      );
+
+      expect(resolveGateway).toHaveBeenCalledWith(PaymentGatewayType.TOSS);
+      expect(tossGateway.confirm).toHaveBeenCalledWith(
+        'pay_toss',
+        30000,
+        'ORD-20240101-ABCD1',
+      );
+    });
+
+    it('게이트웨이가 던지면 payment 를 FAILED 로 마킹하고 InternalServerErrorException', async () => {
+      const payment = makePayment();
+      const paymentRepo = {
+        findOne: jest.fn().mockResolvedValue(payment),
+        update: jest.fn().mockResolvedValue({}),
+      };
+      const { service, gateway } = buildService({ paymentRepo });
+      (gateway.confirm as jest.Mock).mockRejectedValue(
+        new Error('gateway down'),
+      );
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
+      ).rejects.toThrow(InternalServerErrorException);
+      expect(paymentRepo.update).toHaveBeenCalledWith(payment.id, {
+        status: PaymentStatus.FAILED,
+      });
+    });
+
+    it('트랜잭션 내부 실패 → payment FAILED 마킹', async () => {
+      const payment = makePayment();
+      const failingManager = makeTransactionManager({
+        save: jest.fn().mockRejectedValue(new Error('shipping insert 실패')),
+      });
+      const dataSource = makeDataSource(failingManager);
+      const paymentRepo = {
+        findOne: jest.fn().mockResolvedValue(payment),
+        update: jest.fn().mockResolvedValue({}),
+      };
+      const { service, gateway } = buildService({
+        paymentRepo,
+        dataSource,
+      });
+      (gateway.confirm as jest.Mock).mockResolvedValue({
+        paymentKey: 'pk',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: {},
+      });
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
+      ).rejects.toThrow(InternalServerErrorException);
+      expect(paymentRepo.update).toHaveBeenCalledWith(payment.id, {
+        status: PaymentStatus.FAILED,
+      });
+    });
+  });
+
+  describe('confirm() — 알림 디스패치', () => {
+    it('성공 시 fire-and-forget 으로 결제완료 알림을 디스패치한다', async () => {
+      const payment = makePayment();
+      const { service, gateway, notificationDispatch } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+      (gateway.confirm as jest.Mock).mockResolvedValue({
+        paymentKey: 'pk',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: {},
+      });
+
+      await service.confirm(
+        { orderId: 1, paymentKey: 'pk', amount: 30000 },
+        10,
+      );
+
+      expect(notificationDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'payment.confirmed',
+          userId: 10,
+          resourceId: 1,
+          mode: 'fire-and-forget',
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/modules/payments/services/payment-refund.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-refund.service.spec.ts
@@ -1,0 +1,437 @@
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { PaymentRefundService } from './payment-refund.service';
+import {
+  Payment,
+  PaymentGatewayType,
+  PaymentStatus,
+} from '../entities/payment.entity';
+import { Refund, RefundStatus } from '../entities/refund.entity';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { PaymentGateway } from '../interfaces/payment-gateway.interface';
+
+const makeConfirmedPayment = (overrides: Partial<Payment> = {}): Payment =>
+  ({
+    id: 100,
+    orderId: 1,
+    amount: 30000,
+    status: PaymentStatus.CONFIRMED,
+    paymentKey: 'pay_abc',
+    gateway: PaymentGatewayType.MOCK,
+    ...overrides,
+  } as unknown as Payment);
+
+const makePendingRefund = (overrides: Partial<Refund> = {}): Refund =>
+  ({
+    id: 1,
+    paymentId: 100,
+    orderItemId: null,
+    amount: 10000,
+    reason: '부분 환불',
+    status: RefundStatus.PENDING,
+    gatewayRefundId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as unknown as Refund);
+
+const makeQueryBuilderRefundSum = (total: string) => ({
+  select: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  getRawOne: jest.fn().mockResolvedValue({ total }),
+});
+
+const makePhase1Manager = (
+  payment: Payment,
+  refundedTotal = '0',
+  pendingRefund: Refund = makePendingRefund(),
+) => ({
+  findOne: jest.fn().mockResolvedValue(payment),
+  create: jest
+    .fn()
+    .mockImplementation((_entity: unknown, data: unknown) => ({
+      ...pendingRefund,
+      ...(data as object),
+    })),
+  save: jest
+    .fn()
+    .mockImplementation((_entity: unknown, data: unknown) =>
+      Promise.resolve({ ...pendingRefund, ...(data as object) }),
+    ),
+  createQueryBuilder: jest
+    .fn()
+    .mockReturnValue(makeQueryBuilderRefundSum(refundedTotal)),
+  update: jest.fn().mockResolvedValue({}),
+});
+
+const makePhase3Manager = (refundedAfter: string) => ({
+  findOne: jest.fn(),
+  save: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn().mockResolvedValue({}),
+  createQueryBuilder: jest
+    .fn()
+    .mockReturnValue(makeQueryBuilderRefundSum(refundedAfter)),
+});
+
+interface BuildArgs {
+  paymentRepo?: { findOne?: jest.Mock };
+  refundRepo?: { findOne?: jest.Mock; update?: jest.Mock };
+  phase1Manager?: ReturnType<typeof makePhase1Manager>;
+  phase3Manager?: ReturnType<typeof makePhase3Manager>;
+  phase3Throws?: Error;
+  gateway?: Partial<PaymentGateway>;
+  resolveGateway?: jest.Mock;
+}
+
+const buildService = (args: BuildArgs = {}) => {
+  const paymentRepo = {
+    findOne: jest.fn(),
+    ...args.paymentRepo,
+  };
+  const refundRepo = {
+    findOne: jest.fn(),
+    update: jest.fn().mockResolvedValue({}),
+    ...args.refundRepo,
+  };
+  const gateway: PaymentGateway = {
+    prepare: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    partialCancel: jest.fn(),
+    verifyWebhook: jest.fn(),
+    ...args.gateway,
+  } as PaymentGateway;
+  const resolveGateway = args.resolveGateway ?? jest.fn(() => gateway);
+
+  const transaction = jest
+    .fn()
+    .mockImplementationOnce(
+      async (
+        fn: (m: ReturnType<typeof makePhase1Manager>) => Promise<unknown>,
+      ) => fn(args.phase1Manager ?? makePhase1Manager(makeConfirmedPayment())),
+    )
+    .mockImplementationOnce(
+      async (
+        fn: (m: ReturnType<typeof makePhase3Manager>) => Promise<unknown>,
+      ) => {
+        if (args.phase3Throws) throw args.phase3Throws;
+        return fn(args.phase3Manager ?? makePhase3Manager('10000'));
+      },
+    );
+
+  const dataSource = { transaction } as never;
+
+  const service = new PaymentRefundService({
+    paymentRepository: paymentRepo as never,
+    refundRepository: refundRepo as never,
+    dataSource,
+    resolveGatewayByType: resolveGateway,
+    logger: new Logger('PaymentRefundService.spec'),
+  });
+
+  return {
+    service,
+    paymentRepo,
+    refundRepo,
+    gateway,
+    resolveGateway,
+    transaction,
+  };
+};
+
+describe('PaymentRefundService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('partialRefund() — 환불 가능 상태 가드', () => {
+    it.each([
+      ['PENDING', PaymentStatus.PENDING],
+      ['CANCELLED', PaymentStatus.CANCELLED],
+      ['REFUNDED', PaymentStatus.REFUNDED],
+      ['FAILED', PaymentStatus.FAILED],
+    ])(
+      '%s 상태에서는 환불을 거부한다 → BadRequestException',
+      async (_label, status) => {
+        const payment = makeConfirmedPayment({ status });
+        const phase1Manager = makePhase1Manager(payment);
+        const { service } = buildService({ phase1Manager });
+
+        await expect(
+          service.partialRefund(1, { amount: 1000, reason: '테스트' }),
+        ).rejects.toThrow(BadRequestException);
+      },
+    );
+
+    it('CONFIRMED 상태는 환불을 허용한다', async () => {
+      const payment = makeConfirmedPayment({ amount: 30000 });
+      const phase1Manager = makePhase1Manager(payment, '0');
+      const phase3Manager = makePhase3Manager('10000');
+      const { service, paymentRepo, refundRepo, gateway } = buildService({
+        phase1Manager,
+        phase3Manager,
+      });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      refundRepo.findOne.mockResolvedValue({
+        ...makePendingRefund({ status: RefundStatus.COMPLETED }),
+      });
+      (gateway.partialCancel as jest.Mock).mockResolvedValue({
+        refundId: 'rid-1',
+        cancelledAt: new Date(),
+        rawResponse: {},
+      });
+
+      await expect(
+        service.partialRefund(1, { amount: 10000, reason: '부분 환불' }),
+      ).resolves.toBeDefined();
+    });
+
+    it('PARTIAL_CANCELLED 상태도 추가 환불을 허용한다', async () => {
+      const payment = makeConfirmedPayment({
+        status: PaymentStatus.PARTIAL_CANCELLED,
+        amount: 30000,
+      });
+      const phase1Manager = makePhase1Manager(payment, '5000');
+      const phase3Manager = makePhase3Manager('10000');
+      const { service, paymentRepo, refundRepo, gateway } = buildService({
+        phase1Manager,
+        phase3Manager,
+      });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      refundRepo.findOne.mockResolvedValue(makePendingRefund());
+      (gateway.partialCancel as jest.Mock).mockResolvedValue({
+        refundId: 'rid-2',
+        cancelledAt: new Date(),
+        rawResponse: {},
+      });
+
+      await expect(
+        service.partialRefund(1, { amount: 5000, reason: '부분 환불 2차' }),
+      ).resolves.toBeDefined();
+    });
+
+    it('paymentKey 가 없으면 BadRequestException', async () => {
+      const payment = makeConfirmedPayment({ paymentKey: null });
+      const phase1Manager = makePhase1Manager(payment);
+      const { service } = buildService({ phase1Manager });
+
+      await expect(
+        service.partialRefund(1, { amount: 1000, reason: '테스트' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('결제가 존재하지 않으면 BadRequestException', async () => {
+      const phase1Manager = {
+        ...makePhase1Manager(makeConfirmedPayment()),
+        findOne: jest.fn().mockResolvedValue(null),
+      };
+      const { service } = buildService({ phase1Manager });
+
+      await expect(
+        service.partialRefund(99, { amount: 1000, reason: '테스트' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('partialRefund() — 환불 금액 계산', () => {
+    it('환불 잔여 금액 초과 시 BadRequestException', async () => {
+      const payment = makeConfirmedPayment({ amount: 10000 });
+      // 이미 7000 환불됨 → 잔여 3000원 → 5000 요청은 거부
+      const phase1Manager = makePhase1Manager(payment, '7000');
+      const { service } = buildService({ phase1Manager });
+
+      await expect(
+        service.partialRefund(1, { amount: 5000, reason: '초과 시도' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('전액 환불 시 Payment=REFUNDED + Order=REFUNDED 로 갱신', async () => {
+      const payment = makeConfirmedPayment({ amount: 10000 });
+      const phase1Manager = makePhase1Manager(payment, '0');
+      const phase3Manager = makePhase3Manager('10000');
+      const { service, paymentRepo, refundRepo, gateway } = buildService({
+        phase1Manager,
+        phase3Manager,
+      });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      refundRepo.findOne.mockResolvedValue({
+        ...makePendingRefund({ amount: 10000, status: RefundStatus.COMPLETED }),
+      });
+      (gateway.partialCancel as jest.Mock).mockResolvedValue({
+        refundId: 'rid-full',
+        cancelledAt: new Date(),
+        rawResponse: {},
+      });
+
+      await service.partialRefund(1, { amount: 10000, reason: '전액 환불' });
+
+      expect(phase3Manager.update).toHaveBeenCalledWith(Payment, payment.id, {
+        status: PaymentStatus.REFUNDED,
+      });
+      expect(phase3Manager.update).toHaveBeenCalledWith(Order, payment.orderId, {
+        status: OrderStatus.REFUNDED,
+      });
+    });
+
+    it('부분 환불 시 Payment=PARTIAL_CANCELLED 로 갱신 (Order 는 유지)', async () => {
+      const payment = makeConfirmedPayment({ amount: 30000 });
+      const phase1Manager = makePhase1Manager(payment, '0');
+      const phase3Manager = makePhase3Manager('10000');
+      const { service, paymentRepo, refundRepo, gateway } = buildService({
+        phase1Manager,
+        phase3Manager,
+      });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      refundRepo.findOne.mockResolvedValue(
+        makePendingRefund({ amount: 10000, status: RefundStatus.COMPLETED }),
+      );
+      (gateway.partialCancel as jest.Mock).mockResolvedValue({
+        refundId: 'rid-partial',
+        cancelledAt: new Date(),
+        rawResponse: {},
+      });
+
+      await service.partialRefund(1, { amount: 10000, reason: '부분 환불' });
+
+      expect(phase3Manager.update).toHaveBeenCalledWith(Payment, payment.id, {
+        status: PaymentStatus.PARTIAL_CANCELLED,
+      });
+      expect(phase3Manager.update).not.toHaveBeenCalledWith(
+        Order,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('Refund 엔티티에 paymentKey 와 cancelAmount 가 게이트웨이로 전달된다', async () => {
+      const payment = makeConfirmedPayment({
+        amount: 30000,
+        paymentKey: 'pk_abc',
+      });
+      const phase1Manager = makePhase1Manager(payment, '0');
+      const phase3Manager = makePhase3Manager('10000');
+      const { service, paymentRepo, refundRepo, gateway } = buildService({
+        phase1Manager,
+        phase3Manager,
+      });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      refundRepo.findOne.mockResolvedValue(
+        makePendingRefund({ status: RefundStatus.COMPLETED }),
+      );
+      (gateway.partialCancel as jest.Mock).mockResolvedValue({
+        refundId: 'rid-z',
+        cancelledAt: new Date(),
+        rawResponse: {},
+      });
+
+      await service.partialRefund(1, { amount: 10000, reason: '환불 사유' });
+
+      expect(gateway.partialCancel).toHaveBeenCalledWith({
+        paymentKey: 'pk_abc',
+        cancelAmount: 10000,
+        cancelReason: '환불 사유',
+      });
+    });
+  });
+
+  describe('partialRefund() — 게이트웨이 분기', () => {
+    it('payment.gateway 값으로 어댑터를 라우팅한다 (TOSS)', async () => {
+      const payment = makeConfirmedPayment({
+        gateway: PaymentGatewayType.TOSS,
+        paymentKey: 'pay_toss',
+      });
+      const phase1Manager = makePhase1Manager(payment, '0');
+      const phase3Manager = makePhase3Manager('10000');
+      const tossGateway: PaymentGateway = {
+        prepare: jest.fn(),
+        confirm: jest.fn(),
+        cancel: jest.fn(),
+        partialCancel: jest.fn().mockResolvedValue({
+          refundId: 'tosrid-1',
+          cancelledAt: new Date(),
+          rawResponse: { toss: true },
+        }),
+        verifyWebhook: jest.fn(),
+      };
+      const resolveGateway = jest.fn(() => tossGateway);
+      const { service, paymentRepo, refundRepo } = buildService({
+        phase1Manager,
+        phase3Manager,
+        resolveGateway,
+      });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      refundRepo.findOne.mockResolvedValue(
+        makePendingRefund({ status: RefundStatus.COMPLETED }),
+      );
+
+      await service.partialRefund(1, { amount: 10000, reason: '환불' });
+
+      expect(resolveGateway).toHaveBeenCalledWith(PaymentGatewayType.TOSS);
+      expect(tossGateway.partialCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('partialRefund() — 게이트웨이 실패 → Refund FAILED + 롤백', () => {
+    it('게이트웨이가 던지면 Refund 를 FAILED 로 마킹하고 InternalServerErrorException', async () => {
+      const payment = makeConfirmedPayment({ amount: 10000 });
+      const phase1Manager = makePhase1Manager(payment, '0');
+      const { service, paymentRepo, refundRepo, gateway } = buildService({
+        phase1Manager,
+      });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      (gateway.partialCancel as jest.Mock).mockRejectedValue(
+        new Error('gateway down'),
+      );
+
+      await expect(
+        service.partialRefund(1, { amount: 5000, reason: '실패' }),
+      ).rejects.toThrow(InternalServerErrorException);
+
+      expect(refundRepo.update).toHaveBeenCalledWith(expect.anything(), {
+        status: RefundStatus.FAILED,
+      });
+    });
+
+    it('게이트웨이가 BadRequestException 을 던지면 그대로 전파', async () => {
+      const payment = makeConfirmedPayment({ amount: 10000 });
+      const phase1Manager = makePhase1Manager(payment, '0');
+      const { service, paymentRepo, gateway } = buildService({ phase1Manager });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      (gateway.partialCancel as jest.Mock).mockRejectedValue(
+        new BadRequestException('이미 환불됨'),
+      );
+
+      await expect(
+        service.partialRefund(1, { amount: 5000, reason: '실패' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('Phase 3 DB 동기화 실패 → Refund 를 FAILED 로 마킹하지 않음 (게이트웨이는 이미 환불 완료)', async () => {
+      const payment = makeConfirmedPayment({ amount: 10000 });
+      const phase1Manager = makePhase1Manager(payment, '0');
+      const { service, paymentRepo, refundRepo, gateway } = buildService({
+        phase1Manager,
+        phase3Throws: new Error('DB sync failed'),
+      });
+      paymentRepo.findOne.mockResolvedValue(payment);
+      (gateway.partialCancel as jest.Mock).mockResolvedValue({
+        refundId: 'rid-x',
+        cancelledAt: new Date(),
+        rawResponse: {},
+      });
+
+      await expect(
+        service.partialRefund(1, { amount: 5000, reason: '환불' }),
+      ).rejects.toThrow(InternalServerErrorException);
+
+      // Phase 3 실패 시 Refund 를 FAILED 로 마킹하면 안 됨 (게이트웨이는 성공)
+      expect(refundRepo.update).not.toHaveBeenCalledWith(expect.anything(), {
+        status: RefundStatus.FAILED,
+      });
+    });
+  });
+});

--- a/backend/src/modules/payments/services/payment-webhook.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.spec.ts
@@ -1,0 +1,330 @@
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { PaymentWebhookService } from './payment-webhook.service';
+import { Payment, PaymentStatus } from '../entities/payment.entity';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { PaymentGateway } from '../interfaces/payment-gateway.interface';
+
+const makeWebhookManager = (overrides: Record<string, jest.Mock> = {}) => ({
+  findOne: jest.fn(),
+  update: jest.fn().mockResolvedValue({}),
+  ...overrides,
+});
+
+interface BuildArgs {
+  gateway?: Partial<PaymentGateway>;
+  paymentRepo?: { findOne?: jest.Mock };
+  manager?: ReturnType<typeof makeWebhookManager>;
+}
+
+const buildService = (args: BuildArgs = {}) => {
+  const gateway: PaymentGateway = {
+    prepare: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    partialCancel: jest.fn(),
+    verifyWebhook: jest.fn(),
+    ...args.gateway,
+  } as PaymentGateway;
+  const paymentRepo = {
+    findOne: jest.fn(),
+    ...args.paymentRepo,
+  };
+  const manager = args.manager ?? makeWebhookManager();
+  const transaction = jest.fn(
+    async (fn: (m: typeof manager) => Promise<unknown>) => fn(manager),
+  );
+  const dataSource = { transaction } as never;
+  const logger = new Logger('PaymentWebhookService.spec');
+
+  const service = new PaymentWebhookService({
+    gateway,
+    paymentRepository: paymentRepo as never,
+    dataSource,
+    logger,
+  });
+
+  return { service, gateway, paymentRepo, manager, transaction, logger };
+};
+
+describe('PaymentWebhookService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('서명 검증', () => {
+    it('서명이 유효하면 처리한다', async () => {
+      const { service, gateway } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+
+      await expect(
+        service.handleWebhook({ eventType: 'PING' }, 'valid_sig'),
+      ).resolves.not.toThrow();
+      expect(gateway.verifyWebhook).toHaveBeenCalledWith(
+        { eventType: 'PING' },
+        'valid_sig',
+      );
+    });
+
+    it('서명이 잘못되면 UnauthorizedException', async () => {
+      const { service, gateway } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(false);
+
+      await expect(service.handleWebhook({}, 'bad_sig')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('서명 검증 실패 시 후속 DB 작업이 일어나지 않는다', async () => {
+      const { service, gateway, paymentRepo, transaction } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(false);
+
+      await expect(service.handleWebhook({}, 'bad_sig')).rejects.toThrow();
+      expect(paymentRepo.findOne).not.toHaveBeenCalled();
+      expect(transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('비동기 결제 상태 갱신', () => {
+    it('DONE 이벤트 → Payment CONFIRMED + Order PAID + paidAt 기록', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'pending' }),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({
+        id: 10,
+        orderId: 7,
+        paidAt: null,
+      });
+
+      await service.handleWebhook(
+        { orderId: 7, status: 'DONE' },
+        'valid_sig',
+      );
+
+      expect(manager.update).toHaveBeenCalledWith(
+        Payment,
+        10,
+        expect.objectContaining({
+          status: PaymentStatus.CONFIRMED,
+          paidAt: expect.any(Date),
+        }),
+      );
+      expect(manager.update).toHaveBeenCalledWith(Order, 7, {
+        status: OrderStatus.PAID,
+      });
+    });
+
+    it('CANCEL 이벤트 → Payment CANCELLED + Order CANCELLED + cancelledAt 기록', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'paid' }),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({
+        id: 10,
+        orderId: 7,
+        paidAt: new Date(),
+        cancelledAt: null,
+      });
+
+      await service.handleWebhook(
+        { orderId: 7, status: 'CANCELLED' },
+        'valid_sig',
+      );
+
+      expect(manager.update).toHaveBeenCalledWith(
+        Payment,
+        10,
+        expect.objectContaining({
+          status: PaymentStatus.CANCELLED,
+          cancelledAt: expect.any(Date),
+        }),
+      );
+      expect(manager.update).toHaveBeenCalledWith(Order, 7, {
+        status: OrderStatus.CANCELLED,
+      });
+    });
+
+    it('REFUND 이벤트 → Payment REFUNDED + Order REFUNDED', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'paid' }),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({
+        id: 10,
+        orderId: 7,
+        paidAt: new Date(),
+        cancelledAt: null,
+      });
+
+      await service.handleWebhook(
+        { orderId: 7, status: 'REFUNDED' },
+        'valid_sig',
+      );
+
+      expect(manager.update).toHaveBeenCalledWith(
+        Payment,
+        10,
+        expect.objectContaining({ status: PaymentStatus.REFUNDED }),
+      );
+      expect(manager.update).toHaveBeenCalledWith(Order, 7, {
+        status: OrderStatus.REFUNDED,
+      });
+    });
+
+    it('eventType 이 우선 매칭된다 (eventType > status > type)', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'pending' }),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7 });
+
+      // eventType=DONE → status=CANCELLED 보다 우선되어 PAID 로 전이
+      await service.handleWebhook(
+        { orderId: 7, eventType: 'DONE', status: 'CANCELLED' },
+        'valid_sig',
+      );
+
+      expect(manager.update).toHaveBeenCalledWith(
+        Payment,
+        10,
+        expect.objectContaining({ status: PaymentStatus.CONFIRMED }),
+      );
+    });
+  });
+
+  describe('Idempotent / 차단 전이', () => {
+    it('이미 PAID 인 주문에 DONE 웹훅 재수신 → allowSameStatus=true 로 멱등 처리', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'paid' }),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({
+        id: 10,
+        orderId: 7,
+        paidAt: new Date('2026-01-01T00:00:00Z'),
+      });
+
+      await expect(
+        service.handleWebhook(
+          { orderId: 7, status: 'DONE' },
+          'valid_sig',
+        ),
+      ).resolves.not.toThrow();
+
+      // 동일 상태(paid → paid) 전이는 허용되어 update 가 호출됨
+      expect(manager.update).toHaveBeenCalled();
+    });
+
+    it('차단 전이(delivered → paid) 는 update 를 수행하지 않음', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'delivered' }),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7 });
+
+      await service.handleWebhook(
+        { orderId: 7, status: 'DONE' },
+        'valid_sig',
+      );
+
+      expect(manager.update).not.toHaveBeenCalled();
+    });
+
+    it('알 수 없는 이벤트 → DB 작업 없이 무시', async () => {
+      const { service, gateway, paymentRepo, transaction } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7 });
+
+      await service.handleWebhook(
+        { orderId: 7, eventType: 'UNKNOWN_TYPE' },
+        'valid_sig',
+      );
+
+      expect(transaction).not.toHaveBeenCalled();
+    });
+
+    it('orderId 가 유효하지 않으면 무시', async () => {
+      const { service, gateway, paymentRepo } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+
+      await service.handleWebhook(
+        { orderId: 'invalid', status: 'DONE' },
+        'valid_sig',
+      );
+
+      expect(paymentRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('이벤트 키가 모두 비어있으면 무시', async () => {
+      const { service, gateway, paymentRepo } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+
+      await service.handleWebhook({ orderId: 7 }, 'valid_sig');
+
+      expect(paymentRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('payment 가 존재하지 않으면 DB 갱신 없이 무시', async () => {
+      const { service, gateway, paymentRepo, transaction } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue(null);
+
+      await service.handleWebhook(
+        { orderId: 999, status: 'DONE' },
+        'valid_sig',
+      );
+
+      expect(transaction).not.toHaveBeenCalled();
+    });
+
+    it('order 가 트랜잭션 내에서 사라졌다면 update 를 수행하지 않음', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue(null),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7 });
+
+      await service.handleWebhook(
+        { orderId: 7, status: 'DONE' },
+        'valid_sig',
+      );
+
+      expect(manager.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('로그 민감 정보 마스킹', () => {
+    it('orderId/status/type 만 로그에 기록되고 카드/계좌 번호는 제외된다', async () => {
+      const { service, gateway, paymentRepo, logger } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue(null); // 빠르게 종료
+      const logSpy = jest.spyOn(logger, 'log');
+
+      await service.handleWebhook(
+        {
+          orderId: 42,
+          status: 'DONE',
+          type: 'PAYMENT',
+          cardNumber: '4111111111111111',
+          accountNumber: '987654321',
+        },
+        'valid_sig',
+      );
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('42'));
+      expect(logSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('4111111111111111'),
+      );
+      expect(logSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('987654321'),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 요약
P0 결제 모듈의 누락 단위 테스트 보강. 본 코드 변경 없이 spec 파일 3종 추가.

Closes #704

## 추가된 spec 파일
- `backend/src/modules/payments/services/payment-confirmation.service.spec.ts` (15 tests)
- `backend/src/modules/payments/services/payment-refund.service.spec.ts` (15 tests)
- `backend/src/modules/payments/services/payment-webhook.service.spec.ts` (14 tests)

총 44 tests, 모두 PASS.

## 검증된 시나리오

### PaymentConfirmationService
- PENDING → CONFIRMED 정상 전환 + paidAt 기록 확인
- order PAID 갱신 + 신규 shipping 생성 (carrier=mock, status=PAYMENT_CONFIRMED)
- 기존 shipping 이 있으면 중복 생성 안 함
- 결제 정보 부재 → NotFoundException
- 타인 주문 → ForbiddenException
- 이미 CONFIRMED → ConflictException (이중 결제 방지)
- FAILED 등 PENDING 외 상태 → BadRequestException
- REFUNDED 상태 → BadRequestException (환불 후 재결제 거부)
- amount mismatch → BadRequestException
- payment.gateway 값으로 어댑터 라우팅 (TOSS 분기 검증)
- 게이트웨이 실패 시 payment FAILED 마킹 + InternalServerErrorException
- 트랜잭션 내부 실패 시 payment FAILED 마킹
- 성공 시 fire-and-forget 알림 디스패치

### PaymentRefundService
- 환불 가능 상태 가드: PENDING / CANCELLED / REFUNDED / FAILED 거부
- CONFIRMED / PARTIAL_CANCELLED 만 허용
- paymentKey 부재 시 BadRequestException
- 결제 부재 시 BadRequestException
- 환불 잔여 금액 초과 시 BadRequestException
- 전액 환불 → Payment=REFUNDED + Order=REFUNDED 갱신
- 부분 환불 → Payment=PARTIAL_CANCELLED, Order 미변경
- 게이트웨이로 paymentKey/cancelAmount/cancelReason 전달
- payment.gateway 값으로 어댑터 라우팅 (TOSS 분기 검증)
- 게이트웨이 실패 → Refund=FAILED + InternalServerErrorException
- 게이트웨이 BadRequestException 그대로 전파
- Phase 3 DB 동기화 실패 시 Refund 를 FAILED 마킹하지 않음 (게이트웨이 이미 처리)

### PaymentWebhookService
- 서명 유효 → 정상 처리
- 서명 실패 → UnauthorizedException
- 서명 실패 시 후속 DB 작업 차단
- DONE → Payment CONFIRMED + Order PAID + paidAt 기록
- CANCEL → Payment CANCELLED + Order CANCELLED + cancelledAt 기록
- REFUND → Payment REFUNDED + Order REFUNDED
- eventType > status > type 우선순위
- Idempotent: 이미 PAID 인 주문에 DONE 재수신 → allowSameStatus 로 처리
- 차단 전이(delivered → paid) update 미수행
- 알 수 없는 이벤트 / 잘못된 orderId / payment 부재 / order 부재 시 무시
- 로그에 카드/계좌 번호 등 민감 정보 미포함

## 검증
- `npm run lint`: PASS (max-warnings 0)
- `npm run build`: PASS
- `npm test`: PASS (75 suites / 738 tests)

## 본 코드 변경 없음
이번 PR 은 spec 파일만 추가하며 production 코드는 변경하지 않음.