### PR TITLE
test: lock admin CMS form and reorder regressions

### DIFF
--- a/src/components/shared/admin/__tests__/NavigationEditor.test.tsx
+++ b/src/components/shared/admin/__tests__/NavigationEditor.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NavigationEditor from '@/components/shared/admin/NavigationEditor';
+import type { NavigationItem } from '@/lib/api';
+
+// 자식 모달/프리뷰는 별개 단위로 테스트 — 여기서는 컨테이너 동작만 검증
+vi.mock('@/components/shared/admin/navigation/NavigationFormModal', () => ({
+  default: ({
+    open,
+    onSubmit,
+    initial,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onSubmit: (data: { label: string; url: string; parent_id: number | null; is_active: boolean }) => Promise<void>;
+    initial: { id?: number } | null;
+  }) =>
+    open ? (
+      <div data-testid="form-modal">
+        <span>{initial ? `editing-${initial.id}` : 'creating'}</span>
+        <button
+          type="button"
+          onClick={() =>
+            void onSubmit({ label: '신규', url: '/new', parent_id: null, is_active: true })
+          }
+        >
+          mock-submit
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('@/components/shared/admin/navigation/NavigationPreview', () => ({
+  default: () => <div data-testid="navigation-preview">preview</div>,
+}));
+
+vi.mock('@/components/shared/admin/navigation/SortableNavigationRow', () => ({
+  default: ({
+    item,
+    onEdit,
+    onDelete,
+    onToggleActive,
+  }: {
+    item: NavigationItem;
+    depth: number;
+    onEdit: (i: NavigationItem) => void;
+    onDelete: (i: NavigationItem) => Promise<void>;
+    onToggleActive: (i: NavigationItem) => Promise<void>;
+  }) => (
+    <div data-testid={`row-${item.id}`}>
+      <span>{item.label}</span>
+      <button type="button" onClick={() => onEdit(item)}>edit-{item.id}</button>
+      <button type="button" onClick={() => void onDelete(item)}>delete-{item.id}</button>
+      <button type="button" onClick={() => void onToggleActive(item)}>toggle-{item.id}</button>
+    </div>
+  ),
+}));
+
+const sampleItems: NavigationItem[] = [
+  { id: 1, group: 'gnb', label: '홈', url: '/', sort_order: 0, is_active: true, parent_id: null, children: [] },
+  { id: 2, group: 'gnb', label: '상품', url: '/products', sort_order: 1, is_active: true, parent_id: null, children: [
+    { id: 3, group: 'gnb', label: '신상품', url: '/products?new=1', sort_order: 0, is_active: true, parent_id: 2, children: [] },
+  ] },
+  { id: 4, group: 'gnb', label: '이벤트', url: '/events', sort_order: 2, is_active: false, parent_id: null, children: [] },
+];
+
+const baseHandlers = () => ({
+  onReload: vi.fn().mockResolvedValue(undefined),
+  onCreate: vi.fn().mockResolvedValue(undefined),
+  onUpdate: vi.fn().mockResolvedValue(undefined),
+  onDelete: vi.fn().mockResolvedValue(undefined),
+  onReorder: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('NavigationEditor', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  it('items=[] 일 때 빈 상태 표시', () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={[]} {...handlers} />);
+    expect(screen.getByText('등록된 메뉴가 없습니다')).toBeInTheDocument();
+  });
+
+  it('아이템 카운트: 총 N개 (활성 M개)', () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    // flatItems = 4 (홈 + 상품 + 신상품 + 이벤트), 활성 root = 2 (홈, 상품)
+    expect(screen.getByText(/총 4개 메뉴/)).toBeInTheDocument();
+    expect(screen.getByText(/2개 활성/)).toBeInTheDocument();
+  });
+
+  it('"메뉴 추가" 버튼 클릭 → 폼 모달 (creating)', async () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    await userEvent.click(screen.getByRole('button', { name: /메뉴 추가/ }));
+    expect(screen.getByTestId('form-modal')).toBeInTheDocument();
+    expect(screen.getByText('creating')).toBeInTheDocument();
+  });
+
+  it('수정 버튼 클릭 → 폼 모달 (editing-id)', async () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    await userEvent.click(screen.getByText('edit-2'));
+    expect(screen.getByText('editing-2')).toBeInTheDocument();
+  });
+
+  it('새 메뉴 폼 제출 → onCreate + onReload', async () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    await userEvent.click(screen.getByRole('button', { name: /메뉴 추가/ }));
+    await userEvent.click(screen.getByText('mock-submit'));
+    expect(handlers.onCreate).toHaveBeenCalledWith({
+      label: '신규',
+      url: '/new',
+      parent_id: null,
+      is_active: true,
+    });
+    expect(handlers.onReload).toHaveBeenCalled();
+  });
+
+  it('수정 폼 제출 → onUpdate(id, data) + onReload', async () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    await userEvent.click(screen.getByText('edit-1'));
+    await userEvent.click(screen.getByText('mock-submit'));
+    expect(handlers.onUpdate).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ label: '신규', url: '/new', parent_id: null, is_active: true }),
+    );
+  });
+
+  it('삭제 버튼 + confirm → onDelete + onReload', async () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    fireEvent.click(screen.getByText('delete-1'));
+    // 비동기 처리 대기
+    await Promise.resolve();
+    expect(window.confirm).toHaveBeenCalled();
+    expect(handlers.onDelete).toHaveBeenCalledWith(1);
+  });
+
+  it('confirm=false → onDelete 호출 안 됨', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    fireEvent.click(screen.getByText('delete-1'));
+    await Promise.resolve();
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+  });
+
+  it('자식 있는 메뉴 삭제 시 confirm 메시지에 자식 개수 포함', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    fireEvent.click(screen.getByText('delete-2'));
+    await Promise.resolve();
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('하위 메뉴 1개'));
+  });
+
+  it('활성 토글 → onUpdate({ is_active: !current })', async () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    fireEvent.click(screen.getByText('toggle-1'));
+    await Promise.resolve();
+    expect(handlers.onUpdate).toHaveBeenCalledWith(1, { is_active: false });
+  });
+
+  it('미리보기 토글 — 클릭 시 NavigationPreview 표시', async () => {
+    const handlers = baseHandlers();
+    render(<NavigationEditor group="gnb" items={sampleItems} {...handlers} />);
+    expect(screen.queryByTestId('navigation-preview')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /미리보기$/ }));
+    expect(screen.getByTestId('navigation-preview')).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/admin/__tests__/ProductOptionsEditor.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductOptionsEditor.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import ProductOptionsEditor, {
+  type ProductOptionDraft,
+} from '@/components/shared/admin/ProductOptionsEditor';
+
+const sampleOptions: ProductOptionDraft[] = [
+  { name: '색상', value: '검정', priceAdjustment: 0, stock: 10 },
+  { name: '색상', value: '빨강', priceAdjustment: 1000, stock: 5 },
+];
+
+describe('ProductOptionsEditor', () => {
+  it('options=[] → 빈 상태 메시지', () => {
+    render(<ProductOptionsEditor options={[]} onChange={vi.fn()} />);
+    expect(screen.getByText('옵션이 없습니다.')).toBeInTheDocument();
+  });
+
+  it('options 렌더링 — 입력값 채워짐', () => {
+    render(<ProductOptionsEditor options={sampleOptions} onChange={vi.fn()} />);
+    expect(screen.getAllByDisplayValue('색상')).toHaveLength(2);
+    expect(screen.getByDisplayValue('검정')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('빨강')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1000')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+  });
+
+  it('"+ 옵션 추가" 클릭 → 빈 옵션 추가된 배열 onChange', async () => {
+    const onChange = vi.fn();
+    render(<ProductOptionsEditor options={sampleOptions} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /옵션 추가/ }));
+    expect(onChange).toHaveBeenCalledWith([
+      ...sampleOptions,
+      { name: '', value: '', priceAdjustment: 0, stock: 0 },
+    ]);
+  });
+
+  it('options=[] 에서 옵션 추가 → 단일 빈 옵션 배열', async () => {
+    const onChange = vi.fn();
+    render(<ProductOptionsEditor options={[]} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /옵션 추가/ }));
+    expect(onChange).toHaveBeenCalledWith([
+      { name: '', value: '', priceAdjustment: 0, stock: 0 },
+    ]);
+  });
+
+  it('옵션명 변경 → onChange(해당 인덱스만 갱신)', () => {
+    const onChange = vi.fn();
+    render(<ProductOptionsEditor options={sampleOptions} onChange={onChange} />);
+    const nameInputs = screen.getAllByPlaceholderText('예: 색상');
+    fireEvent.change(nameInputs[0], { target: { value: '사이즈' } });
+    expect(onChange).toHaveBeenCalledWith([
+      { ...sampleOptions[0], name: '사이즈' },
+      sampleOptions[1],
+    ]);
+  });
+
+  it('값 변경 → onChange', () => {
+    const onChange = vi.fn();
+    render(<ProductOptionsEditor options={sampleOptions} onChange={onChange} />);
+    const valueInputs = screen.getAllByPlaceholderText('예: 빨강');
+    fireEvent.change(valueInputs[1], { target: { value: '파랑' } });
+    expect(onChange).toHaveBeenCalledWith([
+      sampleOptions[0],
+      { ...sampleOptions[1], value: '파랑' },
+    ]);
+  });
+
+  it('추가금액 변경 → number 변환 후 onChange', () => {
+    const onChange = vi.fn();
+    render(<ProductOptionsEditor options={sampleOptions} onChange={onChange} />);
+    const priceInputs = screen.getAllByRole('spinbutton');
+    // index 0 = priceAdjustment[0], 1 = stock[0], 2 = priceAdjustment[1], 3 = stock[1]
+    fireEvent.change(priceInputs[0], { target: { value: '500' } });
+    expect(onChange).toHaveBeenCalledWith([
+      { ...sampleOptions[0], priceAdjustment: 500 },
+      sampleOptions[1],
+    ]);
+  });
+
+  it('재고 변경 → number 변환 후 onChange', () => {
+    const onChange = vi.fn();
+    render(<ProductOptionsEditor options={sampleOptions} onChange={onChange} />);
+    const numberInputs = screen.getAllByRole('spinbutton');
+    fireEvent.change(numberInputs[1], { target: { value: '99' } });
+    expect(onChange).toHaveBeenCalledWith([
+      { ...sampleOptions[0], stock: 99 },
+      sampleOptions[1],
+    ]);
+  });
+
+  it('"x" 버튼 → 해당 인덱스 제거 후 onChange', async () => {
+    const onChange = vi.fn();
+    render(<ProductOptionsEditor options={sampleOptions} onChange={onChange} />);
+    const removeButtons = screen.getAllByRole('button', { name: 'x' });
+    await userEvent.click(removeButtons[0]);
+    expect(onChange).toHaveBeenCalledWith([sampleOptions[1]]);
+  });
+});

