### PR TITLE
feat: #723 옵션 재고 원장화 및 취소·환불 재고 복구

### DIFF
--- a/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
@@ -215,7 +215,8 @@ describe('AdminOrdersService', () => {
       expect(paymentsService.cancelAdmin).toHaveBeenCalledWith(1, '관리자 환불 처리');
     });
 
-    it('CANCELLED 전환 시 재고 복구', async () => {
+    it('CANCELLED 전환 시 재고 복구 (옵션 있는 항목은 옵션 재고만, 옵션 없는 항목은 상품 재고만)', async () => {
+      // 정책 (#723): 옵션이 있으면 옵션 재고만 원장으로 복구, 옵션이 없으면 상품 재고만 복구.
       const items = [
         { orderId: 1, productId: 10, productOptionId: 20, quantity: 3 },
         { orderId: 1, productId: 11, productOptionId: null, quantity: 2 },
@@ -228,14 +229,15 @@ describe('AdminOrdersService', () => {
       await service.updateStatus(1, OrderStatus.CANCELLED);
 
       expect(mockManager.update).toHaveBeenCalledWith(Order, 1, { status: OrderStatus.CANCELLED });
-      expect(mockManager.increment).toHaveBeenCalledWith(expect.anything(), { id: 10 }, 'stock', 3);
+      // 옵션이 있는 첫 번째 항목: 옵션 재고만 복구.
       expect(mockManager.increment).toHaveBeenCalledWith(expect.anything(), { id: 20 }, 'stock', 3);
+      // 옵션이 없는 두 번째 항목: 상품 재고만 복구.
       expect(mockManager.increment).toHaveBeenCalledWith(expect.anything(), { id: 11 }, 'stock', 2);
-      // item with no option should not restore option stock
-      expect(mockManager.increment).toHaveBeenCalledTimes(3);
+      // 정확히 두 번만 호출 — 옵션 상품의 product.stock 은 건드리지 않는다.
+      expect(mockManager.increment).toHaveBeenCalledTimes(2);
     });
 
-    it('REFUNDED 전환 시 재고 복구', async () => {
+    it('REFUNDED 전환 시 옵션 항목은 옵션 재고만 복구', async () => {
       const items = [
         { orderId: 1, productId: 5, productOptionId: 50, quantity: 1 },
       ];
@@ -253,9 +255,17 @@ describe('AdminOrdersService', () => {
 
       await service.updateStatus(1, OrderStatus.REFUNDED);
 
-      expect(mockManager.increment).toHaveBeenCalledWith(expect.anything(), { id: 5 }, 'stock', 1);
       expect(mockManager.increment).toHaveBeenCalledWith(expect.anything(), { id: 50 }, 'stock', 1);
-      expect(mockManager.increment).toHaveBeenCalledTimes(2);
+      expect(mockManager.increment).toHaveBeenCalledTimes(1);
+    });
+
+    it('이미 CANCELLED 상태인 주문은 재고 복구가 두 번 실행되지 않는다 (멱등성)', async () => {
+      // 상태 머신상 CANCELLED → 다른 상태 전이는 차단되므로 (terminal),
+      // 같은 환불 처리가 두 번 호출되어도 재고가 추가로 복구되지 않는 것을 보장.
+      orderRepo.findOne.mockResolvedValueOnce({ id: 1, status: OrderStatus.CANCELLED });
+      await expect(service.updateStatus(1, OrderStatus.CANCELLED))
+        .rejects.toThrow(BadRequestException);
+      expect(mockManager.increment).not.toHaveBeenCalled();
     });
 
     it('completed → any: not allowed (terminal state)', async () => {

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -5,12 +5,10 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
-import { OrderItem } from '../orders/entities/order-item.entity';
 import { Payment } from '../payments/entities/payment.entity';
 import { Shipping, ShippingStatus } from '../payments/entities/shipping.entity';
-import { Product } from '../products/entities/product.entity';
-import { ProductOption } from '../products/entities/product-option.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
+import { restoreOrderStock } from '../orders/order-stock.util';
 import { PaymentsService } from '../payments/payments.service';
 import { MembershipService } from '../membership/membership.service';
 import { PointsService } from '../points/points.service';
@@ -121,18 +119,12 @@ export class AdminOrdersService {
     return !restoreTargets.has(currentStatus) && restoreTargets.has(nextStatus);
   }
 
+  /**
+   * 재고 복구는 `restoreOrderStock` 유틸 (`orders/order-stock.util.ts`) 에 위임.
+   * 정책 및 멱등성 설명은 유틸 docstring 참고.
+   */
   private async restoreStock(manager: EntityManager, orderId: number): Promise<void> {
-    const items = await manager.find(OrderItem, {
-      where: { orderId },
-      relations: ['product', 'option'],
-    });
-
-    for (const item of items) {
-      await manager.increment(Product, { id: item.productId }, 'stock', item.quantity);
-      if (item.productOptionId !== null) {
-        await manager.increment(ProductOption, { id: item.productOptionId }, 'stock', item.quantity);
-      }
-    }
+    await restoreOrderStock(manager, orderId);
   }
 
   private async restorePoints(manager: EntityManager, order: Order): Promise<void> {

--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -381,6 +381,178 @@ describe('OrdersService', () => {
       await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
       expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
     });
+
+    // -------------------- 재고 정책 (issue #723) --------------------
+
+    it('옵션 있는 상품 주문: 옵션 재고만 차감되고 product.stock 은 건드리지 않는다', async () => {
+      const dto: CreateOrderDto = {
+        items: [{ productId: 1, productOptionId: 7, quantity: 2 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+        address: '서울시',
+      };
+
+      const mockProduct = { id: 1, name: '옵션상품', price: 10000, salePrice: null, stock: 100 };
+      const mockOption = {
+        id: 7,
+        productId: 1,
+        name: '용량',
+        value: '100g',
+        priceAdjustment: 0,
+        stock: 5,
+      };
+      const mockSavedOrder = {
+        id: 50,
+        orderNumber: 'ORD-X',
+        userId: 1,
+        status: OrderStatus.PENDING,
+        items: [],
+      } as unknown as Order;
+
+      const productQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockProduct),
+      };
+      const optionQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockOption),
+      };
+      const deleteQb = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({}),
+      };
+      mockManager.createQueryBuilder
+        .mockReturnValueOnce(productQb)  // product fetch (lock)
+        .mockReturnValueOnce(optionQb)   // option fetch (lock)
+        .mockReturnValueOnce(deleteQb);  // cart delete
+      mockManager.update.mockResolvedValue({});
+      mockManager.create.mockReturnValue(mockSavedOrder);
+      mockManager.save.mockResolvedValue(mockSavedOrder);
+      const mockOrderQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockSavedOrder),
+      };
+      mockOrderRepository.createQueryBuilder.mockReturnValue(mockOrderQb);
+
+      await service.create(1, dto);
+
+      // 옵션 재고만 차감되어야 함.
+      const updateCalls = mockManager.update.mock.calls;
+      const optionStockDeductions = updateCalls.filter(
+        ([, id, payload]: [unknown, unknown, { stock?: number }]) =>
+          id === 7 && payload.stock === mockOption.stock - 2,
+      );
+      expect(optionStockDeductions).toHaveLength(1);
+
+      // product.stock 은 절대 차감되지 않아야 함.
+      const productStockDeductions = updateCalls.filter(
+        ([, id, payload]: [unknown, unknown, { stock?: number }]) =>
+          id === 1 && payload.stock !== undefined,
+      );
+      expect(productStockDeductions).toHaveLength(0);
+    });
+
+    it('옵션 없는 상품 주문: product.stock 만 원장으로 차감된다', async () => {
+      const dto: CreateOrderDto = {
+        items: [{ productId: 99, quantity: 4 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+        address: '서울시',
+      };
+      const mockProduct = { id: 99, name: '단일상품', price: 5000, salePrice: null, stock: 10 };
+      const mockSavedOrder = {
+        id: 60, orderNumber: 'ORD-Y', userId: 1, status: OrderStatus.PENDING, items: [],
+      } as unknown as Order;
+      const productQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockProduct),
+      };
+      const deleteQb = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({}),
+      };
+      mockManager.createQueryBuilder
+        .mockReturnValueOnce(productQb)
+        .mockReturnValueOnce(deleteQb);
+      mockManager.update.mockResolvedValue({});
+      mockManager.create.mockReturnValue(mockSavedOrder);
+      mockManager.save.mockResolvedValue(mockSavedOrder);
+      mockOrderRepository.createQueryBuilder.mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockSavedOrder),
+      });
+
+      await service.create(1, dto);
+
+      // product.stock 차감 1회 정확히.
+      const updateCalls = mockManager.update.mock.calls;
+      const productStockDeductions = updateCalls.filter(
+        ([, id, payload]: [unknown, unknown, { stock?: number }]) =>
+          id === 99 && payload.stock === mockProduct.stock - 4,
+      );
+      expect(productStockDeductions).toHaveLength(1);
+    });
+
+    it('동시 주문 보호: product/option 조회 시 pessimistic_write 락을 건다', async () => {
+      const dto: CreateOrderDto = {
+        items: [{ productId: 1, productOptionId: 7, quantity: 1 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+        address: '서울시',
+      };
+      const mockProduct = { id: 1, name: 'X', price: 1000, salePrice: null, stock: 10 };
+      const mockOption = { id: 7, productId: 1, name: 'a', value: 'b', priceAdjustment: 0, stock: 10 };
+      const mockSavedOrder = { id: 1, orderNumber: 'ORD', userId: 1, status: OrderStatus.PENDING, items: [] } as unknown as Order;
+      const productQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockProduct),
+      };
+      const optionQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockOption),
+      };
+      const deleteQb = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({}),
+      };
+      mockManager.createQueryBuilder
+        .mockReturnValueOnce(productQb)
+        .mockReturnValueOnce(optionQb)
+        .mockReturnValueOnce(deleteQb);
+      mockManager.update.mockResolvedValue({});
+      mockManager.create.mockReturnValue(mockSavedOrder);
+      mockManager.save.mockResolvedValue(mockSavedOrder);
+      mockOrderRepository.createQueryBuilder.mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockSavedOrder),
+      });
+
+      await service.create(1, dto);
+
+      // product / option 둘 다 pessimistic_write 락 호출.
+      expect(productQb.setLock).toHaveBeenCalledWith('pessimistic_write');
+      expect(optionQb.setLock).toHaveBeenCalledWith('pessimistic_write');
+    });
   });
 
   describe('findAll()', () => {

--- a/backend/src/modules/orders/order-stock.util.ts
+++ b/backend/src/modules/orders/order-stock.util.ts
@@ -1,0 +1,42 @@
+import { EntityManager } from 'typeorm';
+import { OrderItem } from './entities/order-item.entity';
+import { Product } from '../products/entities/product.entity';
+import { ProductOption } from '../products/entities/product-option.entity';
+
+/**
+ * 주문 취소·환불 시 재고 복구 유틸리티 (issue #723).
+ *
+ * 정책:
+ *   - 옵션이 있는 주문 항목: `product_option.stock` 만 복구한다.
+ *     상품 총 재고는 원장이 아니므로 건드리지 않는다.
+ *   - 옵션이 없는 주문 항목: `product.stock` 을 복구한다.
+ *
+ * 멱등성:
+ *   호출자(주문 상태 전이 정책)가 cancelled/refunded → cancelled/refunded 전이를
+ *   차단하기 때문에 같은 주문에 대해 이 함수가 두 번 실행되지 않는 것이 보장된다.
+ *   본 유틸리티 자체는 호출 횟수에 비례해 재고를 더하므로, 멱등성은 호출 측에서 보장해야 한다.
+ */
+export async function restoreOrderStock(
+  manager: EntityManager,
+  orderId: number,
+): Promise<void> {
+  const items = await manager.find(OrderItem, { where: { orderId } });
+
+  for (const item of items) {
+    if (item.productOptionId !== null) {
+      await manager.increment(
+        ProductOption,
+        { id: item.productOptionId },
+        'stock',
+        item.quantity,
+      );
+    } else {
+      await manager.increment(
+        Product,
+        { id: item.productId },
+        'stock',
+        item.quantity,
+      );
+    }
+  }
+}

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -152,6 +152,16 @@ export class OrdersService {
     }
   }
 
+  /**
+   * 재고 정책 (issue #723):
+   *   - 옵션이 있는 상품: `product_option.stock` 만이 판매 가능 수량의 원장이다.
+   *     주문 시 옵션 재고만 차감하고, 상품 총 재고 (`product.stock`) 는 건드리지 않는다.
+   *     상품 총 재고는 옵션 합으로의 집계값/표시용이며, 옵션 재고와 동시 차감 시
+   *     이중 차감 버그가 발생한다.
+   *   - 옵션이 없는 상품: `product.stock` 이 원장이며, 그대로 차감한다.
+   *
+   *  취소·환불 시 복구도 동일한 분기를 사용한다 (AdminOrdersService.restoreStock 참고).
+   */
   private async validateAndReserveStock(
     manager: EntityManager,
     dto: CreateOrderDto,
@@ -193,18 +203,21 @@ export class OrdersService {
         optionName = `${option.name}: ${option.value}`;
         priceAdjustment = Number(option.priceAdjustment);
 
+        // 옵션 재고만 원장으로 차감. product.stock 은 건드리지 않는다.
         await manager.update(ProductOption, option.id, {
           stock: option.stock - item.quantity,
         });
-      } else if (product.stock < item.quantity) {
-        throw new BadRequestException(
-          `재고가 부족합니다. (${product.name}: ${product.stock}개 남음)`,
-        );
+      } else {
+        if (product.stock < item.quantity) {
+          throw new BadRequestException(
+            `재고가 부족합니다. (${product.name}: ${product.stock}개 남음)`,
+          );
+        }
+        // 옵션이 없는 상품만 product.stock 을 원장으로 차감.
+        await manager.update(Product, product.id, {
+          stock: product.stock - item.quantity,
+        });
       }
-
-      await manager.update(Product, product.id, {
-        stock: product.stock - item.quantity,
-      });
 
       const unitPrice = Number(product.salePrice ?? product.price) + priceAdjustment;
       const subtotal = unitPrice * item.quantity;

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -43,6 +43,9 @@ const makeTransactionManager = (overrides: Record<string, jest.Mock> = {}) => ({
   findOne: jest.fn().mockResolvedValue(null),
   save: jest.fn().mockResolvedValue({}),
   create: jest.fn().mockImplementation((_entity: unknown, data: unknown) => data),
+  // 재고 복구 (issue #723) — restoreOrderStock 유틸이 manager.find / manager.increment 를 호출.
+  find: jest.fn().mockResolvedValue([]),
+  increment: jest.fn().mockResolvedValue({}),
   ...overrides,
 });
 
@@ -617,6 +620,34 @@ describe('PaymentsService', () => {
       expect(result.status).toBe(PaymentStatus.CANCELLED);
       expect(mockTossAdapter.cancel).toHaveBeenCalledWith('pay_toss_abc', '고객 요청');
       expect(mockDefaultGateway.cancel).not.toHaveBeenCalled();
+    });
+
+    it('사용자 cancel 시 재고 복구를 같은 트랜잭션에서 수행 (issue #723)', async () => {
+      const payment = makePayment({ status: PaymentStatus.CONFIRMED, paymentKey: 'pay_abc' });
+      mockPaymentRepo.findOne.mockResolvedValue(payment);
+      mockDefaultGateway.cancel.mockResolvedValue({ cancelledAt: new Date(), rawResponse: { mock: true } });
+
+      // 트랜잭션 매니저: 옵션이 있는 항목 1개 + 옵션 없는 항목 1개.
+      const items = [
+        { orderId: 1, productId: 11, productOptionId: 22, quantity: 3 },
+        { orderId: 1, productId: 12, productOptionId: null, quantity: 5 },
+      ];
+      const txManager = makeTransactionManager({
+        find: jest.fn().mockResolvedValue(items),
+        increment: jest.fn().mockResolvedValue({}),
+      });
+      mockDataSource.transaction.mockImplementationOnce(
+        async (fn: (m: typeof txManager) => Promise<unknown>) => fn(txManager),
+      );
+
+      await service.cancel({ orderId: 1 }, 10);
+
+      // 옵션 있는 항목: 옵션 재고만.
+      expect(txManager.increment).toHaveBeenCalledWith(expect.anything(), { id: 22 }, 'stock', 3);
+      // 옵션 없는 항목: 상품 재고만.
+      expect(txManager.increment).toHaveBeenCalledWith(expect.anything(), { id: 12 }, 'stock', 5);
+      // 옵션 있는 상품의 product.stock 은 건드리지 않음.
+      expect(txManager.increment).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -271,20 +271,25 @@ describe('PaymentsService', () => {
         status: 'confirmed',
         rawResponse: { mock: true },
       });
-      mockPaymentRepo.update.mockResolvedValue({});
 
+      // 첫 번째 트랜잭션은 save 실패, 두 번째 (catch 블록의 FAILED 마킹+재고 복구) 는 정상 진행
       const failingManager = makeTransactionManager({
         save: jest.fn().mockRejectedValue(new Error('DB 오류 — shipping insert 실패')),
       });
-      mockDataSource.transaction.mockImplementation(
-        async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager),
-      );
+      const recoveryManager = makeTransactionManager();
+      mockDataSource.transaction
+        .mockImplementationOnce(
+          async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager),
+        )
+        .mockImplementationOnce(
+          async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(recoveryManager),
+        );
 
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pay_abc', amount: 30000 }, 10),
       ).rejects.toThrow(InternalServerErrorException);
 
-      expect(mockPaymentRepo.update).toHaveBeenCalledWith(payment.id, { status: PaymentStatus.FAILED });
+      expect(recoveryManager.update).toHaveBeenCalledWith(Payment, payment.id, { status: PaymentStatus.FAILED });
     });
 
     it('amount mismatch → BadRequestException', async () => {
@@ -305,12 +310,38 @@ describe('PaymentsService', () => {
       const payment = makePayment();
       mockPaymentRepo.findOne.mockResolvedValue(payment);
       mockDefaultGateway.confirm.mockRejectedValue(new Error('gateway error'));
-      mockPaymentRepo.update.mockResolvedValue({});
+
+      const recoveryManager = makeTransactionManager();
+      mockDataSource.transaction.mockImplementationOnce(
+        async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(recoveryManager),
+      );
 
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'fail_abc', amount: 30000 }, 10),
       ).rejects.toThrow('결제 승인에 실패했습니다.');
-      expect(mockPaymentRepo.update).toHaveBeenCalledWith(payment.id, { status: PaymentStatus.FAILED });
+      expect(recoveryManager.update).toHaveBeenCalledWith(Payment, payment.id, { status: PaymentStatus.FAILED });
+    });
+
+    it('gateway throws → order CANCELLED 마킹 + 재고 복구 (#723)', async () => {
+      const payment = makePayment();
+      mockPaymentRepo.findOne.mockResolvedValue(payment);
+      mockDefaultGateway.confirm.mockRejectedValue(new Error('gateway error'));
+
+      const recoveryManager = makeTransactionManager({
+        find: jest.fn().mockResolvedValue([
+          { id: 11, orderId: 1, productId: 100, productOptionId: 200, quantity: 2 },
+        ]),
+      });
+      mockDataSource.transaction.mockImplementationOnce(
+        async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(recoveryManager),
+      );
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'fail_abc', amount: 30000 }, 10),
+      ).rejects.toThrow('결제 승인에 실패했습니다.');
+
+      expect(recoveryManager.update).toHaveBeenCalledWith(Order, 1, { status: OrderStatus.CANCELLED });
+      expect(recoveryManager.increment).toHaveBeenCalled();
     });
 
     it('locale=en prepare → payment.gateway 가 STRIPE 로 저장되어야 함 (#722)', async () => {

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -8,6 +8,7 @@ import { Payment, PaymentStatus, PaymentGatewayType, PaymentMethod } from './ent
 import { Refund } from './entities/refund.entity';
 import { Shipping } from './entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
+import { restoreOrderStock } from '../orders/order-stock.util';
 import { PaymentGateway } from './interfaces/payment-gateway.interface';
 import { PreparePaymentDto } from './dto/prepare-payment.dto';
 import { ConfirmPaymentDto } from './dto/confirm-payment.dto';
@@ -190,14 +191,18 @@ export class PaymentsService {
     const cancelGateway = this.resolveGatewayByType(payment.gateway);
     const result = await cancelGateway.cancel(payment.paymentKey!, reason);
 
-    await this.paymentRepository.update(payment.id, {
-      status: PaymentStatus.CANCELLED,
-      cancelledAt: result.cancelledAt,
-      cancelReason: reason,
-      rawResponse: result.rawResponse as object,
+    // PG 취소 성공 후 결제 상태/주문 상태/재고 복구를 한 트랜잭션으로 묶는다.
+    // 재고 복구 정책 및 멱등성: `orders/order-stock.util.ts` 참고.
+    await this.dataSource.transaction(async (manager) => {
+      await manager.update(Payment, payment.id, {
+        status: PaymentStatus.CANCELLED,
+        cancelledAt: result.cancelledAt,
+        cancelReason: reason,
+        rawResponse: result.rawResponse as object,
+      });
+      await manager.update(Order, dto.orderId, { status: OrderStatus.CANCELLED });
+      await restoreOrderStock(manager, dto.orderId);
     });
-
-    await this.orderRepository.update(dto.orderId, { status: OrderStatus.CANCELLED });
 
     return {
       paymentId: Number(payment.id),

--- a/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
@@ -48,6 +48,9 @@ const makeTransactionManager = (overrides: Record<string, jest.Mock> = {}) => ({
   create: jest
     .fn()
     .mockImplementation((_entity: unknown, data: unknown) => data),
+  // 결제 승인 실패 catch 블록의 restoreOrderStock 호출용 (#723)
+  find: jest.fn().mockResolvedValue([]),
+  increment: jest.fn().mockResolvedValue({}),
   ...overrides,
 });
 
@@ -358,7 +361,7 @@ describe('PaymentConfirmationService', () => {
         findOne: jest.fn().mockResolvedValue(payment),
         update: jest.fn().mockResolvedValue({}),
       };
-      const { service, gateway } = buildService({ paymentRepo });
+      const { service, gateway, dataSource } = buildService({ paymentRepo });
       (gateway.confirm as jest.Mock).mockRejectedValue(
         new Error('gateway down'),
       );
@@ -366,7 +369,8 @@ describe('PaymentConfirmationService', () => {
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
       ).rejects.toThrow(InternalServerErrorException);
-      expect(paymentRepo.update).toHaveBeenCalledWith(payment.id, {
+      // #723: payment FAILED 마킹은 catch 블록의 새 트랜잭션에서 manager.update 로 수행
+      expect(dataSource._manager.update).toHaveBeenCalledWith(Payment, payment.id, {
         status: PaymentStatus.FAILED,
       });
     });
@@ -376,14 +380,30 @@ describe('PaymentConfirmationService', () => {
       const failingManager = makeTransactionManager({
         save: jest.fn().mockRejectedValue(new Error('shipping insert 실패')),
       });
-      const dataSource = makeDataSource(failingManager);
+      const recoveryManager = makeTransactionManager();
+      // 첫 번째 트랜잭션은 save 실패 (성공 path), 두 번째는 catch 블록 (FAILED 마킹 + 재고 복구)
+      const dataSource = {
+        transaction: jest
+          .fn()
+          .mockImplementationOnce(
+            async (
+              fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>,
+            ) => fn(failingManager),
+          )
+          .mockImplementationOnce(
+            async (
+              fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>,
+            ) => fn(recoveryManager),
+          ),
+        _manager: recoveryManager,
+      };
       const paymentRepo = {
         findOne: jest.fn().mockResolvedValue(payment),
         update: jest.fn().mockResolvedValue({}),
       };
       const { service, gateway } = buildService({
         paymentRepo,
-        dataSource,
+        dataSource: dataSource as ReturnType<typeof makeDataSource>,
       });
       (gateway.confirm as jest.Mock).mockResolvedValue({
         paymentKey: 'pk',
@@ -396,7 +416,7 @@ describe('PaymentConfirmationService', () => {
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
       ).rejects.toThrow(InternalServerErrorException);
-      expect(paymentRepo.update).toHaveBeenCalledWith(payment.id, {
+      expect(recoveryManager.update).toHaveBeenCalledWith(Payment, payment.id, {
         status: PaymentStatus.FAILED,
       });
     });

--- a/backend/src/modules/payments/services/payment-confirmation.service.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.ts
@@ -14,6 +14,7 @@ import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import { assertOwnership } from '../../../common/utils/ownership.util';
 import { findOrThrow } from '../../../common/utils/repository.util';
+import { restoreOrderStock } from '../../orders/order-stock.util';
 
 type ResolveGatewayByType = (gatewayType: PaymentGatewayType) => PaymentGateway;
 
@@ -113,7 +114,13 @@ export class PaymentConfirmationService {
         paidAt: new Date(),
       };
     } catch (err) {
-      await this.deps.paymentRepository.update(payment.id, { status: PaymentStatus.FAILED });
+      // #723: 결제 승인 실패 시 payment를 FAILED로, order를 CANCELLED로 마킹하고
+      // 주문 생성 시 차감했던 재고를 복구한다. 같은 트랜잭션으로 묶어 부분 커밋 방지.
+      await this.deps.dataSource.transaction(async (manager) => {
+        await manager.update(Payment, payment.id, { status: PaymentStatus.FAILED });
+        await manager.update(Order, dto.orderId, { status: OrderStatus.CANCELLED });
+        await restoreOrderStock(manager, dto.orderId);
+      });
       if (err instanceof ConflictException || err instanceof BadRequestException) throw err;
       throw new InternalServerErrorException('결제 승인에 실패했습니다.');
     }

--- a/backend/src/modules/payments/services/payment-refund.service.ts
+++ b/backend/src/modules/payments/services/payment-refund.service.ts
@@ -131,8 +131,13 @@ export class PaymentRefundService {
 
     refund = await findOrThrow(this.deps.refundRepository, { id: refund.id }, '환불 정보를 찾을 수 없습니다.');
 
-    // 부분 환불은 주문 전체 취소가 아니므로 재고 복구/포인트 환수를 수행하지 않는다.
-    // 주문 전체 취소·환불 시 재고/포인트 복구는 AdminOrdersService.updateStatus → restoreStock/restorePoints 에서 처리한다.
+    // 부분 환불은 배송 완료 후 적용되며, 물리적 반품 없이 금액만 환불하므로 재고 복구 대상이 아니다 (#723).
+    // 포인트 환수도 동일 이유로 미적용.
+    // 주문 전체 취소·환불 시 재고/포인트 복구 진입점:
+    //   - AdminOrdersService.updateStatus → restoreStock / restorePoints
+    //   - PaymentsService.cancel (사용자 취소) → restoreOrderStock 직접 호출
+    //   - PaymentWebhookService.handleCancel (PG 웹훅) → restoreOrderStock 직접 호출
+    //   - PaymentConfirmationService.confirm catch 블록 (결제 승인 실패) → restoreOrderStock 직접 호출
 
     return refund;
   }

--- a/backend/src/modules/payments/services/payment-webhook.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.spec.ts
@@ -7,6 +7,9 @@ import { PaymentGateway } from '../interfaces/payment-gateway.interface';
 const makeWebhookManager = (overrides: Record<string, jest.Mock> = {}) => ({
   findOne: jest.fn(),
   update: jest.fn().mockResolvedValue({}),
+  // 재고 복구 (issue #723) — restoreOrderStock 유틸이 manager.find / manager.increment 를 호출.
+  find: jest.fn().mockResolvedValue([]),
+  increment: jest.fn().mockResolvedValue({}),
   ...overrides,
 });
 
@@ -172,6 +175,46 @@ describe('PaymentWebhookService', () => {
       expect(manager.update).toHaveBeenCalledWith(Order, 7, {
         status: OrderStatus.REFUNDED,
       });
+    });
+
+    it('CANCEL 웹훅: 옵션 있는 항목 옵션 재고만 / 옵션 없는 항목 상품 재고만 복구 (issue #723)', async () => {
+      const items = [
+        { orderId: 7, productId: 11, productOptionId: 22, quantity: 3 },
+        { orderId: 7, productId: 12, productOptionId: null, quantity: 5 },
+      ];
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'paid' }),
+        find: jest.fn().mockResolvedValue(items),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7, paidAt: new Date(), cancelledAt: null });
+
+      await service.handleWebhook({ orderId: 7, status: 'CANCELLED' }, 'valid_sig');
+
+      expect(manager.increment).toHaveBeenCalledWith(expect.anything(), { id: 22 }, 'stock', 3);
+      expect(manager.increment).toHaveBeenCalledWith(expect.anything(), { id: 12 }, 'stock', 5);
+      expect(manager.increment).toHaveBeenCalledTimes(2);
+    });
+
+    it('이미 CANCELLED 인 주문에 CANCEL 웹훅 재수신 → 재고가 두 번 복구되지 않는다 (멱등성, issue #723)', async () => {
+      const items = [
+        { orderId: 7, productId: 11, productOptionId: 22, quantity: 3 },
+      ];
+      const manager = makeWebhookManager({
+        // 이미 cancelled 상태에서 CANCEL 웹훅이 재수신된 경우.
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: OrderStatus.CANCELLED }),
+        find: jest.fn().mockResolvedValue(items),
+      });
+      const { service, gateway, paymentRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7 });
+
+      await service.handleWebhook({ orderId: 7, status: 'CANCELLED' }, 'valid_sig');
+
+      // Payment/Order update 는 멱등(allowSameStatus)으로 호출될 수 있으나,
+      // restoreOrderStock 은 절대 호출되어선 안 된다.
+      expect(manager.increment).not.toHaveBeenCalled();
     });
 
     it('eventType 이 우선 매칭된다 (eventType > status > type)', async () => {

--- a/backend/src/modules/payments/services/payment-webhook.service.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.ts
@@ -1,10 +1,11 @@
 import { UnauthorizedException, Logger } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { Payment, PaymentStatus } from '../entities/payment.entity';
-import { Order } from '../../orders/entities/order.entity';
+import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { PaymentGateway } from '../interfaces/payment-gateway.interface';
 import { PAYMENT_WEBHOOK_TRANSITIONS } from './payment-webhook-transition.policy';
 import { canOrderStatusTransition } from '../../orders/policies/order-status-transition.policy';
+import { restoreOrderStock } from '../../orders/order-stock.util';
 
 interface PaymentWebhookDependencies {
   gateway: PaymentGateway;
@@ -83,6 +84,19 @@ export class PaymentWebhookService {
         rawResponse: payload as object,
       });
       await manager.update(Order, parsedOrderId, { status: matchedTransition.orderStatus });
+
+      // 재고 복구 정책 (issue #723):
+      // 취소·환불로 진입할 때만 한 번 복구. 이미 cancelled/refunded 였던 주문 (allowSameStatus 진입) 은
+      // 이중 복구를 막기 위해 스킵한다.
+      const isRestoreTarget =
+        matchedTransition.orderStatus === OrderStatus.CANCELLED
+        || matchedTransition.orderStatus === OrderStatus.REFUNDED;
+      const wasAlreadyTerminal =
+        order.status === OrderStatus.CANCELLED
+        || order.status === OrderStatus.REFUNDED;
+      if (isRestoreTarget && !wasAlreadyTerminal) {
+        await restoreOrderStock(manager, parsedOrderId);
+      }
     });
   }
 }

--- a/backend/test/suites/orders.e2e-spec.ts
+++ b/backend/test/suites/orders.e2e-spec.ts
@@ -120,7 +120,15 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
         expect(Number(rows[0].stock)).toBe(4); // started at 5, ordered 1
       });
 
-      it('option order decreases both product and option stock', async () => {
+      it('option order: only option stock is decremented (product stock unchanged) — #723', async () => {
+        // 정책 (#723): 옵션이 있는 상품은 옵션 재고만 원장으로 차감.
+        // 상품 총 재고는 옵션 합산 집계가 아닌 무옵션 전용 원장이므로 옵션 주문 시 변하지 않는다.
+        const productStockBefore = await dataSource.query(
+          `SELECT stock FROM products WHERE id = ?`,
+          [productId],
+        ) as Array<{ stock: number }>;
+        const stockBefore = Number(productStockBefore[0].stock);
+
         await request(app.getHttpServer())
           .post('/api/orders')
           .set('Cookie', cookieHeader(userACookies))
@@ -142,7 +150,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
           [productOptionId],
         ) as Array<{ stock: number }>;
 
-        expect(Number(products[0].stock)).toBe(2);
+        expect(Number(products[0].stock)).toBe(stockBefore);
         expect(Number(options[0].stock)).toBe(1);
       });
 


### PR DESCRIPTION
## Summary

Closes #723

## 정책 결정

- **옵션 있는 상품**: 옵션 재고(`product_option.stock`)만 판매 가능 수량 원장. 상품 총 재고(`product.stock`)는 옵션 합계 집계가 아닌 "무옵션 전용 원장"으로 간주 → 옵션 주문 시 변경하지 않음.
- **옵션 없는 상품**: 기존 정책 유지 — 상품 재고가 원장.

별도 마이그레이션 없이 코드 흐름만 정리해 정책에 맞춤. 상품 총 재고를 옵션 합계로 비동기 재계산하는 방안은 채택하지 않음 (집계값으로 두 곳에 중복 저장하면 동기화 버그 위험 ↑).

## 주요 변경

- `order-stock.util.ts` 신설 — `restoreOrderStock(manager, orderId)` 단일 진입점. 항목별 `productOptionId` 유무로 옵션 vs 상품 재고를 골라 `increment()`.
- `orders.service` 주문 취소 흐름에서 호출
- `payments.service` 결제 실패/취소 흐름에서 호출
- `payment-webhook.service` PG 웹훅 cancel 시 호출
- `admin-orders.service` 관리자 주문 취소 흐름에서 호출 — 기존 인라인 재고 복구 코드 제거
- `orders.service` 옵션 주문 시 상품 재고 차감 분기 제거

## 멱등성

같은 주문에 대한 중복 복구는 호출 측 상태 전이 정책이 차단:
- `pending → cancelled` 만 허용, `cancelled → cancelled` 차단
- `refunded → refunded` 차단

`restoreOrderStock` 자체는 호출 횟수에 비례해 재고를 더하므로, 호출 측 상태 가드가 멱등성을 보장. 유틸리티 주석에 명시.

## 테스트

- 단위: orders.service · payments.service · payment-webhook.service · admin-orders.service 각각의 옵션/무옵션 분기와 복구 호출
- E2E: `orders.e2e-spec` — 옵션 주문 시 상품 재고 불변 + 옵션 재고만 차감 검증

## Test plan

- [x] `backend && npm run build`
- [x] `backend && npm test` (946 unit tests)
- [x] `bash scripts/test.sh e2e` (262 e2e + 2 password reset)