### PR TITLE
feat: #722 Stripe 결제 gateway enum 분리

### DIFF
--- a/.claude/rules/backend-patterns.md
+++ b/.claude/rules/backend-patterns.md
@@ -11,7 +11,7 @@ NestJS-specific patterns and utilities. Complements `backend/CLAUDE.md`.
 ## Payment Gateway Selection
 
 - Locale-based gateway choice in `prepare()` must be persisted to `payment.gateway`, and all later operations (`confirm`, `cancel`, `partialRefund`) must resolve the adapter from the stored `payment.gateway` value — never from the default injected gateway.
-- `PaymentGatewayType.INICIS` is currently used as the persisted placeholder for the Stripe adapter. If a real Inicis integration is added later, introduce a distinct enum value and migrate existing data instead of overloading runtime resolution logic.
+- `PaymentGatewayType` 값별 매핑은 1:1 — `STRIPE` → `StripeAdapter`, `TOSS` → `TossAdapter`, `INICIS` → 향후 KG이니시스 어댑터(#721 도입 예정), `MOCK` → 기본 게이트웨이. 한 enum 값을 다른 어댑터로 재사용하는 placeholder 패턴 금지.
 
 ## API Documentation (Swagger/OpenAPI)
 

--- a/backend/src/database/migrations/1783300000000-AddStripeGatewayEnum.ts
+++ b/backend/src/database/migrations/1783300000000-AddStripeGatewayEnum.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Stripe 결제 gateway enum 분리 마이그레이션 (#722)
+ *
+ * 배경:
+ *   기존에는 Stripe 결제를 PaymentGatewayType.INICIS placeholder 로 저장하고 있었음.
+ *   (resolveGatewayByType 에서 INICIS → stripeAdapter 로 강제 매핑)
+ *   국내 KG이니시스(#721)와 글로벌 Stripe 를 둘 다 지원하려면 enum 을 분리해야 함.
+ *
+ * 마이그레이션 전략:
+ *   1) `payments.gateway` ENUM 에 'stripe' 값 추가.
+ *   2) 기존 'inicis' 로 저장된 행은 모두 Stripe 결제를 의미하므로 'stripe' 로 백필.
+ *      (실제 Inicis 연동은 아직 운영 도입 전이라 안전한 백필. 도입 후에는
+ *       #721 에서 별도 KG이니시스 어댑터를 추가하면서 새로운 enum 값을 사용함)
+ *   3) INICIS enum 값은 그대로 보존하여 #721 후속 작업에서 재사용 가능.
+ */
+export class AddStripeGatewayEnum1783300000000 implements MigrationInterface {
+  name = 'AddStripeGatewayEnum1783300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1) Add 'stripe' to ENUM (idempotent — listing all values explicitly)
+    await queryRunner.query(
+      `ALTER TABLE \`payments\` MODIFY COLUMN \`gateway\`
+       ENUM('mock','toss','inicis','stripe')
+       NOT NULL DEFAULT 'mock'`,
+    );
+
+    // 2) Backfill: any row stored as 'inicis' was actually a Stripe payment
+    //    (placeholder usage prior to this migration). Promote them to 'stripe'.
+    await queryRunner.query(
+      `UPDATE \`payments\` SET \`gateway\` = 'stripe' WHERE \`gateway\` = 'inicis'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert backfill: 'stripe' rows return to 'inicis' placeholder so the
+    // ENUM shrink in step 2 doesn't lose data.
+    await queryRunner.query(
+      `UPDATE \`payments\` SET \`gateway\` = 'inicis' WHERE \`gateway\` = 'stripe'`,
+    );
+
+    // Shrink ENUM back to original values
+    await queryRunner.query(
+      `ALTER TABLE \`payments\` MODIFY COLUMN \`gateway\`
+       ENUM('mock','toss','inicis')
+       NOT NULL DEFAULT 'mock'`,
+    );
+  }
+}

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -436,6 +436,38 @@ describe('PaymentsService', () => {
       expect(result.status).toBe(RefundStatus.COMPLETED);
     });
 