--- a/src/components/shared/admin/page-editor/__tests__/EditorCanvas.test.tsx
+++ b/src/components/shared/admin/page-editor/__tests__/EditorCanvas.test.tsx
@@ -1,8 +1,50 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import EditorCanvas from '@/components/shared/admin/page-editor/EditorCanvas';
 import type { DraftBlock } from '@/components/shared/admin/page-editor/SortableBlockItem';
+
+vi.mock('@dnd-kit/core', async (importActual) => {
+  const actual = await importActual<typeof import('@dnd-kit/core')>();
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: ReactNode;
+      onDragEnd?: (event: { active: { id: number }; over: { id: number } | null }) => void;
+    }) => (
+      <div>
+        <button type="button" onClick={() => onDragEnd?.({ active: { id: 1 }, over: { id: 2 } })}>
+          reorder 1 over 2
+        </button>
+        <button type="button" onClick={() => onDragEnd?.({ active: { id: 1 }, over: { id: 1 } })}>
+          reorder same
+        </button>
+        <button type="button" onClick={() => onDragEnd?.({ active: { id: 1 }, over: null })}>
+          reorder no target
+        </button>
+        {children}
+      </div>
+    ),
+  };
+});
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: vi.fn(),
+  sortableKeyboardCoordinates: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
 
 const blocks: DraftBlock[] = [
   {
@@ -166,5 +208,40 @@ describe('EditorCanvas', () => {
       />,
     );
     expect(screen.getByRole('button', { name: '표시' })).toBeInTheDocument();
+  });
+
+  it('드래그 종료 시 active/over id가 다르면 onReorder(activeId, overId)를 호출', async () => {
+    const onReorder = vi.fn();
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={null}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+        onToggleVisibility={vi.fn()}
+        onReorder={onReorder}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'reorder 1 over 2' }));
+    expect(onReorder).toHaveBeenCalledWith(1, 2);
+  });
+
+  it('드래그 종료 시 타겟이 없거나 같은 블록이면 onReorder를 호출하지 않음', async () => {
+    const onReorder = vi.fn();
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={null}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+        onToggleVisibility={vi.fn()}
+        onReorder={onReorder}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'reorder same' }));
+    await userEvent.click(screen.getByRole('button', { name: 'reorder no target' }));
+    expect(onReorder).not.toHaveBeenCalled();
   });
 });

