### PR TITLE
test: cover frontend search, hooks, and utils

### DIFF
--- a/src/components/shared/filters/__tests__/FilterSidebar.test.tsx
+++ b/src/components/shared/filters/__tests__/FilterSidebar.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FilterSidebar from '@/components/shared/filters/FilterSidebar';
+import { CollectionType, type Category, type Collection } from '@/lib/api';
+
+const { updateQueryMock, resetQueryMock, useCatalogQueryParamsMock, setMobileOpenMock } = vi.hoisted(() => ({
+  updateQueryMock: vi.fn(),
+  resetQueryMock: vi.fn(),
+  useCatalogQueryParamsMock: vi.fn(),
+  setMobileOpenMock: vi.fn(),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace: string) => (key: string) => {
+    const labels: Record<string, string> = {
+      filterLabel: '상품 필터',
+      label: '필터',
+      resetFilter: '초기화',
+      category: '카테고리',
+      clayType: '니료',
+      teapotShape: '형태',
+      priceRange: '가격대',
+      closeFilter: '필터 닫기',
+      openFilter: '필터 열기',
+      priceMin: '최소 가격',
+      priceMax: '최대 가격',
+      apply: '적용',
+      all: '전체',
+    };
+    return labels[key] ?? `${namespace}.${key}`;
+  },
+}));
+
+vi.mock('@/hooks/useUrlModal', () => ({
+  useUrlModal: () => [true, setMobileOpenMock],
+}));
+
+vi.mock('@/components/shared/hooks/useCatalogQueryParams', async () => {
+  const actual = await vi.importActual<typeof import('@/components/shared/hooks/useCatalogQueryParams')>(
+    '@/components/shared/hooks/useCatalogQueryParams',
+  );
+  return {
+    ...actual,
+    useCatalogQueryParams: () => useCatalogQueryParamsMock(),
+  };
+});
+
+const categories: Category[] = [
+  {
+    id: 1,
+    name: '다기',
+    slug: 'wares',
+    parentId: null,
+    imageUrl: null,
+    children: [
+      { id: 2, name: '자사호', slug: 'teapots', parentId: 1, imageUrl: null },
+    ],
+  },
+];
+
+const clayCollections: Collection[] = [
+  {
+    id: 11,
+    type: CollectionType.CLAY,
+    name: '자니',
+    nameKo: null,
+    color: null,
+    description: null,
+    imageUrl: null,
+    productUrl: '/products?attrs=clay_type:zini',
+    isActive: true,
+    sortOrder: 0,
+  },
+];
+
+const shapeCollections: Collection[] = [
+  {
+    id: 21,
+    type: CollectionType.SHAPE,
+    name: '원형',
+    nameKo: null,
+    color: null,
+    description: null,
+    imageUrl: null,
+    productUrl: '/products?attrs=teapot_shape:round',
+    isActive: true,
+    sortOrder: 0,
+  },
+];
+
+describe('FilterSidebar', () => {
+  beforeEach(() => {
+    updateQueryMock.mockReset();
+    resetQueryMock.mockReset();
+    setMobileOpenMock.mockReset();
+    useCatalogQueryParamsMock.mockReturnValue({
+      attrs: new Map(),
+      categoryId: undefined,
+      priceMin: undefined,
+      priceMax: undefined,
+      updateQuery: updateQueryMock,
+      resetQuery: resetQueryMock,
+    });
+  });
+
+  it('toggles the mobile filter panel', async () => {
+    render(<FilterSidebar categories={categories} clayCollections={clayCollections} shapeCollections={shapeCollections} />);
+
+    await userEvent.click(screen.getByRole('button', { name: '필터 닫기' }));
+
+    expect(setMobileOpenMock).toHaveBeenCalledWith(false);
+  });
+
+  it('applies category and price filters through query params', async () => {
+    render(<FilterSidebar categories={categories} clayCollections={clayCollections} shapeCollections={shapeCollections} />);
+
+    const filterRegions = screen.getAllByLabelText('상품 필터');
+    await userEvent.click(within(filterRegions[0]).getByRole('button', { name: /다기/ }));
+    expect(updateQueryMock).toHaveBeenCalledWith({ categoryId: 1 });
+
+    await userEvent.clear(screen.getAllByLabelText('최소 가격')[0]);
+    await userEvent.type(screen.getAllByLabelText('최소 가격')[0], '30000');
+    await userEvent.clear(screen.getAllByLabelText('최대 가격')[0]);
+    await userEvent.type(screen.getAllByLabelText('최대 가격')[0], '10000');
+    await userEvent.click(screen.getAllByRole('button', { name: '적용' })[0]);
+
+    expect(updateQueryMock).toHaveBeenCalledWith({ price_min: 10000, price_max: 30000 });
+  });
+
+  it('builds attrs for clay and shape filters and can reset active filters', async () => {
+    useCatalogQueryParamsMock.mockReturnValue({
+      attrs: new Map([['clay_type', '자니']]),
+      categoryId: 1,
+      priceMin: 10000,
+      priceMax: undefined,
+      updateQuery: updateQueryMock,
+      resetQuery: resetQueryMock,
+    });
+
+    render(<FilterSidebar categories={categories} clayCollections={clayCollections} shapeCollections={shapeCollections} />);
+
+    await userEvent.click(screen.getAllByRole('button', { name: '자니' })[0]);
+    expect(updateQueryMock).toHaveBeenCalledWith({ attrs: undefined });
+
+    await userEvent.click(screen.getAllByRole('radio', { name: '원형' })[0]);
+    expect(updateQueryMock).toHaveBeenCalledWith({ attrs: 'clay_type:자니,teapot_shape:원형' });
+
+    await userEvent.click(screen.getAllByRole('button', { name: '초기화' })[0]);
+    expect(resetQueryMock).toHaveBeenCalledWith(['categoryId', 'price_min', 'price_max', 'attrs']);
+  });
+});

