### PR TITLE
Render collection description emphasis

### DIFF
--- a/src/app/[locale]/collection/page.tsx
+++ b/src/app/[locale]/collection/page.tsx
@@ -5,6 +5,7 @@ import { getTranslations } from 'next-intl/server';
 import { fetchCollections } from '@/lib/api-server';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { SectionHeading } from '@/components/shared/common/SectionHeading';
+import { sanitizeInlineHtml } from '@/lib/sanitize-inline-html';
 import type { Collection } from '@/lib/api';
 
 interface CollectionPageProps {
@@ -22,6 +23,19 @@ export async function generateMetadata({ params }: CollectionPageProps): Promise
       description: t('metaOgDescription'),
     },
   };
+}
+
+function CollectionDescription({ description }: { description: string | null }) {
+  const sanitized = sanitizeInlineHtml(description);
+
+  if (!sanitized) return null;
+
+  return (
+    <div
+      className="text-sm text-muted-foreground leading-relaxed [&_b]:font-semibold [&_strong]:font-semibold [&_b]:text-foreground [&_strong]:text-foreground"
+      dangerouslySetInnerHTML={{ __html: sanitized }}
+    />
+  );
 }
 
 function ClayCard({
@@ -59,9 +73,7 @@ function ClayCard({
         <h3 className="text-lg font-bold text-foreground mb-1">
           {displayName}
         </h3>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          {collection.description}
-        </p>
+        <CollectionDescription description={collection.description} />
         <span className="inline-block mt-4 text-xs font-medium text-foreground border-b border-foreground pb-0.5 group-hover:border-foreground/60 transition-colors">
           {cta}
         </span>
@@ -103,9 +115,7 @@ function ShapeCard({
         <h3 className="text-lg font-bold text-foreground mb-1">
           {collection.name}
         </h3>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          {collection.description}
-        </p>
+        <CollectionDescription description={collection.description} />
         <span className="inline-block mt-4 text-xs font-medium text-foreground border-b border-foreground pb-0.5 group-hover:border-foreground/60 transition-colors">
           {cta}
         </span>

--- a/src/lib/__tests__/sanitize-inline-html.test.ts
+++ b/src/lib/__tests__/sanitize-inline-html.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeInlineHtml } from '@/lib/sanitize-inline-html';
+
+describe('sanitizeInlineHtml', () => {
+  it('keeps simple emphasis tags for admin-authored inline copy', () => {
+    expect(sanitizeInlineHtml('주철질의 <b>대표 니료</b>입니다.')).toBe(
+      '주철질의 <b>대표 니료</b>입니다.',
+    );
+  });
+
+  it('removes scripts, event handlers, and unsupported tags', () => {
+    const sanitized = sanitizeInlineHtml(
+      '<img src=x onerror=alert(1)>안전한 <strong onclick="alert(1)">강조</strong><script>alert(1)</script>',
+    );
+
+    expect(sanitized).toBe('안전한 <strong>강조</strong>');
+  });
+});

--- a/src/lib/sanitize-inline-html.ts
+++ b/src/lib/sanitize-inline-html.ts
@@ -1,0 +1,43 @@
+const INLINE_CONTENT_TAGS = new Set(['b', 'strong', 'em', 'i', 'br', 'p', 'span']);
+const RAW_TEXT_TAG_PATTERN = /<(script|style|iframe|object|embed|svg|math)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const HTML_TAG_PATTERN = /<\/?([a-zA-Z][\w:-]*)(?:\s[^<>]*)?\/?\s*>/g;
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function sanitizeInlineHtml(html: string | null | undefined): string {
+  if (!html) return '';
+
+  const withoutRawTextBlocks = html.replace(RAW_TEXT_TAG_PATTERN, '');
+  let sanitized = '';
+  let cursor = 0;
+
+  for (const match of withoutRawTextBlocks.matchAll(HTML_TAG_PATTERN)) {
+    const [rawTag, rawName] = match;
+    const index = match.index ?? 0;
+
+    sanitized += escapeHtml(withoutRawTextBlocks.slice(cursor, index));
+
+    const tagName = rawName.toLowerCase();
+    if (INLINE_CONTENT_TAGS.has(tagName)) {
+      if (tagName === 'br') {
+        sanitized += '<br>';
+      } else if (rawTag.startsWith('</')) {
+        sanitized += `</${tagName}>`;
+      } else {
+        sanitized += `<${tagName}>`;
+      }
+    }
+
+    cursor = index + rawTag.length;
+  }
+
+  sanitized += escapeHtml(withoutRawTextBlocks.slice(cursor));
+  return sanitized;
+}


### PR DESCRIPTION
## Summary
- Render collection card descriptions through a small sanitized inline-HTML subset.
- Preserve simple emphasis tags like `<b>`/`<strong>` so admin-authored copy displays bold instead of literal tags.
- Strip unsupported tags, scripts, and attributes before using `dangerouslySetInnerHTML`.

## Verification
- npm test -- --run src/lib/__tests__/sanitize-inline-html.test.ts
- npm run build