--- a/src/components/shared/admin/page-editor/__tests__/EditorCanvas.test.tsx
+++ b/src/components/shared/admin/page-editor/__tests__/EditorCanvas.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import EditorCanvas from '@/components/shared/admin/page-editor/EditorCanvas';
+import type { DraftBlock } from '@/components/shared/admin/page-editor/SortableBlockItem';
+
+const blocks: DraftBlock[] = [
+  {
+    id: 1,
+    type: 'hero_banner',
+    content: { title: '메인 배너' },
+    sort_order: 0,
+    is_visible: true,
+  },
+  {
+    id: 2,
+    type: 'product_grid',
+    content: { title: '추천 상품', limit: 8, template: '4col' },
+    sort_order: 1,
+    is_visible: true,
+  },
+  {
+    id: 3,
+    type: 'text_content',
+    content: { html: '<p>안녕하세요</p>' },
+    sort_order: 2,
+    is_visible: false,
+  },
+];
+
+describe('EditorCanvas', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  it('blocks=[] → 빈 상태 메시지', () => {
+    render(
+      <EditorCanvas
+        blocks={[]}
+        selectedBlockId={null}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+        onToggleVisibility={vi.fn()}
+        onReorder={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('블록이 없습니다')).toBeInTheDocument();
+  });
+
+  it('블록 목록 렌더 — 타입 라벨 + 순번 표시', () => {
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={null}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+        onToggleVisibility={vi.fn()}
+        onReorder={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('히어로 배너')).toBeInTheDocument();
+    expect(screen.getByText('상품 그리드')).toBeInTheDocument();
+    expect(screen.getByText('텍스트')).toBeInTheDocument();
+    // 순번 1, 2, 3
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('블록 클릭 → onSelectBlock(id) 호출', async () => {
+    const onSelectBlock = vi.fn();
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={null}
+        onSelectBlock={onSelectBlock}
+        onDeleteBlock={vi.fn()}
+        onToggleVisibility={vi.fn()}
+        onReorder={vi.fn()}
+      />,
+    );
+    // 블록 본문 영역 클릭 (라벨 텍스트가 있는 버튼)
+    await userEvent.click(screen.getByText('히어로 배너'));
+    expect(onSelectBlock).toHaveBeenCalledWith(1);
+  });
+
+  it('가시성 토글 버튼 → onToggleVisibility(id)', async () => {
+    const onToggleVisibility = vi.fn();
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={null}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+        onToggleVisibility={onToggleVisibility}
+        onReorder={vi.fn()}
+      />,
+    );
+    // is_visible=true 인 블록은 "숨기기" aria-label
+    const hideButtons = screen.getAllByRole('button', { name: '숨기기' });
+    await userEvent.click(hideButtons[0]);
+    expect(onToggleVisibility).toHaveBeenCalledWith(1);
+  });
+
+  it('삭제 버튼 + confirm → onDeleteBlock(id)', async () => {
+    const onDeleteBlock = vi.fn();
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={null}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={onDeleteBlock}
+        onToggleVisibility={vi.fn()}
+        onReorder={vi.fn()}
+      />,
+    );
+    const deleteButtons = screen.getAllByRole('button', { name: '블록 삭제' });
+    await userEvent.click(deleteButtons[1]);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(onDeleteBlock).toHaveBeenCalledWith(2);
+  });
+
+  it('삭제 버튼 + confirm=false → onDeleteBlock 호출 안 됨', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const onDeleteBlock = vi.fn();
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={null}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={onDeleteBlock}
+        onToggleVisibility={vi.fn()}
+        onReorder={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getAllByRole('button', { name: '블록 삭제' })[0]);
+    expect(onDeleteBlock).not.toHaveBeenCalled();
+  });
+
+  it('selectedBlockId 와 일치하는 블록은 ring-2 클래스', () => {
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={2}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+        onToggleVisibility={vi.fn()}
+        onReorder={vi.fn()}
+      />,
+    );
+    // SortableBlockItem 의 컨테이너 div 가 ring-2 클래스를 가짐
+    const selectedTitle = screen.getByText('상품 그리드');
+    const wrapper = selectedTitle.closest('div.mb-2');
+    expect(wrapper?.className).toContain('ring-2');
+  });
+
+  it('is_visible=false 블록은 EyeOff 아이콘 ("표시" aria-label)', () => {
+    render(
+      <EditorCanvas
+        blocks={blocks}
+        selectedBlockId={null}
+        onSelectBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+        onToggleVisibility={vi.fn()}
+        onReorder={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: '표시' })).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/checkout/__tests__/AddressSelectorSection.test.tsx
+++ b/src/components/shared/checkout/__tests__/AddressSelectorSection.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { AddressSelectorSection } from '@/components/shared/checkout/AddressSelectorSection';
+import type { UserAddress } from '@/lib/api';
+
+const sampleAddresses: UserAddress[] = [
+  {
+    id: 1,
+    userId: 10,
+    recipientName: '홍길동',
+    phone: '010-1111-2222',
+    zipcode: '06234',
+    address: '서울 강남구 테헤란로 123',
+    addressDetail: '101호',
+    label: '집',
+    isDefault: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+  },
+  {
+    id: 2,
+    userId: 10,
+    recipientName: '홍길동',
+    phone: '010-3333-4444',
+    zipcode: '03187',
+    address: '서울 종로구 종로 1',
+    addressDetail: null,
+    label: '회사',
+    isDefault: false,
+    createdAt: '2024-01-02T00:00:00.000Z',
+  },
+];
+
+describe('AddressSelectorSection', () => {
+  it('addressLoading=true → 로딩 메시지', () => {
+    render(
+      <AddressSelectorSection
+        addresses={[]}
+        selectedAddressId={null}
+        addressLoading={true}
+        onSelect={vi.fn()}
+        locale="ko"
+      />,
+    );
+    expect(screen.getByText('주소 불러오는 중...')).toBeInTheDocument();
+  });
+
+  it('addresses=[] → 배송지 추가 안내 + 버튼', () => {
+    render(
+      <AddressSelectorSection
+        addresses={[]}
+        selectedAddressId={null}
+        addressLoading={false}
+        onSelect={vi.fn()}
+        locale="ko"
+      />,
+    );
+    expect(screen.getByText('저장된 배송지가 없습니다.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '배송지 추가' })).toBeInTheDocument();
+  });
+
+  it('addresses 있으면 라디오 + 직접 입력 옵션 렌더', () => {
+    render(
+      <AddressSelectorSection
+        addresses={sampleAddresses}
+        selectedAddressId={1}
+        addressLoading={false}
+        onSelect={vi.fn()}
+        locale="ko"
+      />,
+    );
+    // 두 주소 + 직접 입력
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.getByText('집')).toBeInTheDocument();
+    expect(screen.getByText('회사')).toBeInTheDocument();
+    expect(screen.getByText('직접 입력')).toBeInTheDocument();
+  });
+
+  it('selectedAddressId=1 → 첫 번째 주소 라디오 checked', () => {
+    render(
+      <AddressSelectorSection
+        addresses={sampleAddresses}
+        selectedAddressId={1}
+        addressLoading={false}
+        onSelect={vi.fn()}
+        locale="ko"
+      />,
+    );
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).toBeChecked();
+    expect(radios[1]).not.toBeChecked();
+    expect(radios[2]).not.toBeChecked();
+  });
+
+  it('selectedAddressId=manual → 직접 입력 라디오 checked', () => {
+    render(
+      <AddressSelectorSection
+        addresses={sampleAddresses}
+        selectedAddressId="manual"
+        addressLoading={false}
+        onSelect={vi.fn()}
+        locale="ko"
+      />,
+    );
+    const radios = screen.getAllByRole('radio');
+    expect(radios[2]).toBeChecked();
+  });
+
+  it('주소 라디오 클릭 → onSelect(id) 호출', async () => {
+    const onSelect = vi.fn();
+    render(
+      <AddressSelectorSection
+        addresses={sampleAddresses}
+        selectedAddressId={1}
+        addressLoading={false}
+        onSelect={onSelect}
+        locale="ko"
+      />,
+    );
+    await userEvent.click(screen.getAllByRole('radio')[1]);
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it('직접 입력 클릭 → onSelect("manual") 호출', async () => {
+    const onSelect = vi.fn();
+    render(
+      <AddressSelectorSection
+        addresses={sampleAddresses}
+        selectedAddressId={1}
+        addressLoading={false}
+        onSelect={onSelect}
+        locale="ko"
+      />,
+    );
+    await userEvent.click(screen.getAllByRole('radio')[2]);
+    expect(onSelect).toHaveBeenCalledWith('manual');
+  });
+});

--- a/src/components/shared/checkout/__tests__/CouponSelector.test.tsx
+++ b/src/components/shared/checkout/__tests__/CouponSelector.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import CouponSelector from '@/components/shared/checkout/CouponSelector';
+import type { CouponItem, CalculateDiscountResponse } from '@/lib/api';
+
+const { getListMock, calculateMock, toastErrorMock } = vi.hoisted(() => ({
+  getListMock: vi.fn(),
+  calculateMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  couponsApi: {
+    getList: getListMock,
+    calculate: calculateMock,
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+  },
+}));
+
+const sampleCoupons: CouponItem[] = [
+  {
+    id: 1,
+    couponId: 100,
+    code: 'WELCOME',
+    name: '신규가입 할인',
+    type: 'percentage',
+    value: 10,
+    minOrderAmount: 30000,
+    maxDiscount: 5000,
+    expiresAt: '2030-12-31T23:59:59.000Z',
+    status: 'available',
+    issuedAt: '2024-01-01T00:00:00.000Z',
+    usedAt: null,
+  },
+  {
+    id: 2,
+    couponId: 101,
+    code: 'FIXED5K',
+    name: '5천원 정액 할인',
+    type: 'fixed',
+    value: 5000,
+    minOrderAmount: 50000,
+    maxDiscount: null,
+    expiresAt: '2030-12-31T23:59:59.000Z',
+    status: 'available',
+    issuedAt: '2024-01-01T00:00:00.000Z',
+    usedAt: null,
+  },
+];
+
+const discountResult: CalculateDiscountResponse = {
+  originalAmount: 100000,
+  couponDiscount: 5000,
+  pointsDiscount: 0,
+  finalAmount: 95000,
+  shippingFee: 0,
+  totalPayable: 95000,
+};
+
+describe('CouponSelector', () => {
+  beforeEach(() => {
+    getListMock.mockReset();
+    calculateMock.mockReset();
+    toastErrorMock.mockReset();
+  });
+
+  it('마운트 시 쿠폰 목록 fetch 후 select 옵션 렌더', async () => {
+    getListMock.mockResolvedValue({ coupons: sampleCoupons, points: { balance: 0, willExpireSoon: 0 } });
+    render(<CouponSelector orderAmount={100000} onDiscountChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledWith('available');
+    });
+    expect(await screen.findByRole('option', { name: /신규가입 할인/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /5천원 정액 할인/ })).toBeInTheDocument();
+  });
+
+  it('쿠폰 선택 → calculate 호출 + onDiscountChange(result, id)', async () => {
+    getListMock.mockResolvedValue({ coupons: sampleCoupons, points: { balance: 0, willExpireSoon: 0 } });
+    calculateMock.mockResolvedValue(discountResult);
+    const onDiscountChange = vi.fn();
+    render(<CouponSelector orderAmount={100000} onDiscountChange={onDiscountChange} />);
+
+    await screen.findByRole('option', { name: /신규가입 할인/ });
+    await userEvent.selectOptions(screen.getByLabelText('쿠폰 선택'), '1');
+
+    await waitFor(() => {
+      expect(calculateMock).toHaveBeenCalledWith({ orderAmount: 100000, userCouponId: 1 });
+    });
+    expect(onDiscountChange).toHaveBeenCalledWith(discountResult, 1);
+  });
+
+  it('빈 값 선택 → onDiscountChange(null, undefined)', async () => {
+    getListMock.mockResolvedValue({ coupons: sampleCoupons, points: { balance: 0, willExpireSoon: 0 } });
+    calculateMock.mockResolvedValue(discountResult);
+    const onDiscountChange = vi.fn();
+    render(<CouponSelector orderAmount={100000} onDiscountChange={onDiscountChange} />);
+
+    await screen.findByRole('option', { name: /신규가입 할인/ });
+    const select = screen.getByLabelText('쿠폰 선택');
+    // 먼저 쿠폰 선택 후 다시 빈 값으로
+    await userEvent.selectOptions(select, '1');
+    await waitFor(() => expect(calculateMock).toHaveBeenCalled());
+    calculateMock.mockClear();
+    onDiscountChange.mockClear();
+    await userEvent.selectOptions(select, '');
+
+    expect(onDiscountChange).toHaveBeenLastCalledWith(null, undefined);
+    expect(calculateMock).not.toHaveBeenCalled();
+  });
+
+  it('calculate 실패 → toast.error + onDiscountChange(null) + 선택 초기화', async () => {
+    getListMock.mockResolvedValue({ coupons: sampleCoupons, points: { balance: 0, willExpireSoon: 0 } });
+    calculateMock.mockRejectedValue(new Error('최소 주문금액 미달'));
+    const onDiscountChange = vi.fn();
+    render(<CouponSelector orderAmount={100000} onDiscountChange={onDiscountChange} />);
+
+    await screen.findByRole('option', { name: /신규가입 할인/ });
+    await userEvent.selectOptions(screen.getByLabelText('쿠폰 선택'), '1');
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled();
+    });
+    expect(onDiscountChange).toHaveBeenLastCalledWith(null, undefined);
+  });
+
+  it('쿠폰 목록이 비어있으면 안내 문구 표시', async () => {
+    getListMock.mockResolvedValue({ coupons: [], points: { balance: 0, willExpireSoon: 0 } });
+    render(<CouponSelector orderAmount={100000} onDiscountChange={vi.fn()} />);
+
+    expect(await screen.findByText('사용 가능한 쿠폰이 없습니다.')).toBeInTheDocument();
+  });
+
+  it('빈 목록 + 선택 안 함 → onDiscountChange 호출 안 됨', async () => {
+    getListMock.mockResolvedValue({ coupons: [], points: { balance: 0, willExpireSoon: 0 } });
+    const onDiscountChange = vi.fn();
+    render(<CouponSelector orderAmount={100000} onDiscountChange={onDiscountChange} />);
+
+    await screen.findByText('사용 가능한 쿠폰이 없습니다.');
+    expect(onDiscountChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/shared/checkout/__tests__/PaymentGateway.test.tsx
+++ b/src/components/shared/checkout/__tests__/PaymentGateway.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { createRef } from 'react';
+import PaymentGateway, { type PaymentGatewayHandle } from '@/components/shared/checkout/PaymentGateway';
+import type { PreparePaymentResponse } from '@/lib/api';
+
+vi.mock('@tosspayments/tosspayments-sdk', () => ({
+  loadTossPayments: vi.fn().mockResolvedValue({
+    payment: vi.fn().mockReturnValue({
+      requestPayment: vi.fn().mockResolvedValue(undefined),
+    }),
+  }),
+}));
+
+vi.mock('@stripe/stripe-js', () => ({
+  loadStripe: vi.fn().mockResolvedValue({
+    elements: vi.fn().mockReturnValue({
+      create: vi.fn().mockReturnValue({
+        mount: vi.fn(),
+        on: vi.fn(),
+      }),
+    }),
+    confirmPayment: vi.fn().mockResolvedValue({ error: null }),
+  }),
+}));
+
+const baseProps = {
+  orderId: 1,
+  orderNumber: 'ORDER-001',
+  amount: 50000,
+  onError: vi.fn(),
+};
+
+describe('PaymentGateway', () => {
+  it('locale=ko + 유효 clientKey → Toss 라디오 표시', () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORDER-001',
+      amount: 50000,
+      gateway: 'toss',
+      clientKey: 'test_ck_real_value',
+    };
+    render(
+      <PaymentGateway
+        prepareResult={prepareResult}
+        locale="ko"
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText('토스페이먼츠 (카드)')).toBeInTheDocument();
+  });
+
+  it('gateway=stripe + 유효 clientKey → Stripe Element 라디오 표시', () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORDER-001',
+      amount: 50000,
+      gateway: 'stripe',
+      clientKey: 'pi_secret_value',
+    };
+    render(
+      <PaymentGateway
+        prepareResult={prepareResult}
+        locale="en"
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText('Stripe (International Card)')).toBeInTheDocument();
+  });
+
+  it('clientKey=mock_client_key → Mock 라디오 표시', () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORDER-001',
+      amount: 50000,
+      gateway: 'mock',
+      clientKey: 'mock_client_key',
+    };
+    render(
+      <PaymentGateway
+        prepareResult={prepareResult}
+        locale="ko"
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText('테스트 결제 (Mock)')).toBeInTheDocument();
+  });
+
+  it('locale=en + clientKey=mock_client_key → Mock 라디오 (Stripe 분기 안 탐)', () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORDER-001',
+      amount: 50000,
+      gateway: 'stripe',
+      clientKey: 'mock_client_key',
+    };
+    render(
+      <PaymentGateway
+        prepareResult={prepareResult}
+        locale="en"
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText('테스트 결제 (Mock)')).toBeInTheDocument();
+    expect(screen.queryByText('Stripe (International Card)')).not.toBeInTheDocument();
+  });
+
+  it('Mock gateway: confirm() 은 no-op (resolve)', async () => {
+    const ref = createRef<PaymentGatewayHandle>();
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORDER-001',
+      amount: 50000,
+      gateway: 'mock',
+      clientKey: 'mock_client_key',
+    };
+    render(
+      <PaymentGateway
+        ref={ref}
+        prepareResult={prepareResult}
+        locale="ko"
+        {...baseProps}
+      />,
+    );
+    await expect(ref.current!.confirm()).resolves.toBeUndefined();
+  });
+});

