### PR TITLE
feat: #727 감사 로그 보관·권한·마스킹 정책 구현

### DIFF
--- a/backend/src/common/interceptors/audit-log.interceptor.spec.ts
+++ b/backend/src/common/interceptors/audit-log.interceptor.spec.ts
@@ -52,6 +52,27 @@ describe('AuditLogInterceptor', () => {
     } as unknown as ExecutionContext;
   }
 
+  function createMockExecutionContextWithQuery(
+    query: Record<string, unknown>,
+    user: { id: number; role: string } = { id: 1, role: 'admin' },
+  ): ExecutionContext {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user,
+          query,
+          body: {},
+          params: {},
+          ip: '192.168.1.1',
+          headers: { 'user-agent': 'Mozilla/5.0' },
+          socket: { remoteAddress: '192.168.1.1' },
+        }),
+      }),
+      getHandler: () => ({}),
+      getParamTypes: () => [],
+    } as unknown as ExecutionContext;
+  }
+
   function createMockCallHandler(responseBody?: unknown): CallHandler {
     return {
       handle: () => of(responseBody),
@@ -198,4 +219,39 @@ describe('AuditLogInterceptor', () => {
       },
     });
   });
+  it('records export download reason and target scope in audit metadata', (done) => {
+    mockReflector.get.mockReturnValue({
+      action: AuditAction.EXPORT_ORDERS,
+      resourceType: 'order',
+    });
+    const context = createMockExecutionContextWithQuery({
+      reason: '월말 정산 검증',
+      from: '2026-04-01',
+      to: '2026-04-30',
+      format: 'csv',
+      mask: 'true',
+    });
+    const handler = createMockCallHandler(null);
+
+    auditLogService.log.mockResolvedValue({ id: 1 } as never);
+
+    interceptor.intercept(context, handler).subscribe({
+      next: () => {
+        expect(auditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: AuditAction.EXPORT_ORDERS,
+            beforeJson: expect.objectContaining({
+              reason: '월말 정산 검증',
+              from: '2026-04-01',
+              to: '2026-04-30',
+              format: 'csv',
+              mask: 'true',
+            }),
+          }),
+        );
+        done();
+      },
+    });
+  });
+
 });

--- a/backend/src/common/interceptors/audit-log.interceptor.ts
+++ b/backend/src/common/interceptors/audit-log.interceptor.ts
@@ -50,6 +50,7 @@ export class AuditLogInterceptor implements NestInterceptor {
       const request = context.switchToHttp().getRequest<{
         user?: { id?: number; role?: string };
         body?: Record<string, unknown>;
+        query?: Record<string, unknown>;
         params?: Record<string, string>;
         ip?: string;
         headers?: Record<string, string | string[] | undefined>;
@@ -64,7 +65,10 @@ export class AuditLogInterceptor implements NestInterceptor {
 
       const resourceId = request.params?.id ? parseInt(request.params.id, 10) || null : null;
 
-      const beforeJson = error ? null : redactSensitiveFields(request.body ?? null);
+      const beforeJson = error ? null : redactSensitiveFields({
+        ...(request.query ?? {}),
+        ...(request.body ?? {}),
+      });
       const afterJson = error
         ? null
         : redactSensitiveFields(this.extractResponseData(responseBody));

--- a/backend/src/common/utils/redaction.util.spec.ts
+++ b/backend/src/common/utils/redaction.util.spec.ts
@@ -1,0 +1,45 @@
+import { redactSensitiveFields } from './redaction.util';
+
+describe('redactSensitiveFields', () => {
+  it('masks credentials, tokens, API keys, payment raw values, and excessive PII before storage', () => {
+    const result = redactSensitiveFields({
+      password: 'plain-password',
+      refreshToken: 'refresh-token',
+      apiKey: 'sk_live_secret',
+      payment: {
+        rawResponse: { cardNumber: '4111111111111111', cvv: '123' },
+        approvalNumber: 'A-123',
+      },
+      customer: {
+        email: 'buyer@example.com',
+        phone: '010-1234-5678',
+        address: '서울시 중구',
+        name: '홍길동',
+      },
+      items: [
+        { productName: '보이차', token: 'nested-token' },
+      ],
+      status: 'paid',
+    });
+
+    expect(result).toEqual({
+      password: '[REDACTED]',
+      refreshToken: '[REDACTED]',
+      apiKey: '[REDACTED]',
+      payment: {
+        rawResponse: '[REDACTED]',
+        approvalNumber: 'A-123',
+      },
+      customer: {
+        email: 'buyer@example.com',
+        phone: '[REDACTED]',
+        address: '[REDACTED]',
+        name: '홍길동',
+      },
+      items: [
+        { productName: '보이차', token: '[REDACTED]' },
+      ],
+      status: 'paid',
+    });
+  });
+});

--- a/backend/src/common/utils/redaction.util.ts
+++ b/backend/src/common/utils/redaction.util.ts
@@ -1,3 +1,5 @@
+export const REDACTED_VALUE = '[REDACTED]';
+
 export const SENSITIVE_FIELDS = [
   'password',
   'token',
@@ -13,25 +15,51 @@ export const SENSITIVE_FIELDS = [
   'cardno',
   'refreshtoken',
   'secret',
+  'api_key',
+  'apikey',
+  'apiKey',
+  'rawpayment',
+  'paymentraw',
+  'rawresponse',
+  'rawRequest',
+  'rawResponse',
   'ssn',
+  'residentregistrationnumber',
+  'rrn',
+  'birthdate',
   'phone',
   'address',
   'clientSecret',
 ];
 
+function normalizeField(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function isSensitiveField(key: string): boolean {
+  const normalized = normalizeField(key);
+  return SENSITIVE_FIELDS.some((field) => normalized.includes(normalizeField(field)));
+}
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item));
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    redacted[key] = isSensitiveField(key) ? REDACTED_VALUE : redactValue(nestedValue);
+  }
+  return redacted;
+}
+
 export function redactSensitiveFields<T extends Record<string, unknown>>(
   obj: T | null | undefined,
 ): T | null {
   if (!obj || typeof obj !== 'object') return null;
-  const redacted: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (SENSITIVE_FIELDS.some((f) => k.toLowerCase().includes(f))) {
-      redacted[k] = '[REDACTED]';
-    } else if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
-      redacted[k] = redactSensitiveFields(v as Record<string, unknown>);
-    } else {
-      redacted[k] = v;
-    }
-  }
-  return redacted as T;
+  return redactValue(obj) as T;
 }