--- a/src/components/shared/hooks/__tests__/useAutocomplete.test.tsx
+++ b/src/components/shared/hooks/__tests__/useAutocomplete.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAutocomplete } from '@/components/shared/hooks/useAutocomplete';
+
+const { autocompleteMock } = vi.hoisted(() => ({
+  autocompleteMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  productsApi: {
+    autocomplete: autocompleteMock,
+  },
+}));
+
+describe('useAutocomplete', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    autocompleteMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not fetch for one-character queries', () => {
+    const { result } = renderHook(() => useAutocomplete('자'));
+
+    expect(result.current.suggestions).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(autocompleteMock).not.toHaveBeenCalled();
+  });
+
+  it('debounces autocomplete calls and exposes results', async () => {
+    autocompleteMock.mockResolvedValue([{ id: 1, name: '자사호', slug: 'zisha' }]);
+    const { result } = renderHook(() => useAutocomplete('자사'));
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(autocompleteMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(result.current.suggestions).toEqual([{ id: 1, name: '자사호', slug: 'zisha' }]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('clears suggestions on API failure', async () => {
+    autocompleteMock.mockRejectedValue(new Error('fail'));
+    const { result } = renderHook(() => useAutocomplete('검색'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(result.current.suggestions).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/components/shared/hooks/__tests__/useBlockData.test.tsx
+++ b/src/components/shared/hooks/__tests__/useBlockData.test.tsx
@@ -1,0 +1,48 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useBlockData } from '@/components/shared/hooks/useBlockData';
+
+describe('useBlockData', () => {
+  it('uses prefetched data without fetching', () => {
+    const fetch = vi.fn();
+    const prefetched = [{ id: 1, title: 'prefetched' }];
+
+    const { result } = renderHook(() => useBlockData({ prefetched, fetch, deps: [] }));
+
+    expect(result.current.data).toEqual(prefetched);
+    expect(result.current.loading).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches client fallback data when no prefetched data exists', async () => {
+    const fetch = vi.fn().mockResolvedValue([{ id: 2, title: 'loaded' }]);
+    const { result } = renderHook(() => useBlockData({ prefetched: null, fetch, deps: [] }));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual([{ id: 2, title: 'loaded' }]);
+  });
+
+  it('does not update state after unmount', async () => {
+    let resolve!: (value: Array<{ id: number }>) => void;
+    const fetch = vi.fn().mockReturnValue(new Promise((res) => { resolve = res; }));
+    const { unmount } = renderHook(() => useBlockData({ prefetched: [], fetch, deps: [] }));
+
+    unmount();
+
+    await act(async () => {
+      resolve([{ id: 3 }]);
+    });
+
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  it('treats fetch failures as non-fatal empty data', async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useBlockData({ prefetched: null, fetch, deps: [] }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/src/components/shared/hooks/__tests__/useFormModal.test.tsx
+++ b/src/components/shared/hooks/__tests__/useFormModal.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useFormModal } from '@/components/shared/hooks/useFormModal';
+
+interface FormState {
+  title: string;
+  published: boolean;
+}
+
+describe('useFormModal', () => {
+  const defaults: FormState = { title: '', published: false };
+  const initial: FormState = { title: '기존 글', published: true };
+
+  it('switches between defaults and initial data when the modal opens', () => {
+    const { result, rerender } = renderHook(
+      ({ current, open }) => useFormModal(defaults, current, open),
+      { initialProps: { current: null as FormState | null, open: false } },
+    );
+
+    expect(result.current.formData).toEqual(defaults);
+
+    rerender({ current: initial, open: true });
+    expect(result.current.formData).toEqual(initial);
+
+    rerender({ current: null, open: true });
+    expect(result.current.formData).toEqual(defaults);
+  });
+
+  it('submits current form data, closes on success, and clears loading', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const preventDefault = vi.fn();
+    const { result } = renderHook(() => useFormModal(defaults, initial, true));
+
+    act(() => {
+      result.current.setFormData({ title: '수정됨', published: false });
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(
+        { preventDefault } as unknown as React.FormEvent,
+        onSubmit,
+        onClose,
+      );
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledWith({ title: '수정됨', published: false });
+    expect(onClose).toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('keeps the modal open but still clears loading when submit fails', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('fail'));
+    const onClose = vi.fn();
+    const { result } = renderHook(() => useFormModal(defaults, initial, true));
+
+    await expect(act(async () => {
+      await result.current.handleSubmit(
+        { preventDefault: vi.fn() } as unknown as React.FormEvent,
+        onSubmit,
+        onClose,
+      );
+    })).rejects.toThrow('fail');
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/components/shared/hooks/__tests__/useLightboxInteraction.test.tsx
+++ b/src/components/shared/hooks/__tests__/useLightboxInteraction.test.tsx
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useLightboxInteraction } from '@/components/shared/hooks/useLightboxInteraction';
+
+function mouseEvent(clientX: number, clientY: number) {
+  return { clientX, clientY } as React.MouseEvent;
+}
+
+function touchEvent(clientX: number, clientY: number) {
+  return { touches: [{ clientX, clientY }] } as unknown as React.TouchEvent;
+}
+
+describe('useLightboxInteraction', () => {
+  it('ignores drag gestures until zoom is enabled', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+
+    act(() => {
+      result.current.handleLightboxMouseDown(mouseEvent(10, 10));
+      result.current.handleLightboxMouseMove(mouseEvent(200, 200));
+    });
+
+    expect(result.current.lightboxPan).toEqual({ x: 0, y: 0 });
+    expect(result.current.isDragging.current).toBe(false);
+  });
+
+  it('pans a zoomed image and clamps mouse movement', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+
+    act(() => {
+      result.current.setLightboxZoomed(true);
+    });
+    act(() => {
+      result.current.handleLightboxMouseDown(mouseEvent(0, 0));
+      result.current.handleLightboxMouseMove(mouseEvent(999, -999));
+    });
+
+    expect(result.current.lightboxPan).toEqual({ x: 150, y: -150 });
+
+    act(() => {
+      result.current.handleLightboxMouseUp();
+    });
+    expect(result.current.isDragging.current).toBe(false);
+  });
+
+  it('supports touch panning and reset', () => {
+    const { result } = renderHook(() => useLightboxInteraction());
+
+    act(() => {
+      result.current.setLightboxZoomed(true);
+    });
+
+    act(() => {
+      result.current.handleLightboxTouchStart(touchEvent(0, 0));
+      result.current.handleLightboxTouchMove(touchEvent(-250, 250));
+    });
+
+    expect(result.current.lightboxPan).toEqual({ x: -100, y: 100 });
+
+    act(() => {
+      result.current.handleLightboxTouchEnd();
+      result.current.resetLightboxState();
+    });
+
+    expect(result.current.lightboxZoomed).toBe(false);
+    expect(result.current.lightboxPan).toEqual({ x: 0, y: 0 });
+    expect(result.current.lightboxPanRef.current).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/src/components/shared/hooks/__tests__/useScrollAnimation.test.tsx
+++ b/src/components/shared/hooks/__tests__/useScrollAnimation.test.tsx
@@ -1,0 +1,86 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useScrollAnimation } from '@/components/shared/hooks/useScrollAnimation';
+
+function Harness({ once = false }: { once?: boolean }) {
+  const { ref, visible } = useScrollAnimation<HTMLDivElement>({ once });
+  return (
+    <div>
+      <div ref={ref}>target</div>
+      <span>{visible ? 'visible' : 'hidden'}</span>
+    </div>
+  );
+}
+
+describe('useScrollAnimation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stays visible and does not observe when reduced motion is preferred', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+    const observe = vi.fn();
+    window.IntersectionObserver = vi.fn(function MockIntersectionObserver() {
+      return {
+        observe,
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+      };
+    }) as unknown as typeof IntersectionObserver;
+
+    render(<Harness />);
+
+    expect(screen.getByText('visible')).toBeInTheDocument();
+    expect(observe).not.toHaveBeenCalled();
+  });
+
+  it('updates visibility from IntersectionObserver and disconnects on unmount', () => {
+    let callback: IntersectionObserverCallback | undefined;
+    const disconnect = vi.fn();
+
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+    window.IntersectionObserver = vi.fn(function MockIntersectionObserver(cb: IntersectionObserverCallback) {
+      callback = cb;
+      return {
+        observe: vi.fn(),
+        unobserve: vi.fn(),
+        disconnect,
+      };
+    }) as unknown as typeof IntersectionObserver;
+
+    const { unmount } = render(<Harness />);
+
+    act(() => {
+      callback?.([{ isIntersecting: false } as IntersectionObserverEntry], {} as IntersectionObserver);
+    });
+
+    expect(screen.getByText('hidden')).toBeInTheDocument();
+
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('unobserves the target after the first intersection when once=true', () => {
+    let callback: IntersectionObserverCallback | undefined;
+    const unobserve = vi.fn();
+
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+    window.IntersectionObserver = vi.fn(function MockIntersectionObserver(cb: IntersectionObserverCallback) {
+      callback = cb;
+      return {
+        observe: vi.fn(),
+        unobserve,
+        disconnect: vi.fn(),
+      };
+    }) as unknown as typeof IntersectionObserver;
+
+    render(<Harness once />);
+
+    act(() => {
+      callback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+    });
+
+    expect(screen.getByText('visible')).toBeInTheDocument();
+    expect(unobserve).toHaveBeenCalled();
+  });
+});

--- a/src/components/shared/hooks/__tests__/useViewMode.test.tsx
+++ b/src/components/shared/hooks/__tests__/useViewMode.test.tsx
@@ -1,0 +1,36 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useViewMode } from '@/components/shared/hooks/useViewMode';
+
+describe('useViewMode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('uses default mode before storage is loaded', () => {
+    const { result } = renderHook(() => useViewMode('products-view', 'list'));
+
+    expect(result.current.mode).toBe('list');
+  });
+
+  it('loads a valid stored mode and persists updates', async () => {
+    localStorage.setItem('products-view', JSON.stringify('list'));
+    const { result } = renderHook(() => useViewMode('products-view', 'grid'));
+
+    await waitFor(() => expect(result.current.mode).toBe('list'));
+
+    act(() => {
+      result.current.setMode('grid');
+    });
+
+    expect(result.current.mode).toBe('grid');
+    expect(localStorage.getItem('products-view')).toBe('"grid"');
+  });
+
+  it('ignores invalid stored values', async () => {
+    localStorage.setItem('products-view', JSON.stringify('cards'));
+    const { result } = renderHook(() => useViewMode('products-view', 'grid'));
+
+    await waitFor(() => expect(result.current.mode).toBe('grid'));
+  });
+});

--- a/src/components/shared/products/__tests__/SortDropdown.test.tsx
+++ b/src/components/shared/products/__tests__/SortDropdown.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SortDropdown from '@/components/shared/products/SortDropdown';
+
+const { updateQueryMock, useCatalogQueryParamsMock } = vi.hoisted(() => ({
+  updateQueryMock: vi.fn(),
+  useCatalogQueryParamsMock: vi.fn(),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => ({
+    label: '정렬',
+    latest: '최신순',
+    priceAsc: '낮은 가격순',
+    priceDesc: '높은 가격순',
+    popular: '인기순',
+  }[key] ?? key),
+}));
+
+vi.mock('@/components/shared/hooks/useCatalogQueryParams', () => ({
+  useCatalogQueryParams: () => useCatalogQueryParamsMock(),
+}));
+
+describe('SortDropdown', () => {
+  beforeEach(() => {
+    updateQueryMock.mockReset();
+    useCatalogQueryParamsMock.mockReturnValue({ sort: undefined, updateQuery: updateQueryMock });
+  });
+
+  it('defaults to latest when no sort query exists', () => {
+    render(<SortDropdown />);
+
+    expect(screen.getByLabelText('정렬')).toHaveValue('latest');
+  });
+
+  it('writes selected sort value into catalog query params', async () => {
+    render(<SortDropdown />);
+
+    await userEvent.selectOptions(screen.getByLabelText('정렬'), 'price_desc');
+
+    expect(updateQueryMock).toHaveBeenCalledWith({ sort: 'price_desc' });
+  });
+});

--- a/src/components/shared/search/__tests__/SearchInput.test.tsx
+++ b/src/components/shared/search/__tests__/SearchInput.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SearchInput from '@/components/shared/search/SearchInput';
+
+const {
+  pushMock,
+  setOpenMock,
+  addSearchMock,
+  removeSearchMock,
+  clearSearchesMock,
+  getPopularMock,
+  useAutocompleteMock,
+  useRecentSearchesMock,
+} = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  setOpenMock: vi.fn(),
+  addSearchMock: vi.fn(),
+  removeSearchMock: vi.fn(),
+  clearSearchesMock: vi.fn(),
+  getPopularMock: vi.fn(),
+  useAutocompleteMock: vi.fn(),
+  useRecentSearchesMock: vi.fn(),
+}));
+
+let modalOpen = true;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock('@/hooks/useUrlModal', () => ({
+  useUrlModal: () => [modalOpen, setOpenMock],
+}));
+
+vi.mock('@/components/shared/hooks/useAutocomplete', () => ({
+  useAutocomplete: (query: string) => useAutocompleteMock(query),
+}));
+
+vi.mock('@/components/shared/hooks/useRecentSearches', () => ({
+  useRecentSearches: () => useRecentSearchesMock(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  searchApi: {
+    getPopular: getPopularMock,
+  },
+}));
+
+describe('SearchInput', () => {
+  beforeEach(() => {
+    modalOpen = true;
+    pushMock.mockReset();
+    setOpenMock.mockReset();
+    addSearchMock.mockReset();
+    removeSearchMock.mockReset();
+    clearSearchesMock.mockReset();
+    getPopularMock.mockReset();
+    getPopularMock.mockResolvedValue({ keywords: ['자사호', '찻잔'] });
+    useAutocompleteMock.mockReset();
+    useAutocompleteMock.mockReturnValue({ suggestions: [], isLoading: false });
+    useRecentSearchesMock.mockReset();
+    useRecentSearchesMock.mockReturnValue({
+      recentSearches: [],
+      addSearch: addSearchMock,
+      removeSearch: removeSearchMock,
+      clearSearches: clearSearchesMock,
+    });
+  });
+
+  it('submits a trimmed query, stores it, and navigates to search', async () => {
+    render(<SearchInput />);
+
+    await userEvent.type(screen.getByLabelText('상품 검색'), '  teapot  ');
+    await userEvent.keyboard('{Enter}');
+
+    expect(addSearchMock).toHaveBeenCalledWith('teapot');
+    expect(setOpenMock).toHaveBeenCalledWith(false);
+    expect(pushMock).toHaveBeenCalledWith('/search?q=teapot');
+  });
+
+  it('renders autocomplete suggestions for debounced hook results and selects them', async () => {
+    useAutocompleteMock.mockReturnValue({
+      suggestions: [{ id: 1, name: '청자 다기', slug: 'celadon' }],
+      isLoading: false,
+    });
+
+    render(<SearchInput />);
+
+    await userEvent.type(screen.getByLabelText('상품 검색'), '청자');
+    await userEvent.click(await screen.findByRole('button', { name: /청자 다기/ }));
+
+    expect(addSearchMock).toHaveBeenCalledWith('청자 다기');
+    expect(pushMock).toHaveBeenCalledWith('/search?q=%EC%B2%AD%EC%9E%90%20%EB%8B%A4%EA%B8%B0');
+  });
+
+  it('shows recent searches below two characters and supports delete/clear', async () => {
+    useRecentSearchesMock.mockReturnValue({
+      recentSearches: ['말차', '다완'],
+      addSearch: addSearchMock,
+      removeSearch: removeSearchMock,
+      clearSearches: clearSearchesMock,
+    });
+
+    render(<SearchInput />);
+
+    expect(await screen.findByText('최근 검색어')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: '말차 삭제' }));
+    expect(removeSearchMock).toHaveBeenCalledWith('말차');
+
+    await userEvent.click(screen.getByRole('button', { name: '전체 삭제' }));
+    expect(clearSearchesMock).toHaveBeenCalled();
+  });
+
+  it('closes on Escape and outside clicks', async () => {
+    render(
+      <div>
+        <SearchInput />
+        <button type="button">outside</button>
+      </div>,
+    );
+
+    await userEvent.keyboard('{Escape}');
+    expect(setOpenMock).toHaveBeenCalledWith(false);
+
+    await userEvent.click(screen.getByRole('button', { name: 'outside' }));
+    await waitFor(() => expect(setOpenMock).toHaveBeenCalledWith(false, 'replace'));
+  });
+});

--- a/src/utils/__tests__/currency.test.ts
+++ b/src/utils/__tests__/currency.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { convertPrice, formatCurrency } from '@/utils/currency';
+import { calcDiscount, convertPrice, formatCurrency } from '@/utils/currency';
+
+describe('calcDiscount', () => {
+  it('할인율을 반올림한 정수로 계산', () => {
+    expect(calcDiscount(30000, 25000)).toBe(17);
+  });
+
+  it('원가가 0 이하이면 0 반환', () => {
+    expect(calcDiscount(0, 1000)).toBe(0);
+    expect(calcDiscount(-1000, 500)).toBe(0);
+  });
+});
 
 describe('convertPrice', () => {
   it('KRW는 그대로 반환', () => {
@@ -27,6 +38,15 @@ describe('formatCurrency', () => {
   it('0원은 ₩0으로 포맷', () => {
     expect(formatCurrency(0, 'ko')).toBe('₩0');
   });
+
+  it('KRW 축약 표기 옵션을 지원', () => {
+    expect(formatCurrency(150000, 'ko', { abbreviated: true })).toBe('15만');
+    expect(formatCurrency(9500, 'ko', { abbreviated: true })).toBe('9,500');
+  });
+
+  it('USD는 축약 옵션이 있어도 통화 포맷 유지', () => {
+    expect(formatCurrency(13500, 'en', { abbreviated: true })).toBe('$10.00');
+  });
 });
 
 describe('NEXT_PUBLIC_EXCHANGE_RATES 환경변수', () => {
@@ -38,6 +58,11 @@ describe('NEXT_PUBLIC_EXCHANGE_RATES 환경변수', () => {
     vi.stubEnv('NEXT_PUBLIC_EXCHANGE_RATES', JSON.stringify({ USD: 1000 }));
     // 환율 오버라이드: 15000 / 1000 = 15 USD
     expect(convertPrice(15000, 'USD')).toBeCloseTo(15, 2);
+  });
+
+  it('환경변수에 USD가 없으면 기본 USD 환율 사용', () => {
+    vi.stubEnv('NEXT_PUBLIC_EXCHANGE_RATES', JSON.stringify({}));
+    expect(convertPrice(15000, 'USD')).toBeCloseTo(11.111, 2);
   });
 
   it('잘못된 환경변수는 기본값 사용', () => {

--- a/src/utils/__tests__/phone.test.ts
+++ b/src/utils/__tests__/phone.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { formatPhone } from '@/utils/phone';
+
+describe('formatPhone', () => {
+  it('formats Korean mobile numbers into international display form', () => {
+    expect(formatPhone('01012345678')).toBe('+82 10-1234-5678');
+    expect(formatPhone('010-1234-5678')).toBe('+82 10-1234-5678');
+    expect(formatPhone('010 1234 5678')).toBe('+82 10-1234-5678');
+  });
+
+  it('formats Seoul and regional landline numbers', () => {
+    expect(formatPhone('0212345678')).toBe('+82 0212345678');
+    expect(formatPhone('0311234567')).toBe('+82 031-123-4567');
+    expect(formatPhone('05112345678')).toBe('+82 051-1234-5678');
+  });
+
+  it('returns empty or original values when input cannot be normalized', () => {
+    expect(formatPhone(null)).toBe('');
+    expect(formatPhone(undefined)).toBe('');
+    expect(formatPhone('대표번호')).toBe('대표번호');
+  });
+});

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getStorageItem, removeStorageItem, setStorageItem } from '@/utils/storage';
+
+describe('storage utils', () => {
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('reads and writes JSON values through localStorage', () => {
+    setStorageItem('view-mode', { mode: 'grid' });
+
+    expect(localStorage.getItem('view-mode')).toBe('{"mode":"grid"}');
+    expect(getStorageItem('view-mode', { mode: 'list' })).toEqual({ mode: 'grid' });
+  });
+
+  it('returns the default value for missing or malformed entries', () => {
+    localStorage.setItem('broken', '{not-json');
+
+    expect(getStorageItem('missing', 'fallback')).toBe('fallback');
+    expect(getStorageItem('broken', 'fallback')).toBe('fallback');
+  });
+
+  it('ignores storage access failures', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    expect(getStorageItem('key', 123)).toBe(123);
+    expect(() => setStorageItem('key', 456)).not.toThrow();
+    expect(() => removeStorageItem('key')).not.toThrow();
+  });
+
+  it('removes stored values', () => {
+    setStorageItem('dismissed', true);
+    removeStorageItem('dismissed');
+
+    expect(getStorageItem('dismissed', false)).toBe(false);
+  });
+});

--- a/src/utils/__tests__/upload.test.ts
+++ b/src/utils/__tests__/upload.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { uploadImage, uploadReviewImage } from '@/utils/upload';
+
+const { uploadImageMock, uploadReviewImageMock } = vi.hoisted(() => ({
+  uploadImageMock: vi.fn(),
+  uploadReviewImageMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  uploadApi: {
+    uploadImage: uploadImageMock,
+  },
+  reviewsApi: {
+    uploadImage: uploadReviewImageMock,
+  },
+}));
+
+describe('upload utils', () => {
+  beforeEach(() => {
+    uploadImageMock.mockReset();
+    uploadReviewImageMock.mockReset();
+  });
+
+  it('delegates product/admin image uploads to uploadApi', async () => {
+    uploadImageMock.mockResolvedValue({ url: '/uploads/product.jpg' });
+    const file = new File(['image'], 'product.jpg', { type: 'image/jpeg' });
+
+    await expect(uploadImage(file, 'products')).resolves.toEqual({ url: '/uploads/product.jpg' });
+    expect(uploadImageMock).toHaveBeenCalledWith(file, 'products');
+  });
+
+  it('delegates review image uploads to reviewsApi', async () => {
+    uploadReviewImageMock.mockResolvedValue({ url: '/uploads/review.jpg' });
+    const file = new File(['image'], 'review.jpg', { type: 'image/jpeg' });
+
+    await expect(uploadReviewImage(file)).resolves.toEqual({ url: '/uploads/review.jpg' });
+    expect(uploadReviewImageMock).toHaveBeenCalledWith(file);
+  });
+});

--- a/src/utils/__tests__/url.test.ts
+++ b/src/utils/__tests__/url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeUrl } from '@/utils/url';
+
+describe('isSafeUrl', () => {
+  it('allows relative application paths', () => {
+    expect(isSafeUrl('/products')).toBe(true);
+    expect(isSafeUrl('/search?q=teapot')).toBe(true);
+  });
+
+  it('rejects empty, protocol-relative, and absolute URLs', () => {
+    expect(isSafeUrl('')).toBe(false);
+    expect(isSafeUrl('//evil.example/path')).toBe(false);
+    expect(isSafeUrl('https://example.com')).toBe(false);
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Vitest coverage for `SearchInput`, `SortDropdown`, and `FilterSidebar` interaction flows.
- Add hook coverage for autocomplete, block data fallback, form modal state, lightbox interaction, scroll animation, and view mode persistence.
- Add utility coverage for phone/storage/url/upload and extend currency coverage to keep utility line coverage above the issue threshold.

## Scope Notes
- No production code changes. This PR only hardens current frontend behavior with regression tests.
- Issue #711 also mentions `SearchPage`, `CategoryFilterSidebar`, and low-priority contexts. This PR focuses on the highest-signal shared hooks, filters, search input, sort behavior, and utility coverage needed to satisfy the green-path completion criteria without inventing new behavior.

## Verification
- `npm run lint`
- `npm run test:run`
- `npm run test:coverage -- src/utils`

Closes #711