### PR TITLE
Fix header language switching

### DIFF
--- a/src/components/__tests__/LanguageSelector.integration.test.tsx
+++ b/src/components/__tests__/LanguageSelector.integration.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import LanguageSelector from '@/components/shared/LanguageSelector';
+
+let mockLocale = 'ko';
+const replaceMock = vi.fn();
+let historyBackSpy: ReturnType<typeof vi.spyOn>;
+
+const translations: Record<string, string> = {
+  'header.languageSelector': '언어 선택',
+  'header.languageList': '언어 목록',
+};
+
+vi.mock('next-intl', () => ({
+  useLocale: () => mockLocale,
+  useTranslations: (namespace?: string) => (key: string) => {
+    const fullKey = namespace ? `${namespace}.${key}` : key;
+    return translations[fullKey] ?? fullKey;
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}));
+
+describe('LanguageSelector integration', () => {
+  beforeEach(() => {
+    mockLocale = 'ko';
+    replaceMock.mockClear();
+    historyBackSpy = vi.spyOn(window.history, 'back').mockImplementation(() => undefined);
+    window.history.replaceState({}, '', 'http://localhost:3000/ko?search=1');
+    document.cookie = 'NEXT_LOCALE=; max-age=0; path=/';
+  });
+
+  afterEach(() => {
+    historyBackSpy?.mockRestore();
+  });
+
+  it('keeps localized navigation when selecting a new language after opening from URL state', async () => {
+    const user = userEvent.setup();
+
+    render(<LanguageSelector />);
+
+    await user.click(screen.getByRole('button', { name: '언어 선택' }));
+    expect(window.location.search).toContain('language=1');
+    expect(screen.getByRole('listbox', { name: '언어 목록' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'English' }));
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith('/?search=1', { locale: 'en' });
+    });
+    expect(historyBackSpy).not.toHaveBeenCalled();
+    expect(document.cookie).toContain('NEXT_LOCALE=en');
+  });
+});

--- a/src/components/__tests__/LanguageSelector.test.tsx
+++ b/src/components/__tests__/LanguageSelector.test.tsx
@@ -32,7 +32,7 @@ vi.mock('next-intl', () => ({
   },
 }));
 
-vi.mock('next/navigation', () => ({
+vi.mock('@/i18n/navigation', () => ({
   useRouter: () => ({
     replace: replaceMock,
   }),
@@ -73,22 +73,22 @@ describe('LanguageSelector', () => {
     expect(screen.queryByText('中文')).not.toBeInTheDocument();
   });
 
-  it('selecting a different language navigates to the localized path and closes dropdown', async () => {
+  it('selecting a different language navigates to the same internal path with locale option and closes dropdown', async () => {
     const user = userEvent.setup();
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
     await user.click(screen.getByText('English'));
-    expect(replaceMock).toHaveBeenCalledWith('/en');
+    expect(replaceMock).toHaveBeenCalledWith('/', { locale: 'en' });
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
-  it('keeps the current pathname when switching language', async () => {
+  it('keeps the current internal pathname and hash when switching language', async () => {
     window.history.replaceState({}, '', 'http://localhost:3000/ko/products/123?language=1#details');
     const user = userEvent.setup();
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
     await user.click(screen.getByText('English'));
-    expect(replaceMock).toHaveBeenCalledWith('/en/products/123#details');
+    expect(replaceMock).toHaveBeenCalledWith('/products/123#details', { locale: 'en' });
   });
 
   it('selecting current locale does not navigate', async () => {
@@ -153,7 +153,7 @@ describe('LanguageSelector', () => {
     const user = userEvent.setup();
     render(<LanguageSelector variant="inline" />);
     await user.click(screen.getByRole('button', { name: 'English' }));
-    expect(replaceMock).toHaveBeenCalledWith('/en');
+    expect(replaceMock).toHaveBeenCalledWith('/', { locale: 'en' });
   });
 
   it('inline variant does not navigate when clicking current locale', async () => {

--- a/src/components/shared/LanguageSelector.tsx
+++ b/src/components/shared/LanguageSelector.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect, useTransition } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { Globe } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import { useUrlModal } from '@/hooks/useUrlModal';
@@ -31,27 +31,30 @@ interface LanguageSelectorProps {
   variant?: 'dropdown' | 'inline';
 }
 
-function getLocalizedHref(nextLocale: Locale): string {
-  if (typeof window === 'undefined') return `/${nextLocale}`;
+function getInternalHref(): string {
+  if (typeof window === 'undefined') return '/';
 
   const url = new URL(window.location.href);
   const segments = url.pathname.split('/').filter(Boolean);
 
   if (segments.length > 0 && routing.locales.includes(segments[0] as Locale)) {
-    segments[0] = nextLocale;
-  } else {
-    segments.unshift(nextLocale);
+    segments.shift();
   }
 
-  url.pathname = `/${segments.join('/')}`;
+  const pathname = `/${segments.join('/')}`;
+  url.pathname = pathname;
   url.searchParams.delete('language');
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
-function switchLocale(locale: Locale, currentLocale: Locale, onNavigate: (href: string) => void) {
+function switchLocale(
+  locale: Locale,
+  currentLocale: Locale,
+  onNavigate: (href: string, options: { locale: Locale }) => void,
+) {
   if (locale === currentLocale) return;
   document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
-  onNavigate(getLocalizedHref(locale));
+  onNavigate(getInternalHref(), { locale });
 }
 
 /** 모바일 사이드바용 — 세그먼트 버튼, 드롭다운 없음 */
@@ -73,7 +76,7 @@ function InlineLanguageSelector({ className }: { className?: string }) {
               type="button"
               onClick={() => {
                 startTransition(() => {
-                  switchLocale(option.locale, currentLocale, (href) => router.replace(href));
+                  switchLocale(option.locale, currentLocale, (href, options) => router.replace(href, options));
                 });
               }}
               aria-pressed={isSelected}
@@ -107,9 +110,9 @@ function DropdownLanguageSelector({ className, compact = false }: { className?: 
   const current = LANG_OPTIONS.find((o) => o.locale === currentLocale) ?? LANG_OPTIONS[0];
 
   const handleSelect = (locale: Locale) => {
-    setIsOpen(false);
+    setIsOpen(false, 'replace');
     startTransition(() => {
-      switchLocale(locale, currentLocale, (href) => router.replace(href));
+      switchLocale(locale, currentLocale, (href, options) => router.replace(href, options));
     });
   };
 


### PR DESCRIPTION
## Summary
- Use the next-intl navigation wrapper for language changes so locale is passed via router options.
- Close the language dropdown with URL replacement instead of history.back before locale navigation.
- Add integration coverage for URL-backed dropdown state, cookie update, and avoiding history.back during locale switch.

## Verification
- npm test -- --run src/components/__tests__/LanguageSelector.integration.test.tsx src/components/__tests__/LanguageSelector.test.tsx
- npm test -- --run src/components/__tests__/LanguageSelector.integration.test.tsx src/components/__tests__/LanguageSelector.test.tsx src/hooks/useUrlModal.test.ts
- npm run build

Note: build reports the existing ESLint minimatch default-export warning, but completed successfully.