### PR TITLE
feat: #721 국내 PG 어댑터 확장 (NaverPay + KGInicis)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -51,11 +51,21 @@ SENTRY_TRACES_SAMPLE_RATE=0.1
 # 캐시: 백엔드 프로세스 내 in-memory (CacheService).
 # Redis/ElastiCache 연결 불필요.
 # ─────────────────────────────────────────────
-PAYMENT_GATEWAY=mock  # REQUIRED — 'mock' is blocked in production. Options: mock, toss, stripe
-TOSS_SECRET_KEY=   # Toss Payments secret key (for ko locale)
+PAYMENT_GATEWAY=mock  # REQUIRED — 'mock' is blocked in production. Options: mock, toss, stripe, inicis, naverpay
+TOSS_SECRET_KEY=   # Toss Payments secret key (for ko locale, default 국내 PG)
 TOSS_CLIENT_KEY=   # Toss Payments client key (for ko locale)
 STRIPE_SECRET_KEY=   # Stripe secret key (for global locale)
 STRIPE_WEBHOOK_SECRET=   # Stripe webhook signing secret
+# KG Inicis (#721 국내 PG)
+INICIS_MID=
+INICIS_SIGN_KEY=
+INICIS_API_KEY=
+INICIS_CLIENT_KEY=
+# NaverPay (#721 국내 PG)
+NAVERPAY_PARTNER_ID=
+NAVERPAY_CLIENT_ID=
+NAVERPAY_CLIENT_SECRET=
+NAVERPAY_CHAIN_ID=
 # Shipping carrier API
 CJ_TRACKING_API_URL=
 CJ_TRACKING_API_KEY=

--- a/backend/src/config/payment.config.ts
+++ b/backend/src/config/payment.config.ts
@@ -2,7 +2,7 @@ import { Provider } from '@nestjs/common';
 
 export const PAYMENT_CONFIG = Symbol('PAYMENT_CONFIG');
 
-export type PaymentGatewayName = 'mock' | 'toss' | 'stripe';
+export type PaymentGatewayName = 'mock' | 'toss' | 'stripe' | 'inicis' | 'naverpay';
 
 export interface PaymentConfig {
   nodeEnv: string;
@@ -17,10 +17,28 @@ export interface PaymentConfig {
     publishableKey: string;
     webhookSecret: string;
   };
+  inicis: {
+    mid: string;
+    signKey: string;
+    apiKey: string;
+    clientKey: string;
+  };
+  naverpay: {
+    partnerId: string;
+    clientId: string;
+    clientSecret: string;
+    chainId: string;
+  };
 }
 
 function isPaymentGatewayName(value: string): value is PaymentGatewayName {
-  return value === 'mock' || value === 'toss' || value === 'stripe';
+  return (
+    value === 'mock' ||
+    value === 'toss' ||
+    value === 'stripe' ||
+    value === 'inicis' ||
+    value === 'naverpay'
+  );
 }
 
 export function createPaymentConfig(env: NodeJS.ProcessEnv = process.env): PaymentConfig {
@@ -49,6 +67,18 @@ export function createPaymentConfig(env: NodeJS.ProcessEnv = process.env): Payme
       secretKey: env.STRIPE_SECRET_KEY ?? '',
       publishableKey: env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '',
       webhookSecret: env.STRIPE_WEBHOOK_SECRET ?? '',
+    },
+    inicis: {
+      mid: env.INICIS_MID ?? '',
+      signKey: env.INICIS_SIGN_KEY ?? '',
+      apiKey: env.INICIS_API_KEY ?? '',
+      clientKey: env.INICIS_CLIENT_KEY ?? '',
+    },
+    naverpay: {
+      partnerId: env.NAVERPAY_PARTNER_ID ?? '',
+      clientId: env.NAVERPAY_CLIENT_ID ?? '',
+      clientSecret: env.NAVERPAY_CLIENT_SECRET ?? '',
+      chainId: env.NAVERPAY_CHAIN_ID ?? '',
     },
   };
 }

