### PR TITLE
Fix admin CMS editor reads for drafts

### DIFF
--- a/backend/src/modules/pages/__tests__/pages.service.spec.ts
+++ b/backend/src/modules/pages/__tests__/pages.service.spec.ts
@@ -142,6 +142,39 @@ describe('PagesService', () => {
     });
   });
 
+  describe('findOneAdmin', () => {
+    it('비공개 페이지와 숨김 블록을 필터링하지 않고 sort_order 순서로 반환한다', async () => {
+      const page = {
+        id: 7,
+        slug: 'draft-page',
+        is_published: false,
+        blocks: [
+          { id: 1, is_visible: false, sort_order: 2 },
+          { id: 2, is_visible: true, sort_order: 0 },
+          { id: 3, is_visible: false, sort_order: 1 },
+        ],
+      };
+      mockPageRepository.findOne.mockResolvedValue(page);
+
+      const result = await service.findOneAdmin(7);
+
+      expect(mockPageRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 7 },
+        relations: ['blocks'],
+      });
+      expect(result.is_published).toBe(false);
+      expect(result.blocks).toHaveLength(3);
+      expect(result.blocks.map((block) => block.id)).toEqual([2, 3, 1]);
+      expect(result.blocks.filter((block) => !block.is_visible)).toHaveLength(2);
+    });
+
+    it('존재하지 않는 관리자 페이지 상세 → NotFoundException', async () => {
+      mockPageRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOneAdmin(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
   describe('create', () => {
     it('페이지를 생성한다', async () => {
       const dto = { slug: 'new-page', title: '새 페이지' };

--- a/backend/src/modules/pages/admin-pages.controller.ts
+++ b/backend/src/modules/pages/admin-pages.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiCookieAuth,
+  ApiParam,
 } from '@nestjs/swagger';
 import { PagesService } from './pages.service';
 import { Roles } from '../../common/decorators/roles.decorator';
@@ -22,5 +23,20 @@ export class AdminPagesController {
   @ApiResponse({ status: 403, description: '권한 없음' })
   findAll() {
     return this.pagesService.findAllAdmin();
+  }
+
+  @Get(':id')
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '페이지 상세 조회',
+    description: '관리자 편집용 페이지 상세를 조회합니다. (비공개 및 숨김 블록 포함)',
+  })
+  @ApiResponse({ status: 200, description: '페이지 상세 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 404, description: '페이지를 찾을 수 없음' })
+  @ApiParam({ name: 'id', type: Number, description: '페이지 ID' })
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.pagesService.findOneAdmin(id);
   }
 }

--- a/backend/src/modules/pages/pages.service.ts
+++ b/backend/src/modules/pages/pages.service.ts
@@ -63,10 +63,28 @@ export class PagesService {
   }
 
   async findAllAdmin(): Promise<Page[]> {
-    return this.pageRepository.find({
+    const pages = await this.pageRepository.find({
       relations: ['blocks'],
       order: { created_at: 'DESC' },
     });
+    return pages.map((page) => this.sortBlocks(page));
+  }
+
+  async findOneAdmin(id: number): Promise<Page> {
+    const page = await findOrThrow(
+      this.pageRepository,
+      { id },
+      '존재하지 않는 페이지입니다.',
+      ['blocks'],
+    );
+    return this.sortBlocks(page);
+  }
+
+  private sortBlocks(page: Page): Page {
+    if (page.blocks) {
+      page.blocks = [...page.blocks].sort((a, b) => a.sort_order - b.sort_order);
+    }
+    return page;
   }
 
   async create(dto: CreatePageDto): Promise<Page> {

--- a/backend/test/suites/cms-modules.e2e-spec.ts
+++ b/backend/test/suites/cms-modules.e2e-spec.ts
@@ -287,7 +287,7 @@ export function registerCmsModulesSuite(getApp: () => INestApplication) {
       const promotionRes = await request(app.getHttpServer())
         .post('/api/admin/promotions')
         .set('Cookie', adminCookies)
-        .send({ title: promotionTitle, type: 'event', startsAt: '2026-04-01T00:00:00.000Z', endsAt: '2026-05-01T00:00:00.000Z', isActive: true })
+        .send({ title: promotionTitle, type: 'event', startsAt: '2026-04-01T00:00:00.000Z', endsAt: '2099-05-01T00:00:00.000Z', isActive: true })
         .expect(201);
       promotionId = Number((promotionRes.body as { id: number }).id);
 

--- a/backend/test/suites/commerce-modules.e2e-spec.ts
+++ b/backend/test/suites/commerce-modules.e2e-spec.ts
@@ -133,7 +133,7 @@ export function registerCommerceModulesSuite(getApp: () => INestApplication) {
       await request(app.getHttpServer())
         .post('/api/admin/coupons')
         .set('Cookie', userCookies)
-        .send({ code: 'FAIL', name: '실패', type: 'fixed', value: 1000, startsAt: '2026-04-01T00:00:00.000Z', expiresAt: '2026-05-01T00:00:00.000Z' })
+        .send({ code: 'FAIL', name: '실패', type: 'fixed', value: 1000, startsAt: '2026-04-01T00:00:00.000Z', expiresAt: '2099-05-01T00:00:00.000Z' })
         .expect(403);
 
       const couponRes = await request(app.getHttpServer())
@@ -146,7 +146,7 @@ export function registerCommerceModulesSuite(getApp: () => INestApplication) {
           value: 3000,
           minOrderAmount: 10000,
           startsAt: '2026-04-01T00:00:00.000Z',
-          expiresAt: '2026-05-01T00:00:00.000Z',
+          expiresAt: '2099-05-01T00:00:00.000Z',
           isActive: true,
         })
         .expect(201);

--- a/src/app/[locale]/admin/pages/__tests__/AdminPagesPage.test.tsx
+++ b/src/app/[locale]/admin/pages/__tests__/AdminPagesPage.test.tsx
@@ -28,11 +28,12 @@ const mockAddBlock = vi.fn();
 const mockUpdateBlock = vi.fn();
 const mockDeleteBlock = vi.fn();
 const mockReorderBlocks = vi.fn();
-const mockGetBySlug = vi.fn();
+const mockGetById = vi.fn();
 
 vi.mock('@/lib/api', () => ({
   adminPagesApi: {
     getAll: (...args: unknown[]) => mockGetAll(...args),
+    getById: (...args: unknown[]) => mockGetById(...args),
     create: (...args: unknown[]) => mockCreate(...args),
     update: (...args: unknown[]) => mockUpdate(...args),
     remove: (...args: unknown[]) => mockRemove(...args),
@@ -40,9 +41,6 @@ vi.mock('@/lib/api', () => ({
     updateBlock: (...args: unknown[]) => mockUpdateBlock(...args),
     deleteBlock: (...args: unknown[]) => mockDeleteBlock(...args),
     reorderBlocks: (...args: unknown[]) => mockReorderBlocks(...args),
-  },
-  pagesApi: {
-    getBySlug: (...args: unknown[]) => mockGetBySlug(...args),
   },
 }));
 
@@ -66,7 +64,7 @@ describe('AdminPagesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAll.mockResolvedValue([mockPage]);
-    mockGetBySlug.mockResolvedValue(mockPage);
+    mockGetById.mockResolvedValue(mockPage);
     mockCreate.mockResolvedValue({ id: 2, title: '새 페이지', slug: 'new-page', is_published: false, blocks: [] });
     mockUpdate.mockResolvedValue(mockPage);
     mockAddBlock.mockResolvedValue({ id: 20, type: 'text_content', content: { html: '' }, sort_order: 0, is_visible: true });
@@ -95,7 +93,7 @@ describe('AdminPagesPage', () => {
     fireEvent.click(screen.getByText('메인 페이지'));
 
     await waitFor(() => {
-      expect(mockGetBySlug).toHaveBeenCalledWith('main');
+      expect(mockGetById).toHaveBeenCalledWith(1);
     });
 
     await waitFor(() => {
@@ -175,7 +173,7 @@ describe('AdminPagesPage', () => {
     expect(saveBtn).not.toBeDisabled();
 
     // Mock the reload after save
-    mockGetBySlug.mockResolvedValue({
+    mockGetById.mockResolvedValue({
       ...mockPage,
       blocks: [
         ...mockPage.blocks,
@@ -215,6 +213,93 @@ describe('AdminPagesPage', () => {
     });
 
     addSpy.mockRestore();
+  });
+
+  it('비공개 페이지 선택 시 관리자 상세 API로 숨김 블록까지 표시한다', async () => {
+    const draftPage = {
+      id: 2,
+      title: '비공개 페이지',
+      slug: 'draft-page',
+      is_published: false,
+      blocks: [],
+    };
+    const draftPageWithHiddenBlock = {
+      ...draftPage,
+      blocks: [
+        {
+          id: 30,
+          type: 'text_content' as const,
+          content: { html: '<p>숨김 블록</p>', template: 'default' },
+          sort_order: 0,
+          is_visible: false,
+        },
+      ],
+    };
+    mockGetAll.mockResolvedValue([draftPage]);
+    mockGetById.mockResolvedValue(draftPageWithHiddenBlock);
+
+    render(<AdminPagesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('비공개 페이지')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('비공개 페이지'));
+
+    await waitFor(() => {
+      expect(mockGetById).toHaveBeenCalledWith(2);
+    });
+    expect(screen.getAllByText('텍스트').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: '표시' })).toBeInTheDocument();
+  });
+
+  it('숨김 블록 저장 후 관리자 상세 API로 reload하여 dirty state를 초기화한다', async () => {
+    const hiddenPage = {
+      ...mockPage,
+      is_published: false,
+      blocks: [
+        {
+          id: 30,
+          type: 'text_content' as const,
+          content: { html: '<p>숨김 블록</p>', template: 'default' },
+          sort_order: 0,
+          is_visible: false,
+        },
+      ],
+    };
+    mockGetAll.mockResolvedValue([hiddenPage]);
+    mockGetById.mockResolvedValueOnce(hiddenPage).mockResolvedValueOnce({
+      ...hiddenPage,
+      blocks: [{ ...hiddenPage.blocks[0], is_visible: true }],
+    });
+    mockUpdateBlock.mockResolvedValue({ ...hiddenPage.blocks[0], is_visible: true });
+
+    render(<AdminPagesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('메인 페이지')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('메인 페이지'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '표시' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '표시' }));
+    fireEvent.click(screen.getByLabelText('저장'));
+
+    await waitFor(() => {
+      expect(mockUpdateBlock).toHaveBeenCalledWith(1, 30, expect.objectContaining({
+        is_visible: true,
+      }));
+    });
+    await waitFor(() => {
+      expect(mockGetById).toHaveBeenLastCalledWith(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText('저장')).toBeDisabled();
+    });
   });
 
   it('미리보기 버튼 클릭 시 미리보기 모달이 표시된다', async () => {

--- a/src/components/shared/admin/page-editor/usePageEditor.ts
+++ b/src/components/shared/admin/page-editor/usePageEditor.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
-import { adminPagesApi, pagesApi } from '@/lib/api';
+import { adminPagesApi } from '@/lib/api';
 import type { Page, PageBlock } from '@/lib/api';
 import type { DraftState, DraftAction } from '@/components/shared/admin/page-editor/useDraftReducer';
 
@@ -39,7 +39,7 @@ export function usePageEditor({
         if (!confirmed) return;
       }
       try {
-        const fullPage = await pagesApi.getBySlug(page.slug);
+        const fullPage = await adminPagesApi.getById(page.id);
         setSelectedPage(fullPage);
         setSelectedBlockId(null);
         dispatch({ type: 'INIT', blocks: fullPage.blocks, title: fullPage.title, slug: fullPage.slug });
@@ -88,9 +88,11 @@ export function usePageEditor({
       const updated = await adminPagesApi.update(selectedPage.id, {
         is_published: !selectedPage.is_published,
       } as Partial<Page>);
-      setSelectedPage(updated);
+      const fullPage = await adminPagesApi.getById(updated.id);
+      setSelectedPage(fullPage);
+      dispatch({ type: 'INIT', blocks: fullPage.blocks, title: fullPage.title, slug: fullPage.slug });
       await loadPages();
-      toast.success(updated.is_published ? '페이지가 공개되었습니다.' : '페이지가 비공개로 전환되었습니다.');
+      toast.success(fullPage.is_published ? '페이지가 공개되었습니다.' : '페이지가 비공개로 전환되었습니다.');
     } catch (err) {
       toast.error(handleApiError(err, '상태 변경에 실패했습니다.'));
     }
@@ -146,22 +148,10 @@ export function usePageEditor({
 
       toast.success('저장되었습니다.');
 
-      // Reload the page data via admin API to avoid slug issues
-      const allPages = await adminPagesApi.getAll();
-      const reloadedMeta = allPages.find((p) => p.id === selectedPage.id);
-      if (reloadedMeta?.slug) {
-        const reloaded = await pagesApi.getBySlug(reloadedMeta.slug);
-        setSelectedPage(reloaded);
-        dispatch({ type: 'INIT', blocks: reloaded.blocks, title: reloaded.title, slug: reloaded.slug });
-      } else {
-        // fallback: clear dirty flags to prevent duplicate save
-        const cleanBlocks: PageBlock[] = draft.blocks
-          .filter((b) => !b._isNew || b.id > 0)
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          .map(({ _isNew, _isModified, ...b }) => b as PageBlock);
-        setSelectedPage((prev) => prev ? { ...prev, title: draft.title, slug: draft.slug } : prev);
-        dispatch({ type: 'INIT', blocks: cleanBlocks, title: draft.title, slug: draft.slug });
-      }
+      // Reload the page data via admin API so private pages and hidden blocks remain editable.
+      const reloaded = await adminPagesApi.getById(selectedPage.id);
+      setSelectedPage(reloaded);
+      dispatch({ type: 'INIT', blocks: reloaded.blocks, title: reloaded.title, slug: reloaded.slug });
       await loadPages();
     } catch (err) {
       toast.error(handleApiError(err, '저장에 실패했습니다.'));

--- a/src/lib/api/admin/pages.ts
+++ b/src/lib/api/admin/pages.ts
@@ -16,6 +16,7 @@ export interface CreateBlockData {
 
 export const adminPagesApi = {
   getAll: () => apiClient.get<Page[]>('/admin/pages'),
+  getById: (id: number) => apiClient.get<Page>(`/admin/pages/${id}`),
   create: (data: CreatePageData) => apiClient.post<Page>('/pages', data),
   update: (id: number, data: Partial<Page>) =>
     apiClient.patch<Page>(`/pages/${id}`, data),


### PR DESCRIPTION
## Summary\n- Add protected admin page detail API that returns private pages and hidden blocks for editor use\n- Switch admin page editor selection, publish toggles, and save reloads away from public storefront page reads\n- Add backend/frontend regressions for private pages, hidden blocks, and dirty-state reset after reload\n\n## Verification\n- npm run test:run -- src/app/[locale]/admin/pages/__tests__/AdminPagesPage.test.tsx\n- cd backend && npm test -- --runInBand src/modules/pages/__tests__/pages.service.spec.ts\n- cd backend && npm run build\n- npm run build\n- bash scripts/test.sh frontend\n- bash scripts/test.sh backend\n\nCloses #736