### PR TITLE
test: harden frontend auth cart checkout coverage

### DIFF
--- a/src/components/__tests__/AuthContext.test.tsx
+++ b/src/components/__tests__/AuthContext.test.tsx
@@ -20,7 +20,12 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock('@/utils/navigation', () => ({
+  redirectTo: vi.fn(),
+}));
+
 import { authApi } from '@/lib/api';
+import { redirectTo } from '@/utils/navigation';
 
 const mockUser: AuthUser = { id: 1, email: 'test@example.com', name: '홍길동', role: 'user' };
 const mockTokenResponse: AuthTokenResponse = {
@@ -34,6 +39,7 @@ function AuthDisplay() {
       <span data-testid="loading">{isLoading ? 'loading' : 'idle'}</span>
       <span data-testid="authenticated">{isAuthenticated ? 'yes' : 'no'}</span>
       <span data-testid="user">{user ? user.email : 'none'}</span>
+      <span data-testid="name">{user ? user.name : 'none'}</span>
     </div>
   );
 }
@@ -53,6 +59,21 @@ function RegisterButton() {
   return <button onClick={() => register('test@example.com', 'password1', '홍길동')}>register</button>;
 }
 
+function UpdateUserButton() {
+  const { updateUser } = useAuth();
+  return <button onClick={() => updateUser({ name: '수정된 이름', phone: '010-0000-0000' })}>update-user</button>;
+}
+
+function OAuthButtons() {
+  const { loginWithKakao, loginWithGoogle } = useAuth();
+  return (
+    <>
+      <button onClick={loginWithKakao}>kakao</button>
+      <button onClick={loginWithGoogle}>google</button>
+    </>
+  );
+}
+
 function renderWithProvider(ui: React.ReactNode) {
   return render(<AuthProvider>{ui}</AuthProvider>);
 }
@@ -61,6 +82,16 @@ describe('AuthContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
+    vi.stubEnv('NEXT_PUBLIC_KAKAO_CLIENT_ID', 'kakao-client');
+    vi.stubEnv('NEXT_PUBLIC_KAKAO_REDIRECT_URI', 'https://shop.test/auth/kakao/callback');
+    vi.stubEnv('NEXT_PUBLIC_GOOGLE_CLIENT_ID', 'google-client');
+    vi.stubEnv('NEXT_PUBLIC_GOOGLE_REDIRECT_URI', 'https://shop.test/auth/google/callback');
+    vi.stubGlobal('crypto', {
+      getRandomValues: (array: Uint8Array) => {
+        array.fill(1);
+        return array;
+      },
+    });
   });
 
   it('isLoading starts true then becomes false after init', async () => {
@@ -186,5 +217,60 @@ describe('AuthContext', () => {
       expect(authApi.register).toHaveBeenCalledWith('test@example.com', 'password1', '홍길동');
     });
     expect(screen.getByTestId('user').textContent).toBe('none');
+  });
+
+  it('updateUser merges partial user fields without dropping existing profile', async () => {
+    vi.mocked(authApi.me).mockResolvedValue(mockUser);
+    const { getByRole } = renderWithProvider(
+      <>
+        <AuthDisplay />
+        <UpdateUserButton />
+      </>,
+    );
+    await waitFor(() => expect(screen.getByTestId('user').textContent).toBe('test@example.com'));
+
+    await act(async () => {
+      getByRole('button', { name: 'update-user' }).click();
+    });
+
+    expect(screen.getByTestId('user').textContent).toBe('test@example.com');
+    expect(screen.getByTestId('name').textContent).toBe('수정된 이름');
+  });
+
+  it('loginWithKakao stores CSRF state and redirects to Kakao authorize URL', async () => {
+    vi.mocked(authApi.me).mockRejectedValue(new Error('Unauthorized'));
+    vi.mocked(authApi.refresh).mockRejectedValue(new Error('Refresh failed'));
+    const { getByRole } = renderWithProvider(<OAuthButtons />);
+    await waitFor(() => expect(screen.queryByText('loading')).not.toBeInTheDocument());
+
+    await act(async () => {
+      getByRole('button', { name: 'kakao' }).click();
+    });
+
+    const state = sessionStorage.getItem('oauth_state');
+    expect(state).toBe('01'.repeat(32));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining('https://kauth.kakao.com/oauth/authorize'));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining('client_id=kakao-client'));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining('redirect_uri=https%3A%2F%2Fshop.test%2Fauth%2Fkakao%2Fcallback'));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining(`state=${state}`));
+  });
+
+  it('loginWithGoogle stores CSRF state and redirects with openid email profile scope', async () => {
+    vi.mocked(authApi.me).mockRejectedValue(new Error('Unauthorized'));
+    vi.mocked(authApi.refresh).mockRejectedValue(new Error('Refresh failed'));
+    const { getByRole } = renderWithProvider(<OAuthButtons />);
+    await waitFor(() => expect(authApi.refresh).toHaveBeenCalled());
+
+    await act(async () => {
+      getByRole('button', { name: 'google' }).click();
+    });
+
+    const state = sessionStorage.getItem('oauth_state');
+    expect(state).toBe('01'.repeat(32));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining('https://accounts.google.com/o/oauth2/v2/auth'));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining('client_id=google-client'));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining('redirect_uri=https%3A%2F%2Fshop.test%2Fauth%2Fgoogle%2Fcallback'));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining('scope=openid%20email%20profile'));
+    expect(redirectTo).toHaveBeenCalledWith(expect.stringContaining(`state=${state}`));
   });
 });

