### PR TITLE
Fix English promotion seed data

### DIFF
--- a/backend/src/database/migrations/1783300000000-BackfillPromotionBannerEnglishSeedData.ts
+++ b/backend/src/database/migrations/1783300000000-BackfillPromotionBannerEnglishSeedData.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BackfillPromotionBannerEnglishSeedData1783300000000 implements MigrationInterface {
+  name = 'BackfillPromotionBannerEnglishSeedData1783300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`banners\`
+       SET \`title_en\` = 'Spring Collection — <b>New Zhuni Teapots</b>'
+       WHERE \`title\` = '봄 기획전 — <b>주니 신작</b> 입고'
+         AND (\`title_en\` IS NULL OR \`title_en\` = '')`,
+    );
+    await queryRunner.query(
+      `UPDATE \`banners\`
+       SET \`title_en\` = '<b>Bangzhang Ancient Tree</b> Raw Pu-erh 2019 Limited Arrival'
+       WHERE \`title\` = '<b>반장 고수</b> 생병 2019년 한정 입고'
+         AND (\`title_en\` IS NULL OR \`title_en\` = '')`,
+    );
+    await queryRunner.query(
+      `UPDATE \`banners\`
+       SET \`title_en\` = 'Starter Tea Set — <b>14% Off</b> KRW 240,000'
+       WHERE \`title\` = '입문 다도구 세트 — <b>14% 특가</b> 240,000원'
+         AND (\`title_en\` IS NULL OR \`title_en\` = '')`,
+    );
+
+    await queryRunner.query(
+      `UPDATE \`promotions\`
+       SET \`title_en\` = 'Spring Collection — New Zhuni Teapots',
+           \`description_en\` = 'Limited spring pricing on new <b>Fujian Zhuni</b> Yixing teapots. Small quantities of <b>Zhuni Xishi, Zhuxing, and Shibiao</b> pieces are available and may sell out early.'
+       WHERE \`title\` = '봄 기획전 — 주니 신작'
+         AND ((\`title_en\` IS NULL OR \`title_en\` = '') OR (\`description_en\` IS NULL OR \`description_en\` = ''))`,
+    );
+    await queryRunner.query(
+      `UPDATE \`promotions\`
+       SET \`title_en\` = 'Starter Tea Set 14% Time Sale',
+           \`description_en\` = 'Limited special price on the <b>Okhwadang starter tea set</b>. <b>KRW 280,000 → KRW 240,000</b> (KRW 40,000 off). Complete set with Yixing teapot, teacup, tea tray, and tea tools.'
+       WHERE \`title\` = '입문 세트 14% 타임세일'
+         AND ((\`title_en\` IS NULL OR \`title_en\` = '') OR (\`description_en\` IS NULL OR \`description_en\` = ''))`,
+    );
+    await queryRunner.query(
+      `UPDATE \`promotions\`
+       SET \`title_en\` = 'Pu-erh Tea Starter Event',
+           \`description_en\` = 'Receive a <b>five-piece bamboo tea tool set</b> with purchase of <b>Dayi 7572 ripe pu-erh cake</b>. Includes essential beginner tools such as tea scoop, needle, tongs, and funnel.'
+       WHERE \`title\` = '보이차 입문 이벤트'
+         AND ((\`title_en\` IS NULL OR \`title_en\` = '') OR (\`description_en\` IS NULL OR \`description_en\` = ''))`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Intentionally no-op: preserve any manually curated production English copy.
+  }
+}

