### PR TITLE
feat: #725 결제 웹훅 멱등성 보장 및 재시도 관측성

### DIFF
--- a/backend/src/database/migrations/1783500000000-CreatePaymentWebhookEvents.ts
+++ b/backend/src/database/migrations/1783500000000-CreatePaymentWebhookEvents.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * 결제 웹훅 멱등성·관측성 테이블 (#725)
+ *
+ * 목적:
+ *   - PG 웹훅 중복 수신을 (gateway, event_id) UNIQUE 제약으로 차단 → 멱등성 보장
+ *   - 처리 결과(success/ignored/failed)를 보존하여 운영자가 재처리 가능
+ *
+ * idempotent up:
+ *   - 부분 적용 상태에서도 안전하게 재실행되도록 CREATE TABLE IF NOT EXISTS 사용
+ */
+export class CreatePaymentWebhookEvents1783500000000 implements MigrationInterface {
+  name = 'CreatePaymentWebhookEvents1783500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS \`payment_webhook_events\` (
+        \`id\` bigint NOT NULL AUTO_INCREMENT,
+        \`gateway\` enum('mock','toss','inicis','stripe','naverpay') NOT NULL,
+        \`event_id\` varchar(255) NOT NULL,
+        \`event_type\` varchar(64) NOT NULL,
+        \`payment_id\` bigint NULL,
+        \`order_id\` bigint NULL,
+        \`received_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        \`processed_at\` datetime NULL,
+        \`result\` enum('success','ignored','failed') NOT NULL,
+        \`error_message\` text NULL,
+        \`raw_payload\` json NULL,
+        UNIQUE INDEX \`IDX_payment_webhook_events_gateway_event\` (\`gateway\`, \`event_id\`),
+        INDEX \`IDX_payment_webhook_events_received_at\` (\`received_at\`),
+        PRIMARY KEY (\`id\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE IF EXISTS `payment_webhook_events`');
+  }
+}

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -4,6 +4,7 @@ import { DataSource } from 'typeorm';
 import { NotFoundException, BadRequestException, ConflictException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
 import { PaymentsService } from '../payments.service';
 import { Payment, PaymentStatus, PaymentMethod, PaymentGatewayType } from '../entities/payment.entity';
+import { PaymentWebhookEvent } from '../entities/payment-webhook-event.entity';
 import { Refund, RefundStatus } from '../entities/refund.entity';
 import { Shipping } from '../entities/shipping.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
@@ -172,6 +173,14 @@ describe('PaymentsService', () => {
         { provide: getRepositoryToken(Refund), useValue: mockRefundRepo },
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockShippingRepo },
+        {
+          provide: getRepositoryToken(PaymentWebhookEvent),
+          useValue: {
+            create: jest.fn((e: object) => e),
+            save: jest.fn(async (e: object) => ({ id: 1, ...e })),
+            update: jest.fn().mockResolvedValue({}),
+          },
+        },
         { provide: getRepositoryToken(User), useValue: { findOne: jest.fn().mockResolvedValue(null) } },
         {
           provide: PAYMENT_CONFIG,

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { PaymentsService } from '../payments.service';
 import { Payment, PaymentStatus } from '../entities/payment.entity';
+import { PaymentWebhookEvent } from '../entities/payment-webhook-event.entity';
 import { Refund } from '../entities/refund.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { Shipping } from '../entities/shipping.entity';
@@ -29,6 +30,11 @@ describe('PaymentsService — webhook', () => {
     save: jest.fn(),
     update: jest.fn(),
   };
+  const mockWebhookEventRepo = {
+    create: jest.fn((e: object) => e),
+    save: jest.fn(async (e: object) => ({ id: 1, ...e })),
+    update: jest.fn().mockResolvedValue({}),
+  };
   const mockWebhookManager = {
     findOne: jest.fn(),
     update: jest.fn(),
@@ -50,6 +56,7 @@ describe('PaymentsService — webhook', () => {
         { provide: getRepositoryToken(Refund), useValue: mockRepo },
         { provide: getRepositoryToken(Order), useValue: mockRepo },
         { provide: getRepositoryToken(Shipping), useValue: mockRepo },
+        { provide: getRepositoryToken(PaymentWebhookEvent), useValue: mockWebhookEventRepo },
         { provide: 'PaymentGateway', useValue: mockGateway },
         {
           provide: PAYMENT_CONFIG,

--- a/backend/src/modules/payments/admin-payment-webhooks.controller.ts
+++ b/backend/src/modules/payments/admin-payment-webhooks.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  PaymentWebhookEvent,
+  PaymentWebhookResult,
+} from './entities/payment-webhook-event.entity';
+import { PaymentGatewayType } from './entities/payment.entity';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
+
+/**
+ * 웹훅 이벤트 관측성 (issue #725)
+ *
+ * 운영자가 다음을 추적할 수 있도록 한다:
+ *   - 어떤 PG 에서 어떤 이벤트가 수신되었는가 (received_at desc)
+ *   - 결과(success/ignored/failed) 별 필터
+ *   - failed 인 경우 error_message 와 raw_payload 로 사후 재처리 판단
+ */
+@ApiTags('관리자 - 결제 웹훅')
+@Controller('admin/payment-webhooks')
+@Roles('admin', 'super_admin')
+export class AdminPaymentWebhooksController {
+  constructor(
+    @InjectRepository(PaymentWebhookEvent)
+    private readonly repo: Repository<PaymentWebhookEvent>,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: '웹훅 이벤트 목록', description: '결제 웹훅 수신 로그를 페이지네이션으로 조회.' })
+  @ApiQuery({ name: 'gateway', required: false, enum: PaymentGatewayType })
+  @ApiQuery({ name: 'result', required: false, enum: PaymentWebhookResult })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: '웹훅 이벤트 목록' })
+  async list(
+    @Query('gateway') gateway?: PaymentGatewayType,
+    @Query('result') result?: PaymentWebhookResult,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ): Promise<PaginatedResult<PaymentWebhookEvent>> {
+    const qb = this.repo.createQueryBuilder('event').orderBy('event.received_at', 'DESC');
+    if (gateway) qb.andWhere('event.gateway = :gateway', { gateway });
+    if (result) qb.andWhere('event.result = :result', { result });
+    return paginate(qb, {
+      page: page ? Number(page) : undefined,
+      limit: limit ? Number(limit) : undefined,
+    });
+  }
+}

--- a/backend/src/modules/payments/entities/payment-webhook-event.entity.ts
+++ b/backend/src/modules/payments/entities/payment-webhook-event.entity.ts
@@ -1,0 +1,82 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { PaymentGatewayType } from './payment.entity';
+
+/**
+ * 웹훅 처리 결과 (issue #725)
+ *
+ * - SUCCESS: payment/order 상태 전이가 정상 완료
+ * - IGNORED: 멱등 재수신, 차단 전이, 알 수 없는 이벤트, payment 미존재 등 의도된 무시
+ * - FAILED: 처리 도중 예외 발생 (관리자 재처리 대상)
+ */
+export enum PaymentWebhookResult {
+  SUCCESS = 'success',
+  IGNORED = 'ignored',
+  FAILED = 'failed',
+}
+
+/**
+ * PG 웹훅 수신 이벤트 로그 (issue #725)
+ *
+ * 목적:
+ *   - 동일 (gateway, event_id) 조합 재수신 시 UNIQUE 제약으로 즉시 중복 차단 → 멱등성 보장
+ *   - 성공 / 무시 / 실패 결과를 운영자가 추적 (관측성)
+ *   - 실패한 웹훅은 raw_payload + error_message 가 보존되어 사후 재처리 가능
+ *
+ * Idempotency key (gateway 별):
+ *   - Toss: `eventId` 우선 → 없으면 `paymentKey + ':' + eventType` 폴백
+ *   - Stripe: `event.id`
+ *   - NaverPay: `paymentId` (취소면 `:cancel` suffix 로 cancel 이벤트 분리)
+ *   - KGInicis: `tid` (취소면 `:cancel` suffix)
+ *   - Mock: `orderId + ':' + eventType` (테스트/개발용)
+ */
+@Entity('payment_webhook_events')
+@Index('IDX_payment_webhook_events_gateway_event', ['gateway', 'eventId'], {
+  unique: true,
+})
+@Index('IDX_payment_webhook_events_received_at', ['receivedAt'])
+export class PaymentWebhookEvent {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({
+    type: 'enum',
+    enum: PaymentGatewayType,
+  })
+  gateway!: PaymentGatewayType;
+
+  @Column({ name: 'event_id', type: 'varchar', length: 255 })
+  eventId!: string;
+
+  @Column({ name: 'event_type', type: 'varchar', length: 64 })
+  eventType!: string;
+
+  @Column({ name: 'payment_id', type: 'bigint', nullable: true })
+  paymentId!: number | null;
+
+  @Column({ name: 'order_id', type: 'bigint', nullable: true })
+  orderId!: number | null;
+
+  @CreateDateColumn({ name: 'received_at' })
+  receivedAt!: Date;
+
+  @Column({ name: 'processed_at', type: 'datetime', nullable: true })
+  processedAt!: Date | null;
+
+  @Column({
+    type: 'enum',
+    enum: PaymentWebhookResult,
+  })
+  result!: PaymentWebhookResult;
+
+  @Column({ name: 'error_message', type: 'text', nullable: true })
+  errorMessage!: string | null;
+
+  @Column({ name: 'raw_payload', type: 'json', nullable: true })
+  rawPayload!: object | null;
+}

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from './entities/payment.entity';
+import { PaymentWebhookEvent } from './entities/payment-webhook-event.entity';
 import { Refund } from './entities/refund.entity';
 import { Shipping } from './entities/shipping.entity';
 import { Order } from '../orders/entities/order.entity';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
 import { AdminOrderRefundsController } from './admin-order-refunds.controller';
+import { AdminPaymentWebhooksController } from './admin-payment-webhooks.controller';
 import { MockPaymentAdapter } from './adapters/mock.adapter';
 import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
@@ -85,8 +87,8 @@ const gatewayProviders = [
 ];
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment, Refund, Shipping, Order])],
-  controllers: [PaymentsController, AdminOrderRefundsController],
+  imports: [TypeOrmModule.forFeature([Payment, PaymentWebhookEvent, Refund, Shipping, Order])],
+  controllers: [PaymentsController, AdminOrderRefundsController, AdminPaymentWebhooksController],
   providers: [...gatewayProviders, PaymentsService],
   exports: [PaymentsService],
 })

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -5,6 +5,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { Payment, PaymentStatus, PaymentGatewayType, PaymentMethod } from './entities/payment.entity';
+import { PaymentWebhookEvent } from './entities/payment-webhook-event.entity';
 import { Refund } from './entities/refund.entity';
 import { Shipping } from './entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
@@ -44,6 +45,8 @@ export class PaymentsService {
     private readonly orderRepository: Repository<Order>,
     @InjectRepository(Shipping)
     private readonly shippingRepository: Repository<Shipping>,
+    @InjectRepository(PaymentWebhookEvent)
+    private readonly webhookEventRepository: Repository<PaymentWebhookEvent>,
     @Inject('PaymentGateway')
     private readonly gateway: PaymentGateway,
     @Inject(PAYMENT_CONFIG)
@@ -76,7 +79,9 @@ export class PaymentsService {
     });
     this.paymentWebhookService = new PaymentWebhookService({
       gateway: this.gateway,
+      gatewayType: this.gatewayNameToType(this.paymentConfig.gateway),
       paymentRepository: this.paymentRepository,
+      webhookEventRepository: this.webhookEventRepository,
       dataSource: this.dataSource,
       logger: this.logger,
     });

--- a/backend/src/modules/payments/services/payment-webhook.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.spec.ts
@@ -1,7 +1,8 @@
 import { Logger, UnauthorizedException } from '@nestjs/common';
 import { PaymentWebhookService } from './payment-webhook.service';
-import { Payment, PaymentStatus } from '../entities/payment.entity';
+import { Payment, PaymentStatus, PaymentGatewayType } from '../entities/payment.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import { PaymentWebhookResult } from '../entities/payment-webhook-event.entity';
 import { PaymentGateway } from '../interfaces/payment-gateway.interface';
 
 const makeWebhookManager = (overrides: Record<string, jest.Mock> = {}) => ({
@@ -15,8 +16,14 @@ const makeWebhookManager = (overrides: Record<string, jest.Mock> = {}) => ({
 
 interface BuildArgs {
   gateway?: Partial<PaymentGateway>;
+  gatewayType?: PaymentGatewayType;
   paymentRepo?: { findOne?: jest.Mock };
   manager?: ReturnType<typeof makeWebhookManager>;
+  webhookEventRepo?: {
+    create?: jest.Mock;
+    save?: jest.Mock;
+    update?: jest.Mock;
+  };
 }
 
 const buildService = (args: BuildArgs = {}) => {
@@ -32,6 +39,13 @@ const buildService = (args: BuildArgs = {}) => {
     findOne: jest.fn(),
     ...args.paymentRepo,
   };
+  let savedEventCounter = 0;
+  const webhookEventRepo = {
+    create: jest.fn((entity: object) => entity),
+    save: jest.fn(async (entity: object) => ({ id: ++savedEventCounter, ...entity })),
+    update: jest.fn().mockResolvedValue({}),
+    ...args.webhookEventRepo,
+  };
   const manager = args.manager ?? makeWebhookManager();
   const transaction = jest.fn(
     async (fn: (m: typeof manager) => Promise<unknown>) => fn(manager),
@@ -41,12 +55,14 @@ const buildService = (args: BuildArgs = {}) => {
 
   const service = new PaymentWebhookService({
     gateway,
+    gatewayType: args.gatewayType ?? PaymentGatewayType.MOCK,
     paymentRepository: paymentRepo as never,
+    webhookEventRepository: webhookEventRepo as never,
     dataSource,
     logger,
   });
 
-  return { service, gateway, paymentRepo, manager, transaction, logger };
+  return { service, gateway, paymentRepo, webhookEventRepo, manager, transaction, logger };
 };
 
 describe('PaymentWebhookService', () => {
@@ -340,6 +356,115 @@ describe('PaymentWebhookService', () => {
       );
 
       expect(manager.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('멱등성 / 결과 추적 (issue #725)', () => {
+    it('성공 케이스: webhook event 가 SUCCESS 로 update 된다', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'pending' }),
+      });
+      const { service, gateway, paymentRepo, webhookEventRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7, paidAt: null });
+
+      await service.handleWebhook({ orderId: 7, status: 'DONE' }, 'valid_sig');
+
+      expect(webhookEventRepo.save).toHaveBeenCalledTimes(1);
+      expect(webhookEventRepo.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          result: PaymentWebhookResult.SUCCESS,
+          paymentId: 10,
+          orderId: 7,
+          processedAt: expect.any(Date),
+        }),
+      );
+    });
+
+    it('동일 eventId 재수신 → ER_DUP_ENTRY 잡고 IGNORED 반환 (DB 작업 없음)', async () => {
+      const dupErr = Object.assign(new Error('Duplicate entry'), { code: 'ER_DUP_ENTRY' });
+      const webhookEventRepo = {
+        create: jest.fn((e: object) => e),
+        save: jest.fn().mockRejectedValue(dupErr),
+        update: jest.fn().mockResolvedValue({}),
+      };
+      const { service, gateway, paymentRepo, transaction } = buildService({ webhookEventRepo });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+
+      await service.handleWebhook({ orderId: 7, status: 'DONE' }, 'valid_sig');
+
+      // 중복 차단 → 후속 처리 없음
+      expect(paymentRepo.findOne).not.toHaveBeenCalled();
+      expect(transaction).not.toHaveBeenCalled();
+      // events 테이블의 후속 update 도 호출되지 않음 (insert 자체가 실패했기 때문)
+      expect(webhookEventRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('처리 도중 예외 발생 → FAILED + errorMessage 기록', async () => {
+      const dbErr = new Error('DB connection lost');
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockRejectedValue(dbErr),
+      });
+      const { service, gateway, paymentRepo, webhookEventRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7 });
+
+      await service.handleWebhook({ orderId: 7, status: 'DONE' }, 'valid_sig');
+
+      expect(webhookEventRepo.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          result: PaymentWebhookResult.FAILED,
+          errorMessage: 'DB connection lost',
+          processedAt: expect.any(Date),
+        }),
+      );
+    });
+
+    it('이미 CANCELLED 인 주문에 CANCEL 재수신 → SUCCESS (allowSameStatus update 가 수행됨)', async () => {
+      // allowSameStatus=true 정책상 update 가 한 번 호출되므로 SUCCESS.
+      // 재고 복구는 멱등성으로 막혀있음.
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: OrderStatus.CANCELLED }),
+      });
+      const { service, gateway, paymentRepo, webhookEventRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7 });
+
+      await service.handleWebhook({ orderId: 7, status: 'CANCELLED' }, 'valid_sig');
+
+      expect(webhookEventRepo.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ result: PaymentWebhookResult.SUCCESS }),
+      );
+      expect(manager.increment).not.toHaveBeenCalled();
+    });
+
+    it('차단 전이 → IGNORED 결과 기록', async () => {
+      const manager = makeWebhookManager({
+        findOne: jest.fn().mockResolvedValue({ id: 7, status: 'delivered' }),
+      });
+      const { service, gateway, paymentRepo, webhookEventRepo } = buildService({ manager });
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+      paymentRepo.findOne.mockResolvedValue({ id: 10, orderId: 7 });
+
+      await service.handleWebhook({ orderId: 7, status: 'DONE' }, 'valid_sig');
+
+      expect(webhookEventRepo.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ result: PaymentWebhookResult.IGNORED }),
+      );
+    });
+
+    it('idempotency key 추출 실패 시 events 테이블에 insert 하지 않음 (return early)', async () => {
+      const { service, gateway, webhookEventRepo } = buildService();
+      (gateway.verifyWebhook as jest.Mock).mockReturnValue(true);
+
+      // MOCK gateway 에서 orderId / eventType 모두 비어있으면 키 추출 실패
+      await service.handleWebhook({}, 'valid_sig');
+
+      expect(webhookEventRepo.save).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/payments/services/payment-webhook.service.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.ts
@@ -79,7 +79,7 @@ export class PaymentWebhookService {
       throw err;
     }
 
-    // 2) 실제 처리. 결과는 finally 에서 events 테이블에 반영.
+    // 2) 실제 처리. 결과는 try/catch 종료 후 events 테이블에 반영.
     let result: PaymentWebhookResult = PaymentWebhookResult.IGNORED;
     let errorMessage: string | null = null;
     let resolvedPaymentId: number | null = null;
@@ -97,13 +97,22 @@ export class PaymentWebhookService {
       );
     }
 
-    await this.deps.webhookEventRepository.update(savedEvent.id, {
-      result,
-      processedAt: new Date(),
-      errorMessage,
-      paymentId: resolvedPaymentId,
-      orderId: resolvedOrderId,
-    });
+    // #725: audit row update 자체가 실패해도 PG 재시도를 유발하지 않도록 swallow.
+    // (audit INSERT 는 이미 커밋되었기 때문에, 여기서 throw 하면 PG 가 재시도하지만
+    // UNIQUE 제약으로 차단되어 영구적으로 IGNORED 상태로 남음.)
+    try {
+      await this.deps.webhookEventRepository.update(savedEvent.id, {
+        result,
+        processedAt: new Date(),
+        errorMessage,
+        paymentId: resolvedPaymentId,
+        orderId: resolvedOrderId,
+      });
+    } catch (updateErr) {
+      this.deps.logger.error(
+        `Webhook event audit row update failed: id=${savedEvent.id}, ${updateErr instanceof Error ? updateErr.message : String(updateErr)}`,
+      );
+    }
   }
 
   private async processWebhook(payload: unknown): Promise<{

--- a/backend/src/modules/payments/services/payment-webhook.service.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.ts
@@ -1,19 +1,41 @@
 import { UnauthorizedException, Logger } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
-import { Payment, PaymentStatus } from '../entities/payment.entity';
+import { Payment, PaymentStatus, PaymentGatewayType } from '../entities/payment.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
+import {
+  PaymentWebhookEvent,
+  PaymentWebhookResult,
+} from '../entities/payment-webhook-event.entity';
 import { PaymentGateway } from '../interfaces/payment-gateway.interface';
 import { PAYMENT_WEBHOOK_TRANSITIONS } from './payment-webhook-transition.policy';
 import { canOrderStatusTransition } from '../../orders/policies/order-status-transition.policy';
 import { restoreOrderStock } from '../../orders/order-stock.util';
+import {
+  extractWebhookIdempotencyKey,
+  isDuplicateKeyError,
+} from './webhook-idempotency.util';
 
 interface PaymentWebhookDependencies {
   gateway: PaymentGateway;
+  gatewayType: PaymentGatewayType;
   paymentRepository: Repository<Payment>;
+  webhookEventRepository: Repository<PaymentWebhookEvent>;
   dataSource: DataSource;
   logger: Logger;
 }
 
+/**
+ * 결제 웹훅 처리 (issue #725)
+ *
+ * 멱등성:
+ *   - 모든 수신 이벤트는 (gateway, event_id) UNIQUE 제약을 가진 `payment_webhook_events` 에 먼저 기록.
+ *   - 중복 ER_DUP_ENTRY → IGNORED 로 처리.
+ *
+ * 결과 분류:
+ *   - SUCCESS: 상태 전이가 실제로 수행됨
+ *   - IGNORED: 차단 전이 / 알 수 없는 이벤트 / payment 미존재 / 이미 동일 상태 / 멱등 재수신
+ *   - FAILED: 처리 도중 예외 발생 — 운영자 재처리 가능하도록 raw_payload + error_message 보존
+ */
 export class PaymentWebhookService {
   constructor(private readonly deps: PaymentWebhookDependencies) {}
 
@@ -28,10 +50,77 @@ export class PaymentWebhookService {
     };
     this.deps.logger.log(`Webhook received: ${JSON.stringify(safe)}`);
 
+    const idempotencyKey = extractWebhookIdempotencyKey(this.deps.gatewayType, payload);
+    if (!idempotencyKey) {
+      this.deps.logger.warn(
+        `Webhook ignored: cannot extract idempotency key (gateway=${this.deps.gatewayType})`,
+      );
+      return;
+    }
+
+    // 1) 이벤트 행을 UNIQUE(gateway, event_id) 위반 캐치하여 즉시 중복 차단.
+    const eventEntity = this.deps.webhookEventRepository.create({
+      gateway: idempotencyKey.gateway,
+      eventId: idempotencyKey.eventId,
+      eventType: idempotencyKey.eventType,
+      result: PaymentWebhookResult.IGNORED,
+      rawPayload: isObject(payload) ? (payload as object) : null,
+    });
+    let savedEvent: PaymentWebhookEvent;
+    try {
+      savedEvent = await this.deps.webhookEventRepository.save(eventEntity);
+    } catch (err) {
+      if (isDuplicateKeyError(err)) {
+        this.deps.logger.warn(
+          `Webhook ignored: duplicate event (gateway=${idempotencyKey.gateway}, eventId=${idempotencyKey.eventId})`,
+        );
+        return;
+      }
+      throw err;
+    }
+
+    // 2) 실제 처리. 결과는 finally 에서 events 테이블에 반영.
+    let result: PaymentWebhookResult = PaymentWebhookResult.IGNORED;
+    let errorMessage: string | null = null;
+    let resolvedPaymentId: number | null = null;
+    let resolvedOrderId: number | null = null;
+    try {
+      const outcome = await this.processWebhook(payload);
+      result = outcome.result;
+      resolvedPaymentId = outcome.paymentId;
+      resolvedOrderId = outcome.orderId;
+    } catch (err) {
+      result = PaymentWebhookResult.FAILED;
+      errorMessage = err instanceof Error ? err.message : String(err);
+      this.deps.logger.error(
+        `Webhook processing failed: gateway=${idempotencyKey.gateway}, eventId=${idempotencyKey.eventId}, error=${errorMessage}`,
+      );
+    }
+
+    await this.deps.webhookEventRepository.update(savedEvent.id, {
+      result,
+      processedAt: new Date(),
+      errorMessage,
+      paymentId: resolvedPaymentId,
+      orderId: resolvedOrderId,
+    });
+  }
+
+  private async processWebhook(payload: unknown): Promise<{
+    result: PaymentWebhookResult;
+    paymentId: number | null;
+    orderId: number | null;
+  }> {
+    const safe = {
+      orderId: (payload as Record<string, unknown>)?.orderId,
+      status: (payload as Record<string, unknown>)?.status,
+      type: (payload as Record<string, unknown>)?.type,
+    };
+
     const parsedOrderId = Number(safe.orderId);
     if (!Number.isFinite(parsedOrderId) || parsedOrderId <= 0) {
       this.deps.logger.warn('Webhook ignored: invalid orderId');
-      return;
+      return { result: PaymentWebhookResult.IGNORED, paymentId: null, orderId: null };
     }
 
     const normalized = String(
@@ -43,22 +132,27 @@ export class PaymentWebhookService {
 
     if (!normalized) {
       this.deps.logger.warn(`Webhook ignored: unknown event for orderId=${parsedOrderId}`);
-      return;
+      return { result: PaymentWebhookResult.IGNORED, paymentId: null, orderId: parsedOrderId };
     }
 
     const payment = await this.deps.paymentRepository.findOne({ where: { orderId: parsedOrderId } });
     if (!payment) {
       this.deps.logger.warn(`Webhook ignored: payment not found (orderId=${parsedOrderId})`);
-      return;
+      return { result: PaymentWebhookResult.IGNORED, paymentId: null, orderId: parsedOrderId };
     }
 
     const matchedTransition = PAYMENT_WEBHOOK_TRANSITIONS.find((transition) =>
       transition.keywords.some((keyword) => normalized.includes(keyword)),
     );
     if (!matchedTransition) {
-      return;
+      return {
+        result: PaymentWebhookResult.IGNORED,
+        paymentId: Number(payment.id),
+        orderId: parsedOrderId,
+      };
     }
 
+    let didMutate = false;
     await this.deps.dataSource.transaction(async (manager) => {
       const order = await manager.findOne(Order, { where: { id: parsedOrderId } });
       if (!order) {
@@ -97,6 +191,17 @@ export class PaymentWebhookService {
       if (isRestoreTarget && !wasAlreadyTerminal) {
         await restoreOrderStock(manager, parsedOrderId);
       }
+      didMutate = true;
     });
+
+    return {
+      result: didMutate ? PaymentWebhookResult.SUCCESS : PaymentWebhookResult.IGNORED,
+      paymentId: Number(payment.id),
+      orderId: parsedOrderId,
+    };
   }
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
 }

--- a/backend/src/modules/payments/services/webhook-idempotency.util.spec.ts
+++ b/backend/src/modules/payments/services/webhook-idempotency.util.spec.ts
@@ -1,0 +1,143 @@
+import { PaymentGatewayType } from '../entities/payment.entity';
+import {
+  extractWebhookIdempotencyKey,
+  isDuplicateKeyError,
+} from './webhook-idempotency.util';
+
+describe('extractWebhookIdempotencyKey', () => {
+  describe('Toss', () => {
+    it('eventId 가 있으면 그대로 사용', () => {
+      const key = extractWebhookIdempotencyKey(
+        PaymentGatewayType.TOSS,
+        { eventId: 'evt-toss-1', eventType: 'PAYMENT_STATUS_CHANGED', paymentKey: 'pk-1' },
+      );
+      expect(key).toEqual({
+        gateway: PaymentGatewayType.TOSS,
+        eventId: 'evt-toss-1',
+        eventType: 'PAYMENT_STATUS_CHANGED',
+      });
+    });
+
+    it('eventId 가 없으면 paymentKey + eventType 으로 폴백', () => {
+      const key = extractWebhookIdempotencyKey(
+        PaymentGatewayType.TOSS,
+        { paymentKey: 'pk-1', eventType: 'DONE' },
+      );
+      expect(key).toEqual({
+        gateway: PaymentGatewayType.TOSS,
+        eventId: 'pk-1:DONE',
+        eventType: 'DONE',
+      });
+    });
+
+    it('paymentKey 도 없으면 null', () => {
+      expect(
+        extractWebhookIdempotencyKey(PaymentGatewayType.TOSS, { eventType: 'DONE' }),
+      ).toBeNull();
+    });
+  });
+
+  describe('Stripe', () => {
+    it('event.id 사용', () => {
+      const key = extractWebhookIdempotencyKey(
+        PaymentGatewayType.STRIPE,
+        { id: 'evt_abc', type: 'payment_intent.succeeded' },
+      );
+      expect(key).toEqual({
+        gateway: PaymentGatewayType.STRIPE,
+        eventId: 'evt_abc',
+        eventType: 'payment_intent.succeeded',
+      });
+    });
+
+    it('id 가 없으면 null', () => {
+      expect(
+        extractWebhookIdempotencyKey(PaymentGatewayType.STRIPE, { type: 'foo' }),
+      ).toBeNull();
+    });
+  });
+
+  describe('NaverPay', () => {
+    it('paymentId + eventType 결합', () => {
+      const key = extractWebhookIdempotencyKey(
+        PaymentGatewayType.NAVERPAY,
+        { paymentId: 'np-1', eventType: 'CANCEL' },
+      );
+      expect(key).toEqual({
+        gateway: PaymentGatewayType.NAVERPAY,
+        eventId: 'np-1:CANCEL',
+        eventType: 'CANCEL',
+      });
+    });
+
+    it('동일 paymentId 라도 confirm/cancel 이 분리됨', () => {
+      const confirm = extractWebhookIdempotencyKey(
+        PaymentGatewayType.NAVERPAY,
+        { paymentId: 'np-1', eventType: 'DONE' },
+      );
+      const cancel = extractWebhookIdempotencyKey(
+        PaymentGatewayType.NAVERPAY,
+        { paymentId: 'np-1', eventType: 'CANCEL' },
+      );
+      expect(confirm?.eventId).not.toEqual(cancel?.eventId);
+    });
+  });
+
+  describe('KGInicis', () => {
+    it('tid + eventType 결합', () => {
+      const key = extractWebhookIdempotencyKey(
+        PaymentGatewayType.INICIS,
+        { tid: 'tid-123', status: 'CANCELLED' },
+      );
+      expect(key).toEqual({
+        gateway: PaymentGatewayType.INICIS,
+        eventId: 'tid-123:CANCELLED',
+        eventType: 'CANCELLED',
+      });
+    });
+  });
+
+  describe('Mock', () => {
+    it('orderId + eventType 결합', () => {
+      const key = extractWebhookIdempotencyKey(
+        PaymentGatewayType.MOCK,
+        { orderId: 7, status: 'DONE' },
+      );
+      expect(key).toEqual({
+        gateway: PaymentGatewayType.MOCK,
+        eventId: '7:DONE',
+        eventType: 'DONE',
+      });
+    });
+
+    it('payload 가 객체가 아니면 null', () => {
+      expect(extractWebhookIdempotencyKey(PaymentGatewayType.MOCK, null)).toBeNull();
+      expect(extractWebhookIdempotencyKey(PaymentGatewayType.MOCK, 'string')).toBeNull();
+    });
+
+    it('orderId 누락 시 null', () => {
+      expect(
+        extractWebhookIdempotencyKey(PaymentGatewayType.MOCK, { status: 'DONE' }),
+      ).toBeNull();
+    });
+  });
+});
+
+describe('isDuplicateKeyError', () => {
+  it('top-level code === ER_DUP_ENTRY → true', () => {
+    expect(isDuplicateKeyError({ code: 'ER_DUP_ENTRY' })).toBe(true);
+  });
+
+  it('TypeORM driverError.code === ER_DUP_ENTRY → true', () => {
+    expect(
+      isDuplicateKeyError({ driverError: { code: 'ER_DUP_ENTRY' } }),
+    ).toBe(true);
+  });
+
+  it('관계없는 에러 → false', () => {
+    expect(isDuplicateKeyError(new Error('boom'))).toBe(false);
+    expect(isDuplicateKeyError({ code: 'ER_OTHER' })).toBe(false);
+    expect(isDuplicateKeyError(null)).toBe(false);
+    expect(isDuplicateKeyError(undefined)).toBe(false);
+  });
+});

--- a/backend/src/modules/payments/services/webhook-idempotency.util.ts
+++ b/backend/src/modules/payments/services/webhook-idempotency.util.ts
@@ -1,0 +1,85 @@
+import { PaymentGatewayType } from '../entities/payment.entity';
+
+/**
+ * 웹훅 멱등성 키 추출 유틸 (issue #725)
+ *
+ * PG 마다 web hook event identifier 가 다르므로, 다음 규칙으로 (gateway, eventId) 페어를 만든다.
+ * DB UNIQUE 제약이 (gateway, event_id) 라서 PG 간 충돌은 자동으로 방지된다.
+ *
+ * - Toss: 우선 `eventId` (Toss 웹훅 v2). 없으면 `paymentKey + ':' + eventType` 으로 폴백.
+ * - Stripe: `event.id` (예: `evt_xxx`). Stripe webhook 의 표준 필드.
+ * - NaverPay: `paymentId` 이지만 cancel 이벤트와 confirm 이벤트가 같은 paymentId 를 공유할 수 있어
+ *   `eventType` 을 함께 묶어 분리한다 (`naverpay-paymentId:CANCEL` 등).
+ * - KGInicis: `tid` 와 `eventType` 결합 (취소 / 승인 분리).
+ * - Mock: `orderId + ':' + eventType` (테스트 용도).
+ *
+ * key 추출 실패 시 `null` 을 반환하면 호출 측은 처리를 거부 (FAILED 기록 가능).
+ */
+export interface WebhookIdempotencyKey {
+  gateway: PaymentGatewayType;
+  eventId: string;
+  eventType: string;
+}
+
+export function extractWebhookIdempotencyKey(
+  gateway: PaymentGatewayType,
+  payload: unknown,
+): WebhookIdempotencyKey | null {
+  if (!isRecord(payload)) return null;
+
+  const eventType = String(
+    payload.eventType ?? payload.status ?? payload.type ?? '',
+  ).toUpperCase();
+
+  switch (gateway) {
+    case PaymentGatewayType.STRIPE: {
+      const id = stringOf(payload.id);
+      if (!id) return null;
+      const stripeType = stringOf(payload.type) ?? eventType;
+      return { gateway, eventId: id, eventType: stripeType };
+    }
+    case PaymentGatewayType.TOSS: {
+      const eventId = stringOf(payload.eventId);
+      const paymentKey = stringOf(payload.paymentKey);
+      if (eventId) return { gateway, eventId, eventType };
+      if (paymentKey && eventType) return { gateway, eventId: `${paymentKey}:${eventType}`, eventType };
+      return null;
+    }
+    case PaymentGatewayType.NAVERPAY: {
+      const paymentId = stringOf(payload.paymentId);
+      if (!paymentId || !eventType) return null;
+      return { gateway, eventId: `${paymentId}:${eventType}`, eventType };
+    }
+    case PaymentGatewayType.INICIS: {
+      const tid = stringOf(payload.tid);
+      if (!tid || !eventType) return null;
+      return { gateway, eventId: `${tid}:${eventType}`, eventType };
+    }
+    case PaymentGatewayType.MOCK:
+    default: {
+      const orderId = stringOf(payload.orderId);
+      if (!orderId || !eventType) return null;
+      return { gateway, eventId: `${orderId}:${eventType}`, eventType };
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringOf(value: unknown): string | null {
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+/**
+ * MySQL ER_DUP_ENTRY 감지. (gateway, event_id) UNIQUE 위반을 멱등 처리로 변환.
+ */
+export function isDuplicateKeyError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const code = (err as { code?: string }).code;
+  const driverError = (err as { driverError?: { code?: string } }).driverError;
+  return code === 'ER_DUP_ENTRY' || driverError?.code === 'ER_DUP_ENTRY';
+}


### PR DESCRIPTION
Closes #725

## 배경

PG 4종(Toss, Stripe, NaverPay, KGInicis)이 모두 등록된 상태에서 (#721) 웹훅 중복 수신, 순서 역전, 재시도 실패를 안전하게 처리할 인프라가 필요했다.

## 변경 요약

### 1. `payment_webhook_events` 테이블 (관측성 + 멱등성 잠금)

| 컬럼 | 용도 |
|---|---|
| `(gateway, event_id)` UNIQUE | 동일 이벤트 재수신을 DB 레벨에서 즉시 차단 |
| `event_type`, `payment_id`, `order_id` | 운영자 검색용 |
| `received_at`, `processed_at` | 도착 / 처리 완료 시각 |
| `result` enum(`success`/`ignored`/`failed`) | 처리 결과 분류 |
| `error_message`, `raw_payload` | 실패 시 사후 재처리 |

migration: `1783500000000-CreatePaymentWebhookEvents` (idempotent — `CREATE TABLE IF NOT EXISTS`).

### 2. PG별 멱등성 키 정의

`webhook-idempotency.util.ts` 의 `extractWebhookIdempotencyKey(gateway, payload)`:

- **Toss**: `eventId` 우선 → 없으면 `paymentKey:eventType` 폴백 (Toss v2 웹훅은 eventId 제공, 구버전 호환)
- **Stripe**: `event.id` (`evt_xxx` — Stripe 표준 idempotency)
- **NaverPay**: `paymentId:eventType` — 동일 paymentId 의 confirm/cancel 이벤트를 분리
- **KGInicis**: `tid:eventType` — 동일 tid 의 승인/취소 분리
- **Mock**: `orderId:eventType` (테스트/개발)

### 3. `PaymentWebhookService` 동작 변경

1. `verifyWebhook` 통과 후 `(gateway, eventId)` 추출 → 실패하면 즉시 종료 (events 테이블에 기록 없음, return early).
2. `webhook_events` 에 INSERT 시도. `ER_DUP_ENTRY` 캐치 → `ignored` 로그 후 종료 (멱등성).
3. 실제 처리(`processWebhook`) 결과를 `result` 컬럼에 update:
   - `SUCCESS` — payment/order 상태 전이 수행됨
   - `IGNORED` — 차단 전이, 알 수 없는 이벤트, payment 미존재, invalid orderId
   - `FAILED` — 처리 도중 예외 (errorMessage 보존, 운영자 재처리 가능)

### 4. 관리자 관측성 — `GET /api/admin/payment-webhooks`

- `gateway` / `result` 필터, `received_at desc` 정렬, 페이지네이션.
- `@Roles('admin', 'super_admin')` 가드 적용.

## 순서 역전 (out-of-order) 처리

이미 `canOrderStatusTransition` 정책 (#723) 이 `paid → pending` 같은 역방향 전이를 차단하고 있어, 본 PR 은 이를 `IGNORED` 결과로 명시 기록하는 데 집중한다. 운영자는 admin 엔드포인트에서 `result=ignored` 로 필터하여 비정상 시퀀스를 즉시 인지 가능.

## 테스트

- `webhook-idempotency.util.spec.ts` — 5개 PG 별 키 추출 + ER_DUP_ENTRY 감지
- `payment-webhook.service.spec.ts` 신규 케이스:
  - 성공 → SUCCESS 기록
  - 동일 eventId 재수신 (ER_DUP_ENTRY) → 후속 DB 작업 없음
  - 처리 중 예외 → FAILED + errorMessage 기록
  - 이미 CANCELLED 인 주문 재수신 → SUCCESS (allowSameStatus) 이지만 재고 복구는 스킵
  - 차단 전이 → IGNORED 기록
  - idempotency 키 추출 실패 → events 테이블 insert 안함

## 검증

- `npm run lint`: pass
- `cd backend && npm run build`: pass
- `cd backend && npm run test`: 1000 / 1000 pass
- `bash scripts/test.sh e2e`: pass (마이그레이션 적용 포함)
- 프론트엔드 빌드/테스트: pass (영향 없음)

## DB 변경

- 신규 테이블 `payment_webhook_events` (FK 없음 — payment_id / order_id 는 nullable + 인덱스 없이 운영 로그 용도)
- 기존 테이블 변경 없음