### PR TITLE
test: cover critical order business scenarios

### DIFF
--- a/backend/test/suites/admin-orders.e2e-spec.ts
+++ b/backend/test/suites/admin-orders.e2e-spec.ts
@@ -18,11 +18,12 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
     let orderId: number;
     let refundOrderId: number;
     let productId: number;
+    let userId: number;
 
     const adminEmail = `admin-orders-admin-${Date.now()}@test.com`;
     const userEmail = `admin-orders-user-${Date.now()}@test.com`;
 
-    async function createOrder(): Promise<number> {
+    async function createOrder(options: { pointsUsed?: number } = {}): Promise<number> {
       const orderRes = await request(app.getHttpServer())
         .post('/api/orders')
         .set('Cookie', cookieHeader(userCookies))
@@ -32,9 +33,26 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
           recipientPhone: '010-1234-5678',
           zipcode: '12345',
           address: '서울시 강남구',
+          ...(options.pointsUsed === undefined ? {} : { pointsUsed: options.pointsUsed }),
         })
         .expect(201);
       return Number((orderRes.body as { id: number | string }).id);
+    }
+
+    async function getProductStock(): Promise<number> {
+      const rows = await dataSource.query(
+        `SELECT stock FROM products WHERE id = ?`,
+        [productId],
+      ) as Array<{ stock: number }>;
+      return Number(rows[0].stock);
+    }
+
+    async function getLatestPointBalance(): Promise<{ balance: number; type: string }> {
+      const rows = await dataSource.query(
+        `SELECT balance, type FROM point_history WHERE user_id = ? ORDER BY id DESC LIMIT 1`,
+        [userId],
+      ) as Array<{ balance: number; type: string }>;
+      return { balance: Number(rows[0].balance), type: rows[0].type };
     }
 
     beforeAll(async () => {
@@ -59,6 +77,11 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
         password: 'Test1234!',
         name: '일반유저',
       });
+      const userRows = await dataSource.query(
+        `SELECT id FROM users WHERE email = ?`,
+        [userEmail],
+      ) as Array<{ id: number }>;
+      userId = Number(userRows[0].id);
       userCookies = await loginAndGetCookies(app, {
         email: userEmail,
         password: 'Test1234!',
@@ -72,6 +95,17 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
 
       orderId = await createOrder();
       refundOrderId = await createOrder();
+    });
+
+    afterAll(async () => {
+      await dataSource.query('SET FOREIGN_KEY_CHECKS = 0');
+      await dataSource.query(`DELETE FROM point_history WHERE user_id = ?`, [userId]);
+      await dataSource.query(`DELETE FROM shipping WHERE order_id IN (SELECT id FROM orders WHERE user_id = ?)`, [userId]);
+      await dataSource.query(`DELETE FROM order_items WHERE order_id IN (SELECT id FROM orders WHERE user_id = ?)`, [userId]);
+      await dataSource.query(`DELETE FROM orders WHERE user_id = ?`, [userId]);
+      await dataSource.query(`DELETE FROM products WHERE id = ?`, [productId]);
+      await dataSource.query(`DELETE FROM users WHERE email IN (?, ?)`, [adminEmail, userEmail]);
+      await dataSource.query('SET FOREIGN_KEY_CHECKS = 1');
     });
 
     describe('GET /api/admin/orders', () => {
@@ -162,6 +196,55 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       });
     });
 
+    describe('stock and point reversals', () => {
+      it('paid → cancelled restores reserved product stock', async () => {
+        const stockBeforeOrder = await getProductStock();
+        const cancelOrderId = await createOrder();
+
+        expect(await getProductStock()).toBe(stockBeforeOrder - 1);
+
+        await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${cancelOrderId}`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ status: 'paid' })
+          .expect(200);
+
+        await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${cancelOrderId}`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ status: 'cancelled' })
+          .expect(200);
+
+        expect(await getProductStock()).toBe(stockBeforeOrder);
+      });
+
+      it('paid → cancelled restores spent points', async () => {
+        await dataSource.query(
+          `INSERT INTO point_history (user_id, type, amount, balance, description, expires_at, related_entity_type)
+           VALUES (?, 'earn', 5000, 5000, '테스트 적립', DATE_ADD(NOW(), INTERVAL 30 DAY), 'order')`,
+          [userId],
+        );
+
+        const pointsOrderId = await createOrder({ pointsUsed: 2000 });
+
+        expect(await getLatestPointBalance()).toEqual({ balance: 3000, type: 'spend' });
+
+        await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${pointsOrderId}`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ status: 'paid' })
+          .expect(200);
+
+        await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${pointsOrderId}`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ status: 'cancelled' })
+          .expect(200);
+
+        expect(await getLatestPointBalance()).toEqual({ balance: 5000, type: 'admin_adjust' });
+      });
+    });
+
     describe('POST /api/admin/shipping/:orderId', () => {
       it('운송장 등록 → 201', async () => {
         const res = await request(app.getHttpServer())
@@ -202,6 +285,14 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
 
         const body = res.body as { status: string };
         expect(body.status).toBe('shipped');
+      });
+
+      it('shipped → cancelled: 전이 불가', async () => {
+        await request(app.getHttpServer())
+          .patch(`/api/admin/orders/${orderId}`)
+          .set('Cookie', cookieHeader(adminCookies))
+          .send({ status: 'cancelled' })
+          .expect(400);
       });
 
       it('shipped → delivered', async () => {
@@ -304,6 +395,8 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
       });
 
       it('refund_requested → refunded', async () => {
+        const stockBeforeRefund = await getProductStock();
+
         const res = await request(app.getHttpServer())
           .patch(`/api/admin/orders/${refundOrderId}`)
           .set('Cookie', cookieHeader(adminCookies))
@@ -312,6 +405,7 @@ export function registerAdminOrdersSuite(getApp: () => INestApplication) {
 
         const body = res.body as { status: string };
         expect(body.status).toBe('refunded');
+        expect(await getProductStock()).toBe(stockBeforeRefund + 1);
       });
     });
   });