--- a/backend/src/database/migrations/1783600000000-AddAuditLogRetentionPolicy.ts
+++ b/backend/src/database/migrations/1783600000000-AddAuditLogRetentionPolicy.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAuditLogRetentionPolicy1783600000000 implements MigrationInterface {
+  name = 'AddAuditLogRetentionPolicy1783600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.addColumnIfMissing(queryRunner, 'legalHold', '`legalHold` tinyint NOT NULL DEFAULT 0');
+    await this.addColumnIfMissing(queryRunner, 'legalHoldReason', '`legalHoldReason` varchar(500) NULL');
+    await this.addIndexIfMissing(
+      queryRunner,
+      'IDX_audit_logs_retention_cleanup',
+      'CREATE INDEX `IDX_audit_logs_retention_cleanup` ON `audit_logs` (`legalHold`, `createdAt`)',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await this.dropIndexIfExists(queryRunner, 'IDX_audit_logs_retention_cleanup');
+    await this.dropColumnIfExists(queryRunner, 'legalHoldReason');
+    await this.dropColumnIfExists(queryRunner, 'legalHold');
+  }
+
+  private async addColumnIfMissing(queryRunner: QueryRunner, columnName: string, columnSql: string): Promise<void> {
+    const [existing] = (await queryRunner.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'audit_logs' AND COLUMN_NAME = ?`,
+      [columnName],
+    )) as Array<{ COLUMN_NAME: string }>;
+    if (!existing) {
+      await queryRunner.query(`ALTER TABLE \`audit_logs\` ADD COLUMN ${columnSql}`);
+    }
+  }
+
+  private async dropColumnIfExists(queryRunner: QueryRunner, columnName: string): Promise<void> {
+    const [existing] = (await queryRunner.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'audit_logs' AND COLUMN_NAME = ?`,
+      [columnName],
+    )) as Array<{ COLUMN_NAME: string }>;
+    if (existing) {
+      await queryRunner.query(`ALTER TABLE \`audit_logs\` DROP COLUMN \`${columnName}\``);
+    }
+  }
+
+  private async addIndexIfMissing(queryRunner: QueryRunner, indexName: string, createSql: string): Promise<void> {
+    const [existing] = (await queryRunner.query(
+      `SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'audit_logs' AND INDEX_NAME = ?`,
+      [indexName],
+    )) as Array<{ INDEX_NAME: string }>;
+    if (!existing) {
+      await queryRunner.query(createSql);
+    }
+  }
+
+  private async dropIndexIfExists(queryRunner: QueryRunner, indexName: string): Promise<void> {
+    const [existing] = (await queryRunner.query(
+      `SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'audit_logs' AND INDEX_NAME = ?`,
+      [indexName],
+    )) as Array<{ INDEX_NAME: string }>;
+    if (existing) {
+      await queryRunner.query(`DROP INDEX \`${indexName}\` ON \`audit_logs\``);
+    }
+  }
+}

