### PR TITLE
fix: #737 CMS 블록 계약 불일치 해소

### DIFF
--- a/backend/src/modules/pages/__tests__/pages.service.spec.ts
+++ b/backend/src/modules/pages/__tests__/pages.service.spec.ts
@@ -219,6 +219,21 @@ describe('PagesService', () => {
       expect(result.type).toBe('hero_banner');
     });
 
+    it('저널 미리보기 블록을 생성한다', async () => {
+      const dto = { type: 'journal_preview', content: { title: '저널', limit: 3 } };
+      mockPageRepository.findOne.mockResolvedValue({ id: 1 });
+      mockBlockRepository.create.mockReturnValue({ id: 1, ...dto, page_id: 1 });
+      mockBlockRepository.save.mockResolvedValue({ id: 1, ...dto, page_id: 1 });
+
+      const result = await service.createBlock(1, dto);
+
+      expect(result.type).toBe('journal_preview');
+      expect(mockBlockRepository.create).toHaveBeenCalledWith({
+        ...dto,
+        page_id: 1,
+      });
+    });
+
     it('존재하지 않는 페이지 → NotFoundException', async () => {
       mockPageRepository.findOne.mockResolvedValue(null);
       await expect(

--- a/backend/src/modules/pages/pages.service.ts
+++ b/backend/src/modules/pages/pages.service.ts
@@ -24,6 +24,7 @@ const SUPPORTED_BLOCK_TYPES = [
   'text_content',
   'split_content',
   'brand_story',
+  'journal_preview',
 ];
 
 @Injectable()

--- a/backend/test/suites/cms-modules.e2e-spec.ts
+++ b/backend/test/suites/cms-modules.e2e-spec.ts
@@ -287,7 +287,7 @@ export function registerCmsModulesSuite(getApp: () => INestApplication) {
       const promotionRes = await request(app.getHttpServer())
         .post('/api/admin/promotions')
         .set('Cookie', adminCookies)
-        .send({ title: promotionTitle, type: 'event', startsAt: '2026-04-01T00:00:00.000Z', endsAt: '2026-05-01T00:00:00.000Z', isActive: true })
+        .send({ title: promotionTitle, type: 'event', startsAt: '2026-04-01T00:00:00.000Z', endsAt: '2099-05-01T00:00:00.000Z', isActive: true })
         .expect(201);
       promotionId = Number((promotionRes.body as { id: number }).id);
 

--- a/backend/test/suites/commerce-modules.e2e-spec.ts
+++ b/backend/test/suites/commerce-modules.e2e-spec.ts
@@ -133,7 +133,7 @@ export function registerCommerceModulesSuite(getApp: () => INestApplication) {
       await request(app.getHttpServer())
         .post('/api/admin/coupons')
         .set('Cookie', userCookies)
-        .send({ code: 'FAIL', name: '실패', type: 'fixed', value: 1000, startsAt: '2026-04-01T00:00:00.000Z', expiresAt: '2026-05-01T00:00:00.000Z' })
+        .send({ code: 'FAIL', name: '실패', type: 'fixed', value: 1000, startsAt: '2026-04-01T00:00:00.000Z', expiresAt: '2099-05-01T00:00:00.000Z' })
         .expect(403);
 
       const couponRes = await request(app.getHttpServer())
@@ -146,7 +146,7 @@ export function registerCommerceModulesSuite(getApp: () => INestApplication) {
           value: 3000,
           minOrderAmount: 10000,
           startsAt: '2026-04-01T00:00:00.000Z',
-          expiresAt: '2026-05-01T00:00:00.000Z',
+          expiresAt: '2099-05-01T00:00:00.000Z',
           isActive: true,
         })
         .expect(201);

--- a/src/components/shared/admin/page-editor/__tests__/BlockPropertyPanel.test.tsx
+++ b/src/components/shared/admin/page-editor/__tests__/BlockPropertyPanel.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import BlockPropertyPanel from '@/components/shared/admin/page-editor/BlockPropertyPanel';
+import type { DraftBlock } from '@/components/shared/admin/page-editor/SortableBlockItem';
+
+describe('BlockPropertyPanel', () => {
+  it('프로모션 배너 종료일은 렌더러 계약인 end_date로 저장한다', async () => {
+    const onUpdateContent = vi.fn();
+    const block: DraftBlock = {
+      id: 1,
+      type: 'promotion_banner',
+      content: {
+        title: '타이머 프로모션',
+        template: 'timer',
+        expires_at: '2026-01-01',
+      },
+      sort_order: 0,
+      is_visible: true,
+    };
+
+    render(<BlockPropertyPanel block={block} onUpdateContent={onUpdateContent} />);
+
+    fireEvent.change(screen.getByLabelText('종료일'), {
+      target: { value: '2026-12-31' },
+    });
+
+    expect(onUpdateContent).toHaveBeenLastCalledWith(
+      1,
+      expect.objectContaining({ end_date: '2026-12-31' }),
+    );
+    expect(onUpdateContent).toHaveBeenLastCalledWith(
+      1,
+      expect.not.objectContaining({ expires_at: expect.any(String) }),
+    );
+  });
+});

--- a/src/components/shared/admin/page-editor/block-property-panel/FormFields.tsx
+++ b/src/components/shared/admin/page-editor/block-property-panel/FormFields.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useId } from 'react';
 import { cn } from '@/components/ui/utils';
 
 interface StringFieldProps {
@@ -12,11 +13,14 @@ interface StringFieldProps {
 }
 
 export function StringField({ label, value, onChange, placeholder, multiline, onBlur }: StringFieldProps) {
+  const id = useId();
+
   return (
     <div>
-      <label className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
+      <label htmlFor={id} className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
       {multiline ? (
         <textarea
+          id={id}
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onBlur={onBlur}
@@ -26,6 +30,7 @@ export function StringField({ label, value, onChange, placeholder, multiline, on
         />
       ) : (
         <input
+          id={id}
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
@@ -44,10 +49,13 @@ interface NumberFieldProps {
 }
 
 export function NumberField({ label, value, onChange }: NumberFieldProps) {
+  const id = useId();
+
   return (
     <div>
-      <label className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
+      <label htmlFor={id} className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
       <input
+        id={id}
         type="number"
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
@@ -73,11 +81,13 @@ interface SelectFieldProps {
 }
 
 export function SelectField({ label, value, options, onChange, hint }: SelectFieldProps) {
+  const id = useId();
   const selectedHint = hint ?? options.find((o) => o.value === value)?.hint;
   return (
     <div>
-      <label className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
+      <label htmlFor={id} className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
       <select
+        id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="w-full rounded-md border border-input px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"

--- a/src/components/shared/admin/page-editor/block-property-panel/blocks/PromotionBannerFields.tsx
+++ b/src/components/shared/admin/page-editor/block-property-panel/blocks/PromotionBannerFields.tsx
@@ -10,6 +10,11 @@ interface PromotionBannerFieldsProps {
 
 export default function PromotionBannerFields({ content, onChange }: PromotionBannerFieldsProps) {
   const update = createContentUpdater(content, onChange);
+  const updateEndDate = (value: string) => {
+    const nextContent = { ...content };
+    delete nextContent.expires_at;
+    onChange({ ...nextContent, end_date: value });
+  };
 
   return (
     <>
@@ -21,7 +26,12 @@ export default function PromotionBannerFields({ content, onChange }: PromotionBa
       <StringField label="CTA 텍스트" value={(content.cta_text as string) ?? ''} onChange={(v) => update('cta_text', v)} />
       <StringField label="CTA 텍스트 (EN)" value={(content.cta_text_en as string) ?? ''} onChange={(v) => update('cta_text_en', v)} placeholder="영문 CTA" />
       <StringField label="CTA URL" value={(content.cta_url as string) ?? ''} onChange={(v) => update('cta_url', v)} />
-      <StringField label="종료일" value={(content.expires_at as string) ?? ''} onChange={(v) => update('expires_at', v)} placeholder="YYYY-MM-DD" />
+      <StringField
+        label="종료일"
+        value={((content.end_date as string) ?? (content.expires_at as string)) ?? ''}
+        onChange={updateEndDate}
+        placeholder="YYYY-MM-DD"
+      />
       <SelectField
         label="템플릿"
         value={(content.template as string) ?? 'full-width'}

--- a/src/components/shared/blocks/PromotionBannerBlock.tsx
+++ b/src/components/shared/blocks/PromotionBannerBlock.tsx
@@ -13,7 +13,8 @@ interface Props {
 }
 
 export default function PromotionBannerBlock({ content }: Props) {
-  const { title, subtitle, image_url, cta_text, cta_url, template, end_date } = content;
+  const { title, subtitle, image_url, cta_text, cta_url, template, end_date, expires_at } = content;
+  const countdownEndDate = end_date ?? expires_at;
   const { ref, visible } = useScrollAnimation<HTMLElement>();
   const t = useTranslations('promotion');
 
@@ -23,7 +24,7 @@ export default function PromotionBannerBlock({ content }: Props) {
         <p className="text-sm tracking-widest text-[#B8976A] uppercase mb-3">{t('limitedTime')}</p>
         <h2 className="text-2xl font-display font-medium">{title}</h2>
         {subtitle && <p className="mt-2 text-muted-foreground">{subtitle}</p>}
-        {end_date && <CountdownTimer endDate={end_date} />}
+        {countdownEndDate && <CountdownTimer endDate={countdownEndDate} />}
         {cta_text && cta_url && (
           <Link
             href={isSafeUrl(cta_url) ? cta_url : '#'}

--- a/src/components/shared/blocks/TextContentBlock.tsx
+++ b/src/components/shared/blocks/TextContentBlock.tsx
@@ -1,18 +1,33 @@
-import type { TextContentContent } from '@/lib/api';
 import SafeHtml from '@/components/shared/common/SafeHtml';
+import { cn } from '@/components/ui/utils';
+import type { TextContentContent } from '@/lib/api';
 
 interface Props {
   content: TextContentContent;
 }
 
 export default function TextContentBlock({ content }: Props) {
-  const { html, textAlign = 'center' } = content;
+  const { html, textAlign = 'center', template = 'default' } = content;
+  const isHighlight = template === 'highlight';
 
   return (
-    <section className="my-12 md:my-20">
-      <hr className="border-divider-soft" />
-      <SafeHtml html={html} className="prose max-w-none py-6" style={{ textAlign }} />
-      <hr className="border-divider-soft" />
+    <section
+      className={cn(
+        'my-12 md:my-20',
+        isHighlight && 'rounded-2xl border border-primary/30 bg-primary/5 px-6 py-8 md:px-10',
+      )}
+      data-template={template}
+    >
+      {!isHighlight && <hr className="border-divider-soft" />}
+      <SafeHtml
+        html={html}
+        className={cn(
+          'prose max-w-none py-6',
+          isHighlight && 'text-foreground [&_a]:font-medium [&_a]:text-primary [&_strong]:text-primary',
+        )}
+        style={{ textAlign }}
+      />
+      {!isHighlight && <hr className="border-divider-soft" />}
     </section>
   );
 }

--- a/src/components/shared/blocks/__tests__/BlockRenderer.test.tsx
+++ b/src/components/shared/blocks/__tests__/BlockRenderer.test.tsx
@@ -303,6 +303,42 @@ describe('BlockRenderer', () => {
     expect(screen.getByRole('timer')).toBeInTheDocument();
   });
 
+  it('renders PromotionBannerBlock timer from legacy expires_at content', () => {
+    const futureDate = new Date(Date.now() + 86400000).toISOString();
+    const blocks: PageBlock[] = [
+      makeBlock({
+        type: 'promotion_banner',
+        content: {
+          title: '레거시 타이머 프로모션',
+          template: 'timer',
+          expires_at: futureDate,
+        },
+      }),
+    ];
+    render(<BlockRenderer blocks={blocks} />);
+    expect(screen.getByText('레거시 타이머 프로모션')).toBeInTheDocument();
+    expect(screen.getByRole('timer')).toBeInTheDocument();
+  });
+
+  it('renders TextContentBlock highlight template with distinct styling', async () => {
+    const blocks: PageBlock[] = [
+      makeBlock({
+        type: 'text_content',
+        content: {
+          html: '<p>강조 텍스트</p>',
+          template: 'highlight',
+        },
+      }),
+    ];
+    const { container } = render(<BlockRenderer blocks={blocks} />);
+    await waitFor(() => {
+      expect(screen.getByText('강조 텍스트')).toBeInTheDocument();
+    });
+    const section = container.querySelector('section[data-template="highlight"]');
+    expect(section).toBeInTheDocument();
+    expect(section?.className).toContain('bg-primary/5');
+  });
+
   it('renders PromotionBannerBlock with card template', () => {
     const blocks: PageBlock[] = [
       makeBlock({

--- a/src/lib/api/pages.ts
+++ b/src/lib/api/pages.ts
@@ -75,6 +75,8 @@ export interface PromotionBannerContent {
   cta_url?: string;
   template: 'full-width' | 'card' | 'timer';
   end_date?: string;
+  /** @deprecated 기존 CMS 데이터 호환용. 새 저장 경로는 end_date 입니다. */
+  expires_at?: string;
 }
 
 export interface TextContentContent {


### PR DESCRIPTION
## Summary
- backend pages service supports `journal_preview` blocks exposed by the CMS editor and renderer
- promotion banner editor now writes `end_date`, while renderer keeps legacy `expires_at` read compatibility
- text content `highlight` template now renders distinct highlighted styling
- added regression tests for backend block support, admin field persistence, timer rendering, and highlight rendering

## Tests
- npm run build
- npm run test:run
- cd backend && npm run build
- cd backend && npm test
- npm run test:run -- src/components/shared/blocks/__tests__/BlockRenderer.test.tsx src/components/shared/admin/page-editor/__tests__/BlockPropertyPanel.test.tsx
- cd backend && npm test -- --runInBand src/modules/pages/__tests__/pages.service.spec.ts

Closes #737