+    it('payment.gateway=STRIPE → 부분 환불 시 Stripe adapter의 partialCancel()이 호출되어야 함 (#722)', async () => {
+      const stripePayment = makePayment({
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: 'pi_stripe_abc',
+        amount: 30000,
+        gateway: PaymentGatewayType.STRIPE,
+      });
+      const stripeManager = makeRefundManager({
+        findOne: jest.fn().mockResolvedValue(stripePayment),
+      });
+      mockDataSource.transaction
+        .mockImplementationOnce(async (fn: (m: typeof stripeManager) => Promise<unknown>) => fn(stripeManager))
+        .mockImplementationOnce(async (fn: (m: typeof stripeManager) => Promise<unknown>) => fn(stripeManager));
+
+      mockPaymentRepo.findOne.mockResolvedValue(stripePayment);
+      mockRefundRepo.findOne.mockResolvedValue({
+        id: 1, paymentId: 100, amount: 10000, status: RefundStatus.COMPLETED, reason: '부분 환불',
+      });
+
+      mockStripeAdapter.partialCancel.mockResolvedValue({
+        refundId: 're_stripe_123',
+        cancelledAt: new Date(),
+        rawResponse: { stripe: true },
+      });
+
+      const result = await service.partialRefund(1, { amount: 10000, reason: '부분 환불' });
+
+      expect(result.status).toBe(RefundStatus.COMPLETED);
+      expect(mockStripeAdapter.partialCancel).toHaveBeenCalled();
+      expect(mockDefaultGateway.partialCancel).not.toHaveBeenCalled();
+    });
+
     it('결제 CONFIRMED 아님 → BadRequestException', async () => {
       const pendingManager = makeRefundManager({
         findOne: jest.fn().mockResolvedValue(makePayment({ status: PaymentStatus.PENDING, paymentKey: 'pay_abc' })),

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -310,6 +310,44 @@ describe('PaymentsService', () => {
       expect(mockPaymentRepo.update).toHaveBeenCalledWith(payment.id, { status: PaymentStatus.FAILED });
     });
 
+    it('locale=en prepare → payment.gateway 가 STRIPE 로 저장되어야 함 (#722)', async () => {
+      const order = makeOrder();
+      mockOrderRepo.findOne.mockResolvedValue(order);
+      mockPaymentRepo.findOne.mockResolvedValue(null);
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.STRIPE });
+      mockPaymentRepo.create.mockReturnValue(savedPayment);
+      mockPaymentRepo.save.mockResolvedValue(savedPayment);
+      mockStripeAdapter.prepare.mockResolvedValue({ clientKey: 'pi_secret_xyz', orderId: '1' });
+
+      const result = await service.prepare({ orderId: 1, locale: 'en' }, 10);
+
+      expect(result.gateway).toBe('stripe');
+      expect(mockPaymentRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ gateway: PaymentGatewayType.STRIPE }),
+      );
+      expect(mockPaymentRepo.create).not.toHaveBeenCalledWith(
+        expect.objectContaining({ gateway: PaymentGatewayType.INICIS }),
+      );
+    });
+
+    it('payment.gateway=STRIPE 로 저장된 결제는 cancel 시 Stripe adapter 가 사용되어야 함 (#722)', async () => {
+      const payment = makePayment({
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: 'pi_test',
+        gateway: PaymentGatewayType.STRIPE,
+      });
+      mockPaymentRepo.findOne.mockResolvedValue(payment);
+      mockStripeAdapter.cancel.mockResolvedValue({ cancelledAt: new Date(), rawResponse: { stripe: true } });
+      mockPaymentRepo.update.mockResolvedValue({});
+      mockOrderRepo.update.mockResolvedValue({});
+
+      const result = await service.cancel({ orderId: 1 }, 10);
+
+      expect(result.status).toBe(PaymentStatus.CANCELLED);
+      expect(mockStripeAdapter.cancel).toHaveBeenCalledWith('pi_test', '고객 요청');
+      expect(mockDefaultGateway.cancel).not.toHaveBeenCalled();
+    });
+
     it('locale=ko prepare → confirm 시 Toss adapter의 confirm()이 호출되어야 함', async () => {
       const order = makeOrder();
       mockOrderRepo.findOne.mockResolvedValue(order);

--- a/backend/src/modules/payments/entities/payment.entity.ts
+++ b/backend/src/modules/payments/entities/payment.entity.ts
@@ -25,6 +25,7 @@ export enum PaymentGatewayType {
   MOCK = 'mock',
   TOSS = 'toss',
   INICIS = 'inicis',
+  STRIPE = 'stripe',
 }
 
 @Entity('payments')

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -85,15 +85,16 @@ export class PaymentsService {
     return this.gateway;
   }
 
-  // NOTE: PaymentGatewayType enum에는 아직 STRIPE 값이 없어서 INICIS를 overseas 게이트웨이
-  // placeholder로 겸용 중 (stripe/inicis 문자열 → INICIS enum). 실제 Inicis 연동을 추가하려면
-  // enum에 STRIPE를 추가하고 마이그레이션으로 기존 INICIS 데이터를 재분류해야 한다. (#476 후속)
   private resolveGatewayByType(gatewayType: PaymentGatewayType): PaymentGateway {
     switch (gatewayType) {
       case PaymentGatewayType.TOSS:
         return this.tossAdapter;
+      case PaymentGatewayType.STRIPE:
+        return this.stripeAdapter;
       case PaymentGatewayType.INICIS:
-        return this.stripeAdapter; // 임시: INICIS enum이 stripe 어댑터를 의미함 (위 NOTE 참고)
+        // INICIS는 #721 국내 PG 어댑터 확장 이후 별도 어댑터로 분리될 예정.
+        // 그 전까지는 명시적으로 미지원으로 처리하여 잘못된 라우팅을 방지.
+        throw new Error('INICIS 게이트웨이는 아직 지원되지 않습니다. (#721 참고)');
       case PaymentGatewayType.MOCK:
       default:
         return this.gateway;
@@ -105,8 +106,9 @@ export class PaymentsService {
       case 'toss':
         return PaymentGatewayType.TOSS;
       case 'stripe':
+        return PaymentGatewayType.STRIPE;
       case 'inicis':
-        return PaymentGatewayType.INICIS; // 임시: stripe도 INICIS enum으로 저장 (위 NOTE 참고)
+        return PaymentGatewayType.INICIS;
       case 'mock':
       default:
         return PaymentGatewayType.MOCK;

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -94,7 +94,7 @@ export class PaymentsService {
       case PaymentGatewayType.INICIS:
         // INICIS는 #721 국내 PG 어댑터 확장 이후 별도 어댑터로 분리될 예정.
         // 그 전까지는 명시적으로 미지원으로 처리하여 잘못된 라우팅을 방지.
-        throw new Error('INICIS 게이트웨이는 아직 지원되지 않습니다. (#721 참고)');
+        throw new BadRequestException('INICIS 게이트웨이는 아직 지원되지 않습니다. (#721 참고)');
       case PaymentGatewayType.MOCK:
       default:
         return this.gateway;


### PR DESCRIPTION
## Summary

Closes #722

기존에 `PaymentGatewayType.INICIS` 값이 Stripe 결제용 placeholder 로 사용되고 있었음. 국내 KG이니시스(#721)와 글로벌 Stripe 를 모두 지원하기 위해 enum 과 DB 컬럼을 분리.

## 주요 변경

- `PaymentGatewayType.STRIPE = 'stripe'` enum 값 추가
- `payments.gateway` ENUM 에 `'stripe'` 값 추가하는 idempotent 마이그레이션 (`AddStripeGatewayEnum1783300000000`)
- 기존 `'inicis'` 행 백필 → `'stripe'` (현재 운영에 진짜 Inicis 연동 미도입 상태이므로 안전한 백필)
- `payments.service` 의 `INICIS → stripeAdapter` 강제 매핑 제거, `STRIPE` enum 으로 직접 라우팅
- `INICIS` enum 값은 보존 → #721 에서 KG이니시스 어댑터 추가 시 사용
- `.claude/rules/backend-patterns.md` placeholder 사용 규칙 갱신

## 마이그레이션 경로

- 운영 DB 에 아직 진짜 Inicis 결제가 없는 현 시점에서, `gateway='inicis'` 로 저장된 모든 행은 사실상 Stripe 결제. 마이그레이션이 자동 백필.
- 향후 KG이니시스 연동(#721) 도입 시점에는 새로 `gateway='inicis'` 로 저장되는 결제만 KG이니시스로 라우팅됨.
- down 마이그레이션도 `stripe → inicis` 역백필 + ENUM 축소를 모두 수행.

## Test plan

- [x] `backend && npm run build`
- [x] `backend && npm test` (935 tests passed)
- [x] payments service unit tests 신규 케이스 2건 추가 (#722)
  - locale=en prepare → STRIPE 로 저장
  - STRIPE 결제 cancel → Stripe adapter 호출
- [x] `bash scripts/test.sh e2e` (262 e2e + 2 password reset)