### PR TITLE
Fix theme editor runtime typography and spacing tokens

### DIFF
--- a/backend/src/modules/settings/settings.service.spec.ts
+++ b/backend/src/modules/settings/settings.service.spec.ts
@@ -166,9 +166,28 @@ describe('SettingsService', () => {
       await service.resetToDefaults();
       expect(mockDataSource.transaction).toHaveBeenCalled();
       expect(mockManager.query).toHaveBeenCalledWith(
-        'UPDATE site_settings SET value = default_value',
+        'UPDATE site_settings SET value = default_value, value_en = NULL, value_ja = NULL, value_zh = NULL',
       );
       expect(mockCache.delPattern).toHaveBeenCalledWith('settings:*');
+    });
+
+    it('should clear locale overrides so EN/legacy locales fall back to defaults', async () => {
+      const mockManager = {
+        query: jest.fn(),
+      };
+      mockDataSource.transaction.mockImplementation(async (cb: (m: unknown) => Promise<void>) => cb(mockManager));
+
+      await service.resetToDefaults();
+
+      expect(mockManager.query).toHaveBeenCalledWith(
+        expect.stringContaining('value_en = NULL'),
+      );
+      expect(mockManager.query).toHaveBeenCalledWith(
+        expect.stringContaining('value_ja = NULL'),
+      );
+      expect(mockManager.query).toHaveBeenCalledWith(
+        expect.stringContaining('value_zh = NULL'),
+      );
     });
 
     it('should propagate DB errors', async () => {

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -76,7 +76,7 @@ export class SettingsService {
   async resetToDefaults(): Promise<void> {
     await this.dataSource.transaction(async (manager) => {
       await manager.query(
-        `UPDATE site_settings SET value = default_value`,
+        `UPDATE site_settings SET value = default_value, value_en = NULL, value_ja = NULL, value_zh = NULL`,
       );
       this.logger.log('Settings reset to defaults');
     });

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -11,6 +11,7 @@ import Providers from '@/components/Providers';
 import RecentlyViewedWidget from '@/components/RecentlyViewedWidget';
 import { routing } from '@/i18n/routing';
 import type { Locale } from '@/i18n/routing';
+import { getThemeStyle } from '@/lib/theme-style';
 
 const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
 
@@ -45,42 +46,6 @@ export async function generateMetadata({
 }
 
 const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
-
-async function getThemeStyle(map: Record<string, string> | null): Promise<string> {
-  if (!map) return '';
-  const COLOR_RE = /^#[0-9a-fA-F]{3,8}$|^rgb\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)$/;
-  const LENGTH_RE = /^\d+(\.\d+)?(px|rem|em)$/;
-  const FONT_RE = /^['"]?[\w\s,-]+['"]?(?:\s*,\s*[\w\s-]+)*$/;
-  const NUMBER_RE = /^\d+(\.\d+)?$/;
-
-  function isValidCssValue(key: string, value: string): boolean {
-    const trimmed = value.trim();
-    if (key.startsWith('color_')) return COLOR_RE.test(trimmed);
-    if (key.startsWith('font_size') || key.startsWith('spacing') || key.startsWith('radius')) return LENGTH_RE.test(trimmed);
-    if (key.startsWith('font_family')) return FONT_RE.test(trimmed);
-    if (key.startsWith('font_weight') || key.startsWith('line_height')) return NUMBER_RE.test(trimmed);
-    return false;
-  }
-
-  const lightVars: string[] = [];
-  const darkVars: string[] = [];
-
-  for (const [k, v] of Object.entries(map)) {
-    if (!isValidCssValue(k, String(v))) continue;
-    const safeKey = k.replace(/[^a-zA-Z0-9_-]/g, '');
-    const cssVar = `--db-${safeKey.replace(/_/g, '-')}: ${String(v).trim()}`;
-    if (k.startsWith('color_dark_')) {
-      darkVars.push(cssVar);
-    } else {
-      lightVars.push(cssVar);
-    }
-  }
-
-  const parts: string[] = [];
-  if (lightVars.length > 0) parts.push(`:root { ${lightVars.join('; ')} }`);
-  if (darkVars.length > 0) parts.push(`[data-theme="dark"] { ${darkVars.join('; ')} }`);
-  return parts.join('\n');
-}
 
 async function getSettingsMap(locale?: string): Promise<Record<string, string> | null> {
   try {

--- a/src/lib/__tests__/theme-style.test.ts
+++ b/src/lib/__tests__/theme-style.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { getThemeStyle } from '../theme-style';
+
+describe('getThemeStyle', () => {
+  it('emits safe DB CSS variables for typography, spacing, radius, and colors', () => {
+    const style = getThemeStyle({
+      color_primary: '#123456',
+      font_family_base: "'Pretendard', sans-serif",
+      font_size_base: '18px',
+      font_weight_normal: '450',
+      line_height_base: '1.7',
+      spacing_lg: '2rem',
+      radius_md: '0.75rem',
+    });
+
+    expect(style).toContain('--db-color-primary: #123456');
+    expect(style).toContain("--db-font-family-base: 'Pretendard', sans-serif");
+    expect(style).toContain('--db-font-size-base: 18px');
+    expect(style).toContain('--db-font-weight-normal: 450');
+    expect(style).toContain('--db-line-height-base: 1.7');
+    expect(style).toContain('--db-spacing-lg: 2rem');
+    expect(style).toContain('--db-radius-md: 0.75rem');
+  });
+
+  it('drops unsafe values before creating inline CSS', () => {
+    const style = getThemeStyle({
+      font_size_base: '16px; color:red',
+      font_family_base: "Pretendard; background:url('x')",
+      spacing_md: 'calc(100vw)',
+      radius_md: '1rem',
+    });
+
+    expect(style).not.toContain('font-size-base');
+    expect(style).not.toContain('background:url');
+    expect(style).not.toContain('calc(100vw)');
+    expect(style).toContain('--db-radius-md: 1rem');
+  });
+
+  it('scopes dark color settings separately from locale-specific light settings', () => {
+    const koStyle = getThemeStyle({ font_size_base: '1rem', color_primary: '#111111' });
+    const enStyle = getThemeStyle({ font_size_base: '1.125rem', color_primary: '#222222' });
+    const darkStyle = getThemeStyle({ color_dark_primary: '#000000' });
+
+    expect(koStyle).toContain(':root { --db-font-size-base: 1rem; --db-color-primary: #111111 }');
+    expect(enStyle).toContain(':root { --db-font-size-base: 1.125rem; --db-color-primary: #222222 }');
+    expect(darkStyle).toContain('[data-theme="dark"] { --db-color-dark-primary: #000000 }');
+  });
+});

--- a/src/lib/theme-style.ts
+++ b/src/lib/theme-style.ts
@@ -1,0 +1,36 @@
+const COLOR_RE = /^#[0-9a-fA-F]{3,8}$|^rgb\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)$/;
+const LENGTH_RE = /^\d+(\.\d+)?(px|rem|em)$/;
+const FONT_RE = /^['"]?[\w\s,-]+['"]?(?:\s*,\s*[\w\s-]+)*$/;
+const NUMBER_RE = /^\d+(\.\d+)?$/;
+
+function isValidThemeCssValue(key: string, value: string): boolean {
+  const trimmed = value.trim();
+  if (key.startsWith('color_')) return COLOR_RE.test(trimmed);
+  if (key.startsWith('font_size') || key.startsWith('spacing') || key.startsWith('radius')) return LENGTH_RE.test(trimmed);
+  if (key.startsWith('font_family')) return FONT_RE.test(trimmed);
+  if (key.startsWith('font_weight') || key.startsWith('line_height')) return NUMBER_RE.test(trimmed);
+  return false;
+}
+
+export function getThemeStyle(map: Record<string, string> | null): string {
+  if (!map) return '';
+
+  const lightVars: string[] = [];
+  const darkVars: string[] = [];
+
+  for (const [k, v] of Object.entries(map)) {
+    if (!isValidThemeCssValue(k, String(v))) continue;
+    const safeKey = k.replace(/[^a-zA-Z0-9_-]/g, '');
+    const cssVar = `--db-${safeKey.replace(/_/g, '-')}: ${String(v).trim()}`;
+    if (k.startsWith('color_dark_')) {
+      darkVars.push(cssVar);
+    } else {
+      lightVars.push(cssVar);
+    }
+  }
+
+  const parts: string[] = [];
+  if (lightVars.length > 0) parts.push(`:root { ${lightVars.join('; ')} }`);
+  if (darkVars.length > 0) parts.push(`[data-theme="dark"] { ${darkVars.join('; ')} }`);
+  return parts.join('\n');
+}

--- a/src/styles/__tests__/theme-runtime-tokens.test.ts
+++ b/src/styles/__tests__/theme-runtime-tokens.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const globals = readFileSync(join(process.cwd(), 'src/styles/globals.css'), 'utf8');
+
+describe('runtime theme tokens', () => {
+  it('connects admin typography settings to live CSS tokens', () => {
+    expect(globals).toContain('--font-body: var(--db-font-family-base');
+    expect(globals).toContain('--font-size-body: var(--db-font-size-base');
+    expect(globals).toContain('--line-height-body: var(--db-line-height-base');
+    expect(globals).toContain('--font-weight-normal: var(--db-font-weight-normal');
+    expect(globals).toContain('--font-weight-bold: var(--db-font-weight-bold');
+  });
+
+  it('connects admin spacing settings to layout rhythm tokens', () => {
+    expect(globals).toContain('--spacing-xs: var(--db-spacing-xs');
+    expect(globals).toContain('--spacing-sm: var(--db-spacing-sm');
+    expect(globals).toContain('--spacing-md: var(--db-spacing-md');
+    expect(globals).toContain('--spacing-lg: var(--db-spacing-lg');
+    expect(globals).toContain('--spacing-xl: var(--db-spacing-xl');
+    expect(globals).toContain('--layout-page-y: var(--spacing-xl)');
+    expect(globals).toContain('--layout-section-y: var(--spacing-lg)');
+    expect(globals).toContain('--layout-grid-gap: var(--spacing-lg)');
+    expect(globals).toContain('padding-inline: var(--spacing-md)');
+  });
+});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -31,17 +31,19 @@
   --font-size-heading-1: 1.5rem;   /* 24px mobile */
   --font-size-heading-2: 1.25rem;  /* 20px mobile */
   --font-size-heading-3: 1.125rem; /* 18px mobile */
-  --font-size-title: 1rem;         /* 16px mobile */
-  --font-size-body: 1rem;          /* 16px */
+  --font-size-title: var(--db-font-size-base, 1rem);         /* 16px mobile */
+  --font-size-body: var(--db-font-size-base, 1rem);          /* 16px */
   --font-size-body-sm: 0.875rem;   /* 14px */
   --font-size-label: 0.625rem;      /* 10px */
   --font-size-label-sm: 0.5625rem;  /* 9px */
   --font-size-button: 0.875rem;    /* 14px */
 
-  /* Typography — line-height scale */
+  /* Typography — line-height and weight scale */
   --line-height-heading: 1.25;
-  --line-height-body: 1.6;
+  --line-height-body: var(--db-line-height-base, 1.6);
   --line-height-compact: 1.1;
+  --font-weight-normal: var(--db-font-weight-normal, 400);
+  --font-weight-bold: var(--db-font-weight-bold, 600);
 }
 
 /* ── Default light theme colors in :root (for non-Korean locales) ── */
@@ -96,9 +98,14 @@
 
   /* ── Layout rhythm tokens ── */
   --layout-max-width: 80rem; /* 1280px */
-  --layout-page-y: 2rem;
-  --layout-section-y: 1.5rem;
-  --layout-grid-gap: 1.5rem;
+  --spacing-xs: var(--db-spacing-xs, 0.25rem);
+  --spacing-sm: var(--db-spacing-sm, 0.5rem);
+  --spacing-md: var(--db-spacing-md, 1rem);
+  --spacing-lg: var(--db-spacing-lg, 1.5rem);
+  --spacing-xl: var(--db-spacing-xl, 2rem);
+  --layout-page-y: var(--spacing-xl);
+  --layout-section-y: var(--spacing-lg);
+  --layout-grid-gap: var(--spacing-lg);
   --layout-text-max: 42rem;
 
   /* ── Admin density / contrast tokens ── */
@@ -110,7 +117,7 @@
 
   /* ── 타이포그래피 — 폰트 패밀리 (3종) ── */
   --font-display: 'Noto Serif KR', 'Georgia', serif;
-  --font-body: 'Pretendard', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;
+  --font-body: var(--db-font-family-base, 'Pretendard', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif);
   --font-mono: 'DM Mono', 'Courier New', monospace;
 
   /* ── Height tokens for arbitrary value replacements ── */
@@ -133,11 +140,11 @@
     --font-size-heading-1: 2.25rem;  /* 36px desktop */
     --font-size-heading-2: 1.5rem;   /* 24px desktop */
     --font-size-heading-3: 1.25rem;  /* 20px desktop */
-    --font-size-title: 1.125rem;     /* 18px desktop */
+    --font-size-title: var(--db-font-size-base, 1.125rem);     /* 18px desktop */
     --font-size-heading-0: 3rem;     /* 48px desktop - hero only */
-    --layout-page-y: 2.5rem;
-    --layout-section-y: 2rem;
-    --layout-grid-gap: 2rem;
+    --layout-page-y: var(--spacing-xl, 2.5rem);
+    --layout-section-y: var(--spacing-xl, 2rem);
+    --layout-grid-gap: var(--spacing-xl, 2rem);
   }
 }
 
@@ -158,9 +165,9 @@
 .mobile-sticky-cta {
   left: 0;
   right: 0;
-  padding-top: 0.75rem;
-  padding-inline: 1rem;
-  padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+  padding-top: var(--spacing-sm);
+  padding-inline: var(--spacing-md);
+  padding-bottom: calc(var(--spacing-sm) + env(safe-area-inset-bottom));
 }
 
 .mobile-sticky-inner {
@@ -188,7 +195,7 @@ body.overflow-hidden .mobile-sticky-cta {
   width: 100%;
   max-width: var(--layout-max-width);
   margin-inline: auto;
-  padding-inline: 1rem;
+  padding-inline: var(--spacing-md);
 }
 
 @utility layout-page {
@@ -240,34 +247,34 @@ body.overflow-hidden .mobile-sticky-cta {
 @utility typo-h0 {
   font-size: var(--font-size-heading-0, 2rem);
   line-height: var(--line-height-heading);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
   letter-spacing: -0.02em;
 }
 
 @utility typo-h1 {
   font-size: var(--font-size-heading-1);
   line-height: var(--line-height-heading);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
   letter-spacing: -0.02em;
 }
 
 @utility typo-h2 {
   font-size: var(--font-size-heading-2);
   line-height: var(--line-height-heading);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
   letter-spacing: -0.01em;
 }
 
 @utility typo-h3 {
   font-size: var(--font-size-heading-3);
   line-height: var(--line-height-heading);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
 }
 
 @utility typo-title {
   font-size: var(--font-size-title);
   font-family: var(--font-body);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
   line-height: var(--line-height-compact);
 }
 
@@ -286,13 +293,13 @@ body.overflow-hidden .mobile-sticky-cta {
 @utility typo-label {
   font-size: var(--font-size-label);
   line-height: var(--line-height-compact);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
 }
 
 @utility typo-button {
   font-size: var(--font-size-button);
   line-height: var(--line-height-compact);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
 }
 
 @utility typo-title-sm {
@@ -306,7 +313,7 @@ body.overflow-hidden .mobile-sticky-cta {
 @utility typo-price {
   font-size: 1.0625rem;
   line-height: 1.15;
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
   letter-spacing: -0.01em;
   font-family: var(--font-body);
   font-variant-numeric: tabular-nums;
@@ -315,7 +322,7 @@ body.overflow-hidden .mobile-sticky-cta {
 @utility typo-price-lg {
   font-size: 1.5rem;
   line-height: 1.1;
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
   letter-spacing: -0.015em;
   font-family: var(--font-body);
   font-variant-numeric: tabular-nums;
@@ -324,7 +331,7 @@ body.overflow-hidden .mobile-sticky-cta {
 @utility typo-price-original {
   font-size: 0.75rem;
   line-height: 1.1;
-  font-weight: 400;
+  font-weight: var(--font-weight-normal);
   color: var(--color-muted-foreground);
   text-decoration: line-through;
 }
@@ -332,13 +339,14 @@ body.overflow-hidden .mobile-sticky-cta {
 @utility typo-price-discount {
   font-size: 0.75rem;
   line-height: 1.1;
-  font-weight: 700;
+  font-weight: var(--db-font-weight-bold, 700);
   letter-spacing: 0.02em;
 }
 
 /* ── Base styles ───────────────────────────────────────────────── */
 body {
   font-family: var(--font-body);
+  font-weight: var(--font-weight-normal);
   color: var(--color-foreground);
   background-color: var(--color-background);
   -webkit-font-smoothing: antialiased;
@@ -349,7 +357,7 @@ h1 {
   font-family: var(--font-display);
   font-size: var(--font-size-heading-1);
   line-height: var(--line-height-heading);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
   letter-spacing: -0.02em;
 }
 
@@ -357,7 +365,7 @@ h2 {
   font-family: var(--font-display);
   font-size: var(--font-size-heading-2);
   line-height: var(--line-height-heading);
-  font-weight: 600;
+  font-weight: var(--font-weight-bold);
   letter-spacing: -0.01em;
 }
 
@@ -393,7 +401,7 @@ h3 {
 .spec-data {
   font-family: var(--font-mono);
   font-size: 0.875rem;
-  font-weight: 400;
+  font-weight: var(--font-weight-normal);
   letter-spacing: 0.025em;
 }
 
@@ -401,7 +409,7 @@ h3 {
 .data-label {
   font-family: var(--font-mono);
   font-size: 0.6875rem;
-  font-weight: 400;
+  font-weight: var(--font-weight-normal);
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--color-muted-foreground);


### PR DESCRIPTION
## Summary
- Closes #738
- Extracts the safe DB-theme inline CSS generator into a testable helper.
- Connects admin typography settings (`font_family_base`, `font_size_base`, `font_weight_*`, `line_height_base`) to runtime CSS tokens.
- Connects admin spacing settings (`spacing_xs`~`spacing_xl`) to Tailwind/runtime spacing and layout tokens.
- Makes settings reset clear locale overrides (`value_en`, legacy `value_ja`/`value_zh`) so `/en` cannot keep shadowing defaults after reset.

## Verification
- `npm run test:run`
- `npm run build`
- `cd backend && npm test -- --runInBand`
- `cd backend && npm run build`
- `git diff --check`

## Not tested
- Browser-based visual inspection of `/ko` and `/en` after editing theme settings.