--- a/backend/test/suites/commerce-modules.e2e-spec.ts
+++ b/backend/test/suites/commerce-modules.e2e-spec.ts
@@ -26,6 +26,7 @@ export function registerCommerceModulesSuite(getApp: () => INestApplication) {
     const categorySlug = `commerce-category-${unique}`;
     const productSlug = `commerce-product-${unique}`;
     const couponCode = `COUPON${unique}`;
+    const expiredCouponCode = `COUPON${unique}EXP`;
 
     let adminCookies: string[];
     let userCookies: string[];
@@ -75,15 +76,20 @@ export function registerCommerceModulesSuite(getApp: () => INestApplication) {
     });
 
     afterAll(async () => {
+      await dataSource.query('SET FOREIGN_KEY_CHECKS = 0');
+      await dataSource.query('DELETE FROM point_history WHERE user_id = ?', [userId]);
+      await dataSource.query('DELETE FROM order_items WHERE order_id IN (SELECT id FROM orders WHERE user_id = ?)', [userId]);
+      await dataSource.query('DELETE FROM orders WHERE user_id = ?', [userId]);
       await dataSource.query('DELETE FROM user_addresses WHERE user_id = ?', [userId]);
       await dataSource.query('DELETE FROM wishlist WHERE product_id = ?', [productId]);
       await dataSource.query('DELETE FROM user_coupons WHERE user_id = ?', [userId]);
-      await dataSource.query('DELETE FROM coupons WHERE code = ?', [couponCode]);
+      await dataSource.query('DELETE FROM coupons WHERE code IN (?, ?)', [couponCode, expiredCouponCode]);
       await dataSource.query('DELETE FROM product_images WHERE product_id = ?', [productId]);
       await dataSource.query('DELETE FROM product_options WHERE product_id = ?', [productId]);
       await dataSource.query('DELETE FROM products WHERE id = ?', [productId]);
       await dataSource.query('DELETE FROM categories WHERE id = ?', [categoryId]);
       await dataSource.query('DELETE FROM users WHERE id IN (?, ?)', [adminUserId, userId]);
+      await dataSource.query('SET FOREIGN_KEY_CHECKS = 1');
     });
 
     it('wishlist supports create/check/list/delete for a user', async () => {
@@ -164,12 +170,87 @@ export function registerCommerceModulesSuite(getApp: () => INestApplication) {
       await request(app.getHttpServer())
         .post('/api/coupons/calculate')
         .set('Cookie', userCookies)
+        .send({ orderAmount: 5000, userCouponId })
+        .expect(400);
+
+      await request(app.getHttpServer())
+        .post('/api/coupons/calculate')
+        .set('Cookie', userCookies)
+        .send({ orderAmount: 15000, pointsToUse: 1 })
+        .expect(400);
+
+      await request(app.getHttpServer())
+        .post('/api/coupons/calculate')
+        .set('Cookie', userCookies)
         .send({ orderAmount: 15000, userCouponId })
         .expect(200)
         .expect((res) => {
           expect((res.body as { couponDiscount: number }).couponDiscount).toBe(3000);
           expect((res.body as { totalPayable: number }).totalPayable).toBe(15000);
         });
+
+      const expiredCouponRes = await request(app.getHttpServer())
+        .post('/api/admin/coupons')
+        .set('Cookie', adminCookies)
+        .send({
+          code: expiredCouponCode,
+          name: `만료쿠폰-${unique}`,
+          type: 'fixed',
+          value: 1000,
+          startsAt: '2020-01-01T00:00:00.000Z',
+          expiresAt: '2020-01-02T00:00:00.000Z',
+          isActive: true,
+        })
+        .expect(201);
+      const expiredCouponId = Number((expiredCouponRes.body as { id: number }).id);
+
+      const expiredIssueRes = await request(app.getHttpServer())
+        .post('/api/admin/coupons/issue')
+        .set('Cookie', adminCookies)
+        .send({ couponId: expiredCouponId, userId })
+        .expect(201);
+      const expiredUserCouponId = Number((expiredIssueRes.body as { id: number }).id);
+
+      await request(app.getHttpServer())
+        .post('/api/coupons/calculate')
+        .set('Cookie', userCookies)
+        .send({ orderAmount: 15000, userCouponId: expiredUserCouponId })
+        .expect(400);
+
+      const orderRes = await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Cookie', userCookies)
+        .send({
+          items: [{ productId, quantity: 1 }],
+          recipientName: '커머스 사용자',
+          recipientPhone: '010-1234-5678',
+          zipcode: '12345',
+          address: '서울특별시 강남구',
+          userCouponId,
+        })
+        .expect(201);
+
+      const orderId = Number((orderRes.body as { id: number }).id);
+      const usedCoupons = await dataSource.query(
+        `SELECT status, order_id FROM user_coupons WHERE id = ?`,
+        [userCouponId],
+      ) as Array<{ status: string; order_id: number }>;
+
+      expect(usedCoupons[0].status).toBe('used');
+      expect(Number(usedCoupons[0].order_id)).toBe(orderId);
+
+      await request(app.getHttpServer())
+        .post('/api/orders')
+        .set('Cookie', userCookies)
+        .send({
+          items: [{ productId, quantity: 1 }],
+          recipientName: '커머스 사용자',
+          recipientPhone: '010-1234-5678',
+          zipcode: '12345',
+          address: '서울특별시 강남구',
+          userCouponId,
+        })
+        .expect(400);
 
       await request(app.getHttpServer())
         .get('/api/coupons/points')

--- a/backend/test/suites/orders.e2e-spec.ts
+++ b/backend/test/suites/orders.e2e-spec.ts
@@ -17,6 +17,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
     let userACookies: AuthCookies;
     let userBCookies: AuthCookies;
     let productId: number;
+    let productOptionId: number;
     let orderId: number;
 
     const userAEmail = `orders-user-a-${Date.now()}@test.com`;
@@ -61,7 +62,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
          VALUES (?, '사이즈', 'M', 0, 3, 0)`,
         [productId],
       );
-      void (optResult as { insertId: number }).insertId;
+      productOptionId = (optResult as { insertId: number }).insertId;
     });
 
     afterAll(async () => {
@@ -119,6 +120,46 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
         expect(Number(rows[0].stock)).toBe(4); // started at 5, ordered 1
       });
 
+      it('option order decreases both product and option stock', async () => {
+        await request(app.getHttpServer())
+          .post('/api/orders')
+          .set('Cookie', cookieHeader(userACookies))
+          .send({
+            items: [{ productId, productOptionId, quantity: 2 }],
+            recipientName: '홍길동',
+            recipientPhone: '010-1234-5678',
+            zipcode: '12345',
+            address: '서울시 강남구',
+          })
+          .expect(201);
+
+        const products = await dataSource.query(
+          `SELECT stock FROM products WHERE id = ?`,
+          [productId],
+        ) as Array<{ stock: number }>;
+        const options = await dataSource.query(
+          `SELECT stock FROM product_options WHERE id = ?`,
+          [productOptionId],
+        ) as Array<{ stock: number }>;
+
+        expect(Number(products[0].stock)).toBe(2);
+        expect(Number(options[0].stock)).toBe(1);
+      });
+
+      it('option excess quantity → 400', () => {
+        return request(app.getHttpServer())
+          .post('/api/orders')
+          .set('Cookie', cookieHeader(userACookies))
+          .send({
+            items: [{ productId, productOptionId, quantity: 2 }],
+            recipientName: '홍길동',
+            recipientPhone: '010-1234-5678',
+            zipcode: '12345',
+            address: '서울시 강남구',
+          })
+          .expect(400);
+      });
+
       it('excess quantity → 400', () => {
         return request(app.getHttpServer())
           .post('/api/orders')
@@ -129,6 +170,21 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
             recipientPhone: '010-1234-5678',
             zipcode: '12345',
             address: '서울시 강남구',
+          })
+          .expect(400);
+      });
+
+      it('insufficient points → 400', () => {
+        return request(app.getHttpServer())
+          .post('/api/orders')
+          .set('Cookie', cookieHeader(userACookies))
+          .send({
+            items: [{ productId, quantity: 1 }],
+            recipientName: '홍길동',
+            recipientPhone: '010-1234-5678',
+            zipcode: '12345',
+            address: '서울시 강남구',
+            pointsUsed: 1,
           })
           .expect(400);
       });


### PR DESCRIPTION
## Summary
- Add E2E coverage for option stock reservation and insufficient point usage during order creation.
- Add admin order E2E coverage for paid cancellation stock restoration, spent-point restoration, shipped cancellation rejection, and refund stock restoration.
- Add commerce E2E coverage for coupon minimum order rejection, expired coupon rejection, coupon usage marking, and reuse rejection.

## Scope Notes
- No production code changes. This PR locks existing implemented behavior at the integration boundary.
- Issue #705 also mentions pending cancellation, return-window policy, concurrent race tests, and membership-rate/earned-point reversal. Those are not currently represented as direct implemented/API behavior in this branch, so this PR does not invent policy semantics.

## Verification
- `bash scripts/test.sh all`
- `cd backend && npm run lint`

Closes #705