--- a/src/components/shared/checkout/__tests__/ShippingFormSection.test.tsx
+++ b/src/components/shared/checkout/__tests__/ShippingFormSection.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ShippingFormSection,
+  PhoneInputSection,
+  ZipcodeInputSection,
+  AddressInputSection,
+  AddressDetailInputSection,
+  MemoInputSection,
+} from '@/components/shared/checkout/ShippingFormSection';
+import type { ShippingForm, FormErrors } from '@/app/[locale]/checkout/page';
+
+const baseForm: ShippingForm = {
+  recipientName: '',
+  recipientPhone: '',
+  zipcode: '',
+  address: '',
+  addressDetail: '',
+  memo: '',
+};
+
+describe('ShippingFormSection', () => {
+  it('받는 분 이름 입력 시 onChange 호출', async () => {
+    const onChange = vi.fn();
+    render(<ShippingFormSection form={baseForm} errors={{}} onChange={onChange} />);
+
+    await userEvent.type(screen.getByLabelText(/받는 분 이름/), '홍길동');
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.target.name).toBe('recipientName');
+  });
+
+  it('errors.recipientName 있으면 에러 메시지 표시', () => {
+    const errors: FormErrors = { recipientName: '받는 분 이름을 입력하세요.' };
+    render(<ShippingFormSection form={baseForm} errors={errors} onChange={vi.fn()} />);
+    expect(screen.getByText('받는 분 이름을 입력하세요.')).toBeInTheDocument();
+  });
+
+  it('errors 없으면 에러 메시지 미표시', () => {
+    render(<ShippingFormSection form={baseForm} errors={{}} onChange={vi.fn()} />);
+    expect(screen.queryByText(/입력하세요/)).not.toBeInTheDocument();
+  });
+
+  it('form.recipientName 값이 input에 반영', () => {
+    render(
+      <ShippingFormSection
+        form={{ ...baseForm, recipientName: '김철수' }}
+        errors={{}}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText(/받는 분 이름/)).toHaveValue('김철수');
+  });
+});
+
+describe('PhoneInputSection', () => {
+  it('연락처 입력 onChange 호출', async () => {
+    const onChange = vi.fn();
+    render(<PhoneInputSection form={baseForm} errors={{}} onChange={onChange} />);
+
+    await userEvent.type(screen.getByLabelText(/연락처/), '010');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('errors.recipientPhone 표시', () => {
+    render(
+      <PhoneInputSection
+        form={baseForm}
+        errors={{ recipientPhone: '연락처를 입력하세요.' }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('연락처를 입력하세요.')).toBeInTheDocument();
+  });
+});
+
+describe('ZipcodeInputSection', () => {
+  it('우편번호 maxLength=5', () => {
+    render(<ZipcodeInputSection form={baseForm} errors={{}} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/우편번호/)).toHaveAttribute('maxLength', '5');
+  });
+
+  it('errors.zipcode 표시', () => {
+    render(
+      <ZipcodeInputSection
+        form={baseForm}
+        errors={{ zipcode: '우편번호를 입력하세요.' }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('우편번호를 입력하세요.')).toBeInTheDocument();
+  });
+});
+
+describe('AddressInputSection', () => {
+  it('주소 입력 onChange 호출', async () => {
+    const onChange = vi.fn();
+    render(<AddressInputSection form={baseForm} errors={{}} onChange={onChange} />);
+    await userEvent.type(screen.getByLabelText(/^주소/), '서울');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('errors.address 표시', () => {
+    render(
+      <AddressInputSection
+        form={baseForm}
+        errors={{ address: '주소를 입력하세요.' }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('주소를 입력하세요.')).toBeInTheDocument();
+  });
+});
+
+describe('AddressDetailInputSection', () => {
+  it('상세 주소는 선택적 — 에러 없음', () => {
+    render(<AddressDetailInputSection form={baseForm} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/상세 주소/)).toBeInTheDocument();
+  });
+
+  it('상세 주소 입력 onChange 호출', async () => {
+    const onChange = vi.fn();
+    render(<AddressDetailInputSection form={baseForm} onChange={onChange} />);
+    await userEvent.type(screen.getByLabelText(/상세 주소/), '101호');
+    expect(onChange).toHaveBeenCalled();
+  });
+});
+
+describe('MemoInputSection', () => {
+  it('배송 메모 textarea 렌더', () => {
+    render(<MemoInputSection form={baseForm} onChange={vi.fn()} />);
+    const memo = screen.getByLabelText(/배송 메모/);
+    expect(memo.tagName).toBe('TEXTAREA');
+  });
+
+  it('memo 입력 onChange 호출', async () => {
+    const onChange = vi.fn();
+    render(<MemoInputSection form={baseForm} onChange={onChange} />);
+    await userEvent.type(screen.getByLabelText(/배송 메모/), '문 앞');
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/src/components/shared/products/__tests__/LightboxOverlay.test.tsx
+++ b/src/components/shared/products/__tests__/LightboxOverlay.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, fireEvent, renderHook, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import LightboxOverlay from '@/components/shared/products/LightboxOverlay';
+import { useLightboxInteraction } from '@/components/shared/hooks/useLightboxInteraction';
+
+const sampleImages = [
+  { id: 1, url: '/img1.jpg', alt: '이미지1', sortOrder: 0, isThumbnail: true },
+  { id: 2, url: '/img2.jpg', alt: '이미지2', sortOrder: 1, isThumbnail: false },
+  { id: 3, url: '/img3.jpg', alt: null, sortOrder: 2, isThumbnail: false },
+];
+
+function makeBaseProps(overrides: Partial<React.ComponentProps<typeof LightboxOverlay>> = {}) {
+  // 기본 ref 들
+  const lightboxPanRef = { current: { x: 0, y: 0 } } as React.MutableRefObject<{ x: number; y: number }>;
+  const isDragging = { current: false } as React.MutableRefObject<boolean>;
+
+  return {
+    images: sampleImages,
+    selectedIndex: 0,
+    onSelectIndex: vi.fn(),
+    lightboxOpen: true,
+    lightboxZoomed: false,
+    setLightboxZoomed: vi.fn(),
+    lightboxPanRef,
+    lightboxImageStyle: {},
+    onClose: vi.fn(),
+    onPrev: vi.fn(),
+    onNext: vi.fn(),
+    handleLightboxMouseDown: vi.fn(),
+    handleLightboxMouseMove: vi.fn(),
+    handleLightboxMouseUp: vi.fn(),
+    handleLightboxTouchStart: vi.fn(),
+    handleLightboxTouchMove: vi.fn(),
+    handleLightboxTouchEnd: vi.fn(),
+    isDragging,
+    ...overrides,
+  };
+}
+
+describe('LightboxOverlay', () => {
+  it('lightboxOpen=false 면 null 반환 (DOM 없음)', () => {
+    const { container } = render(<LightboxOverlay {...makeBaseProps({ lightboxOpen: false })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('인덱스 표시 — "1 / 3"', () => {
+    render(<LightboxOverlay {...makeBaseProps()} />);
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+  });
+
+  it('이미지 1장이면 prev/next 버튼/도트 미렌더', () => {
+    render(<LightboxOverlay {...makeBaseProps({ images: [sampleImages[0]] })} />);
+    expect(screen.queryByLabelText('이전 이미지')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('다음 이미지')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/이미지 \d+/)).not.toBeInTheDocument();
+  });
+
+  it('닫기 버튼 클릭 → onClose', async () => {
+    const props = makeBaseProps();
+    render(<LightboxOverlay {...props} />);
+    await userEvent.click(screen.getByLabelText('닫기'));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('이전/다음 버튼 클릭 → onPrev/onNext 만 호출 (close 전파 X)', async () => {
+    const props = makeBaseProps();
+    render(<LightboxOverlay {...props} />);
+    await userEvent.click(screen.getByLabelText('이전 이미지'));
+    expect(props.onPrev).toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByLabelText('다음 이미지'));
+    expect(props.onNext).toHaveBeenCalled();
+  });
+
+  it('도트 클릭 → onSelectIndex(i) 호출', async () => {
+    const props = makeBaseProps();
+    render(<LightboxOverlay {...props} />);
+    await userEvent.click(screen.getByLabelText('이미지 3'));
+    expect(props.onSelectIndex).toHaveBeenCalledWith(2);
+  });
+
+  it('확대 버튼 클릭 → setLightboxZoomed(true) 호출', async () => {
+    const setLightboxZoomed = vi.fn();
+    render(
+      <LightboxOverlay
+        {...makeBaseProps({ lightboxZoomed: false, setLightboxZoomed })}
+      />,
+    );
+    await userEvent.click(screen.getByLabelText('확대'));
+    expect(setLightboxZoomed).toHaveBeenCalledWith(true);
+  });
+
+  it('이미 확대된 상태 → 축소 버튼 + setLightboxZoomed(false) + pan 초기화', async () => {
+    const setLightboxZoomed = vi.fn();
+    const lightboxPanRef = { current: { x: 50, y: 50 } } as React.MutableRefObject<{ x: number; y: number }>;
+    render(
+      <LightboxOverlay
+        {...makeBaseProps({ lightboxZoomed: true, setLightboxZoomed, lightboxPanRef })}
+      />,
+    );
+    await userEvent.click(screen.getByLabelText('축소'));
+    expect(setLightboxZoomed).toHaveBeenCalledWith(false);
+    expect(lightboxPanRef.current).toEqual({ x: 0, y: 0 });
+  });
+
+  it('selectedImage 의 alt 가 null 이면 기본 "상품 이미지" 사용', () => {
+    render(<LightboxOverlay {...makeBaseProps({ selectedIndex: 2 })} />);
+    expect(screen.getByAltText('상품 이미지')).toBeInTheDocument();
+  });
+
+  it('마우스 이벤트 → 핸들러 호출', () => {
+    const props = makeBaseProps();
+    render(<LightboxOverlay {...props} />);
+    const image = screen.getByAltText('이미지1');
+    const interactiveContainer = image.closest('[style*="cursor"]') as HTMLElement;
+    fireEvent.mouseDown(interactiveContainer);
+    fireEvent.mouseMove(interactiveContainer);
+    fireEvent.mouseUp(interactiveContainer);
+    expect(props.handleLightboxMouseDown).toHaveBeenCalled();
+    expect(props.handleLightboxMouseMove).toHaveBeenCalled();
+    expect(props.handleLightboxMouseUp).toHaveBeenCalled();
+  });
+});
+
+describe('useLightboxInteraction', () => {
+  it('초기 상태: zoomed=false, pan={0,0}', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+    expect(result.current.lightboxZoomed).toBe(false);
+    expect(result.current.lightboxPan).toEqual({ x: 0, y: 0 });
+  });
+
+  it('setLightboxZoomed(true) → zoomed=true', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+    act(() => result.current.setLightboxZoomed(true));
+    expect(result.current.lightboxZoomed).toBe(true);
+  });
+
+  it('zoomed=true 일 때 mouseDown → mouseMove 시 pan 업데이트', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+    act(() => result.current.setLightboxZoomed(true));
+
+    act(() => {
+      result.current.handleLightboxMouseDown({
+        clientX: 0,
+        clientY: 0,
+      } as React.MouseEvent);
+    });
+    act(() => {
+      result.current.handleLightboxMouseMove({
+        clientX: 50,
+        clientY: 30,
+      } as React.MouseEvent);
+    });
+    expect(result.current.lightboxPan).toEqual({ x: 50, y: 30 });
+  });
+
+  it('mouseMove pan 은 maxPan=150 으로 클램핑', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+    act(() => result.current.setLightboxZoomed(true));
+    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0 } as React.MouseEvent));
+    act(() => result.current.handleLightboxMouseMove({ clientX: 9999, clientY: -9999 } as React.MouseEvent));
+    expect(result.current.lightboxPan).toEqual({ x: 150, y: -150 });
+  });
+
+  it('zoomed=false 면 mouseMove 무시', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+    act(() => {
+      result.current.handleLightboxMouseMove({ clientX: 100, clientY: 100 } as React.MouseEvent);
+    });
+    expect(result.current.lightboxPan).toEqual({ x: 0, y: 0 });
+  });
+
+  it('mouseUp → isDragging.current=false', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+    act(() => result.current.setLightboxZoomed(true));
+    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0 } as React.MouseEvent));
+    expect(result.current.isDragging.current).toBe(true);
+    act(() => result.current.handleLightboxMouseUp());
+    expect(result.current.isDragging.current).toBe(false);
+  });
+
+  it('resetLightboxState → zoom 초기화 + pan 초기화', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+    act(() => result.current.setLightboxZoomed(true));
+    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0 } as React.MouseEvent));
+    act(() => result.current.handleLightboxMouseMove({ clientX: 30, clientY: 30 } as React.MouseEvent));
+    expect(result.current.lightboxPan).toEqual({ x: 30, y: 30 });
+
+    act(() => result.current.resetLightboxState());
+    expect(result.current.lightboxZoomed).toBe(false);
+    expect(result.current.lightboxPan).toEqual({ x: 0, y: 0 });
+    expect(result.current.lightboxPanRef.current).toEqual({ x: 0, y: 0 });
+  });
+
+  it('touchMove pan 은 maxPan=100 으로 클램핑', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+    act(() => result.current.setLightboxZoomed(true));
+    act(() => {
+      result.current.handleLightboxTouchStart({
+        touches: [{ clientX: 0, clientY: 0 }],
+      } as unknown as React.TouchEvent);
+    });
+    act(() => {
+      result.current.handleLightboxTouchMove({
+        touches: [{ clientX: 500, clientY: -500 }],
+      } as unknown as React.TouchEvent);
+    });
+    expect(result.current.lightboxPan).toEqual({ x: 100, y: -100 });
+  });
+});
+