--- a/backend/src/modules/admin/dto/export-query.dto.ts
+++ b/backend/src/modules/admin/dto/export-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsIn } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsIn, MaxLength } from 'class-validator';
 
 export class ExportQueryDto {
   @ApiProperty({
@@ -28,4 +28,10 @@ export class ExportQueryDto {
   @IsString()
   @IsIn(['true', 'false'])
   mask?: string;
+
+  @ApiProperty({ example: '월말 정산 검증', description: '다운로드 사유(감사 로그 기록용)', required: true })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  reason?: string;
 }

--- a/backend/src/modules/audit-logs/__tests__/audit-log.controller.spec.ts
+++ b/backend/src/modules/audit-logs/__tests__/audit-log.controller.spec.ts
@@ -1,0 +1,26 @@
+import 'reflect-metadata';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext } from '@nestjs/common';
+import { AuditLogController } from '../audit-log.controller';
+import { ROLES_KEY } from '../../../common/decorators/roles.decorator';
+import { RolesGuard } from '../../../common/guards/roles.guard';
+
+describe('AuditLogController access policy', () => {
+  it('limits audit log lookup API to super_admin only', () => {
+    expect(Reflect.getMetadata(ROLES_KEY, AuditLogController)).toEqual(['super_admin']);
+  });
+
+  it('blocks regular admin from full audit log lookup', () => {
+    const reflector = new Reflector();
+    const guard = new RolesGuard(reflector);
+    const context = {
+      getHandler: () => AuditLogController.prototype.findAll,
+      getClass: () => AuditLogController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { id: 7, role: 'admin' } }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(context)).toBe(false);
+  });
+});

--- a/backend/src/modules/audit-logs/__tests__/audit-log.service.spec.ts
+++ b/backend/src/modules/audit-logs/__tests__/audit-log.service.spec.ts
@@ -11,6 +11,7 @@ describe('AuditLogService', () => {
     save: jest.fn(),
     findAndCount: jest.fn(),
     find: jest.fn(),
+    delete: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -61,6 +62,8 @@ describe('AuditLogService', () => {
         afterJson: { status: 'paid' },
         ip: '192.168.1.1',
         userAgent: 'Mozilla/5.0',
+        legalHold: false,
+        legalHoldReason: null,
       });
       expect(mockRepository.save).toHaveBeenCalledWith(mockEntry);
       expect(result).toEqual(mockEntry);
@@ -86,6 +89,30 @@ describe('AuditLogService', () => {
         expect.objectContaining({ resourceId: null }),
       );
       expect(result.resourceId).toBeNull();
+    });
+
+    it('masks sensitive fields before saving direct audit logs', async () => {
+      const dto: CreateAuditLogDto = {
+        actorId: 1,
+        actorRole: 'admin',
+        action: AuditAction.LOGIN_FAILURE,
+        resourceType: 'auth',
+        beforeJson: { email: 'admin@example.com', password: 'plain', nested: { apiKey: 'secret-key' } },
+        afterJson: { token: 'jwt', reason: 'invalid_password' },
+      };
+
+      const mockEntry = { id: 1, ...dto, createdAt: new Date() };
+      mockRepository.create.mockReturnValue(mockEntry as AuditLog);
+      mockRepository.save.mockResolvedValue(mockEntry as AuditLog);
+
+      await service.log(dto);
+
+      expect(mockRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          beforeJson: { email: 'admin@example.com', password: '[REDACTED]', nested: { apiKey: '[REDACTED]' } },
+          afterJson: { token: '[REDACTED]', reason: 'invalid_password' },
+        }),
+      );
     });
   });
 
@@ -206,6 +233,22 @@ describe('AuditLogService', () => {
         take: 20,
       });
       expect(result).toEqual({ data: mockLogs, total: 2 });
