### PR TITLE
Fix event pages to respect active locale

### DIFF
--- a/src/app/[locale]/event/[id]/page.tsx
+++ b/src/app/[locale]/event/[id]/page.tsx
@@ -3,23 +3,31 @@
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 import { promotionsApi } from '@/lib/api';
 import type { Promotion } from '@/lib/api';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import CountdownTimer from '@/components/shared/home/CountdownTimer';
 
-const TYPE_LABELS: Record<Promotion['type'], string> = {
-  timesale: '타임세일',
-  exhibition: '기획전',
-  event: '이벤트',
+const TYPE_KEY_MAP: Record<Promotion['type'], string> = {
+  timesale: 'types.timesale',
+  exhibition: 'types.exhibition',
+  event: 'types.event',
+};
+
+const DATE_LOCALE_MAP: Record<string, string> = {
+  ko: 'ko-KR',
+  en: 'en-US',
 };
 
 export default function EventDetailPage() {
   const { id, locale } = useParams<{ id: string; locale: string }>();
   const router = useRouter();
+  const t = useTranslations('event');
   const [promotion, setPromotion] = useState<Promotion | null>(null);
   const [notFound, setNotFound] = useState(false);
+  const dateLocale = DATE_LOCALE_MAP[locale] ?? locale;
 
   const { execute: loadPromotion, isLoading: loading } = useAsyncAction(
     async () => {
@@ -53,12 +61,12 @@ export default function EventDetailPage() {
   if (notFound || !promotion) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-16 text-center">
-        <p className="text-gray-500 mb-4">프로모션을 찾을 수 없습니다.</p>
+        <p className="text-gray-500 mb-4">{t('notFound')}</p>
         <button
           onClick={() => router.back()}
           className="text-sm text-blue-600 underline"
         >
-          돌아가기
+          {t('back')}
         </button>
       </div>
     );
@@ -70,27 +78,29 @@ export default function EventDetailPage() {
         onClick={() => router.back()}
         className="text-sm text-gray-500 mb-4 flex items-center gap-1 hover:text-gray-800 transition-colors"
       >
-        ← 목록으로
+        {t('list')}
       </button>
 
       <div className="inline-block text-xs font-semibold px-2 py-0.5 rounded bg-blue-100 text-blue-700 mb-3">
-        {TYPE_LABELS[promotion.type]}
+        {t(TYPE_KEY_MAP[promotion.type])}
       </div>
 
       <h1 className="text-2xl font-bold text-gray-900 mb-2">{promotion.title}</h1>
 
       {promotion.discountRate && (
-        <p className="text-red-500 font-bold text-lg mb-2">{promotion.discountRate}% 할인</p>
+        <p className="text-red-500 font-bold text-lg mb-2">
+          {t('discount', { percent: promotion.discountRate })}
+        </p>
       )}
 
       <div className="flex flex-wrap items-center gap-3 text-sm text-gray-400 mb-6">
         <span>
-          {new Date(promotion.startsAt).toLocaleDateString('ko-KR')} ~{' '}
-          {new Date(promotion.endsAt).toLocaleDateString('ko-KR')}
+          {new Date(promotion.startsAt).toLocaleDateString(dateLocale)} ~{' '}
+          {new Date(promotion.endsAt).toLocaleDateString(dateLocale)}
         </span>
         {promotion.type === 'timesale' && (
           <span className="flex items-center gap-1">
-            남은 시간: <CountdownTimer endsAt={promotion.endsAt} />
+            {t('timeLeft')}: <CountdownTimer endsAt={promotion.endsAt} />
           </span>
         )}
       </div>

--- a/src/app/[locale]/event/__tests__/event-i18n.test.ts
+++ b/src/app/[locale]/event/__tests__/event-i18n.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import koMessages from '@/i18n/messages/ko.json';
+import enMessages from '@/i18n/messages/en.json';
+
+const EVENT_PAGE_FILES = [
+  'src/app/[locale]/event/page.tsx',
+  'src/app/[locale]/event/[id]/page.tsx',
+];
+
+const REQUIRED_EVENT_KEYS = [
+  'title',
+  'empty',
+  'notFound',
+  'back',
+  'list',
+  'discount',
+  'until',
+  'timeLeft',
+  'errorLoad',
+  'types.timesale',
+  'types.exhibition',
+  'types.event',
+];
+
+const FORMER_HARDCODED_KOREAN = [
+  '타임세일',
+  '기획전',
+  '이벤트 목록을 불러오지 못했습니다.',
+  '이벤트/프로모션',
+  '진행 중인 프로모션이 없습니다.',
+  '% 할인',
+  '까지',
+  '남은 시간',
+  '프로모션을 찾을 수 없습니다.',
+  '돌아가기',
+  '목록으로',
+];
+
+function getByPath(source: unknown, keyPath: string): unknown {
+  return keyPath.split('.').reduce<unknown>((current, key) => {
+    if (current == null || typeof current !== 'object') return undefined;
+    return (current as Record<string, unknown>)[key];
+  }, source);
+}
+
+describe('event page i18n', () => {
+  it('defines every event translation key for Korean and English', () => {
+    for (const key of REQUIRED_EVENT_KEYS) {
+      expect(getByPath(koMessages, `event.${key}`), `ko event.${key}`).toEqual(expect.any(String));
+      expect(getByPath(enMessages, `event.${key}`), `en event.${key}`).toEqual(expect.any(String));
+    }
+  });
+
+  it('keeps event page UI labels out of hardcoded Korean literals', () => {
+    for (const relativeFile of EVENT_PAGE_FILES) {
+      const source = fs.readFileSync(path.join(process.cwd(), relativeFile), 'utf8');
+
+      for (const literal of FORMER_HARDCODED_KOREAN) {
+        expect(source, `${relativeFile} should not contain ${literal}`).not.toContain(literal);
+      }
+    }
+  });
+
+  it('formats event dates with the active locale instead of a fixed Korean locale', () => {
+    for (const relativeFile of EVENT_PAGE_FILES) {
+      const source = fs.readFileSync(path.join(process.cwd(), relativeFile), 'utf8');
+
+      expect(source).not.toContain("toLocaleDateString('ko-KR')");
+      expect(source).toContain('DATE_LOCALE_MAP');
+      expect(source).toContain('dateLocale');
+    }
+  });
+});

--- a/src/app/[locale]/event/page.tsx
+++ b/src/app/[locale]/event/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { promotionsApi } from '@/lib/api';
 import type { Promotion } from '@/lib/api';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
@@ -11,24 +12,31 @@ import { SkeletonBox } from '@/components/ui/Skeleton';
 import EmptyState from '@/components/shared/EmptyState';
 import CountdownTimer from '@/components/shared/home/CountdownTimer';
 
-const TYPE_LABELS: Record<Promotion['type'], string> = {
-  timesale: '타임세일',
-  exhibition: '기획전',
-  event: '이벤트',
+const TYPE_KEY_MAP: Record<Promotion['type'], string> = {
+  timesale: 'types.timesale',
+  exhibition: 'types.exhibition',
+  event: 'types.event',
 };
 
 const TYPE_ORDER: Promotion['type'][] = ['timesale', 'exhibition', 'event'];
 
+const DATE_LOCALE_MAP: Record<string, string> = {
+  ko: 'ko-KR',
+  en: 'en-US',
+};
+
 export default function EventPage() {
   const { locale } = useParams<{ locale: string }>();
+  const t = useTranslations('event');
   const [promotions, setPromotions] = useState<Promotion[]>([]);
+  const dateLocale = DATE_LOCALE_MAP[locale] ?? locale;
 
   const { execute: loadPromotions, isLoading: loading } = useAsyncAction(
     async () => {
       const data = await promotionsApi.getList(locale);
       setPromotions(Array.isArray(data) ? data : []);
     },
-    { errorMessage: '이벤트 목록을 불러오지 못했습니다.' },
+    { errorMessage: t('errorLoad') },
   );
 
   useEffect(() => {
@@ -38,7 +46,7 @@ export default function EventPage() {
   if (loading) {
     return (
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <h1 className="text-2xl font-bold mb-6">이벤트/프로모션</h1>
+        <h1 className="text-2xl font-bold mb-6">{t('title')}</h1>
         <div className="space-y-4">
           {Array.from({ length: 4 }).map((_, i) => (
             <SkeletonBox key={i} className="h-32 rounded-xl" />
@@ -51,8 +59,8 @@ export default function EventPage() {
   if (promotions.length === 0) {
     return (
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <h1 className="text-2xl font-bold mb-6">이벤트/프로모션</h1>
-        <EmptyState title="진행 중인 프로모션이 없습니다." />
+        <h1 className="text-2xl font-bold mb-6">{t('title')}</h1>
+        <EmptyState title={t('empty')} />
       </div>
     );
   }
@@ -67,7 +75,7 @@ export default function EventPage() {
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-8">이벤트/프로모션</h1>
+      <h1 className="text-2xl font-bold mb-8">{t('title')}</h1>
 
       {TYPE_ORDER.map((type) => {
         const items = grouped[type];
@@ -80,7 +88,7 @@ export default function EventPage() {
                   LIVE
                 </span>
               )}
-              {TYPE_LABELS[type]}
+              {t(TYPE_KEY_MAP[type])}
             </h2>
             <ul className="space-y-4">
               {items.map((promo) => (
@@ -109,14 +117,18 @@ export default function EventPage() {
                       )}
                       <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
                         {promo.discountRate && (
-                          <span className="text-red-500 font-bold">{promo.discountRate}% 할인</span>
+                          <span className="text-red-500 font-bold">
+                            {t('discount', { percent: promo.discountRate })}
+                          </span>
                         )}
                         <span>
-                          {new Date(promo.endsAt).toLocaleDateString('ko-KR')} 까지
+                          {t('until', {
+                            date: new Date(promo.endsAt).toLocaleDateString(dateLocale),
+                          })}
                         </span>
                         {type === 'timesale' && (
                           <span className="flex items-center gap-1">
-                            남은 시간: <CountdownTimer endsAt={promo.endsAt} />
+                            {t('timeLeft')}: <CountdownTimer endsAt={promo.endsAt} />
                           </span>
                         )}
                       </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -824,6 +824,22 @@
     "minutes": "Minutes",
     "seconds": "Seconds"
   },
+  "event": {
+    "title": "Events & Promotions",
+    "empty": "There are no active promotions.",
+    "notFound": "Promotion not found.",
+    "back": "Go back",
+    "list": "← Back to list",
+    "discount": "{percent}% off",
+    "until": "Until {date}",
+    "timeLeft": "Time left",
+    "errorLoad": "Failed to load events.",
+    "types": {
+      "timesale": "Time Sale",
+      "exhibition": "Exhibition",
+      "event": "Event"
+    }
+  },
   "myCoupons": {
     "title": "Coupons",
     "pointBalance": "Point Balance",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -824,6 +824,22 @@
     "minutes": "분",
     "seconds": "초"
   },
+  "event": {
+    "title": "이벤트/프로모션",
+    "empty": "진행 중인 프로모션이 없습니다.",
+    "notFound": "프로모션을 찾을 수 없습니다.",
+    "back": "돌아가기",
+    "list": "← 목록으로",
+    "discount": "{percent}% 할인",
+    "until": "{date} 까지",
+    "timeLeft": "남은 시간",
+    "errorLoad": "이벤트 목록을 불러오지 못했습니다.",
+    "types": {
+      "timesale": "타임세일",
+      "exhibition": "기획전",
+      "event": "이벤트"
+    }
+  },
   "myCoupons": {
     "title": "쿠폰함",
     "pointBalance": "보유 적립금",


### PR DESCRIPTION
## Summary\n- Add event translation namespace for Korean and English UI labels/messages\n- Replace hardcoded Korean strings in /event and /event/[id] with next-intl translations\n- Format event dates with the active locale and add a regression test for event i18n coverage\n\n## Tests\n- npm run build\n- npm run test:run\n- cd backend && npm run build && npm run test\n\nCloses #731