### PR TITLE
fix: #755 상품상세 문의 탭 무한 렌더 루프 차단

### DIFF
--- a/src/components/shared/hooks/__tests__/useAsyncAction.test.tsx
+++ b/src/components/shared/hooks/__tests__/useAsyncAction.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { ReactNode } from 'react';
-import { GlobalLoadingProvider } from '@/contexts/GlobalLoadingContext';
+import { GlobalLoadingProvider, useGlobalLoading } from '@/contexts/GlobalLoadingContext';
 import { useAsyncAction } from '../useAsyncAction';
 
 vi.mock('sonner', () => ({
@@ -133,5 +133,41 @@ describe('useAsyncAction', () => {
     });
 
     expect(fn).toHaveBeenCalledWith({ id: 7 });
+  });
+
+  // 회귀 가드 (#755): execute reference 가 GlobalLoadingContext 의 pendingCount
+  // 변화에도 안정적이어야 한다. GlobalLoadingContext 가 pendingCount 변화에
+  // 따라 startLoading/stopLoading 함수를 새로 만들면 execute reference 가 변하고,
+  // 이를 effect deps 로 쓰는 컴포넌트(예: ProductTabs)에서 무한 렌더 루프 발생.
+  it('execute reference 는 GlobalLoading 활동 후에도 안정적이다 (#755 무한 루프 방지)', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    // 같은 Provider 안에서 두 훅을 함께 렌더 — 외부 startLoading 호출이
+    // pendingCount 를 흔들어도 execute reference 가 보존되는지 검증.
+    const { result } = renderHook(
+      () => {
+        const action = useAsyncAction(fn);
+        const loading = useGlobalLoading();
+        return { action, loading };
+      },
+      { wrapper },
+    );
+
+    const initialExecute = result.current.action.execute;
+
+    await act(async () => {
+      await result.current.action.execute(undefined);
+    });
+
+    expect(result.current.action.execute).toBe(initialExecute);
+
+    act(() => {
+      result.current.loading.startLoading();
+    });
+    act(() => {
+      result.current.loading.stopLoading();
+    });
+
+    expect(result.current.action.execute).toBe(initialExecute);
   });
 });

--- a/src/components/shared/hooks/useAsyncAction.ts
+++ b/src/components/shared/hooks/useAsyncAction.ts
@@ -22,10 +22,16 @@ export function useAsyncAction<T, A = void>(
   fnRef.current = fn;
   const optRef = useRef(options);
   optRef.current = options;
+  // 외부 컨텍스트(GlobalLoadingContext) 의 함수 reference 가 흔들려도 execute 가
+  // 매 렌더 새 reference 가 되어 useEffect deps 무한 루프를 유발하지 않도록 ref 로 격리.
+  const startLoadingRef = useRef(startLoading);
+  startLoadingRef.current = startLoading;
+  const stopLoadingRef = useRef(stopLoading);
+  stopLoadingRef.current = stopLoading;
 
   const execute = useCallback(async (arg: A) => {
     setIsLoading(true);
-    startLoading();
+    startLoadingRef.current();
     try {
       const result = await fnRef.current(arg);
       if (optRef.current.successMessage) {
@@ -40,9 +46,9 @@ export function useAsyncAction<T, A = void>(
       throw err;
     } finally {
       setIsLoading(false);
-      stopLoading();
+      stopLoadingRef.current();
     }
-  }, [startLoading, stopLoading]);
+  }, []);
 
   return { execute, isLoading };
 }

--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -86,8 +86,18 @@ export default function ProductTabs({ description, descriptionImages, productId,
     })
   }, [description])
 
+  // 한 세션 동안 같은 (사용자, 탭 진입) 조건에서 중복 호출을 막는 가드.
+  // GlobalLoadingContext / useAsyncAction 의 reference 안정화로도 방어되지만,
+  // 향후 다른 외부 컨텍스트가 흔들릴 가능성에 대비한 다층 방어.
+  const inquiriesLoadedRef = useRef(false)
   useEffect(() => {
-    if (activeTab !== 'inquiry' || !isAuthenticated) return
+    if (!isAuthenticated) {
+      inquiriesLoadedRef.current = false
+      return
+    }
+    if (activeTab !== 'inquiry') return
+    if (inquiriesLoadedRef.current) return
+    inquiriesLoadedRef.current = true
     void loadInquiries(undefined)
   }, [activeTab, isAuthenticated, loadInquiries])
 

--- a/src/contexts/GlobalLoadingContext.tsx
+++ b/src/contexts/GlobalLoadingContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { GLOBAL_LOADING_END_EVENT, GLOBAL_LOADING_START_EVENT } from '@/constants/global-loading';
 
 interface GlobalLoadingContextValue {
@@ -39,12 +39,20 @@ export function GlobalLoadingProvider({ children }: GlobalLoadingProviderProps) 
     };
   }, []);
 
+  const startLoading = useCallback(() => {
+    setPendingCount((prev) => prev + 1);
+  }, []);
+
+  const stopLoading = useCallback(() => {
+    setPendingCount((prev) => Math.max(0, prev - 1));
+  }, []);
+
   const value = useMemo<GlobalLoadingContextValue>(() => ({
     pendingCount,
     isLoading: pendingCount > 0,
-    startLoading: () => setPendingCount((prev) => prev + 1),
-    stopLoading: () => setPendingCount((prev) => Math.max(0, prev - 1)),
-  }), [pendingCount]);
+    startLoading,
+    stopLoading,
+  }), [pendingCount, startLoading, stopLoading]);
 
   return <GlobalLoadingContext.Provider value={value}>{children}</GlobalLoadingContext.Provider>;
 }