+    });
+  });
+
+
+  describe('retention cleanup', () => {
+    it('deletes logs older than 3 years while preserving legal holds', async () => {
+      mockRepository.delete.mockResolvedValue({ affected: 3 });
+      const now = new Date('2026-05-03T00:00:00.000Z');
+
+      const result = await service.purgeExpiredLogs(now);
+
+      expect(mockRepository.delete).toHaveBeenCalledWith({
+        createdAt: expect.any(Object),
+        legalHold: false,
+      });
+      expect(result).toEqual({ deleted: 3, cutoff: new Date('2023-05-03T00:00:00.000Z') });
     });
   });
 });

--- a/backend/src/modules/audit-logs/__tests__/redaction.util.spec.ts
+++ b/backend/src/modules/audit-logs/__tests__/redaction.util.spec.ts
@@ -55,10 +55,10 @@ describe('redactSensitiveFields', () => {
     expect(result).toEqual({ user_password: '[REDACTED]', password_hash: '[REDACTED]' });
   });
 
-  it('should not recurse into arrays', () => {
+  it('should recurse into arrays', () => {
     const input = { users: [{ name: 'John', password: 'secret' }] };
     const result = redactSensitiveFields(input);
-    expect(result).toEqual({ users: [{ name: 'John', password: 'secret' }] });
+    expect(result).toEqual({ users: [{ name: 'John', password: '[REDACTED]' }] });
   });
 
   it('should handle mixed sensitive and non-sensitive fields', () => {

--- a/backend/src/modules/audit-logs/audit-log.controller.ts
+++ b/backend/src/modules/audit-logs/audit-log.controller.ts
@@ -15,7 +15,7 @@ import { AuditLogQueryDto } from './dto/audit-log-query.dto';
 
 @ApiTags('관리자 - 감사 로그')
 @Controller('admin/audit-logs')
-@Roles('admin', 'super_admin')
+@Roles('super_admin')
 export class AuditLogController {
   constructor(private readonly auditLogService: AuditLogService) {}
 

--- a/backend/src/modules/audit-logs/audit-log.service.ts
+++ b/backend/src/modules/audit-logs/audit-log.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindOptionsWhere, Between, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
+import { Repository, FindOptionsWhere, Between, LessThanOrEqual, LessThan, MoreThanOrEqual } from 'typeorm';
 import { AuditLog, AuditAction } from './entities/audit-log.entity';
+import { redactSensitiveFields } from '../../common/utils/redaction.util';
 
 export interface AuditLogQuery {
   actorId?: number;
@@ -26,6 +28,8 @@ export interface CreateAuditLogDto {
   afterJson?: Record<string, unknown> | null;
   ip?: string | null;
   userAgent?: string | null;
+  legalHold?: boolean;
+  legalHoldReason?: string | null;
 }
 
 @Injectable()
@@ -44,10 +48,12 @@ export class AuditLogService {
       action: dto.action,
       resourceType: dto.resourceType,
       resourceId: dto.resourceId ?? null,
-      beforeJson: dto.beforeJson ?? null,
-      afterJson: dto.afterJson ?? null,
+      beforeJson: redactSensitiveFields(dto.beforeJson ?? null),
+      afterJson: redactSensitiveFields(dto.afterJson ?? null),
       ip: dto.ip ?? null,
       userAgent: dto.userAgent ?? null,
+      legalHold: dto.legalHold ?? false,
+      legalHoldReason: dto.legalHoldReason ?? null,
     });
     const saved = await this.auditLogRepository.save(entry);
     this.logger.log(`Audit log created: ${dto.action} by ${dto.actorId} on ${dto.resourceType}`);
@@ -103,5 +109,23 @@ export class AuditLogService {
       take: limit,
     });
     return { data, total };
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async purgeExpiredLogsJob(): Promise<void> {
+    const { deleted, cutoff } = await this.purgeExpiredLogs();
+    this.logger.log(`Audit log retention cleanup completed: deleted=${deleted}, cutoff=${cutoff.toISOString()}`);
+  }
+
+  async purgeExpiredLogs(now = new Date()): Promise<{ deleted: number; cutoff: Date }> {
+    const cutoff = new Date(now);
+    cutoff.setFullYear(cutoff.getFullYear() - 3);
+
+    const result = await this.auditLogRepository.delete({
+      createdAt: LessThan(cutoff),
+      legalHold: false,
+    });
+
+    return { deleted: result.affected ?? 0, cutoff };
   }
 }

--- a/backend/src/modules/audit-logs/entities/audit-log.entity.ts
+++ b/backend/src/modules/audit-logs/entities/audit-log.entity.ts
@@ -67,6 +67,12 @@ export class AuditLog {
   @Column({ type: 'varchar', length: 500, nullable: true })
   userAgent!: string | null;
 
+  @Column({ type: 'boolean', default: false })
+  legalHold!: boolean;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  legalHoldReason!: string | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 }

--- a/backend/test/suites/audit-logs.e2e-spec.ts
+++ b/backend/test/suites/audit-logs.e2e-spec.ts
@@ -18,11 +18,13 @@ export function registerAuditLogsSuite(getApp: () => INestApplication) {
   describe('Audit logs (e2e)', () => {
     const unique = Date.now();
     const adminEmail = `audit-admin-${unique}@test.com`;
+    const superAdminEmail = `audit-super-admin-${unique}@test.com`;
     const userEmail = `audit-user-${unique}@test.com`;
     const createdUserIds: number[] = [];
     const createdAuditLogIds: number[] = [];
 
     let adminCookies: string[];
+    let superAdminCookies: string[];
     let userCookies: string[];
     let adminUserId: number;
 
@@ -40,6 +42,15 @@ export function registerAuditLogsSuite(getApp: () => INestApplication) {
       adminUserId = Number(adminInsert.insertId);
       createdUserIds.push(adminUserId);
       adminCookies = buildAccessCookie(jwtService, adminUserId, adminEmail, 'admin');
+
+      const superAdminInsert = await dataSource.query(
+        `INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, is_email_verified, email_verified_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'super_admin', 1, 0, 1, NOW(), NOW(), NOW())`,
+        [superAdminEmail, passwordHash, '최고 관리자'],
+      );
+      const superAdminUserId = Number(superAdminInsert.insertId);
+      createdUserIds.push(superAdminUserId);
+      superAdminCookies = buildAccessCookie(jwtService, superAdminUserId, superAdminEmail, 'super_admin');
 
       const userInsert = await dataSource.query(
         `INSERT INTO users (email, password, name, role, is_active, failed_login_attempts, is_email_verified, email_verified_at, created_at, updated_at)
@@ -79,11 +90,11 @@ export function registerAuditLogsSuite(getApp: () => INestApplication) {
     });
 
     describe('GET /api/admin/audit-logs', () => {
-      it('관리자 → 200 감사 로그 목록과 페이지네이션 반환', async () => {
+      it('super_admin → 200 감사 로그 목록과 페이지네이션 반환', async () => {
         const res = await request(app.getHttpServer())
           .get('/api/admin/audit-logs')
           .query({ actorId: adminUserId, action: AuditAction.ORDER_STATUS_UPDATE, resourceType: 'order' })
-          .set('Cookie', adminCookies)
+          .set('Cookie', superAdminCookies)
           .expect(200);
 
         const body = res.body as {
@@ -103,6 +114,13 @@ export function registerAuditLogsSuite(getApp: () => INestApplication) {
         });
       });
 
+      it('일반 admin → 403', async () => {
+        await request(app.getHttpServer())
+          .get('/api/admin/audit-logs')
+          .set('Cookie', adminCookies)
+          .expect(403);
+      });
+
       it('일반 user → 403', async () => {
         await request(app.getHttpServer())
           .get('/api/admin/audit-logs')
@@ -120,7 +138,7 @@ export function registerAuditLogsSuite(getApp: () => INestApplication) {
         await request(app.getHttpServer())
           .get('/api/admin/audit-logs')
           .query({ action: 'NOT_A_REAL_ACTION' })
-          .set('Cookie', adminCookies)
+          .set('Cookie', superAdminCookies)
           .expect(400);
       });
     });


### PR DESCRIPTION
## Summary
- 감사 로그 조회 API를 super_admin 전용으로 제한하고 regular admin 403 검증을 추가했습니다.
- 감사 로그 저장 전 credential/token/API key/raw payment/PII 필드를 재귀 마스킹하도록 공통 redaction 유틸을 확장했습니다.
- export 로그에 다운로드 reason 및 query scope가 남도록 인터셉터/DTO를 보강했습니다.
- 3년 초과 감사 로그를 매일 삭제하되 legalHold 로그는 제외하는 엔티티/마이그레이션/배치 로직을 추가했습니다.

Closes #727

## Verification
- `bash scripts/setup-git-hooks.sh && make bootstrap`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd backend && npm test -- --runInBand`
- targeted audit/redaction Jest specs
- `bash scripts/test.sh e2e` reached and passed the audit-log e2e suite

## Known follow-up
- Full e2e suite did not finish cleanly because an unrelated wishlist e2e timed out after the audit-log suite passed.