--- a/backend/src/database/migrations/1783400000000-AddNaverpayGatewayEnum.ts
+++ b/backend/src/database/migrations/1783400000000-AddNaverpayGatewayEnum.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * NaverPay 결제 gateway enum 추가 마이그레이션 (#721 국내 PG 어댑터 확장)
+ *
+ * 배경:
+ *   국내 결제는 토스 / KG이니시스 / 네이버페이 3개 PG 를 모두 지원해야 한다.
+ *   - 'toss' / 'inicis' / 'stripe' 는 이미 ENUM 에 존재 (#722 에서 분리 완료)
+ *   - 'naverpay' 만 신규 추가 필요
+ *
+ * 마이그레이션 전략:
+ *   `payments.gateway` ENUM 에 'naverpay' 값을 추가한다. 기존 데이터 백필 없음.
+ *   idempotent — 모든 ENUM 값을 명시적으로 나열 (#722 의 AddStripeGatewayEnum 패턴 동일).
+ */
+export class AddNaverpayGatewayEnum1783400000000 implements MigrationInterface {
+  name = 'AddNaverpayGatewayEnum1783400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`payments\` MODIFY COLUMN \`gateway\`
+       ENUM('mock','toss','inicis','stripe','naverpay')
+       NOT NULL DEFAULT 'mock'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Down: NaverPay 결제 행이 존재하면 stripe 로 폴백 후 ENUM 축소.
+    // (실제 운영에서는 NaverPay 결제가 있는 상태로 down 하면 데이터 손실이 있으므로 권장 X)
+    await queryRunner.query(
+      `UPDATE \`payments\` SET \`gateway\` = 'stripe' WHERE \`gateway\` = 'naverpay'`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE \`payments\` MODIFY COLUMN \`gateway\`
+       ENUM('mock','toss','inicis','stripe')
+       NOT NULL DEFAULT 'mock'`,
+    );
+  }
+}

--- a/backend/src/modules/payments/__tests__/inicis.adapter.spec.ts
+++ b/backend/src/modules/payments/__tests__/inicis.adapter.spec.ts
@@ -1,0 +1,181 @@
+import { BadGatewayException } from '@nestjs/common';
+import { KGInicisPaymentAdapter } from '../adapters/inicis.adapter';
+import { createPaymentConfig } from '../../../config/payment.config';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('KGInicisPaymentAdapter', () => {
+  let adapter: KGInicisPaymentAdapter;
+
+  beforeEach(() => {
+    adapter = new KGInicisPaymentAdapter(
+      createPaymentConfig({
+        NODE_ENV: 'development',
+        PAYMENT_GATEWAY: 'inicis',
+        INICIS_MID: 'INIpayTest',
+        INICIS_SIGN_KEY: 'SU5JTElURV9UUklQTEVERVNfS0VZU1RS',
+        INICIS_API_KEY: 'inicis_api_key',
+        INICIS_CLIENT_KEY: 'inicis_client_key',
+      }),
+    );
+    jest.clearAllMocks();
+  });
+
+  describe('prepare', () => {
+    it('clientKey와 orderId를 반환한다', async () => {
+      const result = await adapter.prepare('ORDER-INICIS-123', 50000);
+
+      expect(result.clientKey).toBe('inicis_client_key');
+      expect(result.orderId).toBe('ORDER-INICIS-123');
+    });
+  });
+
+  describe('confirm', () => {
+    it('이니시스 API 200 → ConfirmResult 반환', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          resultCode: '0000',
+          tid: 'StdpayCARD20260101000000',
+          payMethod: 'Card',
+          totPrice: 10000,
+        }),
+      });
+
+      const result = await adapter.confirm('StdpayCARD20260101000000', 10000, 'ORD-INICIS-001');
+
+      expect(result.paymentKey).toBe('StdpayCARD20260101000000');
+      expect(result.method).toBe('card');
+      expect(result.amount).toBe(10000);
+      expect(result.status).toBe('confirmed');
+    });
+
+    it('이니시스 API resultCode != 0000 → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ resultCode: '9999', resultMsg: '거래실패' }),
+      });
+
+      await expect(
+        adapter.confirm('StdpayCARD20260101000000', 10000, 'ORD-INICIS-001'),
+      ).rejects.toThrow(BadGatewayException);
+    });
+
+    it('이니시스 API 5xx → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ message: 'Internal error' }),
+      });
+
+      await expect(
+        adapter.confirm('StdpayCARD20260101000000', 10000, 'ORD-INICIS-001'),
+      ).rejects.toThrow(BadGatewayException);
+    });
+  });
+
+  describe('cancel', () => {
+    it('전액 취소 → CancelResult 반환', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          resultCode: '00',
+          cancelDate: '20260101',
+          cancelTime: '120000',
+        }),
+      });
+
+      const result = await adapter.cancel('StdpayCARD20260101000000', '단순 변심');
+
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('이니시스 취소 실패 → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ resultCode: '99', resultMsg: '취소 불가' }),
+      });
+
+      await expect(
+        adapter.cancel('StdpayCARD20260101000000', '취소'),
+      ).rejects.toThrow(BadGatewayException);
+    });
+  });
+
+  describe('partialCancel', () => {
+    it('부분 취소 응답의 tid를 refundId로 반환', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          resultCode: '00',
+          cancelTid: 'CancelStdpay20260101120000',
+          cancelDate: '20260101',
+          cancelTime: '120000',
+        }),
+      });
+
+      const result = await adapter.partialCancel({
+        paymentKey: 'StdpayCARD20260101000000',
+        cancelAmount: 5000,
+        cancelReason: '부분 환불',
+      });
+
+      expect(result.refundId).toBe('CancelStdpay20260101120000');
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('cancelTid 없으면 inicis- 폴백 ID 사용', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          resultCode: '00',
+          cancelDate: '20260101',
+          cancelTime: '120000',
+        }),
+      });
+
+      const result = await adapter.partialCancel({
+        paymentKey: 'StdpayCARD20260101000000',
+        cancelAmount: 5000,
+        cancelReason: '부분 환불',
+      });
+
+      expect(result.refundId).toMatch(/^inicis-StdpayCARD20260101000000-\d+$/);
+    });
+
+    it('이니시스 부분 취소 실패 → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ resultCode: '99' }),
+      });
+
+      await expect(
+        adapter.partialCancel({
+          paymentKey: 'StdpayCARD20260101000000',
+          cancelAmount: 5000,
+          cancelReason: '환불',
+        }),
+      ).rejects.toThrow(BadGatewayException);
+    });
+  });
+
+  describe('verifyWebhook', () => {
+    it('올바른 서명 → true', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const crypto = require('crypto');
+      const payload = { tid: 'StdpayCARD20260101000000', resultCode: '0000' };
+      const sig = crypto
+        .createHmac('sha256', 'SU5JTElURV9UUklQTEVERVNfS0VZU1RS')
+        .update(JSON.stringify(payload))
+        .digest('hex');
+
+      expect(adapter.verifyWebhook(payload, sig)).toBe(true);
+    });
+
+    it('잘못된 서명 → false', () => {
+      expect(adapter.verifyWebhook({ tid: 'test' }, 'wrong_signature')).toBe(false);
+    });
+  });
+});

