### PR TITLE
test: cover backend admin CMS shipping audit flows

### DIFF
--- a/backend/src/modules/admin/__tests__/admin.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin.service.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminService } from '../admin.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdminService],
+    }).compile();
+
+    service = module.get(AdminService);
+  });
+
+  describe('getDashboardStats', () => {
+    it('기본 stats 객체 반환 (모든 카운터 0)', () => {
+      const result = service.getDashboardStats();
+
+      expect(result).toEqual({
+        totalOrders: 0,
+        totalUsers: 0,
+        totalProducts: 0,
+        totalRevenue: 0,
+      });
+    });
+
+    it('스키마 키가 모두 number 타입이다', () => {
+      const result = service.getDashboardStats();
+
+      expect(typeof result.totalOrders).toBe('number');
+      expect(typeof result.totalUsers).toBe('number');
+      expect(typeof result.totalProducts).toBe('number');
+      expect(typeof result.totalRevenue).toBe('number');
+    });
+  });
+});

--- a/backend/src/modules/archives/__tests__/archives.service.spec.ts
+++ b/backend/src/modules/archives/__tests__/archives.service.spec.ts
@@ -1,0 +1,248 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { ObjectLiteral, Repository } from 'typeorm';
+import { ArchivesService } from '../archives.service';
+import { Artist, NiloType, ProcessStep } from '../entities/archive.entity';
+
+type RepoMock<T extends ObjectLiteral> = jest.Mocked<Pick<Repository<T>, 'find' | 'findOne' | 'create' | 'save' | 'remove' | 'update'>>;
+
+function createRepoMock<T extends ObjectLiteral>(): RepoMock<T> {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+    update: jest.fn(),
+  } as unknown as RepoMock<T>;
+}
+
+describe('ArchivesService', () => {
+  let service: ArchivesService;
+  let niloRepo: RepoMock<NiloType>;
+  let stepRepo: RepoMock<ProcessStep>;
+  let artistRepo: RepoMock<Artist>;
+
+  beforeEach(async () => {
+    niloRepo = createRepoMock<NiloType>();
+    stepRepo = createRepoMock<ProcessStep>();
+    artistRepo = createRepoMock<Artist>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ArchivesService,
+        { provide: getRepositoryToken(NiloType), useValue: niloRepo },
+        { provide: getRepositoryToken(ProcessStep), useValue: stepRepo },
+        { provide: getRepositoryToken(Artist), useValue: artistRepo },
+      ],
+    }).compile();
+
+    service = module.get(ArchivesService);
+  });
+
+  describe('findAllNiloTypes', () => {
+    it('활성 항목만 sortOrder ASC 로 조회한다', async () => {
+      const items = [
+        { id: 1, name: 'A', nameKo: 'A한글', characteristics: ['c1'], characteristicsEn: null, sortOrder: 0, isActive: true },
+      ];
+      niloRepo.find.mockResolvedValue(items as unknown as NiloType[]);
+
+      const result = await service.findAllNiloTypes();
+
+      expect(niloRepo.find).toHaveBeenCalledWith({
+        where: { isActive: true },
+        order: { sortOrder: 'ASC' },
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('A');
+    });
+
+    it('locale=en 이면 nameEn 으로 name 을 덮고, characteristicsEn 으로 characteristics 를 치환한다', async () => {
+      niloRepo.find.mockResolvedValue([
+        {
+          id: 1,
+          name: '진니',
+          nameEn: 'Zhuni',
+          nameKo: '진니',
+          description: '한글 설명',
+          descriptionEn: 'English desc',
+          region: '의흥',
+          regionEn: 'Yixing',
+          characteristics: ['부드러움'],
+          characteristicsEn: ['smooth', 'sweet'],
+          isActive: true,
+          sortOrder: 0,
+        } as unknown as NiloType,
+      ]);
+
+      const [item] = await service.findAllNiloTypes('en');
+
+      expect(item.name).toBe('Zhuni');
+      expect(item.nameKo).toBe('Zhuni');
+      expect(item.characteristics).toEqual(['smooth', 'sweet']);
+      expect(item.description).toBe('English desc');
+      expect(item.region).toBe('Yixing');
+    });
+
+    it('locale=en 이지만 characteristicsEn 이 비어있으면 한국어 배열 유지', async () => {
+      niloRepo.find.mockResolvedValue([
+        {
+          id: 2,
+          name: '진니',
+          nameEn: 'Zhuni',
+          nameKo: '진니',
+          description: '설명',
+          descriptionEn: null,
+          characteristics: ['부드러움'],
+          characteristicsEn: null,
+          isActive: true,
+          sortOrder: 0,
+        } as unknown as NiloType,
+      ]);
+
+      const [item] = await service.findAllNiloTypes('en');
+
+      expect(item.characteristics).toEqual(['부드러움']);
+    });
+  });
+
+  describe('findAllProcessSteps', () => {
+    it('step ASC 정렬로 조회한다', async () => {
+      stepRepo.find.mockResolvedValue([]);
+      await service.findAllProcessSteps();
+      expect(stepRepo.find).toHaveBeenCalledWith({ order: { step: 'ASC' } });
+    });
+  });
+
+  describe('findAllArtists', () => {
+    it('활성 작가만 sortOrder ASC 로 조회한다', async () => {
+      artistRepo.find.mockResolvedValue([]);
+      await service.findAllArtists();
+      expect(artistRepo.find).toHaveBeenCalledWith({
+        where: { isActive: true },
+        order: { sortOrder: 'ASC' },
+      });
+    });
+  });
+
+  describe('findNiloTypeById', () => {
+    it('없는 ID 조회 시 NotFoundException', async () => {
+      niloRepo.findOne.mockResolvedValue(null as unknown as NiloType);
+      await expect(service.findNiloTypeById(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('createNiloType', () => {
+    it('repository.create -> save 순으로 호출된다', async () => {
+      const dto = {
+        name: 'Zhuni',
+        nameKo: '주니',
+        color: '#aa0000',
+        region: 'Yixing',
+        description: 'desc',
+        characteristics: ['smooth'],
+        productUrl: '/products?nilo=zhuni',
+      };
+      const entity = { id: 10, ...dto } as unknown as NiloType;
+      niloRepo.create.mockReturnValue(entity);
+      niloRepo.save.mockResolvedValue(entity);
+
+      const result = await service.createNiloType(dto);
+
+      expect(niloRepo.create).toHaveBeenCalledWith(dto);
+      expect(niloRepo.save).toHaveBeenCalledWith(entity);
+      expect(result).toBe(entity);
+    });
+  });
+
+  describe('updateNiloType', () => {
+    it('기존 엔티티에 dto를 머지한 뒤 저장한다', async () => {
+      const existing = { id: 1, name: 'old', isActive: true } as unknown as NiloType;
+      niloRepo.findOne.mockResolvedValue(existing);
+      niloRepo.save.mockImplementation(async (entity: unknown) => entity as NiloType);
+
+      const result = await service.updateNiloType(1, { name: 'new' });
+
+      expect(result.name).toBe('new');
+      expect(niloRepo.save).toHaveBeenCalledWith(expect.objectContaining({ id: 1, name: 'new' }));
+    });
+
+    it('없는 ID 수정 시 NotFoundException', async () => {
+      niloRepo.findOne.mockResolvedValue(null as unknown as NiloType);
+      await expect(service.updateNiloType(999, { name: 'x' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteNiloType', () => {
+    it('조회 후 remove 호출', async () => {
+      const entity = { id: 1 } as NiloType;
+      niloRepo.findOne.mockResolvedValue(entity);
+      niloRepo.remove.mockResolvedValue(entity);
+
+      await service.deleteNiloType(1);
+
+      expect(niloRepo.remove).toHaveBeenCalledWith(entity);
+    });
+  });
+
+  describe('reorderNiloTypes', () => {
+    it('reorderEntities 가 update 를 병렬로 호출한다', async () => {
+      niloRepo.update.mockResolvedValue({ affected: 1 } as unknown as Awaited<ReturnType<Repository<NiloType>['update']>>);
+
+      await service.reorderNiloTypes([
+        { id: 1, sortOrder: 5 },
+        { id: 2, sortOrder: 6 },
+      ]);
+
+      expect(niloRepo.update).toHaveBeenCalledTimes(2);
+      expect(niloRepo.update).toHaveBeenCalledWith(1, { sortOrder: 5 });
+      expect(niloRepo.update).toHaveBeenCalledWith(2, { sortOrder: 6 });
+    });
+  });
+
+  describe('Artist CRUD', () => {
+    it('createArtist 는 repo.create -> save 호출', async () => {
+      const dto = { name: 'a', title: 't', region: 'r', story: 's', specialty: 'sp', productUrl: 'u' };
+      const entity = { id: 1, ...dto } as unknown as Artist;
+      artistRepo.create.mockReturnValue(entity);
+      artistRepo.save.mockResolvedValue(entity);
+
+      const result = await service.createArtist(dto);
+      expect(result).toBe(entity);
+    });
+
+    it('updateArtist 는 없는 ID 면 NotFoundException', async () => {
+      artistRepo.findOne.mockResolvedValue(null as unknown as Artist);
+      await expect(service.updateArtist(999, { name: 'x' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('reorderArtists 는 일괄 update', async () => {
+      artistRepo.update.mockResolvedValue({ affected: 1 } as unknown as Awaited<ReturnType<Repository<Artist>['update']>>);
+
+      await service.reorderArtists([
+        { id: 10, sortOrder: 1 },
+        { id: 11, sortOrder: 2 },
+      ]);
+
+      expect(artistRepo.update).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('ProcessStep CRUD', () => {
+    it('createProcessStep -> save 호출', async () => {
+      const dto = { step: 1, title: 't', description: 'd', detail: 'detail' };
+      const entity = { id: 1, ...dto } as unknown as ProcessStep;
+      stepRepo.create.mockReturnValue(entity);
+      stepRepo.save.mockResolvedValue(entity);
+
+      const result = await service.createProcessStep(dto);
+      expect(result).toBe(entity);
+    });
+
+    it('deleteProcessStep 은 없는 ID 면 NotFoundException', async () => {
+      stepRepo.findOne.mockResolvedValue(null as unknown as ProcessStep);
+      await expect(service.deleteProcessStep(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/modules/collections/__tests__/collections.service.spec.ts
+++ b/backend/src/modules/collections/__tests__/collections.service.spec.ts
@@ -1,0 +1,210 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { ObjectLiteral, Repository } from 'typeorm';
+import { CollectionsService } from '../collections.service';
+import { Collection, CollectionType } from '../entities/collection.entity';
+
+type RepoMock<T extends ObjectLiteral> = jest.Mocked<
+  Pick<Repository<T>, 'find' | 'findOne' | 'create' | 'save' | 'remove' | 'update'>
+>;
+
+function createRepoMock<T extends ObjectLiteral>(): RepoMock<T> {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+    update: jest.fn(),
+  } as unknown as RepoMock<T>;
+}
+
+describe('CollectionsService', () => {
+  let service: CollectionsService;
+  let repo: RepoMock<Collection>;
+
+  beforeEach(async () => {
+    repo = createRepoMock<Collection>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CollectionsService,
+        { provide: getRepositoryToken(Collection), useValue: repo },
+      ],
+    }).compile();
+
+    service = module.get(CollectionsService);
+  });
+
+  describe('findAllByType', () => {
+    it('타입별 활성 컬렉션을 sortOrder ASC 로 조회한다', async () => {
+      repo.find.mockResolvedValue([]);
+
+      await service.findAllByType(CollectionType.CLAY);
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { type: CollectionType.CLAY, isActive: true },
+        order: { sortOrder: 'ASC' },
+      });
+    });
+
+    it('locale=en 이면 nameEn 으로 name/nameKo 를 덮어쓴다', async () => {
+      repo.find.mockResolvedValue([
+        {
+          id: 1,
+          type: CollectionType.CLAY,
+          name: '진니',
+          nameEn: 'Zhuni',
+          nameKo: '진니',
+          description: '한글 설명',
+          descriptionEn: 'English desc',
+          isActive: true,
+          sortOrder: 0,
+        } as unknown as Collection,
+      ]);
+
+      const [item] = await service.findAllByType(CollectionType.CLAY, 'en');
+
+      expect(item.name).toBe('Zhuni');
+      expect(item.nameKo).toBe('Zhuni');
+      expect(item.description).toBe('English desc');
+    });
+
+    it('locale=ko 이면 원본 name/nameKo 를 그대로 반환한다', async () => {
+      repo.find.mockResolvedValue([
+        {
+          id: 1,
+          type: CollectionType.CLAY,
+          name: '진니',
+          nameEn: 'Zhuni',
+          nameKo: '진니한글',
+          description: '한글 설명',
+          descriptionEn: 'English desc',
+          isActive: true,
+          sortOrder: 0,
+        } as unknown as Collection,
+      ]);
+
+      const [item] = await service.findAllByType(CollectionType.CLAY, 'ko');
+
+      expect(item.name).toBe('진니');
+      expect(item.nameKo).toBe('진니한글');
+    });
+  });
+
+  describe('findAll', () => {
+    it('타입과 sortOrder 순서로 모든 컬렉션을 조회한다', async () => {
+      repo.find.mockResolvedValue([]);
+
+      await service.findAll();
+
+      expect(repo.find).toHaveBeenCalledWith({
+        order: { type: 'ASC', sortOrder: 'ASC' },
+      });
+    });
+  });
+
+  describe('findById', () => {
+    it('없는 ID 조회 시 NotFoundException', async () => {
+      repo.findOne.mockResolvedValue(null as unknown as Collection);
+
+      await expect(service.findById(999)).rejects.toThrow(NotFoundException);
+    });
+
+    it('존재 시 locale 적용 후 반환', async () => {
+      repo.findOne.mockResolvedValue({
+        id: 1,
+        type: CollectionType.SHAPE,
+        name: 'Pear Shape',
+        nameEn: 'Pear Shape',
+        nameKo: '서시',
+      } as unknown as Collection);
+
+      const result = await service.findById(1, 'ko');
+
+      expect(result.id).toBe(1);
+    });
+  });
+
+  describe('create', () => {
+    it('repository.create -> save 순으로 호출', async () => {
+      const dto = {
+        type: CollectionType.CLAY,
+        name: 'New Collection',
+        productUrl: '/products?collection=new',
+      };
+      const entity = { id: 1, ...dto } as unknown as Collection;
+      repo.create.mockReturnValue(entity);
+      repo.save.mockResolvedValue(entity);
+
+      const result = await service.create(dto);
+
+      expect(repo.create).toHaveBeenCalledWith(dto);
+      expect(result).toBe(entity);
+    });
+  });
+
+  describe('update', () => {
+    it('기존 엔티티에 dto 머지 후 저장', async () => {
+      const existing = { id: 1, name: 'old', type: CollectionType.CLAY } as unknown as Collection;
+      repo.findOne.mockResolvedValue(existing);
+      repo.save.mockImplementation(async (entity: unknown) => entity as Collection);
+
+      const result = await service.update(1, { name: 'new' });
+
+      expect(result.name).toBe('new');
+    });
+
+    it('없는 ID 수정 시 NotFoundException', async () => {
+      repo.findOne.mockResolvedValue(null as unknown as Collection);
+      await expect(service.update(999, { name: 'x' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('조회 후 remove 호출', async () => {
+      const entity = { id: 1 } as Collection;
+      repo.findOne.mockResolvedValue(entity);
+      repo.remove.mockResolvedValue(entity);
+
+      await service.remove(1);
+
+      expect(repo.remove).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+    });
+  });
+
+  describe('reorder', () => {
+    it('순서 일괄 업데이트는 병렬로 update를 호출한다', async () => {
+      repo.update.mockResolvedValue({ affected: 1 } as unknown as Awaited<
+        ReturnType<Repository<Collection>['update']>
+      >);
+
+      await service.reorder([
+        { id: 1, sortOrder: 5 },
+        { id: 2, sortOrder: 6 },
+        { id: 3, sortOrder: 7 },
+      ]);
+
+      expect(repo.update).toHaveBeenCalledTimes(3);
+      expect(repo.update).toHaveBeenCalledWith(1, { sortOrder: 5 });
+      expect(repo.update).toHaveBeenCalledWith(2, { sortOrder: 6 });
+      expect(repo.update).toHaveBeenCalledWith(3, { sortOrder: 7 });
+    });
+
+    it('일부 update 실패 시 reject 된다 (Promise.all 동작)', async () => {
+      repo.update
+        .mockResolvedValueOnce({ affected: 1 } as unknown as Awaited<
+          ReturnType<Repository<Collection>['update']>
+        >)
+        .mockRejectedValueOnce(new Error('DB error'));
+
+      await expect(
+        service.reorder([
+          { id: 1, sortOrder: 1 },
+          { id: 2, sortOrder: 2 },
+        ]),
+      ).rejects.toThrow('DB error');
+    });
+  });
+});

--- a/backend/src/modules/journal/__tests__/journal.service.spec.ts
+++ b/backend/src/modules/journal/__tests__/journal.service.spec.ts
@@ -1,0 +1,182 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { ObjectLiteral, Repository } from 'typeorm';
+import { JournalService } from '../journal.service';
+import { JournalCategory, JournalEntry } from '../entities/journal-entry.entity';
+
+type RepoMock<T extends ObjectLiteral> = jest.Mocked<
+  Pick<Repository<T>, 'find' | 'findOne' | 'create' | 'save' | 'remove'>
+>;
+
+function createRepoMock<T extends ObjectLiteral>(): RepoMock<T> {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+  } as unknown as RepoMock<T>;
+}
+
+describe('JournalService', () => {
+  let service: JournalService;
+  let repo: RepoMock<JournalEntry>;
+
+  beforeEach(async () => {
+    repo = createRepoMock<JournalEntry>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JournalService,
+        { provide: getRepositoryToken(JournalEntry), useValue: repo },
+      ],
+    }).compile();
+
+    service = module.get(JournalService);
+  });
+
+  describe('findAll', () => {
+    it('카테고리 미지정 시 게시된 항목만 조회', async () => {
+      repo.find.mockResolvedValue([]);
+
+      await service.findAll();
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { isPublished: true },
+        order: { date: 'DESC' },
+      });
+    });
+
+    it('카테고리 지정 시 where 에 카테고리 포함', async () => {
+      repo.find.mockResolvedValue([]);
+
+      await service.findAll(JournalCategory.NEWS);
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { isPublished: true, category: JournalCategory.NEWS },
+        order: { date: 'DESC' },
+      });
+    });
+
+    it('locale=en 이면 titleEn/contentEn 으로 덮어씀', async () => {
+      repo.find.mockResolvedValue([
+        {
+          id: 1,
+          slug: 's',
+          title: '한글 제목',
+          titleEn: 'English Title',
+          subtitle: null,
+          subtitleEn: 'EN sub',
+          summary: '요약',
+          summaryEn: 'EN summary',
+          content: '본문',
+          contentEn: 'EN content',
+          isPublished: true,
+        } as unknown as JournalEntry,
+      ]);
+
+      const [item] = await service.findAll(undefined, 'en');
+
+      expect(item.title).toBe('English Title');
+      expect(item.summary).toBe('EN summary');
+      expect(item.content).toBe('EN content');
+    });
+  });
+
+  describe('findAllAdmin', () => {
+    it('isPublished 와 무관하게 전체 조회', async () => {
+      repo.find.mockResolvedValue([]);
+
+      await service.findAllAdmin();
+
+      expect(repo.find).toHaveBeenCalledWith({
+        order: { date: 'DESC' },
+      });
+    });
+  });
+
+  describe('findBySlug', () => {
+    it('없는 slug 조회 시 NotFoundException', async () => {
+      repo.findOne.mockResolvedValue(null as unknown as JournalEntry);
+
+      await expect(service.findBySlug('missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('정상 조회 시 locale 적용', async () => {
+      repo.findOne.mockResolvedValue({
+        id: 1,
+        slug: 's',
+        title: '한글',
+        titleEn: 'English',
+      } as unknown as JournalEntry);
+
+      const result = await service.findBySlug('s', 'en');
+
+      expect(result.title).toBe('English');
+    });
+  });
+
+  describe('findById', () => {
+    it('없는 ID 조회 시 NotFoundException', async () => {
+      repo.findOne.mockResolvedValue(null as unknown as JournalEntry);
+
+      await expect(service.findById(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('repo.create -> save 순으로 호출', async () => {
+      const dto = {
+        slug: 's',
+        title: '제목',
+        category: JournalCategory.CULTURE,
+        date: '2026-01-01',
+      };
+      const entity = { id: 1, ...dto } as unknown as JournalEntry;
+      repo.create.mockReturnValue(entity);
+      repo.save.mockResolvedValue(entity);
+
+      const result = await service.create(dto);
+
+      expect(repo.create).toHaveBeenCalledWith(dto);
+      expect(result).toBe(entity);
+    });
+  });
+
+  describe('update', () => {
+    it('없는 ID 수정 시 NotFoundException', async () => {
+      repo.findOne.mockResolvedValue(null as unknown as JournalEntry);
+
+      await expect(service.update(999, { title: 'x' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('기존 엔티티에 dto 머지 후 save', async () => {
+      const existing = { id: 1, title: 'old' } as unknown as JournalEntry;
+      repo.findOne.mockResolvedValue(existing);
+      repo.save.mockImplementation(async (entity: unknown) => entity as JournalEntry);
+
+      const result = await service.update(1, { title: 'new' });
+
+      expect(result.title).toBe('new');
+    });
+  });
+
+  describe('delete', () => {
+    it('없는 ID 삭제 시 NotFoundException', async () => {
+      repo.findOne.mockResolvedValue(null as unknown as JournalEntry);
+
+      await expect(service.delete(999)).rejects.toThrow(NotFoundException);
+    });
+
+    it('정상 삭제', async () => {
+      const entity = { id: 1 } as JournalEntry;
+      repo.findOne.mockResolvedValue(entity);
+      repo.remove.mockResolvedValue(entity);
+
+      await service.delete(1);
+
+      expect(repo.remove).toHaveBeenCalledWith(entity);
+    });
+  });
+});

--- a/backend/src/modules/products/__tests__/attributes.service.spec.ts
+++ b/backend/src/modules/products/__tests__/attributes.service.spec.ts
@@ -1,0 +1,268 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm';
+import { AttributesService } from '../attributes.service';
+import { AttributeInputType, AttributeType } from '../entities/attribute-type.entity';
+import { ProductAttribute } from '../entities/product-attribute.entity';
+
+type RepoMock<T extends ObjectLiteral> = jest.Mocked<
+  Pick<Repository<T>, 'find' | 'findOne' | 'create' | 'save' | 'remove' | 'update' | 'delete' | 'createQueryBuilder'>
+>;
+
+function createRepoMock<T extends ObjectLiteral>(): RepoMock<T> {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  } as unknown as RepoMock<T>;
+}
+
+function createQueryBuilderMock(overrides: Record<string, unknown> = {}) {
+  const qb: Record<string, jest.Mock> = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([]),
+    getRawMany: jest.fn().mockResolvedValue([]),
+  };
+  Object.assign(qb, overrides);
+  return qb as unknown as SelectQueryBuilder<ProductAttribute>;
+}
+
+describe('AttributesService', () => {
+  let service: AttributesService;
+  let typeRepo: RepoMock<AttributeType>;
+  let attrRepo: RepoMock<ProductAttribute>;
+
+  beforeEach(async () => {
+    typeRepo = createRepoMock<AttributeType>();
+    attrRepo = createRepoMock<ProductAttribute>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AttributesService,
+        { provide: getRepositoryToken(AttributeType), useValue: typeRepo },
+        { provide: getRepositoryToken(ProductAttribute), useValue: attrRepo },
+      ],
+    }).compile();
+
+    service = module.get(AttributesService);
+  });
+
+  describe('createAttributeType', () => {
+    it('기본값을 채워서 저장한다', async () => {
+      typeRepo.findOne.mockResolvedValue(null as unknown as AttributeType);
+      const created = { id: 1, code: 'clay', name: '니료', inputType: AttributeInputType.TEXT } as unknown as AttributeType;
+      typeRepo.create.mockReturnValue(created);
+      typeRepo.save.mockResolvedValue(created);
+
+      await service.createAttributeType({ code: 'clay', name: '니료' });
+
+      expect(typeRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'clay',
+          name: '니료',
+          inputType: AttributeInputType.TEXT,
+          isFilterable: false,
+          isSearchable: false,
+          sortOrder: 0,
+        }),
+      );
+    });
+
+    it('동일 code 가 이미 존재하면 ConflictException', async () => {
+      typeRepo.findOne.mockResolvedValue({ id: 1, code: 'clay' } as AttributeType);
+
+      await expect(
+        service.createAttributeType({ code: 'clay', name: '니료' }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('updateAttributeType', () => {
+    it('없는 ID 수정 시 NotFoundException', async () => {
+      typeRepo.findOne.mockResolvedValue(null as unknown as AttributeType);
+
+      await expect(service.updateAttributeType(999, { name: 'x' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('code 변경 시 다른 동일 code 가 있으면 ConflictException', async () => {
+      typeRepo.findOne
+        .mockResolvedValueOnce({ id: 1, code: 'old', name: 'a' } as AttributeType) // findAttributeTypeById
+        .mockResolvedValueOnce({ id: 2, code: 'new' } as AttributeType); // 충돌 검사
+
+      await expect(service.updateAttributeType(1, { code: 'new' })).rejects.toThrow(ConflictException);
+    });
+
+    it('동일 code 변경 시도는 충돌 검사 스킵', async () => {
+      const existing = { id: 1, code: 'same', name: 'a' } as AttributeType;
+      typeRepo.findOne.mockResolvedValue(existing);
+      typeRepo.save.mockImplementation(async (entity: unknown) => entity as AttributeType);
+
+      const result = await service.updateAttributeType(1, { code: 'same', name: 'b' });
+
+      expect(result.name).toBe('b');
+    });
+  });
+
+  describe('findAttributeTypeById', () => {
+    it('없는 ID 조회 시 NotFoundException', async () => {
+      typeRepo.findOne.mockResolvedValue(null as unknown as AttributeType);
+
+      await expect(service.findAttributeTypeById(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findAttributesByProductIds', () => {
+    it('빈 배열이면 빈 Map 반환', async () => {
+      const result = await service.findAttributesByProductIds([]);
+
+      expect(result.size).toBe(0);
+      expect(attrRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('상품ID별로 그룹화한 Map을 반환한다', async () => {
+      const qb = createQueryBuilderMock({
+        getMany: jest.fn().mockResolvedValue([
+          { id: 1, productId: 10, attributeTypeId: 1, value: 'a' } as ProductAttribute,
+          { id: 2, productId: 10, attributeTypeId: 2, value: 'b' } as ProductAttribute,
+          { id: 3, productId: 11, attributeTypeId: 1, value: 'c' } as ProductAttribute,
+        ]),
+      });
+      attrRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const map = await service.findAttributesByProductIds([10, 11]);
+
+      expect(map.get(10)).toHaveLength(2);
+      expect(map.get(11)).toHaveLength(1);
+    });
+  });
+
+  describe('createOrUpdateProductAttribute', () => {
+    it('기존 값이 있으면 update', async () => {
+      const existing = { id: 1, productId: 1, attributeTypeId: 1, value: 'old', sortOrder: 0 } as ProductAttribute;
+      attrRepo.findOne.mockResolvedValue(existing);
+      attrRepo.save.mockImplementation(async (entity: unknown) => entity as ProductAttribute);
+
+      const result = await service.createOrUpdateProductAttribute(1, 1, {
+        productId: 1,
+        attributeTypeId: 1,
+        value: 'new',
+      });
+
+      expect(result.value).toBe('new');
+    });
+
+    it('기존 값이 없으면 create 호출', async () => {
+      attrRepo.findOne.mockResolvedValue(null as unknown as ProductAttribute);
+      const created = { id: 99 } as unknown as ProductAttribute;
+      attrRepo.create.mockReturnValue(created);
+      attrRepo.save.mockResolvedValue(created);
+
+      await service.createOrUpdateProductAttribute(1, 1, {
+        productId: 1,
+        attributeTypeId: 1,
+        value: 'new',
+      });
+
+      expect(attrRepo.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateProductAttribute', () => {
+    it('없는 ID 수정 시 NotFoundException', async () => {
+      attrRepo.findOne.mockResolvedValue(null as unknown as ProductAttribute);
+
+      await expect(
+        service.updateProductAttribute(999, { value: 'x' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('setProductAttributes', () => {
+    it('기존 attributes 삭제 후 신규 일괄 저장', async () => {
+      attrRepo.delete.mockResolvedValue({ affected: 0 } as unknown as Awaited<ReturnType<Repository<ProductAttribute>['delete']>>);
+      attrRepo.create.mockImplementation((dto: unknown) => dto as ProductAttribute);
+      (attrRepo.save as jest.Mock).mockImplementation(async (entities: unknown) => entities as ProductAttribute[]);
+
+      const result = await service.setProductAttributes(10, [
+        { attributeTypeId: 1, value: 'a' },
+        { attributeTypeId: 2, value: 'b', displayValue: 'B' },
+      ]);
+
+      expect(attrRepo.delete).toHaveBeenCalledWith({ productId: 10 });
+      expect(result).toHaveLength(2);
+    });
+
+    it('빈 배열이면 삭제만 수행하고 빈 배열 반환', async () => {
+      attrRepo.delete.mockResolvedValue({ affected: 0 } as unknown as Awaited<ReturnType<Repository<ProductAttribute>['delete']>>);
+
+      const result = await service.setProductAttributes(10, []);
+
+      expect(result).toEqual([]);
+      expect(attrRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAttributeValuesByTypeCode', () => {
+    it('존재하지 않는 code 면 빈 배열', async () => {
+      typeRepo.findOne.mockResolvedValue(null as unknown as AttributeType);
+
+      const result = await service.getAttributeValuesByTypeCode('missing');
+
+      expect(result).toEqual([]);
+    });
+
+    it('validValues 가 있으면 그것을 반환한다', async () => {
+      typeRepo.findOne.mockResolvedValue({
+        id: 1,
+        code: 'clay',
+        validValues: ['zhuni', 'duanni'],
+      } as unknown as AttributeType);
+
+      const result = await service.getAttributeValuesByTypeCode('clay');
+
+      expect(result).toEqual(['zhuni', 'duanni']);
+      expect(attrRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('validValues 가 없으면 product_attributes 에서 distinct 조회', async () => {
+      typeRepo.findOne.mockResolvedValue({
+        id: 1,
+        code: 'clay',
+        validValues: null,
+      } as unknown as AttributeType);
+
+      const qb = createQueryBuilderMock({
+        getRawMany: jest.fn().mockResolvedValue([{ value: 'a' }, { value: 'b' }]),
+      });
+      attrRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getAttributeValuesByTypeCode('clay');
+
+      expect(result).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('getFilterableAttributes', () => {
+    it('isFilterable && isActive 만 sortOrder 순으로 조회한다', async () => {
+      typeRepo.find.mockResolvedValue([]);
+
+      await service.getFilterableAttributes();
+
+      expect(typeRepo.find).toHaveBeenCalledWith({
+        where: { isFilterable: true, isActive: true },
+        order: { sortOrder: 'ASC' },
+      });
+    });
+  });
+});

--- a/backend/src/modules/products/__tests__/product-command.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-command.service.spec.ts
@@ -1,0 +1,208 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { ObjectLiteral, Repository } from 'typeorm';
+import { ProductCommandService } from '../product-command.service';
+import { Product } from '../entities/product.entity';
+import { CacheService } from '../../cache/cache.service';
+import { RestockAlertsService } from '../../restock-alerts/restock-alerts.service';
+
+type RepoMock<T extends ObjectLiteral> = jest.Mocked<
+  Pick<Repository<T>, 'find' | 'findOne' | 'create' | 'save' | 'remove'>
+>;
+
+function createRepoMock<T extends ObjectLiteral>(): RepoMock<T> {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+  } as unknown as RepoMock<T>;
+}
+
+interface ManagerMock {
+  create: jest.Mock;
+  save: jest.Mock;
+  delete: jest.Mock;
+}
+
+describe('ProductCommandService', () => {
+  let service: ProductCommandService;
+  let productRepo: RepoMock<Product>;
+  let cacheService: { del: jest.Mock; delPattern: jest.Mock };
+  let restockAlerts: { processProductRestock: jest.Mock };
+  let manager: ManagerMock;
+  let dataSource: { transaction: jest.Mock };
+
+  beforeEach(async () => {
+    productRepo = createRepoMock<Product>();
+    cacheService = {
+      del: jest.fn().mockResolvedValue(undefined),
+      delPattern: jest.fn().mockResolvedValue(undefined),
+    };
+    restockAlerts = {
+      processProductRestock: jest.fn().mockResolvedValue(undefined),
+    };
+    manager = {
+      create: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    dataSource = {
+      transaction: jest.fn().mockImplementation(async (cb: (m: ManagerMock) => Promise<unknown>) => cb(manager)),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProductCommandService,
+        { provide: getRepositoryToken(Product), useValue: productRepo },
+        { provide: getDataSourceToken(), useValue: dataSource },
+        { provide: CacheService, useValue: cacheService },
+        { provide: RestockAlertsService, useValue: restockAlerts },
+      ],
+    }).compile();
+
+    service = module.get(ProductCommandService);
+  });
+
+  describe('create', () => {
+    it('정상 생성 후 Product 반환', async () => {
+      const created = { id: 1, name: '신상품', stock: 5 } as Product;
+      manager.create.mockReturnValue(created);
+      manager.save.mockResolvedValue(created);
+
+      const result = await service.create({
+        name: '신상품',
+        slug: 'new',
+        price: 1000,
+      });
+
+      expect(dataSource.transaction).toHaveBeenCalled();
+      expect(result).toBe(created);
+    });
+
+    it('categoryId/salePrice/sku 미지정 시 null 로 저장', async () => {
+      const created = { id: 1 } as Product;
+      manager.create.mockReturnValue(created);
+      manager.save.mockResolvedValue(created);
+
+      await service.create({ name: 'p', slug: 'p1', price: 100 });
+
+      expect(manager.create).toHaveBeenCalledWith(
+        Product,
+        expect.objectContaining({
+          categoryId: null,
+          salePrice: null,
+          sku: null,
+        }),
+      );
+    });
+
+    it('이미지 함께 생성하면 ProductImage 도 저장', async () => {
+      const created = { id: 5 } as Product;
+      manager.create.mockReturnValue(created);
+      manager.save.mockResolvedValue(created);
+
+      await service.create({
+        name: 'p',
+        slug: 'p2',
+        price: 100,
+        images: [
+          { url: 'a.jpg' },
+          { url: 'b.jpg' },
+        ],
+      });
+
+      expect(manager.save).toHaveBeenCalledTimes(2); // product + images batch
+    });
+
+    it('ER_DUP_ENTRY 에러는 ConflictException 으로 변환', async () => {
+      const dupErr = Object.assign(new Error('Duplicate entry'), { code: 'ER_DUP_ENTRY' });
+      manager.create.mockReturnValue({ id: 1 } as Product);
+      manager.save.mockRejectedValue(dupErr);
+
+      await expect(
+        service.create({ name: 'p', slug: 'dup', price: 100 }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('일반 에러는 그대로 전파', async () => {
+      manager.create.mockReturnValue({ id: 1 } as Product);
+      manager.save.mockRejectedValue(new Error('DB down'));
+
+      await expect(
+        service.create({ name: 'p', slug: 'p3', price: 100 }),
+      ).rejects.toThrow('DB down');
+    });
+  });
+
+  describe('update', () => {
+    it('없는 ID 수정 시 NotFoundException', async () => {
+      productRepo.findOne.mockResolvedValue(null as unknown as Product);
+
+      await expect(service.update(999, { name: 'x' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('정상 수정 시 캐시 무효화 호출', async () => {
+      const existing = { id: 1, name: 'old', stock: 5 } as Product;
+      productRepo.findOne.mockResolvedValue(existing);
+      manager.save.mockResolvedValue({ ...existing, name: 'new' } as Product);
+
+      await service.update(1, { name: 'new' });
+
+      expect(cacheService.del).toHaveBeenCalled();
+      expect(cacheService.delPattern).toHaveBeenCalled();
+    });
+
+    it('stock 변경 시 RestockAlertsService.processProductRestock 호출', async () => {
+      const existing = { id: 1, stock: 0 } as Product;
+      productRepo.findOne.mockResolvedValue(existing);
+      manager.save.mockResolvedValue({ id: 1, stock: 10 } as Product);
+
+      await service.update(1, { stock: 10 });
+
+      expect(restockAlerts.processProductRestock).toHaveBeenCalledWith(1, 0, 10);
+    });
+
+    it('stock 변경이 없으면 processProductRestock 미호출', async () => {
+      const existing = { id: 1, stock: 5 } as Product;
+      productRepo.findOne.mockResolvedValue(existing);
+      manager.save.mockResolvedValue(existing);
+
+      await service.update(1, { name: 'newName' });
+
+      expect(restockAlerts.processProductRestock).not.toHaveBeenCalled();
+    });
+
+    it('이미지 교체 시 manager.delete 가 먼저 호출됨', async () => {
+      const existing = { id: 1, stock: 0 } as Product;
+      productRepo.findOne.mockResolvedValue(existing);
+      manager.save.mockResolvedValue(existing);
+
+      await service.update(1, { images: [{ url: 'new.jpg' }] });
+
+      expect(manager.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('없는 ID 삭제 시 NotFoundException', async () => {
+      productRepo.findOne.mockResolvedValue(null as unknown as Product);
+
+      await expect(service.remove(999)).rejects.toThrow(NotFoundException);
+    });
+
+    it('정상 삭제 후 메시지 반환 및 캐시 무효화', async () => {
+      const existing = { id: 1 } as Product;
+      productRepo.findOne.mockResolvedValue(existing);
+      productRepo.remove.mockResolvedValue(existing);
+
+      const result = await service.remove(1);
+
+      expect(result).toEqual({ message: '삭제되었습니다.' });
+      expect(cacheService.del).toHaveBeenCalled();
+      expect(cacheService.delPattern).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/products/__tests__/product-query.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-query.service.spec.ts
@@ -1,0 +1,340 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm';
+import { ProductQueryService } from '../product-query.service';
+import { Product, ProductStatus } from '../entities/product.entity';
+import { Category } from '../entities/category.entity';
+import { AttributeType } from '../entities/attribute-type.entity';
+import { Review } from '../../reviews/entities/review.entity';
+import { CacheService } from '../../cache/cache.service';
+import { ProductSort } from '../dto/query-products.dto';
+
+type RepoMock<T extends ObjectLiteral> = jest.Mocked<
+  Pick<Repository<T>, 'find' | 'findOne' | 'createQueryBuilder' | 'increment'>
+>;
+
+function createRepoMock<T extends ObjectLiteral>(): RepoMock<T> {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+    increment: jest.fn().mockResolvedValue(undefined),
+  } as unknown as RepoMock<T>;
+}
+
+interface QueryBuilderMock {
+  leftJoinAndSelect: jest.Mock;
+  innerJoin: jest.Mock;
+  where: jest.Mock;
+  andWhere: jest.Mock;
+  orderBy: jest.Mock;
+  addOrderBy: jest.Mock;
+  skip: jest.Mock;
+  take: jest.Mock;
+  select: jest.Mock;
+  addSelect: jest.Mock;
+  groupBy: jest.Mock;
+  getMany: jest.Mock;
+  getOne: jest.Mock;
+  getManyAndCount: jest.Mock;
+  getRawMany: jest.Mock;
+  limit: jest.Mock;
+}
+
+function createQueryBuilderMock(): QueryBuilderMock {
+  const qb = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([]),
+    getOne: jest.fn(),
+    getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    getRawMany: jest.fn().mockResolvedValue([]),
+    limit: jest.fn().mockReturnThis(),
+  };
+  return qb;
+}
+
+describe('ProductQueryService', () => {
+  let service: ProductQueryService;
+  let productRepo: RepoMock<Product>;
+  let categoryRepo: RepoMock<Category>;
+  let reviewRepo: RepoMock<Review>;
+  let attrTypeRepo: RepoMock<AttributeType>;
+  let cacheService: { get: jest.Mock; set: jest.Mock; del: jest.Mock; delPattern: jest.Mock };
+  let qb: QueryBuilderMock;
+  let reviewQb: QueryBuilderMock;
+
+  beforeEach(async () => {
+    productRepo = createRepoMock<Product>();
+    categoryRepo = createRepoMock<Category>();
+    reviewRepo = createRepoMock<Review>();
+    attrTypeRepo = createRepoMock<AttributeType>();
+    cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+      delPattern: jest.fn().mockResolvedValue(undefined),
+    };
+
+    qb = createQueryBuilderMock();
+    reviewQb = createQueryBuilderMock();
+
+    productRepo.createQueryBuilder.mockReturnValue(qb as unknown as SelectQueryBuilder<Product>);
+    reviewRepo.createQueryBuilder.mockReturnValue(reviewQb as unknown as SelectQueryBuilder<Review>);
+    categoryRepo.find.mockResolvedValue([]);
+    attrTypeRepo.createQueryBuilder.mockReturnValue(qb as unknown as SelectQueryBuilder<AttributeType>);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProductQueryService,
+        { provide: getRepositoryToken(Product), useValue: productRepo },
+        { provide: getRepositoryToken(Category), useValue: categoryRepo },
+        { provide: getRepositoryToken(Review), useValue: reviewRepo },
+        { provide: getRepositoryToken(AttributeType), useValue: attrTypeRepo },
+        { provide: CacheService, useValue: cacheService },
+      ],
+    }).compile();
+
+    service = module.get(ProductQueryService);
+  });
+
+  describe('findAll - 캐시', () => {
+    it('cache hit 시 즉시 반환하고 DB 조회를 건너뛴다', async () => {
+      const cached = { items: [], total: 0, page: 1, limit: 20 };
+      cacheService.get.mockResolvedValue(cached);
+
+      const result = await service.findAll({});
+
+      expect(result).toBe(cached);
+      expect(productRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAll - 가격 필터', () => {
+    it('price_min > price_max 면 BadRequestException', async () => {
+      await expect(
+        service.findAll({ price_min: 50000, price_max: 10000 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('price_min/price_max 가 정상이면 andWhere 호출', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+      reviewQb.getRawMany.mockResolvedValue([]);
+
+      await service.findAll({ price_min: 1000, price_max: 5000 });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('product.price >= :priceMin', { priceMin: 1000 });
+      expect(qb.andWhere).toHaveBeenCalledWith('product.price <= :priceMax', { priceMax: 5000 });
+    });
+  });
+
+  describe('findAll - 검색', () => {
+    it('q 길이 >= 2 → MATCH AGAINST FULLTEXT 사용', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ q: '보이차' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'MATCH(product.name) AGAINST(:q IN BOOLEAN MODE)',
+        { q: '보이차' },
+      );
+    });
+
+    it('q 길이 < 2 → LIKE 검색', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ q: '보' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'product.name LIKE :q',
+        { q: '%보%' },
+      );
+    });
+  });
+
+  describe('findAll - 정렬', () => {
+    it.each([
+      [ProductSort.LATEST, 'product.createdAt', 'DESC'],
+      [ProductSort.PRICE_ASC, 'product.price', 'ASC'],
+      [ProductSort.PRICE_DESC, 'product.price', 'DESC'],
+      [ProductSort.POPULAR, 'product.viewCount', 'DESC'],
+      [ProductSort.REVIEW_COUNT, 'product.reviewCount', 'DESC'],
+      [ProductSort.RATING, 'product.avgRating', 'DESC'],
+    ])('sort=%s → orderBy(%s, %s)', async (sort, field, direction) => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ sort });
+
+      expect(qb.orderBy).toHaveBeenCalledWith(field, direction);
+    });
+  });
+
+  describe('findAll - 페이지네이션', () => {
+    it('skip/take 가 page,limit 에 맞춰 호출된다', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ page: 3, limit: 10 });
+
+      expect(qb.skip).toHaveBeenCalledWith(20); // (3-1)*10
+      expect(qb.take).toHaveBeenCalledWith(10);
+    });
+
+    it('결과를 캐시에 저장한다', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({});
+
+      expect(cacheService.set).toHaveBeenCalled();
+    });
+  });
+
+  describe('findAll - 카테고리 트리', () => {
+    it('categoryId 지정 시 자식 카테고리 ID 까지 조건에 포함', async () => {
+      categoryRepo.find.mockResolvedValue([
+        { id: 11, parentId: 1 } as Category,
+        { id: 12, parentId: 1 } as Category,
+      ]);
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ categoryId: 1 });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'product.categoryId IN (:...categoryIds)',
+        { categoryIds: [1, 11, 12] },
+      );
+    });
+  });
+
+  describe('findAll - admin/공개 분기', () => {
+    it('비관리자는 status=ACTIVE 강제', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ status: 'draft' }, false);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('product.status = :status', {
+        status: ProductStatus.ACTIVE,
+      });
+    });
+
+    it('관리자가 status 지정 시 그대로 적용', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ status: 'draft' }, true);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('product.status = :status', {
+        status: 'draft',
+      });
+    });
+  });
+
+  describe('findOne', () => {
+    it('없는 ID 조회 시 NotFoundException', async () => {
+      qb.getOne.mockResolvedValue(null);
+
+      await expect(service.findOne(999)).rejects.toThrow(NotFoundException);
+    });
+
+    it('비관리자가 draft 상품 조회 시 NotFoundException', async () => {
+      qb.getOne.mockResolvedValue({ id: 1, status: ProductStatus.DRAFT } as Product);
+
+      await expect(service.findOne(1, false)).rejects.toThrow(NotFoundException);
+    });
+
+    it('비관리자가 hidden 상품 조회 시 NotFoundException', async () => {
+      qb.getOne.mockResolvedValue({ id: 2, status: ProductStatus.HIDDEN } as Product);
+
+      await expect(service.findOne(2, false)).rejects.toThrow(NotFoundException);
+    });
+
+    it('정상 조회 후 viewCount 증가는 fire-and-forget', async () => {
+      qb.getOne.mockResolvedValue({ id: 1, status: ProductStatus.ACTIVE } as Product);
+      reviewQb.getRawMany.mockResolvedValue([]);
+
+      const result = await service.findOne(1);
+
+      expect(result.id).toBe(1);
+      expect(productRepo.increment).toHaveBeenCalledWith({ id: 1 }, 'viewCount', 1);
+    });
+
+    it('cache 에 저장되는지 확인', async () => {
+      qb.getOne.mockResolvedValue({ id: 1, status: ProductStatus.ACTIVE } as Product);
+      reviewQb.getRawMany.mockResolvedValue([]);
+
+      await service.findOne(1);
+
+      expect(cacheService.set).toHaveBeenCalled();
+    });
+
+    it('cache hit 인 draft 상품이라도 비관리자는 NotFoundException', async () => {
+      cacheService.get.mockResolvedValue({ id: 1, status: ProductStatus.DRAFT });
+
+      await expect(service.findOne(1, false)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findBulk', () => {
+    it('빈 배열 입력 시 빈 배열 반환', async () => {
+      const result = await service.findBulk([]);
+      expect(result).toEqual([]);
+    });
+
+    it('비관리자는 ACTIVE 상태만 필터링', async () => {
+      qb.getMany.mockResolvedValue([
+        { id: 1, status: ProductStatus.ACTIVE } as Product,
+        { id: 2, status: ProductStatus.HIDDEN } as Product,
+      ]);
+      reviewQb.getRawMany.mockResolvedValue([]);
+
+      const result = await service.findBulk([1, 2], false);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(1);
+    });
+  });
+
+  describe('autocomplete', () => {
+    it('q 길이 < 2 면 빈 배열', async () => {
+      const result = await service.autocomplete('a');
+
+      expect(result).toEqual([]);
+    });
+
+    it('정상 호출 시 LIKE 쿼리 + status=ACTIVE 조건', async () => {
+      qb.getMany.mockResolvedValue([
+        { id: 1, name: '보이차', slug: 'pu-erh' } as Product,
+      ]);
+
+      const result = await service.autocomplete('보이');
+
+      expect(qb.where).toHaveBeenCalledWith('p.name LIKE :q', { q: '보이%' });
+      expect(qb.andWhere).toHaveBeenCalledWith('p.status = :status', { status: ProductStatus.ACTIVE });
+      expect(result).toEqual([{ id: 1, name: '보이차', slug: 'pu-erh' }]);
+    });
+  });
+
+  describe('locale 적용', () => {
+    it('locale=en 이면 nameEn 으로 name 덮어쓴다', async () => {
+      qb.getOne.mockResolvedValue({
+        id: 1,
+        status: ProductStatus.ACTIVE,
+        name: '보이차',
+        nameEn: 'Pu-erh',
+      } as unknown as Product);
+      reviewQb.getRawMany.mockResolvedValue([]);
+
+      const result = await service.findOne(1, false, 'en');
+
+      expect(result.name).toBe('Pu-erh');
+    });
+  });
+});

--- a/backend/src/modules/restock-alerts/__tests__/restock-alerts.service.spec.ts
+++ b/backend/src/modules/restock-alerts/__tests__/restock-alerts.service.spec.ts
@@ -1,0 +1,217 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ObjectLiteral, Repository } from 'typeorm';
+import { RestockAlertsService } from '../restock-alerts.service';
+import { RestockAlert } from '../entities/restock-alert.entity';
+import { Product } from '../../products/entities/product.entity';
+import { ProductOption } from '../../products/entities/product-option.entity';
+import { NotificationService } from '../../notification/notification.service';
+import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
+
+type RepoMock<T extends ObjectLiteral> = jest.Mocked<
+  Pick<Repository<T>, 'find' | 'findOne' | 'create' | 'save' | 'remove'>
+>;
+
+function createRepoMock<T extends ObjectLiteral>(): RepoMock<T> {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+  } as unknown as RepoMock<T>;
+}
+
+describe('RestockAlertsService', () => {
+  let service: RestockAlertsService;
+  let alertRepo: RepoMock<RestockAlert>;
+  let productRepo: RepoMock<Product>;
+  let optionRepo: RepoMock<ProductOption>;
+  let notificationService: { sendRestockAlert: jest.Mock };
+  let dispatchHelper: { dispatch: jest.Mock };
+  let originalFrontendUrl: string | undefined;
+
+  beforeEach(async () => {
+    originalFrontendUrl = process.env.FRONTEND_URL;
+    process.env.FRONTEND_URL = 'http://test.local';
+
+    alertRepo = createRepoMock<RestockAlert>();
+    productRepo = createRepoMock<Product>();
+    optionRepo = createRepoMock<ProductOption>();
+    notificationService = {
+      sendRestockAlert: jest.fn().mockResolvedValue(undefined),
+    };
+    dispatchHelper = {
+      dispatch: jest.fn().mockImplementation(async ({ send }: { send: (recipient: { email: string; name: string }) => Promise<void> }) => {
+        await send({ email: 'u@test.com', name: '사용자' });
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RestockAlertsService,
+        { provide: getRepositoryToken(RestockAlert), useValue: alertRepo },
+        { provide: getRepositoryToken(Product), useValue: productRepo },
+        { provide: getRepositoryToken(ProductOption), useValue: optionRepo },
+        { provide: NotificationService, useValue: notificationService },
+        { provide: NotificationDispatchHelper, useValue: dispatchHelper },
+      ],
+    }).compile();
+
+    service = module.get(RestockAlertsService);
+  });
+
+  afterEach(() => {
+    if (originalFrontendUrl === undefined) {
+      delete process.env.FRONTEND_URL;
+    } else {
+      process.env.FRONTEND_URL = originalFrontendUrl;
+    }
+  });
+
+  describe('createAlert', () => {
+    it('상품을 찾지 못하면 NotFoundException', async () => {
+      productRepo.findOne.mockResolvedValue(null as unknown as Product);
+
+      await expect(service.createAlert(1, 999, {})).rejects.toThrow(NotFoundException);
+    });
+
+    it('재고가 있는 상품에 등록 시도하면 BadRequestException', async () => {
+      productRepo.findOne.mockResolvedValue({ id: 1, stock: 10 } as Product);
+
+      await expect(service.createAlert(1, 1, {})).rejects.toThrow(BadRequestException);
+    });
+
+    it('이미 활성 알림이 있으면 기존 알림 반환', async () => {
+      productRepo.findOne.mockResolvedValue({ id: 1, stock: 0 } as Product);
+      const existing = { id: 5, userId: 1, productId: 1, notifiedAt: null } as unknown as RestockAlert;
+      alertRepo.findOne.mockResolvedValue(existing);
+
+      const result = await service.createAlert(1, 1, {});
+
+      expect(result).toBe(existing);
+      expect(alertRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('재고 0 + 신규 알림 등록 성공', async () => {
+      productRepo.findOne.mockResolvedValue({ id: 1, stock: 0 } as Product);
+      alertRepo.findOne
+        .mockResolvedValueOnce(null as unknown as RestockAlert) // existing check
+        .mockResolvedValueOnce({ id: 99, userId: 1, productId: 1 } as unknown as RestockAlert); // findOrThrow after save
+      const created = { id: 99, userId: 1, productId: 1 } as unknown as RestockAlert;
+      alertRepo.create.mockReturnValue(created);
+      alertRepo.save.mockResolvedValue(created);
+
+      const result = await service.createAlert(1, 1, {});
+
+      expect(alertRepo.create).toHaveBeenCalledWith(expect.objectContaining({
+        userId: 1,
+        productId: 1,
+        notifiedAt: null,
+      }));
+      expect(result.id).toBe(99);
+    });
+
+    it('productOptionId 지정 시 옵션 stock 으로 검증', async () => {
+      productRepo.findOne.mockResolvedValue({ id: 1, stock: 10 } as Product);
+      optionRepo.findOne.mockResolvedValue({ id: 5, productId: 1, stock: 0 } as ProductOption);
+      alertRepo.findOne
+        .mockResolvedValueOnce(null as unknown as RestockAlert)
+        .mockResolvedValueOnce({ id: 99 } as unknown as RestockAlert);
+      const created = { id: 99 } as unknown as RestockAlert;
+      alertRepo.create.mockReturnValue(created);
+      alertRepo.save.mockResolvedValue(created);
+
+      await service.createAlert(1, 1, { productOptionId: 5 });
+
+      expect(optionRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 5, productId: 1 },
+      });
+    });
+
+    it('지정한 옵션이 없으면 NotFoundException', async () => {
+      productRepo.findOne.mockResolvedValue({ id: 1, stock: 10 } as Product);
+      optionRepo.findOne.mockResolvedValue(null as unknown as ProductOption);
+
+      await expect(
+        service.createAlert(1, 1, { productOptionId: 999 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findUserAlerts', () => {
+    it('유저별 알림을 createdAt DESC 로 조회', async () => {
+      alertRepo.find.mockResolvedValue([]);
+
+      await service.findUserAlerts(1);
+
+      expect(alertRepo.find).toHaveBeenCalledWith({
+        where: { userId: 1 },
+        relations: ['product', 'productOption'],
+        order: { createdAt: 'DESC' },
+      });
+    });
+  });
+
+  describe('processProductRestock', () => {
+    it('재고가 0->양수 가 아니면 아무 동작 없음', async () => {
+      await service.processProductRestock(1, 5, 10); // stock 5 -> 10
+      await service.processProductRestock(1, 0, 0); // 0 -> 0
+      await service.processProductRestock(1, 10, 0); // 10 -> 0
+
+      expect(alertRepo.find).not.toHaveBeenCalled();
+      expect(dispatchHelper.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('알림이 없으면 dispatch 없이 종료', async () => {
+      alertRepo.find.mockResolvedValue([]);
+
+      await service.processProductRestock(1, 0, 5);
+
+      expect(dispatchHelper.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('알림이 있으면 dispatch 후 notifiedAt 갱신', async () => {
+      const alert = {
+        id: 1,
+        userId: 100,
+        productId: 1,
+        product: { name: '보이차', slug: 'pu-erh' },
+      } as unknown as RestockAlert;
+      alertRepo.find.mockResolvedValue([alert]);
+      alertRepo.save.mockImplementation(async (entity: unknown) => entity as RestockAlert);
+
+      await service.processProductRestock(1, 0, 10);
+
+      expect(dispatchHelper.dispatch).toHaveBeenCalledTimes(1);
+      expect(notificationService.sendRestockAlert).toHaveBeenCalledWith(
+        'u@test.com',
+        expect.objectContaining({
+          recipientName: '사용자',
+          productName: '보이차',
+          productUrl: 'http://test.local/products/pu-erh',
+        }),
+      );
+      expect(alertRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1, notifiedAt: expect.any(Date) }),
+      );
+    });
+
+    it('FRONTEND_URL 미설정 시 에러', async () => {
+      delete process.env.FRONTEND_URL;
+      const alert = {
+        id: 1,
+        userId: 100,
+        productId: 1,
+        product: { name: '보이차', slug: 'pu-erh' },
+      } as unknown as RestockAlert;
+      alertRepo.find.mockResolvedValue([alert]);
+      alertRepo.save.mockResolvedValue(alert);
+
+      await expect(service.processProductRestock(1, 0, 10)).rejects.toThrow(
+        'FRONTEND_URL environment variable is required',
+      );
+    });
+  });
+});

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -27,6 +27,7 @@ import { registerCmsModulesSuite } from './suites/cms-modules.e2e-spec';
 import { registerCommerceModulesSuite } from './suites/commerce-modules.e2e-spec';
 import { registerRestockAlertsSuite } from './suites/restock-alerts.e2e-spec';
 import { registerAnnouncementBarsSuite } from './suites/announcement-bars.e2e-spec';
+import { registerAuditLogsSuite } from './suites/audit-logs.e2e-spec';
 import { registerMembershipSuite } from './suites/membership.e2e-spec';
 import { registerSeoSuite } from './suites/seo.e2e-spec';
 
@@ -97,6 +98,7 @@ describe('App (e2e)', () => {
   registerCommerceModulesSuite(() => app);
   registerRestockAlertsSuite(() => app);
   registerAnnouncementBarsSuite(() => app);
+  registerAuditLogsSuite(() => app);
   registerMembershipSuite(() => app);
   registerSeoSuite(() => app);
 });

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -26,6 +26,9 @@ import { registerRefundsSuite } from './suites/refunds.e2e-spec';
 import { registerCmsModulesSuite } from './suites/cms-modules.e2e-spec';
 import { registerCommerceModulesSuite } from './suites/commerce-modules.e2e-spec';
 import { registerRestockAlertsSuite } from './suites/restock-alerts.e2e-spec';
+import { registerAnnouncementBarsSuite } from './suites/announcement-bars.e2e-spec';
+import { registerMembershipSuite } from './suites/membership.e2e-spec';
+import { registerSeoSuite } from './suites/seo.e2e-spec';
 
 describe('App (e2e)', () => {
   let app: INestApplication;
@@ -93,4 +96,7 @@ describe('App (e2e)', () => {
   registerCmsModulesSuite(() => app);
   registerCommerceModulesSuite(() => app);
   registerRestockAlertsSuite(() => app);
+  registerAnnouncementBarsSuite(() => app);
+  registerMembershipSuite(() => app);
+  registerSeoSuite(() => app);
 });

--- a/backend/test/setup-env.js
+++ b/backend/test/setup-env.js
@@ -1,8 +1,21 @@
+const { generateKeyPairSync } = require('crypto');
+
 process.env.JWT_SECRET = 'test-secret-key-for-e2e-tests';
 const testDbPort = process.env.TEST_DB_PORT || '3308';
 process.env.DATABASE_URL =
   process.env.TEST_DATABASE_URL ||
   `mysql://root:__REDACTED_ROOT_PW__@127.0.0.1:${testDbPort}/commerce_test`;
+
+if (!process.env.JWT_PRIVATE_KEY || !process.env.JWT_PUBLIC_KEY) {
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  });
+  process.env.JWT_PRIVATE_KEY = privateKey;
+  process.env.JWT_PUBLIC_KEY = publicKey;
+}
+
 process.env.NODE_ENV = 'test';
 process.env.FRONTEND_URL = 'http://localhost:5173';
 process.env.PAYMENT_GATEWAY = 'mock';

--- a/backend/test/suites/announcement-bars.e2e-spec.ts
+++ b/backend/test/suites/announcement-bars.e2e-spec.ts
@@ -1,0 +1,208 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+
+let app: INestApplication;
+let dataSource: DataSource;
+
+function buildAccessCookie(jwtService: JwtService, userId: number, email: string, role: string): string[] {
+  return [
+    `accessToken=${jwtService.sign({ sub: userId, email, role, tokenType: 'access', jti: `bar-${userId}-${Date.now()}` })}`,
+  ];
+}
+
+export function registerAnnouncementBarsSuite(getApp: () => INestApplication) {
+  describe('AnnouncementBars (e2e)', () => {
+    const unique = Date.now();
+    const adminEmail = `bar-admin-${unique}@test.com`;
+    const userEmail = `bar-user-${unique}@test.com`;
+    const messageMarker = `안내바-${unique}`;
+
+    let adminCookies: string[];
+    let userCookies: string[];
+    let adminUserId: number;
+    let userUserId: number;
+    const createdBarIds: number[] = [];
+
+    beforeAll(async () => {
+      app = getApp();
+      dataSource = app.get(DataSource);
+      const jwtService = app.get(JwtService);
+      const passwordHash = await bcrypt.hash('Test1234!', 10);
+
+      const adminInsert = await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, is_email_verified, email_verified_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'admin', 1, 0, 1, NOW(), NOW(), NOW())`,
+        [adminEmail, passwordHash, '안내바 관리자'],
+      );
+      adminUserId = Number(adminInsert.insertId);
+      adminCookies = buildAccessCookie(jwtService, adminUserId, adminEmail, 'admin');
+
+      const userInsert = await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, is_email_verified, email_verified_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'user', 1, 0, 1, NOW(), NOW(), NOW())`,
+        [userEmail, passwordHash, '일반사용자'],
+      );
+      userUserId = Number(userInsert.insertId);
+      userCookies = buildAccessCookie(jwtService, userUserId, userEmail, 'user');
+    });
+
+    afterAll(async () => {
+      if (createdBarIds.length > 0) {
+        await dataSource.query(
+          `DELETE FROM announcement_bars WHERE id IN (${createdBarIds.map(() => '?').join(',')})`,
+          createdBarIds,
+        );
+      }
+      await dataSource.query('DELETE FROM users WHERE id IN (?, ?)', [adminUserId, userUserId]);
+    });
+
+    describe('POST /api/admin/announcement-bars', () => {
+      it('관리자 → 201 안내바 생성', async () => {
+        const res = await request(app.getHttpServer())
+          .post('/api/admin/announcement-bars')
+          .set('Cookie', adminCookies)
+          .send({
+            message: messageMarker,
+            message_en: `Bar-${unique}`,
+            href: '/promotions',
+            sort_order: 99,
+            is_active: true,
+          })
+          .expect(201);
+
+        const body = res.body as { id: number; message: string };
+        expect(body.message).toBe(messageMarker);
+        createdBarIds.push(Number(body.id));
+      });
+
+      it('일반 user → 403', async () => {
+        await request(app.getHttpServer())
+          .post('/api/admin/announcement-bars')
+          .set('Cookie', userCookies)
+          .send({ message: '실패' })
+          .expect(403);
+      });
+
+      it('비인증 → 401', async () => {
+        await request(app.getHttpServer())
+          .post('/api/admin/announcement-bars')
+          .send({ message: '비인증' })
+          .expect(401);
+      });
+    });
+
+    describe('GET /api/announcement-bars (public)', () => {
+      it('비인증 200 - 활성 안내바 목록 반환', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/announcement-bars')
+          .expect(200);
+
+        const body = res.body as Array<{ id: number; message: string }>;
+        expect(Array.isArray(body)).toBe(true);
+        expect(body.some((b) => Number(b.id) === createdBarIds[0])).toBe(true);
+      });
+
+      it('locale=en 이면 message_en 으로 message 가 치환된다', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/announcement-bars?locale=en')
+          .expect(200);
+
+        const body = res.body as Array<{ id: number; message: string }>;
+        const created = body.find((b) => Number(b.id) === createdBarIds[0]);
+        expect(created?.message).toBe(`Bar-${unique}`);
+      });
+    });
+
+    describe('GET /api/admin/announcement-bars (admin)', () => {
+      it('비활성 항목까지 모두 반환', async () => {
+        // 비활성 안내바 추가
+        const inactiveRes = await request(app.getHttpServer())
+          .post('/api/admin/announcement-bars')
+          .set('Cookie', adminCookies)
+          .send({ message: `${messageMarker}-비활성`, is_active: false, sort_order: 100 })
+          .expect(201);
+        const inactiveId = Number((inactiveRes.body as { id: number }).id);
+        createdBarIds.push(inactiveId);
+
+        const res = await request(app.getHttpServer())
+          .get('/api/admin/announcement-bars')
+          .set('Cookie', adminCookies)
+          .expect(200);
+
+        const body = res.body as Array<{ id: number; is_active: boolean }>;
+        expect(body.some((b) => Number(b.id) === inactiveId)).toBe(true);
+      });
+
+      it('일반 user → 403', async () => {
+        await request(app.getHttpServer())
+          .get('/api/admin/announcement-bars')
+          .set('Cookie', userCookies)
+          .expect(403);
+      });
+    });
+
+    describe('PATCH /api/admin/announcement-bars/:id', () => {
+      it('수정 성공', async () => {
+        const id = createdBarIds[0];
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/announcement-bars/${id}`)
+          .set('Cookie', adminCookies)
+          .send({ message: `${messageMarker}-수정` })
+          .expect(200);
+
+        const body = res.body as { id: number; message: string };
+        expect(body.message).toBe(`${messageMarker}-수정`);
+      });
+
+      it('없는 ID 수정 → 404', async () => {
+        await request(app.getHttpServer())
+          .patch('/api/admin/announcement-bars/999999')
+          .set('Cookie', adminCookies)
+          .send({ message: 'x' })
+          .expect(404);
+      });
+    });
+
+    describe('PATCH /api/admin/announcement-bars/reorder', () => {
+      it('순서 변경 성공 (204)', async () => {
+        if (createdBarIds.length < 2) return;
+        await request(app.getHttpServer())
+          .patch('/api/admin/announcement-bars/reorder')
+          .set('Cookie', adminCookies)
+          .send({
+            orders: [
+              { id: createdBarIds[0], sort_order: 50 },
+              { id: createdBarIds[1], sort_order: 51 },
+            ],
+          })
+          .expect(204);
+      });
+    });
+
+    describe('DELETE /api/admin/announcement-bars/:id', () => {
+      it('삭제 성공 (204)', async () => {
+        const createRes = await request(app.getHttpServer())
+          .post('/api/admin/announcement-bars')
+          .set('Cookie', adminCookies)
+          .send({ message: `${messageMarker}-삭제대상`, is_active: true })
+          .expect(201);
+        const id = Number((createRes.body as { id: number }).id);
+
+        await request(app.getHttpServer())
+          .delete(`/api/admin/announcement-bars/${id}`)
+          .set('Cookie', adminCookies)
+          .expect(204);
+      });
+
+      it('없는 ID 삭제 → 404', async () => {
+        await request(app.getHttpServer())
+          .delete('/api/admin/announcement-bars/999999')
+          .set('Cookie', adminCookies)
+          .expect(404);
+      });
+    });
+  });
+}

--- a/backend/test/suites/audit-logs.e2e-spec.ts
+++ b/backend/test/suites/audit-logs.e2e-spec.ts
@@ -1,0 +1,128 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { AuditAction } from '../../src/modules/audit-logs/entities/audit-log.entity';
+
+let app: INestApplication;
+let dataSource: DataSource;
+
+function buildAccessCookie(jwtService: JwtService, userId: number, email: string, role: string): string[] {
+  return [
+    `accessToken=${jwtService.sign({ sub: userId, email, role, tokenType: 'access', jti: `audit-${userId}-${Date.now()}` })}`,
+  ];
+}
+
+export function registerAuditLogsSuite(getApp: () => INestApplication) {
+  describe('Audit logs (e2e)', () => {
+    const unique = Date.now();
+    const adminEmail = `audit-admin-${unique}@test.com`;
+    const userEmail = `audit-user-${unique}@test.com`;
+    const createdUserIds: number[] = [];
+    const createdAuditLogIds: number[] = [];
+
+    let adminCookies: string[];
+    let userCookies: string[];
+    let adminUserId: number;
+
+    beforeAll(async () => {
+      app = getApp();
+      dataSource = app.get(DataSource);
+      const jwtService = app.get(JwtService);
+      const passwordHash = await bcrypt.hash('Test1234!', 10);
+
+      const adminInsert = await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, is_email_verified, email_verified_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'admin', 1, 0, 1, NOW(), NOW(), NOW())`,
+        [adminEmail, passwordHash, '감사 관리자'],
+      );
+      adminUserId = Number(adminInsert.insertId);
+      createdUserIds.push(adminUserId);
+      adminCookies = buildAccessCookie(jwtService, adminUserId, adminEmail, 'admin');
+
+      const userInsert = await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, is_email_verified, email_verified_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'user', 1, 0, 1, NOW(), NOW(), NOW())`,
+        [userEmail, passwordHash, '일반 사용자'],
+      );
+      const userId = Number(userInsert.insertId);
+      createdUserIds.push(userId);
+      userCookies = buildAccessCookie(jwtService, userId, userEmail, 'user');
+
+      const logInsert = await dataSource.query(
+        `INSERT INTO audit_logs (actorId, actorRole, action, resourceType, resourceId, beforeJson, afterJson, ip, userAgent, createdAt)
+         VALUES (?, 'admin', ?, 'order', 91001, ?, ?, '127.0.0.1', 'e2e-agent', NOW())`,
+        [
+          adminUserId,
+          AuditAction.ORDER_STATUS_UPDATE,
+          JSON.stringify({ status: 'pending' }),
+          JSON.stringify({ status: 'paid' }),
+        ],
+      );
+      createdAuditLogIds.push(Number(logInsert.insertId));
+    });
+
+    afterAll(async () => {
+      if (createdAuditLogIds.length > 0) {
+        await dataSource.query(
+          `DELETE FROM audit_logs WHERE id IN (${createdAuditLogIds.map(() => '?').join(',')})`,
+          createdAuditLogIds,
+        );
+      }
+      if (createdUserIds.length > 0) {
+        await dataSource.query(
+          `DELETE FROM users WHERE id IN (${createdUserIds.map(() => '?').join(',')})`,
+          createdUserIds,
+        );
+      }
+    });
+
+    describe('GET /api/admin/audit-logs', () => {
+      it('관리자 → 200 감사 로그 목록과 페이지네이션 반환', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/admin/audit-logs')
+          .query({ actorId: adminUserId, action: AuditAction.ORDER_STATUS_UPDATE, resourceType: 'order' })
+          .set('Cookie', adminCookies)
+          .expect(200);
+
+        const body = res.body as {
+          data: Array<{ id: number; actorId: number; action: string; resourceType: string; resourceId: number }>;
+          total: number;
+          page: number;
+          limit: number;
+        };
+        expect(body.page).toBe(1);
+        expect(body.limit).toBe(20);
+        expect(body.total).toBeGreaterThanOrEqual(1);
+        expect(body.data.some((log) => Number(log.id) === createdAuditLogIds[0])).toBe(true);
+        expect(body.data[0]).toMatchObject({
+          actorId: adminUserId,
+          action: AuditAction.ORDER_STATUS_UPDATE,
+          resourceType: 'order',
+        });
+      });
+
+      it('일반 user → 403', async () => {
+        await request(app.getHttpServer())
+          .get('/api/admin/audit-logs')
+          .set('Cookie', userCookies)
+          .expect(403);
+      });
+
+      it('비인증 → 401', async () => {
+        await request(app.getHttpServer())
+          .get('/api/admin/audit-logs')
+          .expect(401);
+      });
+
+      it('잘못된 action 필터 → 400', async () => {
+        await request(app.getHttpServer())
+          .get('/api/admin/audit-logs')
+          .query({ action: 'NOT_A_REAL_ACTION' })
+          .set('Cookie', adminCookies)
+          .expect(400);
+      });
+    });
+  });
+}

--- a/backend/test/suites/membership.e2e-spec.ts
+++ b/backend/test/suites/membership.e2e-spec.ts
@@ -151,9 +151,43 @@ export function registerMembershipSuite(getApp: () => INestApplication) {
         const body = res.body as { pointRate: number | string };
         expect(Number(body.pointRate)).toBe(3);
       });
+
+      it('없는 ID 수정 → 404', async () => {
+        await request(app.getHttpServer())
+          .patch('/api/admin/membership-tiers/999999')
+          .set('Cookie', adminCookies)
+          .send({ pointRate: 4 })
+          .expect(404);
+      });
     });
 
     describe('GET /api/users/me/tier', () => {
+      it('누적 금액 기준 현재/다음 등급 정보를 반환', async () => {
+        await dataSource.query(
+          'UPDATE users SET tier = ?, tier_accumulated_amount = ?, tier_evaluated_at = NOW() WHERE id = ?',
+          [tierName, 100000, userUserId],
+        );
+
+        const res = await request(app.getHttpServer())
+          .get('/api/users/me/tier')
+          .set('Cookie', userCookies)
+          .expect(200);
+
+        const body = res.body as {
+          tier: string;
+          tierAccumulatedAmount: number;
+          tierDetails: { id: number; name: string };
+          nextTier: { name: string; minAmount: number | string };
+          amountToNextTier: number;
+        };
+        expect(body.tier).toBe(tierName);
+        expect(Number(body.tierAccumulatedAmount)).toBe(100000);
+        expect(Number(body.tierDetails.id)).toBe(createdTierIds[0]);
+        expect(body.nextTier.name).toBe('Silver');
+        expect(Number(body.nextTier.minAmount)).toBe(300000);
+        expect(Number(body.amountToNextTier)).toBe(200000);
+      });
+
       it('인증된 사용자 → 200, tier 정보 반환', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/users/me/tier')

--- a/backend/test/suites/membership.e2e-spec.ts
+++ b/backend/test/suites/membership.e2e-spec.ts
@@ -1,0 +1,182 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+
+let app: INestApplication;
+let dataSource: DataSource;
+
+function buildAccessCookie(jwtService: JwtService, userId: number, email: string, role: string): string[] {
+  return [
+    `accessToken=${jwtService.sign({ sub: userId, email, role, tokenType: 'access', jti: `mb-${userId}-${Date.now()}` })}`,
+  ];
+}
+
+export function registerMembershipSuite(getApp: () => INestApplication) {
+  describe('Membership (e2e)', () => {
+    const unique = Date.now();
+    const adminEmail = `mb-admin-${unique}@test.com`;
+    const userEmail = `mb-user-${unique}@test.com`;
+    const tierName = `테스트등급-${unique}`;
+
+    let adminCookies: string[];
+    let userCookies: string[];
+    let adminUserId: number;
+    let userUserId: number;
+    const createdTierIds: number[] = [];
+
+    beforeAll(async () => {
+      app = getApp();
+      dataSource = app.get(DataSource);
+      const jwtService = app.get(JwtService);
+      const passwordHash = await bcrypt.hash('Test1234!', 10);
+
+      const adminInsert = await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, is_email_verified, email_verified_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'admin', 1, 0, 1, NOW(), NOW(), NOW())`,
+        [adminEmail, passwordHash, '등급 관리자'],
+      );
+      adminUserId = Number(adminInsert.insertId);
+      adminCookies = buildAccessCookie(jwtService, adminUserId, adminEmail, 'admin');
+
+      const userInsert = await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, is_email_verified, email_verified_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'user', 1, 0, 1, NOW(), NOW(), NOW())`,
+        [userEmail, passwordHash, '일반사용자'],
+      );
+      userUserId = Number(userInsert.insertId);
+      userCookies = buildAccessCookie(jwtService, userUserId, userEmail, 'user');
+    });
+
+    afterAll(async () => {
+      if (createdTierIds.length > 0) {
+        await dataSource.query(
+          `DELETE FROM membership_tiers WHERE id IN (${createdTierIds.map(() => '?').join(',')})`,
+          createdTierIds,
+        );
+      }
+      await dataSource.query('DELETE FROM users WHERE id IN (?, ?)', [adminUserId, userUserId]);
+    });
+
+    describe('POST /api/admin/membership-tiers', () => {
+      it('관리자 → 201 등급 생성', async () => {
+        const res = await request(app.getHttpServer())
+          .post('/api/admin/membership-tiers')
+          .set('Cookie', adminCookies)
+          .send({
+            name: tierName,
+            minAmount: 100000,
+            pointRate: 2,
+            sortOrder: 99,
+          })
+          .expect(201);
+
+        const body = res.body as { id: number; name: string };
+        expect(body.name).toBe(tierName);
+        createdTierIds.push(Number(body.id));
+      });
+
+      it('동일한 등급명 생성 시 409 Conflict', async () => {
+        await request(app.getHttpServer())
+          .post('/api/admin/membership-tiers')
+          .set('Cookie', adminCookies)
+          .send({ name: tierName, minAmount: 100000, pointRate: 1 })
+          .expect(409);
+      });
+
+      it('일반 user → 403', async () => {
+        await request(app.getHttpServer())
+          .post('/api/admin/membership-tiers')
+          .set('Cookie', userCookies)
+          .send({ name: '실패등급', minAmount: 0, pointRate: 1 })
+          .expect(403);
+      });
+
+      it('비인증 → 401', async () => {
+        await request(app.getHttpServer())
+          .post('/api/admin/membership-tiers')
+          .send({ name: '실패', minAmount: 0, pointRate: 1 })
+          .expect(401);
+      });
+    });
+
+    describe('GET /api/admin/membership-tiers', () => {
+      it('관리자 → 200 등급 목록 반환', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/admin/membership-tiers')
+          .set('Cookie', adminCookies)
+          .expect(200);
+
+        const body = res.body as Array<{ id: number; name: string }>;
+        expect(Array.isArray(body)).toBe(true);
+        expect(body.some((t) => Number(t.id) === createdTierIds[0])).toBe(true);
+      });
+
+      it('일반 user → 403', async () => {
+        await request(app.getHttpServer())
+          .get('/api/admin/membership-tiers')
+          .set('Cookie', userCookies)
+          .expect(403);
+      });
+    });
+
+    describe('GET /api/admin/membership-tiers/:id', () => {
+      it('관리자 → 200 단건 조회', async () => {
+        const res = await request(app.getHttpServer())
+          .get(`/api/admin/membership-tiers/${createdTierIds[0]}`)
+          .set('Cookie', adminCookies)
+          .expect(200);
+
+        const body = res.body as { id: number; name: string };
+        expect(body.name).toBe(tierName);
+      });
+
+      it('없는 ID → 404', async () => {
+        await request(app.getHttpServer())
+          .get('/api/admin/membership-tiers/999999')
+          .set('Cookie', adminCookies)
+          .expect(404);
+      });
+    });
+
+    describe('PATCH /api/admin/membership-tiers/:id', () => {
+      it('수정 성공', async () => {
+        const res = await request(app.getHttpServer())
+          .patch(`/api/admin/membership-tiers/${createdTierIds[0]}`)
+          .set('Cookie', adminCookies)
+          .send({ pointRate: 3 })
+          .expect(200);
+
+        const body = res.body as { pointRate: number | string };
+        expect(Number(body.pointRate)).toBe(3);
+      });
+    });
+
+    describe('GET /api/users/me/tier', () => {
+      it('인증된 사용자 → 200, tier 정보 반환', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/users/me/tier')
+          .set('Cookie', userCookies)
+          .expect(200);
+
+        const body = res.body as {
+          tier: string;
+          tierAccumulatedAmount: number;
+          tierDetails: unknown;
+          nextTier: unknown;
+          amountToNextTier: number | null;
+        };
+        expect(body).toHaveProperty('tier');
+        expect(body).toHaveProperty('tierAccumulatedAmount');
+        expect(body).toHaveProperty('tierEvaluatedAt');
+      });
+
+      it('비인증 → 401', async () => {
+        await request(app.getHttpServer())
+          .get('/api/users/me/tier')
+          .expect(401);
+      });
+    });
+  });
+}

--- a/backend/test/suites/seo.e2e-spec.ts
+++ b/backend/test/suites/seo.e2e-spec.ts
@@ -1,0 +1,70 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+
+let app: INestApplication;
+
+export function registerSeoSuite(getApp: () => INestApplication) {
+  describe('SEO (e2e)', () => {
+    beforeAll(() => {
+      app = getApp();
+    });
+
+    describe('GET /api/sitemap.xml', () => {
+      it('200 + Content-Type=application/xml', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/sitemap.xml')
+          .expect(200)
+          .expect('Content-Type', /application\/xml/);
+
+        const xml = res.text;
+        expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+        expect(xml).toContain('<urlset');
+      });
+
+      it('hreflang alternate 링크가 포함된다', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/sitemap.xml')
+          .expect(200);
+
+        const xml = res.text;
+        // 항상 ko/en 두 alternate 가 들어있고 x-default 도 있어야 함
+        // (DB 데이터가 없으면 url 노드가 비어있을 수 있으므로 urlset 자체만 검증)
+        expect(xml).toContain('xmlns:xhtml="http://www.w3.org/1999/xhtml"');
+        expect(xml).toContain('</urlset>');
+      });
+
+      it('Cache-Control 헤더가 설정된다', async () => {
+        await request(app.getHttpServer())
+          .get('/api/sitemap.xml')
+          .expect(200)
+          .expect('Cache-Control', /max-age=3600/);
+      });
+    });
+
+    describe('GET /api/robots.txt', () => {
+      it('200 + Content-Type=text/plain', async () => {
+        const res = await request(app.getHttpServer())
+          .get('/api/robots.txt')
+          .expect(200)
+          .expect('Content-Type', /text\/plain/);
+
+        const txt = res.text;
+        expect(txt).toContain('User-agent: *');
+      });
+
+      it('비프로덕션 환경에서는 Disallow: /', async () => {
+        // E2E 테스트는 NODE_ENV=test 또는 development 로 동작 → Disallow 정책
+        const originalEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'test';
+        try {
+          const res = await request(app.getHttpServer())
+            .get('/api/robots.txt')
+            .expect(200);
+          expect(res.text).toContain('Disallow: /');
+        } finally {
+          process.env.NODE_ENV = originalEnv;
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add backend E2E coverage for admin audit log listing, authz, and invalid filters
- Expand membership tier E2E assertions for missing tier update and current/next tier calculation
- Keep backend E2E self-bootstrapping by generating test JWT keys when local PEM files are absent

## Verification
- bash scripts/test.sh e2e: passed, app E2E 256 tests + password reset 2 tests
- bash scripts/test.sh all: frontend 70/414 and backend unit 93/923 passed; first E2E pass hit an existing Admin Orders 401 flake, rerun E2E passed

## Notes
- No admin SEO mutation or membership subscribe/unsubscribe endpoint exists in the current backend surface, so this locks existing API behavior rather than adding new endpoints.