--- a/src/components/shared/products/__tests__/LightboxOverlay.test.tsx
+++ b/src/components/shared/products/__tests__/LightboxOverlay.test.tsx
@@ -123,7 +123,6 @@ describe('LightboxOverlay', () => {
     expect(props.handleLightboxMouseUp).toHaveBeenCalled();
   });
 });
-
 describe('useLightboxInteraction', () => {
   it('초기 상태: zoomed=false, pan={0,0}', () => {
     const { result } = renderHook(() => useLightboxInteraction());
@@ -210,4 +209,3 @@ describe('useLightboxInteraction', () => {
     expect(result.current.lightboxPan).toEqual({ x: 100, y: -100 });
   });
 });
-

--- a/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
+++ b/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
@@ -1,0 +1,261 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ProductDetailClient from '@/components/shared/products/ProductDetailClient';
+import type { ProductDetail } from '@/lib/api';
+
+const { pushMock, toastSuccessMock, toastErrorMock, addCartItemMock, wishlistAddMock, wishlistRemoveMock, wishlistCheckMock } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  addCartItemMock: vi.fn(),
+  wishlistAddMock: vi.fn(),
+  wishlistRemoveMock: vi.fn(),
+  wishlistCheckMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string | number>) => {
+    const labels: Record<string, string> = {
+      addToCart: '장바구니 담기',
+      buyNow: '바로 구매',
+      quantity: '수량',
+      selectOption: '옵션을 선택하세요.',
+      addToWishlistAria: '찜하기',
+      removeFromWishlistAria: '찜 해제',
+      addToCartSuccess: '장바구니에 담았습니다.',
+      addToCartError: '장바구니 담기 실패',
+      buyNowError: '바로 구매 실패',
+      wishlistAddSuccess: '찜 추가됨',
+      wishlistRemoveSuccess: '찜 해제됨',
+      wishlistError: '찜 오류',
+      reviewCount: `리뷰 ${values?.count ?? 0}건`,
+      lowStock: `재고 ${values?.count ?? 0}개`,
+      discountOff: `${values?.percent ?? 0}% 할인`,
+      selectedQuantity: `수량 ${values?.quantity ?? 0}개`,
+      totalProductPrice: '상품 합계',
+      outOfStockMessage: '품절',
+      clay: '진흙',
+      shape: '모양',
+    };
+    return labels[key] ?? key;
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
+
+vi.mock('@/contexts/CartContext', () => ({
+  useCart: () => ({ addItem: addCartItemMock }),
+}));
+
+vi.mock('@/contexts/MobileNavContext', () => ({
+  useMobileNav: () => ({ isVisible: true }),
+}));
+
+vi.mock('@/components/shared/hooks/useRecentlyViewed', () => ({
+  useRecentlyViewed: () => ({ addItem: vi.fn() }),
+}));
+
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api');
+  return {
+    ...actual,
+    wishlistApi: {
+      check: wishlistCheckMock,
+      add: wishlistAddMock,
+      remove: wishlistRemoveMock,
+    },
+  };
+});
+
+vi.mock('@/components/shared/products/ImageGallery', () => ({
+  default: () => <div data-testid="image-gallery" />,
+}));
+
+vi.mock('@/components/shared/products/OptionSelector', () => ({
+  default: ({
+    options,
+    onSelect,
+  }: {
+    options: Array<{ id: number; name: string; value: string }>;
+    selectedOptionId: number | null;
+    onSelect: (id: number) => void;
+  }) => (
+    <div data-testid="option-selector">
+      {options.map((o) => (
+        <button key={o.id} type="button" onClick={() => onSelect(o.id)}>
+          {o.name}-{o.value}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/shared/products/QuantitySelector', () => ({
+  default: ({
+    quantity,
+    onIncrease,
+    onDecrease,
+  }: {
+    quantity: number;
+    maxQuantity: number;
+    onIncrease: () => void;
+    onDecrease: () => void;
+  }) => (
+    <div data-testid="quantity-selector">
+      <button type="button" onClick={onDecrease}>-</button>
+      <span data-testid="qty-value">{quantity}</span>
+      <button type="button" onClick={onIncrease}>+</button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/shared/products/ProductTabs', () => ({
+  default: () => <div data-testid="product-tabs" />,
+}));
+
+vi.mock('@/components/shared/reviews/StarRating', () => ({
+  default: () => <div data-testid="star-rating" />,
+}));
+
+vi.mock('@/components/shared/common/PriceDisplay', () => ({
+  default: ({ price }: { price: number }) => <div data-testid="price-display">{price}</div>,
+}));
+
+const productWithOptions: ProductDetail = {
+  id: 1,
+  name: '핸드메이드 자사호',
+  slug: 'handmade-teapot',
+  price: 120000,
+  salePrice: null,
+  shortDescription: '짧은 설명',
+  rating: 4.8,
+  reviewCount: 3,
+  status: 'active',
+  isFeatured: false,
+  viewCount: 0,
+  category: { id: 10, name: '자사호', slug: 'teapots', parentId: null, imageUrl: null },
+  images: [{ id: 1, url: '/teapot.jpg', alt: 'Teapot', sortOrder: 0, isThumbnail: true, isDescriptionImage: false }],
+  attributes: [],
+  description: '<p>본문</p>',
+  stock: 12,
+  sku: 'TP-001',
+  options: [
+    { id: 11, name: '크기', value: '대', priceAdjustment: 0, stock: 12, sortOrder: 0 },
+    { id: 12, name: '크기', value: '소', priceAdjustment: -10000, stock: 5, sortOrder: 1 },
+  ],
+  detailImages: [],
+};
+
+const productWithoutOptions: ProductDetail = {
+  ...productWithOptions,
+  options: [],
+};
+
+const soldoutProduct: ProductDetail = {
+  ...productWithOptions,
+  status: 'soldout',
+};
+
+describe('ProductDetailClient', () => {
+  beforeEach(() => {
+    addCartItemMock.mockReset();
+    addCartItemMock.mockResolvedValue(undefined);
+    wishlistCheckMock.mockReset();
+    wishlistCheckMock.mockResolvedValue({ isWishlisted: false, wishlistId: null });
+    wishlistAddMock.mockReset();
+    wishlistAddMock.mockResolvedValue({ id: 999 });
+    wishlistRemoveMock.mockReset();
+    pushMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+  });
+
+  it('옵션 미선택 + 장바구니 담기 → 에러 토스트, addItem 호출 안 됨', async () => {
+    render(<ProductDetailClient product={productWithOptions} locale="ko" />);
+    await userEvent.click(screen.getAllByRole('button', { name: '장바구니 담기' })[0]);
+    expect(toastErrorMock).toHaveBeenCalledWith('옵션을 선택하세요.');
+    expect(addCartItemMock).not.toHaveBeenCalled();
+  });
+
+  it('옵션 선택 후 장바구니 담기 → addItem 호출', async () => {
+    render(<ProductDetailClient product={productWithOptions} locale="ko" />);
+    await userEvent.click(screen.getByRole('button', { name: '크기-대' }));
+    await userEvent.click(screen.getAllByRole('button', { name: '장바구니 담기' })[0]);
+    await waitFor(() => {
+      expect(addCartItemMock).toHaveBeenCalledWith({
+        productId: 1,
+        productOptionId: 11,
+        quantity: 1,
+      });
+    });
+  });
+
+  it('옵션 없는 상품 → 옵션 선택 없이 장바구니 담기 가능', async () => {
+    render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
+    await userEvent.click(screen.getAllByRole('button', { name: '장바구니 담기' })[0]);
+    await waitFor(() => {
+      expect(addCartItemMock).toHaveBeenCalledWith({
+        productId: 1,
+        productOptionId: null,
+        quantity: 1,
+      });
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('바로 구매 → addItem + router.push("/checkout")', async () => {
+    render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
+    await userEvent.click(screen.getAllByRole('button', { name: '바로 구매' })[0]);
+    await waitFor(() => {
+      expect(addCartItemMock).toHaveBeenCalled();
+      expect(pushMock).toHaveBeenCalledWith('/checkout');
+    });
+  });
+
+  it('수량 증가 버튼 → quantity 1→2', async () => {
+    render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
+    expect(screen.getByTestId('qty-value')).toHaveTextContent('1');
+    await userEvent.click(screen.getAllByRole('button', { name: '+' })[0]);
+    expect(screen.getByTestId('qty-value')).toHaveTextContent('2');
+  });
+
+  it('수량 1 에서 감소 버튼 → 1 유지 (최소값)', async () => {
+    render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
+    await userEvent.click(screen.getAllByRole('button', { name: '-' })[0]);
+    expect(screen.getByTestId('qty-value')).toHaveTextContent('1');
+  });
+
+  it('품절 상품 → 장바구니/바로구매 disabled + 안내 메시지', () => {
+    render(<ProductDetailClient product={soldoutProduct} locale="ko" />);
+    const cartButtons = screen.getAllByRole('button', { name: '장바구니 담기' });
+    cartButtons.forEach((btn) => expect(btn).toBeDisabled());
+    expect(screen.getByText('품절')).toBeInTheDocument();
+  });
+
+  it('찜 추가 → wishlistApi.add 호출 + 성공 토스트', async () => {
+    render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
+    // wishlist check 결과 처리 대기
+    await waitFor(() => expect(wishlistCheckMock).toHaveBeenCalled());
+    await userEvent.click(screen.getAllByLabelText('찜하기')[0]);
+    await waitFor(() => {
+      expect(wishlistAddMock).toHaveBeenCalledWith(1);
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith('찜 추가됨');
+  });
+});

--- a/src/components/shared/reviews/__tests__/ReviewForm.test.tsx
+++ b/src/components/shared/reviews/__tests__/ReviewForm.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ReviewForm from '@/components/shared/reviews/ReviewForm';
+
+const { createMock, uploadMock, toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  uploadMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  reviewsApi: {
+    create: createMock,
+    uploadImage: uploadMock,
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
+
+// StarRating 은 별도 테스트가 있으므로 인터랙티브 stub
+vi.mock('@/components/shared/reviews/StarRating', () => ({
+  default: ({
+    rating,
+    onChange,
+  }: {
+    rating: number;
+    size: string;
+    interactive?: boolean;
+    onChange?: (n: number) => void;
+  }) => (
+    <div data-testid="star-rating">
+      <span data-testid="rating-value">{rating}</span>
+      <button type="button" onClick={() => onChange?.(5)}>set-5</button>
+      <button type="button" onClick={() => onChange?.(3)}>set-3</button>
+    </div>
+  ),
+}));
+
+describe('ReviewForm', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    uploadMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+  });
+
+  it('기본 렌더 — 별점 0 + 등록 버튼 disabled', () => {
+    render(
+      <ReviewForm productId={1} orderItemId={2} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByText('리뷰 작성')).toBeInTheDocument();
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('0');
+    expect(screen.getByRole('button', { name: '리뷰 등록' })).toBeDisabled();
+  });
+
+  it('취소 버튼 → onCancel 호출', async () => {
+    const onCancel = vi.fn();
+    render(<ReviewForm productId={1} orderItemId={2} onSuccess={vi.fn()} onCancel={onCancel} />);
+    await userEvent.click(screen.getByRole('button', { name: '취소' }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('별점 0 인 채로 폼 제출 → toast.error + create 미호출', async () => {
+    render(<ReviewForm productId={1} orderItemId={2} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+    // 버튼은 disabled — fireEvent submit 으로 강제 시도
+    const form = screen.getByRole('button', { name: '리뷰 등록' }).closest('form')!;
+    form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('별점을 선택해 주세요.');
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('별점 + 본문 입력 후 제출 → reviewsApi.create + onSuccess + 성공 토스트', async () => {
+    createMock.mockResolvedValue({ id: 100 });
+    const onSuccess = vi.fn();
+    render(<ReviewForm productId={42} orderItemId={99} onSuccess={onSuccess} onCancel={vi.fn()} />);
+
+    await userEvent.click(screen.getByText('set-5'));
+    await userEvent.type(screen.getByPlaceholderText(/리뷰를 작성/), '좋은 제품!');
+    await userEvent.click(screen.getByRole('button', { name: '리뷰 등록' }));
+
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalledWith({
+        productId: 42,
+        orderItemId: 99,
+        rating: 5,
+        content: '좋은 제품!',
+        imageUrls: undefined,
+      });
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith('리뷰가 등록되었습니다.');
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('본문 비워도 제출 가능 (content=null)', async () => {
+    createMock.mockResolvedValue({ id: 100 });
+    render(<ReviewForm productId={1} orderItemId={2} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    await userEvent.click(screen.getByText('set-3'));
+    await userEvent.click(screen.getByRole('button', { name: '리뷰 등록' }));
+
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({ rating: 3, content: null }),
+      );
+    });
+  });
+
+  it('create API 실패 → toast.error', async () => {
+    createMock.mockRejectedValue(new Error('서버 오류'));
+    const onSuccess = vi.fn();
+    render(<ReviewForm productId={1} orderItemId={2} onSuccess={onSuccess} onCancel={vi.fn()} />);
+
+    await userEvent.click(screen.getByText('set-5'));
+    await userEvent.click(screen.getByRole('button', { name: '리뷰 등록' }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled();
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('이미지 업로드 → reviewsApi.uploadImage + 카운터 갱신', async () => {
+    uploadMock.mockResolvedValue({ url: 'https://cdn/img1.jpg' });
+    render(<ReviewForm productId={1} orderItemId={2} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByText('0/5')).toBeInTheDocument();
+    const file = new File(['data'], 'photo.jpg', { type: 'image/jpeg' });
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+
+    await userEvent.upload(fileInput, file);
+    await waitFor(() => {
+      expect(uploadMock).toHaveBeenCalledWith(file);
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith('이미지 업로드 완료');
+    await waitFor(() => {
+      expect(screen.getByText('1/5')).toBeInTheDocument();
+    });
+  });
+
+  it('제출 시 imageUrls 함께 전송', async () => {
+    uploadMock.mockResolvedValue({ url: 'https://cdn/img1.jpg' });
+    createMock.mockResolvedValue({ id: 100 });
+    render(<ReviewForm productId={1} orderItemId={2} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const file = new File(['data'], 'photo.jpg', { type: 'image/jpeg' });
+    await userEvent.upload(document.querySelector<HTMLInputElement>('input[type="file"]')!, file);
+    await waitFor(() => expect(uploadMock).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByText('set-5'));
+    await userEvent.click(screen.getByRole('button', { name: '리뷰 등록' }));
+
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          imageUrls: ['https://cdn/img1.jpg'],
+        }),
+      );
+    });
+  });
+
+  it('이미지 업로드 실패 → toast.error', async () => {
+    uploadMock.mockRejectedValue(new Error('업로드 실패'));
+    render(<ReviewForm productId={1} orderItemId={2} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const file = new File(['data'], 'photo.jpg', { type: 'image/jpeg' });
+    await userEvent.upload(document.querySelector<HTMLInputElement>('input[type="file"]')!, file);
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled();
+    });
+    expect(screen.getByText('0/5')).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/reviews/__tests__/ReviewsTab.test.tsx
+++ b/src/components/shared/reviews/__tests__/ReviewsTab.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ReviewsTab from '@/components/shared/reviews/ReviewsTab';
+import type { ReviewListResponse } from '@/lib/api';
+
+// ReviewsTab 은 ReviewList 의 thin wrapper.
+// ReviewList 가 노출하는 페이징/정렬 동작을 ReviewsTab 통합 시나리오로 검증.
+const { getByProductMock } = vi.hoisted(() => ({
+  getByProductMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  reviewsApi: {
+    getByProduct: getByProductMock,
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/components/shared/reviews/ReviewCard', () => ({
+  default: ({ review }: { review: { id: number; content: string | null } }) => (
+    <div data-testid={`review-card-${review.id}`}>{review.content ?? '(no content)'}</div>
+  ),
+}));
+
+vi.mock('@/components/shared/reviews/ReviewStats', () => ({
+  default: ({ stats }: { stats: { totalCount: number } }) => (
+    <div data-testid="review-stats">총 {stats.totalCount}개</div>
+  ),
+}));
+
+function makeResponse(overrides: Partial<ReviewListResponse> = {}): ReviewListResponse {
+  return {
+    data: [
+      {
+        id: 1,
+        userId: 10,
+        userName: 'Alice',
+        productId: 1,
+        orderItemId: 1,
+        rating: 5,
+        content: '좋아요',
+        imageUrls: null,
+        isVisible: true,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ],
+    stats: { averageRating: 5, totalCount: 1, distribution: { '5': 1, '4': 0, '3': 0, '2': 0, '1': 0 } },
+    pagination: { page: 1, limit: 20, total: 1 },
+    ...overrides,
+  };
+}
+
+describe('ReviewsTab', () => {
+  beforeEach(() => {
+    getByProductMock.mockReset();
+  });
+
+  it('마운트 시 productId 로 reviewsApi.getByProduct 호출 (sort=recent, page=1)', async () => {
+    getByProductMock.mockResolvedValue(makeResponse());
+    render(<ReviewsTab productId={42} />);
+    await waitFor(() => {
+      expect(getByProductMock).toHaveBeenCalledWith(42, expect.objectContaining({
+        sort: 'recent',
+        page: 1,
+        limit: 20,
+      }));
+    });
+  });
+
+  it('리뷰 데이터 렌더링', async () => {
+    getByProductMock.mockResolvedValue(makeResponse());
+    render(<ReviewsTab productId={1} />);
+    expect(await screen.findByTestId('review-card-1')).toHaveTextContent('좋아요');
+  });
+
+  it('빈 결과 → "아직 리뷰가 없습니다." 메시지', async () => {
+    getByProductMock.mockResolvedValue(
+      makeResponse({ data: [], stats: { averageRating: 0, totalCount: 0, distribution: { '5': 0, '4': 0, '3': 0, '2': 0, '1': 0 } } }),
+    );
+    render(<ReviewsTab productId={1} />);
+    expect(await screen.findByText('아직 리뷰가 없습니다.')).toBeInTheDocument();
+  });
+
+  it('정렬 변경 → sort 파라미터 갱신 + page=1 리셋', async () => {
+    getByProductMock.mockResolvedValue(makeResponse());
+    render(<ReviewsTab productId={1} />);
+    await waitFor(() => expect(getByProductMock).toHaveBeenCalled());
+
+    getByProductMock.mockClear();
+    await userEvent.click(screen.getByRole('button', { name: '별점 높은순' }));
+
+    await waitFor(() => {
+      expect(getByProductMock).toHaveBeenCalledWith(1, expect.objectContaining({
+        sort: 'rating_high',
+        page: 1,
+      }));
+    });
+  });
+
+  it('total > limit → 페이지네이션 버튼 렌더', async () => {
+    getByProductMock.mockResolvedValue(
+      makeResponse({ pagination: { page: 1, limit: 20, total: 50 } }),
+    );
+    render(<ReviewsTab productId={1} />);
+    expect(await screen.findByText('1 / 3')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '다음' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '이전' })).toBeDisabled();
+  });
+
+  it('"다음" 버튼 → page=2 로 fetch', async () => {
+    getByProductMock.mockResolvedValue(
+      makeResponse({ pagination: { page: 1, limit: 20, total: 50 } }),
+    );
+    render(<ReviewsTab productId={1} />);
+    await screen.findByText('1 / 3');
+
+    getByProductMock.mockClear();
+    await userEvent.click(screen.getByRole('button', { name: '다음' }));
+    await waitFor(() => {
+      expect(getByProductMock).toHaveBeenCalledWith(1, expect.objectContaining({ page: 2 }));
+    });
+  });
+
+  it('마지막 페이지에서 "다음" 버튼 disabled', async () => {
+    getByProductMock.mockResolvedValue(
+      makeResponse({ pagination: { page: 3, limit: 20, total: 50 } }),
+    );
+    render(<ReviewsTab productId={1} />);
+    await screen.findByText('1 / 3');
+    // 첫 fetch 결과는 page=1, total=50 으로 클라이언트 page 가 1 이므로
+    // "다음" 두 번 눌러서 마지막 페이지로
+    await userEvent.click(screen.getByRole('button', { name: '다음' }));
+    await screen.findByText('2 / 3');
+    await userEvent.click(screen.getByRole('button', { name: '다음' }));
+    await screen.findByText('3 / 3');
+    expect(screen.getByRole('button', { name: '다음' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add EditorCanvas tests for DnD reorder callback behavior
- Assert no reorder is fired when drag target is absent or unchanged
- Preserve existing admin/page-editor test style with jsdom-safe DnD mocks

## Verification
- npx vitest run src/components/shared/admin/page-editor/__tests__/EditorCanvas.test.tsx: passed
- npm run test:run: passed, 81 files / 518 tests