--- a/backend/src/database/seeds/base/seeder.spec.ts
+++ b/backend/src/database/seeds/base/seeder.spec.ts
@@ -1,0 +1,49 @@
+import { Repository } from 'typeorm';
+import { Seeder } from './seeder';
+
+interface Row {
+  id: number;
+  title: string;
+  titleEn?: string;
+  ignored?: string;
+}
+
+class TestSeeder extends Seeder {
+  async run(): Promise<void> {
+    // no-op
+  }
+
+  execute(repo: Repository<Row>, seedData: Partial<Row>[]): Promise<number> {
+    return this.upsert(repo, seedData, (row) => row.title);
+  }
+}
+
+describe('Seeder.upsert', () => {
+  it('updates existing rows by their persisted primary key when seed items omit id', async () => {
+    const repo = {
+      find: jest.fn().mockResolvedValue([{ id: 7, title: '배너', titleEn: null }]),
+      insert: jest.fn(),
+      update: jest.fn(),
+      metadata: {
+        primaryColumns: [{ propertyName: 'id' }],
+        columns: [
+          { propertyName: 'id' },
+          { propertyName: 'title' },
+          { propertyName: 'titleEn' },
+        ],
+      },
+    } as unknown as Repository<Row>;
+    const seeder = new TestSeeder({} as never);
+
+    const inserted = await seeder.execute(repo, [
+      { title: '배너', titleEn: 'Banner', ignored: 'not a column' },
+    ]);
+
+    expect(inserted).toBe(0);
+    expect(repo.update).toHaveBeenCalledWith(
+      { id: 7 },
+      { title: '배너', titleEn: 'Banner' },
+    );
+    expect(repo.insert).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/database/seeds/base/seeder.ts
+++ b/backend/src/database/seeds/base/seeder.ts
@@ -16,18 +16,25 @@ export abstract class Seeder {
   ): Promise<number> {
     const existing = await repo.find();
     const existingKeys = new Set(existing.map(keySelector));
+    const existingByKey = new Map(existing.map((item) => [keySelector(item), item]));
     const toInsert = seedData.filter((s) => !existingKeys.has(keySelector(s as T)));
     const toUpdate = seedData.filter((s) => existingKeys.has(keySelector(s as T)));
     if (toInsert.length > 0) {
       await repo.insert(toInsert as Parameters<typeof repo.insert>[0]);
     }
     const knownColumns = new Set(repo.metadata.columns.map((c) => c.propertyName));
+    const primaryColumn = repo.metadata.primaryColumns[0].propertyName;
     for (const item of toUpdate) {
+      const existingItem = existingByKey.get(keySelector(item as T));
+      if (!existingItem) continue;
+
       const updateData = Object.fromEntries(
-        Object.entries(item as Record<string, unknown>).filter(([k]) => knownColumns.has(k)),
+        Object.entries(item as Record<string, unknown>).filter(
+          ([k]) => k !== primaryColumn && knownColumns.has(k),
+        ),
       );
       await repo.update(
-        { [repo.metadata.primaryColumns[0].propertyName]: (item as Record<string, unknown>)[repo.metadata.primaryColumns[0].propertyName] } as Parameters<typeof repo.update>[0],
+        { [primaryColumn]: (existingItem as Record<string, unknown>)[primaryColumn] } as Parameters<typeof repo.update>[0],
         updateData as Parameters<typeof repo.update>[1],
       );
     }

--- a/backend/src/database/seeds/data/seed-data.spec.ts
+++ b/backend/src/database/seeds/data/seed-data.spec.ts
@@ -1,0 +1,26 @@
+import { banners, promotions } from './seed-data';
+
+function expectEnglish(value: string): void {
+  expect(value).toEqual(expect.any(String));
+  expect(value.trim()).not.toBe('');
+  expect(/[가-힣]/.test(value)).toBe(false);
+}
+
+describe('seed-data English promotion content', () => {
+  it('provides English fields for every promotion rendered on /en/event', () => {
+    expect(promotions.length).toBeGreaterThan(0);
+
+    for (const promotion of promotions) {
+      expectEnglish(promotion.titleEn);
+      expectEnglish(promotion.descriptionEn);
+    }
+  });
+
+  it('provides English title fields for every banner', () => {
+    expect(banners.length).toBeGreaterThan(0);
+
+    for (const banner of banners) {
+      expectEnglish(banner.titleEn);
+    }
+  });
+});

--- a/backend/src/database/seeds/data/seed-data.ts
+++ b/backend/src/database/seeds/data/seed-data.ts
@@ -1027,6 +1027,7 @@ export const announcementBars: SeedAnnouncementBar[] = [
 // ============================================================
 export interface SeedBanner {
   title: string;
+  titleEn: string;
   imageUrl: string;
   linkUrl: string;
   sortOrder: number;
@@ -1038,6 +1039,7 @@ export interface SeedBanner {
 export const banners: SeedBanner[] = [
   {
     title: '봄 기획전 — <b>주니 신작</b> 입고',
+    titleEn: 'Spring Collection — <b>New Zhuni Teapots</b>',
     imageUrl: 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png',
     linkUrl: '/p/spring-2026',
     sortOrder: 0,
@@ -1047,6 +1049,7 @@ export const banners: SeedBanner[] = [
   },
   {
     title: '<b>반장 고수</b> 생병 2019년 한정 입고',
+    titleEn: '<b>Bangzhang Ancient Tree</b> Raw Pu-erh 2019 Limited Arrival',
     imageUrl: 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png',
     linkUrl: '/products/banjang-gushu-2019-sheng',
     sortOrder: 1,
@@ -1056,6 +1059,7 @@ export const banners: SeedBanner[] = [
   },
   {
     title: '입문 다도구 세트 — <b>14% 특가</b> 240,000원',
+    titleEn: 'Starter Tea Set — <b>14% Off</b> KRW 240,000',
     imageUrl: 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png',
     linkUrl: '/products/okhwadang-starter-tea-set',
     sortOrder: 2,
@@ -1072,7 +1076,9 @@ type PromotionType = 'timesale' | 'exhibition' | 'event';
 
 export interface SeedPromotion {
   title: string;
+  titleEn: string;
   description: string;
+  descriptionEn: string;
   type: PromotionType;
   startsAt: Date;
   endsAt: Date;
@@ -1084,7 +1090,9 @@ export interface SeedPromotion {
 export const promotions: SeedPromotion[] = [
   {
     title: '봄 기획전 — 주니 신작',
+    titleEn: 'Spring Collection — New Zhuni Teapots',
     description: '<b>복건 주니(朱泥)</b> 신작 자사호 선착순 특가. <b>주니 서시호·주형호·석표호</b> 한정 수량 입고. 재고 소진 시 조기 마감될 수 있습니다.',
+    descriptionEn: 'Limited spring pricing on new <b>Fujian Zhuni</b> Yixing teapots. Small quantities of <b>Zhuni Xishi, Zhuxing, and Shibiao</b> pieces are available and may sell out early.',
     type: 'exhibition',
     startsAt: new Date('2026-03-29'),
     endsAt: new Date('2026-04-30'),
@@ -1094,7 +1102,9 @@ export const promotions: SeedPromotion[] = [
   },
   {
     title: '입문 세트 14% 타임세일',
+    titleEn: 'Starter Tea Set 14% Time Sale',
     description: '<b>옥화당 입문 다도구 세트</b> 한정 수량 특가. <b>280,000원 → 240,000원</b> (40,000원 할인). 자사호+다완+다반+차도구 완전 구성.',
+    descriptionEn: 'Limited special price on the <b>Okhwadang starter tea set</b>. <b>KRW 280,000 → KRW 240,000</b> (KRW 40,000 off). Complete set with Yixing teapot, teacup, tea tray, and tea tools.',
     type: 'timesale',
     startsAt: new Date('2026-03-29T09:00:00'),
     endsAt: new Date('2026-04-05T23:59:59'),
@@ -1104,7 +1114,9 @@ export const promotions: SeedPromotion[] = [
   },
   {
     title: '보이차 입문 이벤트',
+    titleEn: 'Pu-erh Tea Starter Event',
     description: '<b>대익 7572 숙병</b> 구매 시 <b>대나무 차도구 5종 세트</b> 증정. 차도구(차칙·차침·차협·차루·차침)가 모두 포함된 입문 필수 세트.',
+    descriptionEn: 'Receive a <b>five-piece bamboo tea tool set</b> with purchase of <b>Dayi 7572 ripe pu-erh cake</b>. Includes essential beginner tools such as tea scoop, needle, tongs, and funnel.',
     type: 'event',
     startsAt: new Date('2026-04-01'),
     endsAt: new Date('2026-04-30'),

--- a/backend/src/database/seeds/okhwadang-seed.sql
+++ b/backend/src/database/seeds/okhwadang-seed.sql
@@ -552,18 +552,18 @@ INSERT INTO announcement_bars (message, message_en, href, sort_order, is_active)
 -- ============================================================
 -- 8. 배너
 -- ============================================================
-INSERT INTO banners (title, image_url, link_url, sort_order, is_active, starts_at, ends_at) VALUES
-('봄 기획전 — <b>주니 신작</b> 입고', 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png', '/p/spring-2026', 0, 1, '2026-03-01 00:00:00', '2026-04-30 23:59:59'),
-('<b>반장 고수</b> 생병 2019년 한정 입고', 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png', '/products/banjang-gushu-2019-sheng', 1, 1, '2026-03-15 00:00:00', '2026-05-15 23:59:59'),
-('입문 다도구 세트 — <b>14% 특가</b> 240,000원', 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png', '/products/okhwadang-starter-tea-set', 2, 1, NULL, NULL);
+INSERT INTO banners (title, title_en, image_url, link_url, sort_order, is_active, starts_at, ends_at) VALUES
+('봄 기획전 — <b>주니 신작</b> 입고', 'Spring Collection — <b>New Zhuni Teapots</b>', 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png', '/p/spring-2026', 0, 1, '2026-03-01 00:00:00', '2026-04-30 23:59:59'),
+('<b>반장 고수</b> 생병 2019년 한정 입고', '<b>Bangzhang Ancient Tree</b> Raw Pu-erh 2019 Limited Arrival', 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png', '/products/banjang-gushu-2019-sheng', 1, 1, '2026-03-15 00:00:00', '2026-05-15 23:59:59'),
+('입문 다도구 세트 — <b>14% 특가</b> 240,000원', 'Starter Tea Set — <b>14% Off</b> KRW 240,000', 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png', '/products/okhwadang-starter-tea-set', 2, 1, NULL, NULL);
 
 -- ============================================================
 -- 9. 프로모션
 -- ============================================================
-INSERT INTO promotions (title, description, type, starts_at, ends_at, is_active, discount_rate, image_url) VALUES
-('봄 기획전 — 주니 신작', '<b>복건 주니(朱泥)</b> 신작 자사호 선착순 특가. <b>주니 서시호·주형호·석표호</b> 한정 수량 입고. 재고 소진 시 조기 마감될 수 있습니다.', 'exhibition', '2026-03-29 00:00:00', '2026-04-30 23:59:59', 1, NULL, 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png'),
-('입문 세트 14% 타임세일', '<b>옥화당 입문 다도구 세트</b> 한정 수량 특가. <b>280,000원 → 240,000원</b> (40,000원 할인). 자사호+다완+다반+차도구 완전 구성.', 'timesale', '2026-03-29 09:00:00', '2026-04-05 23:59:59', 1, 14, 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png'),
-('보이차 입문 이벤트', '<b>대익 7572 숙병</b> 구매 시 <b>대나무 차도구 5종 세트</b> 증정. 차도구(차칙·차침·차협·차루·차침)가 모두 포함된 입문 필수 세트.', 'event', '2026-04-01 00:00:00', '2026-04-30 23:59:59', 1, NULL, 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png');
+INSERT INTO promotions (title, title_en, description, description_en, type, starts_at, ends_at, is_active, discount_rate, image_url) VALUES
+('봄 기획전 — 주니 신작', 'Spring Collection — New Zhuni Teapots', '<b>복건 주니(朱泥)</b> 신작 자사호 선착순 특가. <b>주니 서시호·주형호·석표호</b> 한정 수량 입고. 재고 소진 시 조기 마감될 수 있습니다.', 'Limited spring pricing on new <b>Fujian Zhuni</b> Yixing teapots. Small quantities of <b>Zhuni Xishi, Zhuxing, and Shibiao</b> pieces are available and may sell out early.', 'exhibition', '2026-03-29 00:00:00', '2026-04-30 23:59:59', 1, NULL, 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-1.png'),
+('입문 세트 14% 타임세일', 'Starter Tea Set 14% Time Sale', '<b>옥화당 입문 다도구 세트</b> 한정 수량 특가. <b>280,000원 → 240,000원</b> (40,000원 할인). 자사호+다완+다반+차도구 완전 구성.', 'Limited special price on the <b>Okhwadang starter tea set</b>. <b>KRW 280,000 → KRW 240,000</b> (KRW 40,000 off). Complete set with Yixing teapot, teacup, tea tray, and tea tools.', 'timesale', '2026-03-29 09:00:00', '2026-04-05 23:59:59', 1, 14, 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png'),
+('보이차 입문 이벤트', 'Pu-erh Tea Starter Event', '<b>대익 7572 숙병</b> 구매 시 <b>대나무 차도구 5종 세트</b> 증정. 차도구(차칙·차침·차협·차루·차침)가 모두 포함된 입문 필수 세트.', 'Receive a <b>five-piece bamboo tea tool set</b> with purchase of <b>Dayi 7572 ripe pu-erh cake</b>. Includes essential beginner tools such as tea scoop, needle, tongs, and funnel.', 'event', '2026-04-01 00:00:00', '2026-04-30 23:59:59', 1, NULL, 'https://okhwadang-images-978581199241-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/teapot-2.png');
 
 -- ============================================================
 -- 10. 공지사항


### PR DESCRIPTION
## Summary
- closes #730
- add English `titleEn` / `descriptionEn` promotion seed copy and banner `titleEn` copy
- add a deploy-time backfill migration for existing rows with missing English copy
- fix seed upsert updates so reseeding refreshes existing rows by persisted primary key without trying to rewrite primary keys
- cover seed English fields and updater behavior with regression tests

## Verification
- cd backend && npm run lint && npm run build && npm test -- --runInBand database/seeds/data/seed-data.spec.ts database/seeds/base/seeder.spec.ts modules/promotions/__tests__/promotions.service.spec.ts
- bash scripts/run-seed.sh
- npm run build

## Notes
- `npm run build` exits 0 but emits the existing workspace-root warning and an ESLint/minimatch export warning during the Next build lint phase.
- Remote Lightsail DB is handled by the included migration at deploy/migration time; I did not mutate remote DB directly.