--- a/src/components/__tests__/CartContext.test.tsx
+++ b/src/components/__tests__/CartContext.test.tsx
@@ -98,6 +98,11 @@ function AddItemButton({ params }: { params: Parameters<ReturnType<typeof useCar
   return <button onClick={() => addItem(params)}>add</button>;
 }
 
+function UpdateQtyButton({ id, quantity }: { id: number; quantity: number }) {
+  const { updateQuantity } = useCart();
+  return <button onClick={() => updateQuantity(id, quantity)}>update</button>;
+}
+
 function RemoveItemButton({ id }: { id: number }) {
   const { removeItem } = useCart();
   return <button onClick={() => removeItem(id)}>remove</button>;
@@ -106,6 +111,7 @@ function RemoveItemButton({ id }: { id: number }) {
 describe('CartContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it('fetches cart on mount when authenticated', async () => {
@@ -181,15 +187,10 @@ describe('CartContext', () => {
     vi.mocked(cartApi.getList).mockResolvedValue(mockCartResponse);
     vi.mocked(cartApi.updateQuantity).mockResolvedValue({ ...mockCartItem, quantity: 5, subtotal: 75000 });
 
-    function UpdateQtyButton() {
-      const { updateQuantity } = useCart();
-      return <button onClick={() => updateQuantity(1, 5)}>update</button>;
-    }
-
     renderWithAuth(
       <>
         <CartDisplay />
-        <UpdateQtyButton />
+        <UpdateQtyButton id={1} quantity={5} />
       </>,
       makeAuthValue({ isAuthenticated: true, user: { id: 1, email: 'a@b.com', name: 'Test', role: 'user' } }),
     );
@@ -204,5 +205,99 @@ describe('CartContext', () => {
         { quantity: 5 },
       );
     });
+  });
+
+  it('loads guest cart from localStorage without calling backend', async () => {
+    localStorage.setItem('guest_cart', JSON.stringify([{ productId: 10, productOptionId: null, quantity: 3 }]));
+
+    renderWithAuth(<CartDisplay />, makeAuthValue({ isAuthenticated: false }));
+
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('3'));
+    expect(cartApi.getList).not.toHaveBeenCalled();
+    expect(screen.getByTestId('total').textContent).toBe('0');
+  });
+
+  it('guest addItem merges identical product/option and persists localStorage', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('guest_cart', JSON.stringify([{ productId: 10, productOptionId: null, quantity: 1 }]));
+
+    renderWithAuth(
+      <>
+        <CartDisplay />
+        <AddItemButton params={{ productId: 10, productOptionId: null, quantity: 2 }} />
+      </>,
+      makeAuthValue({ isAuthenticated: false }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'add' }));
+
+    expect(screen.getByTestId('count').textContent).toBe('3');
+    expect(JSON.parse(localStorage.getItem('guest_cart') ?? '[]')).toEqual([
+      { productId: 10, productOptionId: null, quantity: 3 },
+    ]);
+    expect(cartApi.add).not.toHaveBeenCalled();
+  });
+
+  it('guest updateQuantity and removeItem update localStorage by negative guest id', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      'guest_cart',
+      JSON.stringify([
+        { productId: 10, productOptionId: null, quantity: 1 },
+        { productId: 11, productOptionId: 7, quantity: 2 },
+      ]),
+    );
+
+    renderWithAuth(
+      <>
+        <CartDisplay />
+        <UpdateQtyButton id={-1} quantity={4} />
+        <RemoveItemButton id={-2} />
+      </>,
+      makeAuthValue({ isAuthenticated: false }),
+    );
+
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('3'));
+    await user.click(screen.getByRole('button', { name: 'update' }));
+    expect(JSON.parse(localStorage.getItem('guest_cart') ?? '[]')[0].quantity).toBe(4);
+    expect(screen.getByTestId('count').textContent).toBe('6');
+
+    await user.click(screen.getByRole('button', { name: 'remove' }));
+    expect(JSON.parse(localStorage.getItem('guest_cart') ?? '[]')).toEqual([
+      { productId: 10, productOptionId: null, quantity: 4 },
+    ]);
+    expect(screen.getByTestId('count').textContent).toBe('4');
+    expect(cartApi.updateQuantity).not.toHaveBeenCalled();
+    expect(cartApi.remove).not.toHaveBeenCalled();
+  });
+
+  it('merges guest cart into backend cart after auth transition and clears guest storage', async () => {
+    const authValue = makeAuthValue({ isAuthenticated: false });
+    localStorage.setItem('guest_cart', JSON.stringify([{ productId: 10, productOptionId: null, quantity: 2 }]));
+    vi.mocked(cartApi.add).mockResolvedValue(mockCartResponse);
+    vi.mocked(cartApi.getList).mockResolvedValue(mockCartResponse);
+
+    const { rerender } = render(
+      <AuthContext.Provider value={authValue}>
+        <CartProvider>
+          <CartDisplay />
+        </CartProvider>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+
+    rerender(
+      <AuthContext.Provider
+        value={makeAuthValue({ isAuthenticated: true, user: { id: 1, email: 'a@b.com', name: 'Test', role: 'user' } })}
+      >
+        <CartProvider>
+          <CartDisplay />
+        </CartProvider>
+      </AuthContext.Provider>,
+    );
+
+    await waitFor(() => expect(cartApi.add).toHaveBeenCalledWith({ productId: 10, productOptionId: null, quantity: 2 }));
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+    expect(localStorage.getItem('guest_cart')).toBeNull();
   });
 });