--- a/backend/src/modules/payments/__tests__/naverpay.adapter.spec.ts
+++ b/backend/src/modules/payments/__tests__/naverpay.adapter.spec.ts
@@ -1,0 +1,188 @@
+import { BadGatewayException } from '@nestjs/common';
+import { NaverPayPaymentAdapter } from '../adapters/naverpay.adapter';
+import { createPaymentConfig } from '../../../config/payment.config';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('NaverPayPaymentAdapter', () => {
+  let adapter: NaverPayPaymentAdapter;
+
+  beforeEach(() => {
+    adapter = new NaverPayPaymentAdapter(
+      createPaymentConfig({
+        NODE_ENV: 'development',
+        PAYMENT_GATEWAY: 'naverpay',
+        NAVERPAY_PARTNER_ID: 'naverpay-test-partner',
+        NAVERPAY_CLIENT_ID: 'naverpay-test-client',
+        NAVERPAY_CLIENT_SECRET: 'naverpay-test-secret',
+        NAVERPAY_CHAIN_ID: 'naverpay-chain-id',
+      }),
+    );
+    jest.clearAllMocks();
+  });
+
+  describe('prepare', () => {
+    it('clientKey와 orderId를 반환한다', async () => {
+      const result = await adapter.prepare('ORDER-NAVERPAY-1', 30000);
+
+      expect(result.clientKey).toBe('naverpay-test-client');
+      expect(result.orderId).toBe('ORDER-NAVERPAY-1');
+    });
+  });
+
+  describe('confirm', () => {
+    it('네이버페이 API code=Success → ConfirmResult 반환', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 'Success',
+          message: '결제가 정상 처리되었습니다.',
+          body: {
+            paymentId: '20260101NP0000001',
+            primaryPayMeans: 'CARD',
+            totalPayAmount: 10000,
+            admissionState: 'SUCCESS',
+          },
+        }),
+      });
+
+      const result = await adapter.confirm('20260101NP0000001', 10000, 'ORD-NAVERPAY-1');
+
+      expect(result.paymentKey).toBe('20260101NP0000001');
+      expect(result.method).toBe('card');
+      expect(result.amount).toBe(10000);
+      expect(result.status).toBe('confirmed');
+    });
+
+    it('네이버페이 API code=Fail → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ code: 'Fail', message: '결제 실패' }),
+      });
+
+      await expect(
+        adapter.confirm('20260101NP0000001', 10000, 'ORD-NAVERPAY-1'),
+      ).rejects.toThrow(BadGatewayException);
+    });
+
+    it('네이버페이 API 5xx → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ message: 'Internal error' }),
+      });
+
+      await expect(
+        adapter.confirm('20260101NP0000001', 10000, 'ORD-NAVERPAY-1'),
+      ).rejects.toThrow(BadGatewayException);
+    });
+  });
+
+  describe('cancel', () => {
+    it('전액 취소 → CancelResult 반환', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 'Success',
+          body: {
+            cancelDetail: { cancelDateTime: '2026-01-01T12:00:00+0900' },
+          },
+        }),
+      });
+
+      const result = await adapter.cancel('20260101NP0000001', '단순 변심');
+
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('네이버페이 취소 실패 → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ code: 'Fail', message: '취소 불가' }),
+      });
+
+      await expect(
+        adapter.cancel('20260101NP0000001', '취소'),
+      ).rejects.toThrow(BadGatewayException);
+    });
+  });
+
+  describe('partialCancel', () => {
+    it('부분 취소 응답의 cancelId를 refundId로 반환', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 'Success',
+          body: {
+            cancelDetail: {
+              cancelId: 'NP-CANCEL-20260101-0001',
+              cancelDateTime: '2026-01-01T12:00:00+0900',
+            },
+          },
+        }),
+      });
+
+      const result = await adapter.partialCancel({
+        paymentKey: '20260101NP0000001',
+        cancelAmount: 5000,
+        cancelReason: '부분 환불',
+      });
+
+      expect(result.refundId).toBe('NP-CANCEL-20260101-0001');
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('cancelId 없으면 naverpay- 폴백 ID 사용', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 'Success',
+          body: { cancelDetail: { cancelDateTime: '2026-01-01T12:00:00+0900' } },
+        }),
+      });
+
+      const result = await adapter.partialCancel({
+        paymentKey: '20260101NP0000001',
+        cancelAmount: 5000,
+        cancelReason: '부분 환불',
+      });
+
+      expect(result.refundId).toMatch(/^naverpay-20260101NP0000001-\d+$/);
+    });
+
+    it('네이버페이 부분 취소 실패 → BadGatewayException', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ code: 'Fail' }),
+      });
+
+      await expect(
+        adapter.partialCancel({
+          paymentKey: '20260101NP0000001',
+          cancelAmount: 5000,
+          cancelReason: '환불',
+        }),
+      ).rejects.toThrow(BadGatewayException);
+    });
+  });
+
+  describe('verifyWebhook', () => {
+    it('올바른 서명 → true', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const crypto = require('crypto');
+      const payload = { paymentId: '20260101NP0000001', code: 'Success' };
+      const sig = crypto
+        .createHmac('sha256', 'naverpay-test-secret')
+        .update(JSON.stringify(payload))
+        .digest('hex');
+
+      expect(adapter.verifyWebhook(payload, sig)).toBe(true);
+    });
+
+    it('잘못된 서명 → false', () => {
+      expect(adapter.verifyWebhook({ paymentId: 'test' }, 'wrong_signature')).toBe(false);
+    });
+  });
+});

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -10,6 +10,8 @@ import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { MockPaymentAdapter, MOCK_TEST_SIGNATURE } from '../adapters/mock.adapter';
 import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