--- a/src/contexts/__tests__/GlobalLoadingContext.test.tsx
+++ b/src/contexts/__tests__/GlobalLoadingContext.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { GlobalLoadingProvider, useGlobalLoading } from '../GlobalLoadingContext';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <GlobalLoadingProvider>{children}</GlobalLoadingProvider>;
+}
+
+describe('GlobalLoadingContext', () => {
+  it('startLoading 호출 시 pendingCount 와 isLoading 이 업데이트된다', () => {
+    const { result } = renderHook(() => useGlobalLoading(), { wrapper });
+
+    expect(result.current.pendingCount).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+
+    act(() => {
+      result.current.startLoading();
+    });
+
+    expect(result.current.pendingCount).toBe(1);
+    expect(result.current.isLoading).toBe(true);
+
+    act(() => {
+      result.current.stopLoading();
+    });
+
+    expect(result.current.pendingCount).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('stopLoading 은 pendingCount 를 0 미만으로 내리지 않는다', () => {
+    const { result } = renderHook(() => useGlobalLoading(), { wrapper });
+
+    act(() => {
+      result.current.stopLoading();
+      result.current.stopLoading();
+    });
+
+    expect(result.current.pendingCount).toBe(0);
+  });
+
+  // 회귀 가드 (#755): startLoading / stopLoading reference 는 pendingCount 변화에
+  // 영향받지 않아야 한다. 함수 reference 가 매 렌더 새로 만들어지면 이를
+  // useCallback deps 로 쓰는 useAsyncAction 의 execute 도 매번 새 reference 가 되고,
+  // 이를 useEffect deps 로 쓰는 컴포넌트는 무한 렌더 루프에 빠진다.
+  it('startLoading / stopLoading reference 는 호출 후에도 동일하다 (#755 무한 루프 방지)', () => {
+    const { result } = renderHook(() => useGlobalLoading(), { wrapper });
+
+    const initialStart = result.current.startLoading;
+    const initialStop = result.current.stopLoading;
+
+    act(() => {
+      result.current.startLoading();
+    });
+
+    expect(result.current.startLoading).toBe(initialStart);
+    expect(result.current.stopLoading).toBe(initialStop);
+
+    act(() => {
+      result.current.stopLoading();
+    });
+
+    expect(result.current.startLoading).toBe(initialStart);
+    expect(result.current.stopLoading).toBe(initialStop);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #755

상품 상세 페이지의 **문의** 탭 클릭 시 `GET /api/inquiries` 가 수천 회 무한 반복 호출되어 `ERR_INSUFFICIENT_RESOURCES` + `429` 가 발생하던 P0 버그를 수정.

## Root cause

세 파일이 결합한 React 렌더 무한 루프:

1. `GlobalLoadingContext.tsx`: `value` `useMemo` deps 가 `[pendingCount]` 라서 `pendingCount` 가 변할 때마다 `startLoading`/`stopLoading` 함수 reference 가 매번 새로 생성됨.
2. `useAsyncAction.ts`: `execute` `useCallback` deps 가 `[startLoading, stopLoading]` 이라 위 1번 때문에 `execute` 도 매 렌더 새 reference.
3. `ProductTabs.tsx`: `useEffect` deps 가 `[..., loadInquiries]` 이라 `loadInquiries(=execute)` 가 변할 때마다 effect 재실행 → 다시 fetch → `setPendingCount` → 1번 재현 → ... 무한 반복.

## Changes

### 1. `src/contexts/GlobalLoadingContext.tsx` (root cause)

`startLoading`/`stopLoading` 을 `useCallback(..., [])` 로 안정화.

### 2. `src/components/shared/hooks/useAsyncAction.ts` (방어 보강)

외부 컨텍스트 함수를 `useRef` 에 격리하고 `execute` 의 `useCallback` deps 를 `[]` 로 변경. 향후 다른 컨텍스트 reference 가 또 흔들려도 무한 루프 재현 차단.

### 3. `src/components/shared/products/ProductTabs.tsx` (방어 보강)

`inquiriesLoadedRef` 가드로 진입당 1회만 `loadInquiries` 호출. 인증 상태가 풀리면 가드 reset.

### 4. 회귀 가드 테스트 2건

- `src/contexts/__tests__/GlobalLoadingContext.test.tsx` (새 파일): `startLoading`/`stopLoading` reference 안정성 검증.
- `src/components/shared/hooks/__tests__/useAsyncAction.test.tsx`: pendingCount 변화 후에도 `execute` reference 가 보존되는지 검증.

테스트는 RED→GREEN 으로 작성: 수정 전 두 테스트 모두 실패하는 것을 먼저 확인 후 구현.

## Test plan

- [x] `npm run lint` (frontend)
- [x] `npm run build` (frontend)
- [x] `npm run test:run` (frontend) — 660 passed (109 files)
- [x] `cd backend && npm run lint`
- [x] `cd backend && npm run build`
- [x] `cd backend && npm run test` — 1010 passed (102 suites)

## 영향 범위 — 다른 컴포넌트도 함께 치료됨

`useAsyncAction` + `useGlobalLoading` 패턴을 effect deps 에 사용하는 **모든 컴포넌트** 가 동일한 잠재 루프에서 함께 해방됨. 1번 수정만으로도 광범위 효과.