--- a/src/components/shared/hooks/__tests__/useAsyncAction.test.tsx
+++ b/src/components/shared/hooks/__tests__/useAsyncAction.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { GlobalLoadingProvider } from '@/contexts/GlobalLoadingContext';
+import { useAsyncAction } from '../useAsyncAction';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <GlobalLoadingProvider>{children}</GlobalLoadingProvider>;
+}
+
+describe('useAsyncAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('성공 시 결과 반환 + successMessage 토스트 + onSuccess 콜백', async () => {
+    const fn = vi.fn().mockResolvedValue('result-value');
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(
+      () => useAsyncAction(fn, { successMessage: '저장되었습니다.', onSuccess }),
+      { wrapper },
+    );
+
+    let returned: unknown;
+    await act(async () => {
+      returned = await result.current.execute(undefined);
+    });
+
+    expect(returned).toBe('result-value');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(toast.success).toHaveBeenCalledWith('저장되었습니다.');
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('successMessage 없으면 토스트는 호출되지 않는다', async () => {
+    const fn = vi.fn().mockResolvedValue(1);
+
+    const { result } = renderHook(() => useAsyncAction(fn), { wrapper });
+
+    await act(async () => {
+      await result.current.execute(undefined);
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('실패 시 에러 토스트 + onError 콜백 + 에러 throw', async () => {
+    const err = new Error('서버 오류');
+    const fn = vi.fn().mockRejectedValue(err);
+    const onError = vi.fn();
+
+    const { result } = renderHook(
+      () => useAsyncAction(fn, { errorMessage: '저장 실패', onError }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await expect(result.current.execute(undefined)).rejects.toThrow('서버 오류');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('서버 오류');
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+
+  it('Error 가 아닌 예외는 errorMessage fallback 사용', async () => {
+    const fn = vi.fn().mockRejectedValue('string-error');
+
+    const { result } = renderHook(
+      () => useAsyncAction(fn, { errorMessage: '커스텀 폴백' }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await expect(result.current.execute(undefined)).rejects.toBe('string-error');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('커스텀 폴백');
+  });
+
+  it('errorMessage 미지정 시 기본 폴백 사용', async () => {
+    const fn = vi.fn().mockRejectedValue(null);
+
+    const { result } = renderHook(() => useAsyncAction(fn), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.execute(undefined)).rejects.toBeNull();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('오류가 발생했습니다.');
+  });
+
+  it('실행 중 isLoading이 true가 되고 완료 후 false로 돌아온다', async () => {
+    let resolve!: (value: number) => void;
+    const fn = vi.fn(() => new Promise<number>((r) => { resolve = r; }));
+
+    const { result } = renderHook(() => useAsyncAction(fn), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+
+    let executePromise!: Promise<number>;
+    act(() => {
+      executePromise = result.current.execute(undefined);
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    await act(async () => {
+      resolve(42);
+      await executePromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('인자(arg)를 받아서 fn에 그대로 전달한다', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useAsyncAction<void, { id: number }>(fn), { wrapper });
+
+    await act(async () => {
+      await result.current.execute({ id: 7 });
+    });
+
+    expect(fn).toHaveBeenCalledWith({ id: 7 });
+  });
+});

--- a/src/components/shared/hooks/__tests__/useCheckout.test.tsx
+++ b/src/components/shared/hooks/__tests__/useCheckout.test.tsx
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type {
+  CartItem,
+  PreparePaymentResponse,
+  OrderResponse,
+} from '@/lib/api';
+import type { ShippingForm } from '@/app/[locale]/checkout/page';
+import type { PaymentGatewayHandle } from '@/components/shared/checkout/PaymentGateway';
+import {
+  useCheckout,
+  type UseCheckoutOptions,
+  type PaymentStep,
+} from '../useCheckout';
+
+const mockReplace = vi.fn();
+const mockOrdersCreate = vi.fn();
+const mockPaymentsPrepare = vi.fn();
+const mockPaymentsConfirm = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  ordersApi: {
+    create: (...args: unknown[]) => mockOrdersCreate(...args),
+  },
+  paymentsApi: {
+    prepare: (...args: unknown[]) => mockPaymentsPrepare(...args),
+    confirm: (...args: unknown[]) => mockPaymentsConfirm(...args),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
+const validForm: ShippingForm = {
+  recipientName: '홍길동',
+  recipientPhone: '010-1234-5678',
+  zipcode: '12345',
+  address: '서울시 강남구 테헤란로',
+  addressDetail: '101호',
+  memo: '문 앞에',
+};
+
+const mockItem: CartItem = {
+  id: 1,
+  productId: 10,
+  productOptionId: null,
+  quantity: 2,
+  unitPrice: 15000,
+  subtotal: 30000,
+  product: {
+    id: 10,
+    name: '테스트 상품',
+    slug: 'test',
+    price: 15000,
+    salePrice: null,
+    status: 'active',
+    images: [],
+  },
+  option: null,
+};
+
+const mockOrder: OrderResponse = {
+  id: 100,
+  orderNumber: 'ORD-100',
+  status: 'pending',
+  totalAmount: 30000,
+  discountAmount: 0,
+  shippingFee: 0,
+  recipientName: '홍길동',
+  recipientPhone: '010-1234-5678',
+  zipcode: '12345',
+  address: '서울시',
+  addressDetail: '101호',
+  memo: null,
+  items: [],
+  createdAt: '2026-04-25T00:00:00Z',
+};
+
+interface OptionsState {
+  step: PaymentStep;
+  prepareResult: PreparePaymentResponse | null;
+  currentOrderId: number | null;
+  currentOrderNumber: string;
+}
+
+function makeOptions(
+  overrides: Partial<UseCheckoutOptions> = {},
+): { options: UseCheckoutOptions; state: OptionsState; paymentRef: { current: PaymentGatewayHandle | null }; refetch: ReturnType<typeof vi.fn> } {
+  const state: OptionsState = {
+    step: 'idle',
+    prepareResult: null,
+    currentOrderId: null,
+    currentOrderNumber: '',
+  };
+  const refetch = vi.fn().mockResolvedValue(undefined);
+  const paymentRef = { current: null as PaymentGatewayHandle | null };
+
+  const options: UseCheckoutOptions = {
+    checkoutItems: [mockItem],
+    form: validForm,
+    grandTotal: 30000,
+    locale: 'ko',
+    paymentRef,
+    prepareResult: state.prepareResult,
+    currentOrderId: state.currentOrderId,
+    currentOrderNumber: state.currentOrderNumber,
+    setStep: vi.fn((s: PaymentStep) => { state.step = s; }),
+    setPrepareResult: vi.fn((r) => { state.prepareResult = r; }),
+    setCurrentOrderId: vi.fn((id) => { state.currentOrderId = id; }),
+    setCurrentOrderNumber: vi.fn((n) => { state.currentOrderNumber = n; }),
+    refetch,
+    ...overrides,
+  };
+
+  return { options, state, paymentRef, refetch };
+}
+
+function makeFormEvent(): React.FormEvent {
+  return { preventDefault: vi.fn() } as unknown as React.FormEvent;
+}
+
+describe('useCheckout - 폼 검증', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('이름이 2자 미만이면 주문 생성을 호출하지 않는다', async () => {
+    const { options } = makeOptions({
+      form: { ...validForm, recipientName: 'A' },
+    });
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(mockOrdersCreate).not.toHaveBeenCalled();
+    expect(options.setStep).not.toHaveBeenCalledWith('creating_order');
+  });
+
+  it('전화번호 형식이 잘못되면 주문 생성을 호출하지 않는다', async () => {
+    const { options } = makeOptions({
+      form: { ...validForm, recipientPhone: '01012345678' },
+    });
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(mockOrdersCreate).not.toHaveBeenCalled();
+  });
+
+  it('우편번호가 5자리가 아니면 주문 생성을 호출하지 않는다', async () => {
+    const { options } = makeOptions({
+      form: { ...validForm, zipcode: '1234' },
+    });
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(mockOrdersCreate).not.toHaveBeenCalled();
+  });
+
+  it('주소가 비어 있으면 주문 생성을 호출하지 않는다', async () => {
+    const { options } = makeOptions({
+      form: { ...validForm, address: '   ' },
+    });
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(mockOrdersCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCheckout - Mock 결제 흐름', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('mock_client_key 응답 시 결제 확인까지 자동 진행 후 라우팅', async () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      amount: 30000,
+      gateway: 'mock',
+      clientKey: 'mock_client_key',
+    };
+    mockOrdersCreate.mockResolvedValue(mockOrder);
+    mockPaymentsPrepare.mockResolvedValue(prepareResult);
+    mockPaymentsConfirm.mockResolvedValue({
+      paymentId: 1,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      status: 'confirmed',
+      method: 'mock',
+      amount: 30000,
+      paidAt: '2026-04-25T00:00:00Z',
+    });
+
+    const { options, refetch } = makeOptions();
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(mockOrdersCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [{ productId: 10, productOptionId: null, quantity: 2 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+      }),
+    );
+    expect(mockPaymentsPrepare).toHaveBeenCalledWith({ orderId: mockOrder.id, locale: 'ko' });
+    expect(mockPaymentsConfirm).toHaveBeenCalledWith({
+      orderId: mockOrder.id,
+      paymentKey: `mock-${mockOrder.orderNumber}`,
+      amount: 30000,
+    });
+    expect(toast.success).toHaveBeenCalledWith('결제가 완료되었습니다.');
+    expect(refetch).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith(
+      `/ko/order/complete?orderId=${mockOrder.id}&orderNumber=${mockOrder.orderNumber}`,
+    );
+    expect(options.setStep).toHaveBeenCalledWith('creating_order');
+    expect(options.setStep).toHaveBeenCalledWith('preparing_payment');
+    expect(options.setStep).toHaveBeenCalledWith('confirming_payment');
+    expect(options.setStep).toHaveBeenCalledWith('success');
+  });
+});
+
+describe('useCheckout - Stripe 결제 흐름', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Stripe 응답 시 prepareResult를 set하고 사용자 입력 대기 (idle)', async () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 2,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      amount: 30000,
+      gateway: 'stripe',
+      clientKey: 'pi_xxx_secret_yyy',
+    };
+    mockOrdersCreate.mockResolvedValue(mockOrder);
+    mockPaymentsPrepare.mockResolvedValue(prepareResult);
+
+    const { options } = makeOptions({ locale: 'en' });
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(options.setCurrentOrderId).toHaveBeenCalledWith(mockOrder.id);
+    expect(options.setCurrentOrderNumber).toHaveBeenCalledWith(mockOrder.orderNumber);
+    expect(options.setPrepareResult).toHaveBeenCalledWith(prepareResult);
+    expect(options.setStep).toHaveBeenCalledWith('idle');
+    expect(toast.info).toHaveBeenCalledWith('카드 정보를 입력하고 결제하기를 눌러주세요.');
+    expect(mockPaymentsConfirm).not.toHaveBeenCalled();
+  });
+
+  it('이미 prepareResult(stripe) 상태에서 submit하면 paymentRef.confirm() 호출', async () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 2,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      amount: 30000,
+      gateway: 'stripe',
+      clientKey: 'pi_xxx_secret_yyy',
+    };
+    const confirmSpy = vi.fn().mockResolvedValue(undefined);
+    const { options } = makeOptions({
+      prepareResult,
+      paymentRef: { current: { confirm: confirmSpy } },
+    });
+
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(options.setStep).toHaveBeenCalledWith('confirming_payment');
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(mockOrdersCreate).not.toHaveBeenCalled();
+  });
+
+  it('Stripe confirm 실패 시 에러 토스트 + step을 idle로 초기화', async () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 2,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      amount: 30000,
+      gateway: 'stripe',
+      clientKey: 'pi_xxx_secret_yyy',
+    };
+    const confirmSpy = vi.fn().mockRejectedValue(new Error('카드 거절'));
+    const { options } = makeOptions({
+      prepareResult,
+      paymentRef: { current: { confirm: confirmSpy } },
+    });
+
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('카드 거절');
+    expect(options.setStep).toHaveBeenCalledWith('idle');
+    expect(options.setPrepareResult).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('useCheckout - Toss 결제 흐름', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it('locale=ko + 실제 clientKey 응답 시 paymentRef.confirm을 setTimeout으로 호출', async () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 3,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      amount: 30000,
+      gateway: 'toss',
+      clientKey: 'test_ck_realkey',
+    };
+    mockOrdersCreate.mockResolvedValue(mockOrder);
+    mockPaymentsPrepare.mockResolvedValue(prepareResult);
+
+    const confirmSpy = vi.fn().mockResolvedValue(undefined);
+    const { options } = makeOptions({
+      paymentRef: { current: { confirm: confirmSpy } },
+    });
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(options.setCurrentOrderId).toHaveBeenCalledWith(mockOrder.id);
+    expect(options.setCurrentOrderNumber).toHaveBeenCalledWith(mockOrder.orderNumber);
+    expect(options.setPrepareResult).toHaveBeenCalledWith(prepareResult);
+    // confirm은 setTimeout 100ms 이후 호출
+    expect(confirmSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(mockPaymentsConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCheckout - 에러 처리', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('주문 생성 실패 시 toast.error 호출 + step idle 복귀', async () => {
+    mockOrdersCreate.mockRejectedValue(new Error('재고 부족'));
+
+    const { options } = makeOptions();
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('재고 부족');
+    expect(options.setStep).toHaveBeenLastCalledWith('idle');
+    expect(mockPaymentsPrepare).not.toHaveBeenCalled();
+  });
+
+  it('paymentsApi.prepare 실패 시 toast.error + step idle', async () => {
+    mockOrdersCreate.mockResolvedValue(mockOrder);
+    mockPaymentsPrepare.mockRejectedValue(new Error('PG 통신 오류'));
+
+    const { options } = makeOptions();
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('PG 통신 오류');
+    expect(options.setStep).toHaveBeenLastCalledWith('idle');
+  });
+
+  it('handlePaymentError 는 메시지를 토스트로 보여주고 step을 idle로 reset', () => {
+    const { options } = makeOptions();
+    const { result } = renderHook(() => useCheckout(options));
+
+    act(() => {
+      result.current.handlePaymentError('결제가 취소되었습니다.');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('결제가 취소되었습니다.');
+    expect(options.setStep).toHaveBeenCalledWith('idle');
+    expect(options.setPrepareResult).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/shared/hooks/__tests__/useFormValidation.test.ts
+++ b/src/components/shared/hooks/__tests__/useFormValidation.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFormValidation } from '../useFormValidation';
+
+interface SampleForm extends Record<string, unknown> {
+  name: string;
+  email: string;
+  age: string;
+}
+
+const validator = (form: SampleForm) => {
+  const errors: Partial<Record<keyof SampleForm, string>> = {};
+  if (!form.name) errors.name = '이름을 입력해주세요.';
+  if (!form.email.includes('@')) errors.email = '올바른 이메일이 아닙니다.';
+  if (!/^\d+$/.test(form.age)) errors.age = '숫자만 입력해주세요.';
+  return errors;
+};
+
+describe('useFormValidation', () => {
+  it('초기 errors는 빈 객체이다', () => {
+    const { result } = renderHook(() => useFormValidation<SampleForm>(validator));
+    expect(result.current.errors).toEqual({});
+  });
+
+  it('validate가 false를 반환하면 errors에 모두 채운다', () => {
+    const { result } = renderHook(() => useFormValidation<SampleForm>(validator));
+
+    let valid = true;
+    act(() => {
+      valid = result.current.validate({ name: '', email: 'invalid', age: 'abc' });
+    });
+
+    expect(valid).toBe(false);
+    expect(result.current.errors.name).toBe('이름을 입력해주세요.');
+    expect(result.current.errors.email).toBe('올바른 이메일이 아닙니다.');
+    expect(result.current.errors.age).toBe('숫자만 입력해주세요.');
+  });
+
+  it('validate가 true를 반환하면 errors는 비어있다', () => {
+    const { result } = renderHook(() => useFormValidation<SampleForm>(validator));
+
+    let valid = false;
+    act(() => {
+      valid = result.current.validate({ name: '홍길동', email: 'a@b.com', age: '30' });
+    });
+
+    expect(valid).toBe(true);
+    expect(result.current.errors).toEqual({});
+  });
+
+  it('clearError는 특정 필드만 제거한다', () => {
+    const { result } = renderHook(() => useFormValidation<SampleForm>(validator));
+
+    act(() => {
+      result.current.validate({ name: '', email: 'invalid', age: 'abc' });
+    });
+    expect(Object.keys(result.current.errors)).toHaveLength(3);
+
+    act(() => {
+      result.current.clearError('email');
+    });
+
+    expect(result.current.errors.email).toBeUndefined();
+    expect(result.current.errors.name).toBe('이름을 입력해주세요.');
+    expect(result.current.errors.age).toBe('숫자만 입력해주세요.');
+  });
+
+  it('clearError로 존재하지 않는 필드를 지워도 안전하다', () => {
+    const { result } = renderHook(() => useFormValidation<SampleForm>(validator));
+
+    act(() => {
+      result.current.validate({ name: '', email: 'a@b.com', age: '30' });
+    });
+    const errorsBefore = result.current.errors;
+
+    act(() => {
+      result.current.clearError('email');
+    });
+
+    // unchanged reference: setState 단축 회피 확인 (no-op)
+    expect(result.current.errors).toBe(errorsBefore);
+  });
+
+  it('clearAll은 모든 errors를 비운다', () => {
+    const { result } = renderHook(() => useFormValidation<SampleForm>(validator));
+
+    act(() => {
+      result.current.validate({ name: '', email: 'invalid', age: 'abc' });
+    });
+
+    act(() => {
+      result.current.clearAll();
+    });
+
+    expect(result.current.errors).toEqual({});
+  });
+
+  it('validator를 호출 시 form 인자를 그대로 전달한다', () => {
+    const spy = vi.fn(() => ({} as Partial<Record<keyof SampleForm, string>>));
+    const { result } = renderHook(() => useFormValidation<SampleForm>(spy));
+
+    const sample = { name: 'A', email: 'a@b.com', age: '30' };
+    act(() => {
+      result.current.validate(sample);
+    });
+
+    expect(spy).toHaveBeenCalledWith(sample);
+  });
+});

--- a/src/components/shared/hooks/__tests__/useRequireAuth.test.tsx
+++ b/src/components/shared/hooks/__tests__/useRequireAuth.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { AuthContext, type AuthContextValue } from '@/contexts/AuthContext';
+import { useRequireAuth } from '../useRequireAuth';
+
+const mockReplace = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, push: vi.fn(), back: vi.fn() }),
+}));
+
+function makeAuthValue(overrides?: Partial<AuthContextValue>): AuthContextValue {
+  return {
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    register: vi.fn(),
+    loginWithKakao: vi.fn(),
+    loginWithGoogle: vi.fn(),
+    updateUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+function wrapperWith(authValue: AuthContextValue) {
+  function AuthWrapper({ children }: { children: ReactNode }) {
+    return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>;
+  }
+  return AuthWrapper;
+}
+
+describe('useRequireAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('isLoading=true 동안에는 리다이렉트하지 않는다', () => {
+    const wrapper = wrapperWith(makeAuthValue({ isLoading: true, isAuthenticated: false }));
+    const { result } = renderHook(() => useRequireAuth(), { wrapper });
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('로딩 완료 후 미인증이면 /login 으로 replace 한다', () => {
+    const wrapper = wrapperWith(makeAuthValue({ isLoading: false, isAuthenticated: false }));
+    renderHook(() => useRequireAuth(), { wrapper });
+
+    expect(mockReplace).toHaveBeenCalledWith('/login');
+  });
+
+  it('인증된 상태에서는 리다이렉트하지 않는다', () => {
+    const wrapper = wrapperWith(
+      makeAuthValue({
+        isLoading: false,
+        isAuthenticated: true,
+        user: { id: 1, email: 'a@b.com', name: '홍', role: 'user' },
+      }),
+    );
+    const { result } = renderHook(() => useRequireAuth(), { wrapper });
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('redirectTo 인자로 리다이렉트 경로를 변경할 수 있다', () => {
+    const wrapper = wrapperWith(makeAuthValue({ isLoading: false, isAuthenticated: false }));
+    renderHook(() => useRequireAuth('/ko/login'), { wrapper });
+
+    expect(mockReplace).toHaveBeenCalledWith('/ko/login');
+  });
+
+  it('인증된 상태에서 redirectTo 인자가 변경되어도 리다이렉트하지 않는다', () => {
+    const wrapper = wrapperWith(
+      makeAuthValue({
+        isLoading: false,
+        isAuthenticated: true,
+        user: { id: 1, email: 'a@b.com', name: '홍', role: 'user' },
+      }),
+    );
+    renderHook(() => useRequireAuth('/admin/login'), { wrapper });
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState, useCallback, useEffect, useMemo, R
 import { toast } from 'sonner';
 import { authApi } from '@/lib/api';
 import { SESSION_KEYS } from '@/constants/storage';
+import { redirectTo } from '@/utils/navigation';
 
 interface User {
   id: number;
@@ -82,7 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID ?? '';
     const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI ?? '';
     const url = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&state=${state}`;
-    window.location.href = url;
+    redirectTo(url);
   }, []);
 
   const updateUser = useCallback((partial: Partial<User>) => {
@@ -95,7 +96,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? '';
     const redirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI ?? '';
     const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&scope=openid%20email%20profile&state=${state}`;
-    window.location.href = url;
+    redirectTo(url);
   }, []);
 
   const value = useMemo(

--- a/src/lib/__tests__/api-auth-skip.test.ts
+++ b/src/lib/__tests__/api-auth-skip.test.ts
@@ -1,0 +1,120 @@
+/**
+ * /auth/* 엔드포인트는 401 응답 시 토큰 갱신 인터셉터를 스킵해야 한다.
+ * 회귀 시 무한 refresh 루프가 발생할 수 있어 별도 회귀 가드 테스트로 분리.
+ * (memory: feedback_api_client.md)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+Object.defineProperty(window, 'location', {
+  writable: true,
+  value: { href: '' },
+});
+
+import { apiClient, authApi } from '@/lib/api';
+
+function makeResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('ApiClient — /auth/* 엔드포인트 401 인터셉터 스킵', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.href = '';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('/auth/login 401 응답 시 refresh 호출하지 않고 에러 throw', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(401, { message: '이메일 또는 비밀번호가 올바르지 않습니다.' }),
+    );
+
+    await expect(
+      apiClient.post('/auth/login', { email: 'a@b.com', password: 'wrong' }),
+    ).rejects.toThrow('이메일 또는 비밀번호가 올바르지 않습니다.');
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe('');
+  });
+
+  it('/auth/refresh 자체가 401 이면 refresh 재호출하지 않음 (무한 루프 방지)', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh');
+    fetchMock.mockResolvedValueOnce(makeResponse(401, { message: 'Refresh expired' }));
+
+    await expect(apiClient.post('/auth/refresh')).rejects.toThrow();
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('/auth/me 401 응답 시 refresh 인터셉터 동작하지 않음', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock.mockResolvedValueOnce(makeResponse(401, { message: 'Unauthorized' }));
+
+    await expect(apiClient.get('/auth/me')).rejects.toThrow();
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('/auth/logout 401 응답 시 refresh 호출하지 않음', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock.mockResolvedValueOnce(makeResponse(401));
+
+    await expect(apiClient.post('/auth/logout')).rejects.toThrow();
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('/auth/register 401 응답 시 refresh 호출하지 않음', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(401, { message: '이미 사용 중인 이메일입니다.' }),
+    );
+
+    await expect(
+      apiClient.post('/auth/register', { email: 'x@y.com', password: 'pw', name: 'a' }),
+    ).rejects.toThrow('이미 사용 중인 이메일입니다.');
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('/auth/kakao 401 응답 시 refresh 호출하지 않음', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock.mockResolvedValueOnce(makeResponse(401, { message: 'OAuth 인증 실패' }));
+
+    await expect(apiClient.post('/auth/kakao', { code: 'abc' })).rejects.toThrow();
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('/auth/google 401 응답 시 refresh 호출하지 않음', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock.mockResolvedValueOnce(makeResponse(401, { message: 'OAuth 인증 실패' }));
+
+    await expect(apiClient.post('/auth/google', { code: 'abc' })).rejects.toThrow();
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('/auth/* 가 아닌 경로는 401 시 refresh 호출 (대조 케이스)', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock
+      .mockResolvedValueOnce(makeResponse(401))
+      .mockResolvedValueOnce(makeResponse(200, { ok: true }));
+
+    const result = await apiClient.get<{ ok: boolean }>('/orders');
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/src/lib/__tests__/validators.test.ts
+++ b/src/lib/__tests__/validators.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidPhone,
+  isValidZipcode,
+  isValidEmail,
+  isValidPassword,
+} from '@/lib/validators';
+
+describe('isValidPhone', () => {
+  it('010-1234-5678 형식을 허용한다', () => {
+    expect(isValidPhone('010-1234-5678')).toBe(true);
+  });
+
+  it('011/016/017/018/019 도 허용한다', () => {
+    expect(isValidPhone('011-123-4567')).toBe(true);
+    expect(isValidPhone('016-1234-5678')).toBe(true);
+    expect(isValidPhone('019-9999-0000')).toBe(true);
+  });
+
+  it('가운데 자리가 3자리도 허용된다', () => {
+    expect(isValidPhone('010-123-4567')).toBe(true);
+  });
+
+  it('하이픈이 없으면 거부', () => {
+    expect(isValidPhone('01012345678')).toBe(false);
+  });
+
+  it('숫자가 아닌 문자는 거부', () => {
+    expect(isValidPhone('010-abcd-5678')).toBe(false);
+  });
+
+  it('자릿수가 부족하면 거부', () => {
+    expect(isValidPhone('010-123-456')).toBe(false);
+    expect(isValidPhone('010-12-3456')).toBe(false);
+  });
+
+  it('국제 번호 형식은 거부', () => {
+    expect(isValidPhone('+82-10-1234-5678')).toBe(false);
+  });
+
+  it('빈 문자열은 거부', () => {
+    expect(isValidPhone('')).toBe(false);
+  });
+});
+
+describe('isValidZipcode', () => {
+  it('5자리 숫자를 허용한다', () => {
+    expect(isValidZipcode('12345')).toBe(true);
+    expect(isValidZipcode('00000')).toBe(true);
+  });
+
+  it('4자리 또는 6자리는 거부', () => {
+    expect(isValidZipcode('1234')).toBe(false);
+    expect(isValidZipcode('123456')).toBe(false);
+  });
+
+  it('숫자가 아닌 문자는 거부', () => {
+    expect(isValidZipcode('1234a')).toBe(false);
+    expect(isValidZipcode('abcde')).toBe(false);
+  });
+
+  it('하이픈 포함된 구 우편번호는 거부', () => {
+    expect(isValidZipcode('123-456')).toBe(false);
+  });
+
+  it('빈 문자열은 거부', () => {
+    expect(isValidZipcode('')).toBe(false);
+  });
+});
+
+describe('isValidEmail', () => {
+  it('일반 이메일은 통과', () => {
+    expect(isValidEmail('test@example.com')).toBe(true);
+    expect(isValidEmail('user.name+tag@sub.domain.co.kr')).toBe(true);
+  });
+
+  it('@ 가 없으면 거부', () => {
+    expect(isValidEmail('test.example.com')).toBe(false);
+  });
+
+  it('도메인이 없으면 거부', () => {
+    expect(isValidEmail('test@')).toBe(false);
+    expect(isValidEmail('@example.com')).toBe(false);
+  });
+
+  it('TLD가 없으면 거부', () => {
+    expect(isValidEmail('test@example')).toBe(false);
+  });
+
+  it('공백을 포함하면 거부', () => {
+    expect(isValidEmail('test @example.com')).toBe(false);
+    expect(isValidEmail('test@ example.com')).toBe(false);
+  });
+
+  it('빈 문자열은 거부', () => {
+    expect(isValidEmail('')).toBe(false);
+  });
+});
+
+describe('isValidPassword', () => {
+  it('8자 이상이면 통과', () => {
+    expect(isValidPassword('12345678')).toBe(true);
+    expect(isValidPassword('password123')).toBe(true);
+  });
+
+  it('7자 이하는 거부', () => {
+    expect(isValidPassword('1234567')).toBe(false);
+    expect(isValidPassword('')).toBe(false);
+  });
+
+  it('정확히 8자는 통과', () => {
+    expect(isValidPassword('abcdefgh')).toBe(true);
+  });
+});

--- a/src/utils/__tests__/error.test.ts
+++ b/src/utils/__tests__/error.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { handleApiError } from '@/utils/error';
+
+describe('handleApiError', () => {
+  it('Error 인스턴스의 message를 반환한다', () => {
+    const err = new Error('네트워크 오류');
+    expect(handleApiError(err)).toBe('네트워크 오류');
+  });
+
+  it('Error가 아닌 경우 fallback을 반환한다', () => {
+    expect(handleApiError('string error')).toBe('오류가 발생했습니다.');
+    expect(handleApiError(null)).toBe('오류가 발생했습니다.');
+    expect(handleApiError(undefined)).toBe('오류가 발생했습니다.');
+    expect(handleApiError({ message: 'object error' })).toBe('오류가 발생했습니다.');
+    expect(handleApiError(123)).toBe('오류가 발생했습니다.');
+  });
+
+  it('명시된 fallback 메시지를 사용한다', () => {
+    expect(handleApiError('not error', '결제 실패')).toBe('결제 실패');
+    expect(handleApiError(null, '주문 생성 실패')).toBe('주문 생성 실패');
+  });
+
+  it('Error 인스턴스이면 fallback이 있어도 message를 우선', () => {
+    const err = new Error('실제 메시지');
+    expect(handleApiError(err, '폴백 메시지')).toBe('실제 메시지');
+  });
+
+  it('Error의 message가 빈 문자열이면 빈 문자열을 그대로 반환한다', () => {
+    const err = new Error('');
+    expect(handleApiError(err, '폴백')).toBe('');
+  });
+
+  it('Error 서브클래스 인스턴스도 처리한다', () => {
+    class CustomError extends Error {
+      constructor() {
+        super('커스텀 에러');
+      }
+    }
+    expect(handleApiError(new CustomError())).toBe('커스텀 에러');
+  });
+});

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,3 @@
+export function redirectTo(url: string): void {
+  window.location.href = url;
+}


### PR DESCRIPTION
## Summary
- Add AuthContext coverage for OAuth CSRF state, redirect URL construction, and updateUser merging
- Add CartContext guest localStorage load/add/update/remove and guest-to-auth merge tests
- Add a tiny redirectTo boundary so browser navigation can be asserted without jsdom navigation side effects

## Verification
- npx vitest run src/components/__tests__/AuthContext.test.tsx src/components/__tests__/CartContext.test.tsx: passed
- npm run test:run: passed, 77 files / 488 tests