+import { KGInicisPaymentAdapter } from '../adapters/inicis.adapter';
+import { NaverPayPaymentAdapter } from '../adapters/naverpay.adapter';
 import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import { PAYMENT_CONFIG, createPaymentConfig } from '../../../config/payment.config';
@@ -141,6 +143,22 @@ describe('PaymentsService', () => {
     verifyWebhook: jest.fn(),
   };
 
+  const mockInicisAdapter = {
+    prepare: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    partialCancel: jest.fn(),
+    verifyWebhook: jest.fn(),
+  };
+
+  const mockNaverpayAdapter = {
+    prepare: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    partialCancel: jest.fn(),
+    verifyWebhook: jest.fn(),
+  };
+
   let mockDataSource: ReturnType<typeof makeDataSourceMock>;
 
   beforeEach(async () => {
@@ -166,6 +184,8 @@ describe('PaymentsService', () => {
         { provide: 'PaymentGateway', useValue: mockDefaultGateway },
         { provide: TossPaymentAdapter, useValue: mockTossAdapter },
         { provide: StripePaymentAdapter, useValue: mockStripeAdapter },
+        { provide: KGInicisPaymentAdapter, useValue: mockInicisAdapter },
+        { provide: NaverPayPaymentAdapter, useValue: mockNaverpayAdapter },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
         { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
         { provide: DataSource, useValue: mockDataSource },

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -9,6 +9,8 @@ import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { Shipping } from '../entities/shipping.entity';
 import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
+import { KGInicisPaymentAdapter } from '../adapters/inicis.adapter';
+import { NaverPayPaymentAdapter } from '../adapters/naverpay.adapter';
 import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import { PAYMENT_CONFIG, createPaymentConfig } from '../../../config/payment.config';
@@ -59,6 +61,8 @@ describe('PaymentsService — webhook', () => {
         },
         { provide: TossPaymentAdapter, useValue: mockGateway },
         { provide: StripePaymentAdapter, useValue: mockGateway },
+        { provide: KGInicisPaymentAdapter, useValue: mockGateway },
+        { provide: NaverPayPaymentAdapter, useValue: mockGateway },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
         { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
         { provide: DataSource, useValue: mockDataSource },

--- a/backend/src/modules/payments/adapters/inicis.adapter.ts
+++ b/backend/src/modules/payments/adapters/inicis.adapter.ts
@@ -1,0 +1,204 @@
+import * as crypto from 'crypto';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { BadGatewayException } from '@nestjs/common';
+import {
+  PaymentGateway,
+  PrepareResult,
+  ConfirmResult,
+  CancelResult,
+  PartialCancelParams,
+  PartialCancelResult,
+} from '../interfaces/payment-gateway.interface';
+import { PAYMENT_CONFIG, PaymentConfig } from '../../../config/payment.config';
+
+/**
+ * KG이니시스 결제 어댑터 (#721 국내 PG 어댑터 확장)
+ *
+ * 본 어댑터는 mock contract 수준으로, 실제 KG이니시스 SDK 콜이 아닌
+ * fetch 기반 HTTP 호출 형태만 잡아두었다. 실 도입 시 SDK 콜로 교체.
+ *
+ * - prepare: clientKey 반환 (FE에서 SDK 호출에 사용)
+ * - confirm: 인증 완료된 거래의 승인 요청
+ * - cancel / partialCancel: 승인 취소 / 부분 취소
+ * - verifyWebhook: HMAC-SHA256 (signKey 기반)
+ */
+@Injectable()
+export class KGInicisPaymentAdapter implements PaymentGateway {
+  private readonly logger = new Logger(KGInicisPaymentAdapter.name);
+  private readonly mid: string;
+  private readonly signKey: string;
+  private readonly apiKey: string;
+  private readonly clientKey: string;
+
+  constructor(
+    @Inject(PAYMENT_CONFIG)
+    config: PaymentConfig,
+  ) {
+    this.mid = config.inicis.mid;
+    this.signKey = config.inicis.signKey;
+    this.apiKey = config.inicis.apiKey;
+    this.clientKey = config.inicis.clientKey;
+  }
+
+  async prepare(orderId: string, _amount: number): Promise<PrepareResult> {
+    return { clientKey: this.clientKey, orderId };
+  }
+
+  async confirm(paymentKey: string, amount: number, orderId: string): Promise<ConfirmResult> {
+    const response = await fetch('https://iniapi.inicis.com/v2/pg/payment', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        type: 'Confirm',
+        mid: this.mid,
+        tid: paymentKey,
+        price: amount,
+        orderId,
+      }),
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!response.ok) {
+      this.logger.error(
+        `Inicis confirm failed: status=${response.status}, paymentKey=${paymentKey}`,
+      );
+      throw new BadGatewayException('이니시스 API 오류');
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+
+    if (body.resultCode !== '0000') {
+      this.logger.error(
+        `Inicis confirm declined: resultCode=${String(body.resultCode)}, paymentKey=${paymentKey}`,
+      );
+      throw new BadGatewayException('이니시스 결제 승인 실패');
+    }
+
+    const payMethod = typeof body.payMethod === 'string' ? body.payMethod.toLowerCase() : 'card';
+
+    return {
+      paymentKey,
+      method: payMethod === 'card' || payMethod === 'vbank' || payMethod === 'bank' ? payMethod : 'card',
+      amount,
+      status: 'confirmed',
+      rawResponse: body as object,
+    };
+  }
+
+  async cancel(paymentKey: string, reason: string): Promise<CancelResult> {
+    const response = await fetch('https://iniapi.inicis.com/v2/pg/refund', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        type: 'Refund',
+        mid: this.mid,
+        tid: paymentKey,
+        msg: reason,
+      }),
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!response.ok) {
+      this.logger.error(
+        `Inicis cancel failed: status=${response.status}, paymentKey=${paymentKey}`,
+      );
+      throw new BadGatewayException('이니시스 API 취소 오류');
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+
+    if (body.resultCode !== '00' && body.resultCode !== '0000') {
+      this.logger.error(
+        `Inicis cancel declined: resultCode=${String(body.resultCode)}, paymentKey=${paymentKey}`,
+      );
+      throw new BadGatewayException('이니시스 취소 실패');
+    }
+
+    const cancelledAt = parseInicisTimestamp(body);
+
+    return {
+      cancelledAt,
+      rawResponse: body as object,
+    };
+  }
+
+  async partialCancel(params: PartialCancelParams): Promise<PartialCancelResult> {
+    const response = await fetch('https://iniapi.inicis.com/v2/pg/refund', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        type: 'PartialRefund',
+        mid: this.mid,
+        tid: params.paymentKey,
+        price: params.cancelAmount,
+        msg: params.cancelReason,
+      }),
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!response.ok) {
+      this.logger.error(
+        `Inicis partialCancel failed: status=${response.status}, paymentKey=${params.paymentKey}`,
+      );
+      throw new BadGatewayException('이니시스 부분 취소 오류');
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+
+    if (body.resultCode !== '00' && body.resultCode !== '0000') {
+      this.logger.error(
+        `Inicis partialCancel declined: resultCode=${String(body.resultCode)}, paymentKey=${params.paymentKey}`,
+      );
+      throw new BadGatewayException('이니시스 부분 취소 실패');
+    }
+
+    const refundId = typeof body.cancelTid === 'string'
+      ? body.cancelTid
+      : `inicis-${params.paymentKey}-${Date.now()}`;
+
+    return {
+      refundId,
+      cancelledAt: parseInicisTimestamp(body),
+      rawResponse: body as object,
+    };
+  }
+
+  verifyWebhook(payload: unknown, signature: string): boolean {
+    try {
+      const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
+      const expected = crypto
+        .createHmac('sha256', this.signKey)
+        .update(body)
+        .digest();
+      const provided = Buffer.from(signature, 'hex');
+      if (expected.length !== provided.length) return false;
+      return crypto.timingSafeEqual(expected, provided);
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Inicis 응답의 cancelDate(YYYYMMDD) + cancelTime(HHmmss) 를 Date로 변환.
+ * 필드 누락 시 현재 시각 폴백.
+ */
+function parseInicisTimestamp(body: Record<string, unknown>): Date {
+  const date = typeof body.cancelDate === 'string' ? body.cancelDate : null;
+  const time = typeof body.cancelTime === 'string' ? body.cancelTime : null;
+  if (date && time && /^\d{8}$/.test(date) && /^\d{6}$/.test(time)) {
+    const iso = `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}T${time.slice(0, 2)}:${time.slice(2, 4)}:${time.slice(4, 6)}+09:00`;
+    const parsed = new Date(iso);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return new Date();
+}

--- a/backend/src/modules/payments/adapters/naverpay.adapter.ts
+++ b/backend/src/modules/payments/adapters/naverpay.adapter.ts
@@ -1,0 +1,206 @@
+import * as crypto from 'crypto';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { BadGatewayException } from '@nestjs/common';
+import {
+  PaymentGateway,
+  PrepareResult,
+  ConfirmResult,
+  CancelResult,
+  PartialCancelParams,
+  PartialCancelResult,
+} from '../interfaces/payment-gateway.interface';
+import { PAYMENT_CONFIG, PaymentConfig } from '../../../config/payment.config';
+
+/**
+ * 네이버페이 결제 어댑터 (#721 국내 PG 어댑터 확장)
+ *
+ * 본 어댑터는 mock contract 수준으로, 실제 네이버페이 SDK 콜이 아닌
+ * fetch 기반 HTTP 호출 형태만 잡아두었다. 실 도입 시 SDK 콜로 교체.
+ *
+ * - prepare: clientKey(=clientId) 반환 (FE에서 NAVER Pay JS SDK 호출에 사용)
+ * - confirm: 결제 승인 요청
+ * - cancel / partialCancel: 결제 취소 / 부분 취소
+ * - verifyWebhook: HMAC-SHA256 (clientSecret 기반)
+ */
+@Injectable()
+export class NaverPayPaymentAdapter implements PaymentGateway {
+  private readonly logger = new Logger(NaverPayPaymentAdapter.name);
+  private readonly partnerId: string;
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly chainId: string;
+
+  constructor(
+    @Inject(PAYMENT_CONFIG)
+    config: PaymentConfig,
+  ) {
+    this.partnerId = config.naverpay.partnerId;
+    this.clientId = config.naverpay.clientId;
+    this.clientSecret = config.naverpay.clientSecret;
+    this.chainId = config.naverpay.chainId;
+  }
+
+  private get authHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'X-Naver-Client-Id': this.clientId,
+      'X-Naver-Client-Secret': this.clientSecret,
+      'X-NaverPay-Chain-Id': this.chainId,
+    };
+  }
+
+  async prepare(orderId: string, _amount: number): Promise<PrepareResult> {
+    return { clientKey: this.clientId, orderId };
+  }
+
+  async confirm(paymentKey: string, amount: number, orderId: string): Promise<ConfirmResult> {
+    const response = await fetch(
+      `https://apis.naver.com/${this.partnerId}/naverpay-partner/naverpay/payments/v2.2/apply/payment`,
+      {
+        method: 'POST',
+        headers: this.authHeaders,
+        body: JSON.stringify({
+          paymentId: paymentKey,
+          merchantPayKey: orderId,
+          totalPayAmount: amount,
+        }),
+        signal: AbortSignal.timeout(8000),
+      },
+    );
+
+    if (!response.ok) {
+      this.logger.error(
+        `NaverPay confirm failed: status=${response.status}, paymentKey=${paymentKey}`,
+      );
+      throw new BadGatewayException('네이버페이 API 오류');
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+
+    if (body.code !== 'Success') {
+      this.logger.error(
+        `NaverPay confirm declined: code=${String(body.code)}, paymentKey=${paymentKey}`,
+      );
+      throw new BadGatewayException('네이버페이 결제 승인 실패');
+    }
+
+    const detail = isRecord(body.body) ? body.body : {};
+    const primary = typeof detail.primaryPayMeans === 'string' ? detail.primaryPayMeans.toLowerCase() : 'card';
+    const method = primary === 'card' || primary === 'point' || primary === 'bank' ? primary : 'card';
+
+    return {
+      paymentKey,
+      method,
+      amount,
+      status: 'confirmed',
+      rawResponse: body as object,
+    };
+  }
+
+  async cancel(paymentKey: string, reason: string): Promise<CancelResult> {
+    const response = await fetch(
+      `https://apis.naver.com/${this.partnerId}/naverpay-partner/naverpay/payments/v2.2/cancel`,
+      {
+        method: 'POST',
+        headers: this.authHeaders,
+        body: JSON.stringify({
+          paymentId: paymentKey,
+          cancelReason: reason,
+        }),
+        signal: AbortSignal.timeout(8000),
+      },
+    );
+
+    if (!response.ok) {
+      this.logger.error(
+        `NaverPay cancel failed: status=${response.status}, paymentKey=${paymentKey}`,
+      );
+      throw new BadGatewayException('네이버페이 취소 오류');
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+
+    if (body.code !== 'Success') {
+      this.logger.error(
+        `NaverPay cancel declined: code=${String(body.code)}, paymentKey=${paymentKey}`,
+      );
+      throw new BadGatewayException('네이버페이 취소 실패');
+    }
+
+    return {
+      cancelledAt: parseNaverPayCancelDateTime(body),
+      rawResponse: body as object,
+    };
+  }
+
+  async partialCancel(params: PartialCancelParams): Promise<PartialCancelResult> {
+    const response = await fetch(
+      `https://apis.naver.com/${this.partnerId}/naverpay-partner/naverpay/payments/v2.2/cancel`,
+      {
+        method: 'POST',
+        headers: this.authHeaders,
+        body: JSON.stringify({
+          paymentId: params.paymentKey,
+          cancelAmount: params.cancelAmount,
+          cancelReason: params.cancelReason,
+        }),
+        signal: AbortSignal.timeout(8000),
+      },
+    );
+
+    if (!response.ok) {
+      this.logger.error(
+        `NaverPay partialCancel failed: status=${response.status}, paymentKey=${params.paymentKey}`,
+      );
+      throw new BadGatewayException('네이버페이 부분 취소 오류');
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+
+    if (body.code !== 'Success') {
+      this.logger.error(
+        `NaverPay partialCancel declined: code=${String(body.code)}, paymentKey=${params.paymentKey}`,
+      );
+      throw new BadGatewayException('네이버페이 부분 취소 실패');
+    }
+
+    const detail = isRecord(body.body) && isRecord(body.body.cancelDetail) ? body.body.cancelDetail : null;
+    const refundId = detail && typeof detail.cancelId === 'string'
+      ? detail.cancelId
+      : `naverpay-${params.paymentKey}-${Date.now()}`;
+
+    return {
+      refundId,
+      cancelledAt: parseNaverPayCancelDateTime(body),
+      rawResponse: body as object,
+    };
+  }
+
+  verifyWebhook(payload: unknown, signature: string): boolean {
+    try {
+      const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
+      const expected = crypto
+        .createHmac('sha256', this.clientSecret)
+        .update(body)
+        .digest();
+      const provided = Buffer.from(signature, 'hex');
+      if (expected.length !== provided.length) return false;
+      return crypto.timingSafeEqual(expected, provided);
+    } catch {
+      return false;
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseNaverPayCancelDateTime(body: Record<string, unknown>): Date {
+  const detail = isRecord(body.body) && isRecord(body.body.cancelDetail) ? body.body.cancelDetail : null;
+  if (detail && typeof detail.cancelDateTime === 'string') {
+    const parsed = new Date(detail.cancelDateTime);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return new Date();
+}

--- a/backend/src/modules/payments/entities/payment.entity.ts
+++ b/backend/src/modules/payments/entities/payment.entity.ts
@@ -26,6 +26,7 @@ export enum PaymentGatewayType {
   TOSS = 'toss',
   INICIS = 'inicis',
   STRIPE = 'stripe',
+  NAVERPAY = 'naverpay',
 }
 
 @Entity('payments')

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -10,6 +10,8 @@ import { AdminOrderRefundsController } from './admin-order-refunds.controller';
 import { MockPaymentAdapter } from './adapters/mock.adapter';
 import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
+import { KGInicisPaymentAdapter } from './adapters/inicis.adapter';
+import { NaverPayPaymentAdapter } from './adapters/naverpay.adapter';
 import {
   PAYMENT_CONFIG,
   PaymentConfig,
@@ -21,9 +23,18 @@ export function resolvePaymentGateway(config: PaymentConfig): string {
 }
 
 /**
- * 로케일 기반 결제 게이트웨이 선택
- * - 한국(ko): Toss Payments
- * - 그 외: Stripe (글로벌)
+ * 로케일 기반 결제 게이트웨이 선택 (#721)
+ *
+ * 정책 결정:
+ * - 한국(ko): Toss Payments — 기본값. 사용자가 별도 PG 선택 시 controller 단계에서
+ *   덮어쓰기 가능 (`/api/payments/prepare` body 의 명시적 gateway 필드는 추후 확장).
+ *   국내 PG(toss / inicis / naverpay) 어댑터가 모두 등록되어 있으므로 Phase 2 에서
+ *   사용자 선택 UI 만 추가하면 된다.
+ * - 그 외 locale: Stripe (글로벌)
+ *
+ * 자율 판단 근거: issue #721 본문은 "사용자 선택 / 관리자 설정 / locale fallback 중 결정"
+ * 을 자율 판단 항목으로 명시. 가장 작은 변화(=기존 ko→toss 매핑 유지)를 선택하고,
+ * 국내 3 PG 어댑터를 미리 등록해 둠으로써 추후 사용자 선택 UI 추가가 비파괴적이도록 설계.
  */
 export function resolveGatewayByLocale(locale: string): string {
   return locale === 'ko' ? 'toss' : 'stripe';
@@ -34,6 +45,8 @@ const gatewayProviders = [
   MockPaymentAdapter,
   TossPaymentAdapter,
   StripePaymentAdapter,
+  KGInicisPaymentAdapter,
+  NaverPayPaymentAdapter,
   {
     provide: 'PaymentGateway',
     useFactory: (
@@ -41,6 +54,8 @@ const gatewayProviders = [
       mock: MockPaymentAdapter,
       toss: TossPaymentAdapter,
       stripe: StripePaymentAdapter,
+      inicis: KGInicisPaymentAdapter,
+      naverpay: NaverPayPaymentAdapter,
     ) => {
       const gateway = resolvePaymentGateway(config);
       switch (gateway) {
@@ -48,13 +63,24 @@ const gatewayProviders = [
           return toss;
         case 'stripe':
           return stripe;
+        case 'inicis':
+          return inicis;
+        case 'naverpay':
+          return naverpay;
         case 'mock':
           return mock;
         default:
           throw new Error(`Unknown PAYMENT_GATEWAY: ${gateway}`);
       }
     },
-    inject: [PAYMENT_CONFIG, MockPaymentAdapter, TossPaymentAdapter, StripePaymentAdapter],
+    inject: [
+      PAYMENT_CONFIG,
+      MockPaymentAdapter,
+      TossPaymentAdapter,
+      StripePaymentAdapter,
+      KGInicisPaymentAdapter,
+      NaverPayPaymentAdapter,
+    ],
   },
 ];
 

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -16,6 +16,8 @@ import { CancelPaymentDto } from './dto/cancel-payment.dto';
 import { CreateRefundDto } from './dto/create-refund.dto';
 import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
+import { KGInicisPaymentAdapter } from './adapters/inicis.adapter';
+import { NaverPayPaymentAdapter } from './adapters/naverpay.adapter';
 import { resolveGatewayByLocale } from './payments.module';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { findOrThrow } from '../../common/utils/repository.util';
@@ -48,6 +50,8 @@ export class PaymentsService {
     private readonly paymentConfig: PaymentConfig,
     private readonly tossAdapter: TossPaymentAdapter,
     private readonly stripeAdapter: StripePaymentAdapter,
+    private readonly inicisAdapter: KGInicisPaymentAdapter,
+    private readonly naverpayAdapter: NaverPayPaymentAdapter,
     private readonly notificationService: NotificationService,
     private readonly notificationDispatchHelper: NotificationDispatchHelper,
     private readonly dataSource: DataSource,
@@ -83,6 +87,8 @@ export class PaymentsService {
     const name = resolveGatewayByLocale(locale);
     if (name === 'toss') return this.tossAdapter;
     if (name === 'stripe') return this.stripeAdapter;
+    if (name === 'inicis') return this.inicisAdapter;
+    if (name === 'naverpay') return this.naverpayAdapter;
     return this.gateway;
   }
 
@@ -93,9 +99,9 @@ export class PaymentsService {
       case PaymentGatewayType.STRIPE:
         return this.stripeAdapter;
       case PaymentGatewayType.INICIS:
-        // INICIS는 #721 국내 PG 어댑터 확장 이후 별도 어댑터로 분리될 예정.
-        // 그 전까지는 명시적으로 미지원으로 처리하여 잘못된 라우팅을 방지.
-        throw new BadRequestException('INICIS 게이트웨이는 아직 지원되지 않습니다. (#721 참고)');
+        return this.inicisAdapter;
+      case PaymentGatewayType.NAVERPAY:
+        return this.naverpayAdapter;
       case PaymentGatewayType.MOCK:
       default:
         return this.gateway;
@@ -110,6 +116,8 @@ export class PaymentsService {
         return PaymentGatewayType.STRIPE;
       case 'inicis':
         return PaymentGatewayType.INICIS;
+      case 'naverpay':
+        return PaymentGatewayType.NAVERPAY;
       case 'mock':
       default:
         return PaymentGatewayType.MOCK;


### PR DESCRIPTION
## 요약
국내 결제는 토스 / KG이니시스 / 네이버페이 3개 PG 를 모두 지원해야 한다는 정책에 따라 국내 PG 어댑터 2종을 추가한다.

Closes #721

## 변경 내용

### 어댑터 (mock contract 수준)
- `backend/src/modules/payments/adapters/inicis.adapter.ts` — KG이니시스 어댑터 (`KGInicisPaymentAdapter`)
- `backend/src/modules/payments/adapters/naverpay.adapter.ts` — 네이버페이 어댑터 (`NaverPayPaymentAdapter`)
- 둘 다 `PaymentGateway` 인터페이스 (`prepare/confirm/cancel/partialCancel/verifyWebhook`) 를 구현하고, 실 PG SDK 호출 대신 fetch 기반 HTTP 호출 형태로 contract 만 잡아두었다 (issue 본문이 mock contract 수준만 요구). 실 도입 시 fetch 콜만 SDK 콜로 교체하면 됨.

### Enum / 마이그레이션
- `PaymentGatewayType.NAVERPAY = 'naverpay'` 신규 추가 (`INICIS` 는 #722 에서 이미 enum 에 존재)
- `backend/src/database/migrations/1783400000000-AddNaverpayGatewayEnum.ts` — `payments.gateway` ENUM 에 `'naverpay'` 추가. #722 의 `AddStripeGatewayEnum` 패턴을 그대로 따라 idempotent 한 `MODIFY COLUMN`.

### 라우팅
- `payments.service.ts` 의 `resolveGatewayByType`:
  - `INICIS` 분기는 #722 가 placeholder 로 두었던 `throw BadRequestException(...)` 를 **제거** → 실제 `KGInicisAdapter` 로 라우팅
  - `NAVERPAY` 분기 신규 추가
- `gatewayNameToType` / `resolveGateway(locale)` 도 동일하게 확장
- `payments.module.ts`: 두 신규 어댑터를 provider 로 등록 + `'PaymentGateway'` factory 의 switch 분기 확장

### 환경변수 (`.env.example`)
- `PAYMENT_GATEWAY` 옵션 라인에 `inicis, naverpay` 추가
- `INICIS_MID / INICIS_SIGN_KEY / INICIS_API_KEY / INICIS_CLIENT_KEY`
- `NAVERPAY_PARTNER_ID / NAVERPAY_CLIENT_ID / NAVERPAY_CLIENT_SECRET / NAVERPAY_CHAIN_ID`
- 운영에서 `mock` 차단은 기존 `createPaymentConfig` 가드(NODE_ENV=production+mock → throw)가 그대로 막음

### 테스트
- `__tests__/inicis.adapter.spec.ts` — prepare / confirm (성공·resultCode != 0000·5xx) / cancel (성공·실패) / partialCancel (성공·cancelTid 폴백·실패) / verifyWebhook (성공·실패)
- `__tests__/naverpay.adapter.spec.ts` — 동일 5 메서드 × 성공/실패 케이스
- 기존 `payments.service.spec.ts` / `payments.webhook.spec.ts` 의 TestingModule providers 에 `KGInicisPaymentAdapter` / `NaverPayPaymentAdapter` 를 등록 (DI 누락 방지)

## 선택 정책 (자율 판단)
issue 본문이 "사용자 선택 / 관리자 설정 / locale fallback 중 결정" 을 자율 판단 항목으로 명시. 다음과 같이 결정:

- **현재**: `resolveGatewayByLocale` 의 기존 `ko → toss` / `그 외 → stripe` 매핑을 그대로 유지. 가장 작은 변경으로 회귀 위험 0.
- **확장 경로**: 국내 3 PG (toss / inicis / naverpay) 어댑터 + DI 등록 + DB enum + `gatewayNameToType` / `resolveGatewayByType` 라우팅을 모두 미리 구현해 두었다. 추후 `/api/payments/prepare` body 에 `gateway?: 'toss'|'inicis'|'naverpay'` 필드를 추가하기만 하면 사용자 선택 UI / 관리자 설정 어느 쪽이든 비파괴적으로 도입 가능.
- **운영 전환**: `PAYMENT_GATEWAY=inicis` 또는 `PAYMENT_GATEWAY=naverpay` 로 PROCESS-WIDE default 도 즉시 전환 가능.

## 아직 mock 인 부분 / 실 PG SDK 도입 시 해야 할 것
- 두 어댑터의 fetch URL / 헤더 / body shape 은 각 PG 의 v2 API 명세에 맞춰 설계했지만, **실 호출 검증은 안 됨**. 실 도입 시 sandbox 환경에서 응답 shape 매칭 확인 + crypto 서명 알고리즘 (Inicis 는 SHA-256 외에 SHA-512 도 지원) 점검 필요.
- 부가세 / 면세 / 부분취소 누적 검증은 기존 `PaymentRefundService` 가 처리하므로 어댑터에서는 단일 호출만 책임.
- 운영 webhook 수신 라우트는 PG 별로 분리되지 않은 단일 `/api/payments/webhook` 이므로, 실 운영 시 PG 별 시그니처 검증 로직을 `PaymentWebhookService` 분기에 추가해야 한다 (현재 default gateway 기준 1회 검증).

## 검증 결과
- `npm run lint` — 통과
- `npm run build` — 통과
- `npm test` — **980/980 passed (99 suites)**
- `bash scripts/test.sh e2e` — **262/262 passed**
