### PR TITLE
chore: Clarify OMX skill routing boundaries

### DIFF
--- a/.codex/skills/autopilot/SKILL.md
+++ b/.codex/skills/autopilot/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autopilot
 description: "[OMX] Full autonomous execution from idea to working code"
+runtime: true
 ---
 
 <Purpose>

--- a/.codex/skills/autoresearch/SKILL.md
+++ b/.codex/skills/autoresearch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autoresearch
 description: "[OMX] Stateful validator-gated research loop with native-hook persistence"
+runtime: true
 ---
 
 # Autoresearch

--- a/.codex/skills/cancel/SKILL.md
+++ b/.codex/skills/cancel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cancel
 description: "[OMX] Cancel any active OMX mode (autopilot, ralph, ultrawork, ecomode, ultraqa, swarm, ultrapilot, pipeline, team)"
+runtime: true
 ---
 
 # Cancel Skill

--- a/.codex/skills/hud/SKILL.md
+++ b/.codex/skills/hud/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: "hud"
 description: "[OMX] Show or configure the OMX HUD (two-layer statusline)"
+runtime: true
 role: "display"
 scope: ".omx/**"
 ---

--- a/.codex/skills/ralph/SKILL.md
+++ b/.codex/skills/ralph/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ralph
 description: "[OMX] Self-referential loop until task completion with architect verification"
+runtime: true
 ---
 
 [RALPH + ULTRAWORK - ITERATION {{ITERATION}}/{{MAX}}]

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -1,11 +1,13 @@
 ---
-name: ship
-description: End-to-end issue delivery workflow for this repository using Codex/OMX conventions.
+name: project-ship
+description: Project-specific end-to-end issue delivery workflow for okhwadang using Codex/OMX conventions. Use `$project-ship` when this repository's GitHub issue workflow should override the user-level `$ship` skill.
 ---
 
-# Ship
+# Project Ship
 
-Use this skill when the user wants a GitHub issue taken from implementation through verification, PR, and merge workflow.
+Use `$project-ship` when the user wants an okhwadang GitHub issue taken from implementation through verification, PR, and merge workflow.
+
+This project-local skill intentionally avoids the generic `ship` name because a user-level `$ship` skill also exists. Keep the names distinct so skill routing is deterministic.
 
 ## Scope
 

--- a/.codex/skills/team/SKILL.md
+++ b/.codex/skills/team/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: team
 description: "[OMX] N coordinated agents on shared task list using tmux-based orchestration"
+runtime: true
 ---
 
 # Team Skill

--- a/.codex/skills/ultraqa/SKILL.md
+++ b/.codex/skills/ultraqa/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ultraqa
 description: "[OMX] QA cycling workflow - test, verify, fix, repeat until goal met"
+runtime: true
 ---
 
 # UltraQA Skill

--- a/.codex/skills/ultrawork/SKILL.md
+++ b/.codex/skills/ultrawork/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ultrawork
 description: "[OMX] Parallel execution engine for high-throughput task completion"
+runtime: true
 ---
 
 <Purpose>

--- a/.codex/skills/worker/SKILL.md
+++ b/.codex/skills/worker/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: worker
 description: "[OMX] Team worker protocol (ACK, mailbox, task lifecycle) for tmux-based OMX teams"
+runtime: true
 ---
 
 # Worker Skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,7 @@ Rules:
 - `$name` — invoke a workflow skill
 - `/skills` — browse available skills
 - Prefer skill invocation and keyword routing as the primary user-facing workflow surface
+- Use `$project-ship` for this repository's issue delivery workflow. The generic `$ship` name is reserved for the user-level skill to avoid project/user skill collisions.
 </invocation_conventions>
 
 <model_routing>
@@ -254,7 +255,7 @@ Specialists remain available through the role catalog and native child-agent sur
 When the user message contains a mapped keyword, activate the corresponding skill immediately.
 Do not ask for confirmation.
 
-Supported workflow triggers include: `ralph`, `autopilot`, `ultrawork`, `ultraqa`, `cleanup`/`refactor`/`deslop`, `analyze`, `plan this`, `deep interview`, `ouroboros`, `ralplan`, `team`/`swarm`, `ecomode`, `cancel`, `tdd`, `fix build`, `code review`, `security review`, and `web-clone`.
+Keyword routing is implemented primarily by native `UserPromptSubmit` hooks and the generated OMX keyword registry shipped with oh-my-codex; do not duplicate that table here. This application repo's `src/hooks/` directory is for frontend React hooks, not OMX prompt-routing hooks.
 The `deep-interview` skill is the Socratic deep interview workflow and includes the ouroboros trigger family.
 
 | Keyword(s) | Skill | Action |
@@ -263,6 +264,7 @@ Runtime availability gate:
 - Treat `autopilot`, `ralph`, `ultrawork`, `ultraqa`, `team`/`swarm`, and `ecomode` as **OMX runtime workflows**, not generic prompt aliases.
 - Auto-activate those runtime workflows only when the current session is actually running under OMX CLI/runtime (for example, launched via `omx`, with OMX session overlay/runtime state available, or when the user explicitly asks to run `omx ...` in the shell).
 - In Codex App or plain Codex sessions without OMX runtime, do **not** treat those keywords alone as activation. Explain that they require OMX CLI runtime support, and continue with the nearest App-safe surface (`deep-interview`, `ralplan`, `plan`, or native subagents) unless the user explicitly wants you to launch OMX from the shell.
+- Runtime-only skills should declare `runtime: true` in their `SKILL.md` frontmatter. Non-runtime surfaces may be loaded in plain Codex/App sessions, but runtime-only surfaces must pass the availability gate above before activation.
 
 | Keyword(s) | Skill | Action |
 |-------------|-------|--------|
@@ -464,6 +466,8 @@ Do not cancel while recoverable work remains.
 ---
 
 <state_management>
+Hooks own normal skill-active and workflow-state persistence under `.omx/state/`.
+
 OMX persists runtime state under `.omx/`:
 - `.omx/state/` — mode state
 - `.omx/notepad.md` — session notes
@@ -478,7 +482,14 @@ Mode lifecycle requirements:
 - Update state on phase or iteration change.
 - Mark inactive with `completed_at` on completion.
 - Clear state on cancel/abort cleanup.
+- SessionStart cleanup should prune inactive `skill-active-state.json` entries whose `active_skills` list is empty, and stale entries for skills no longer installed.
 </state_management>
+
+<generated_surface_ownership>
+`.codex/agents/*.toml` is the source of truth for native child-agent role contracts.
+`.codex/prompts/*.md` is a generated compatibility surface for prompt-style invocation.
+When changing a role contract, update the agent TOML first and regenerate or synchronize the matching prompt file; do not hand-edit only one side.
+</generated_surface_ownership>
 
 ---
 

--- a/scripts/prune-omx-state.mjs
+++ b/scripts/prune-omx-state.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const write = process.argv.includes('--write');
+const root = process.cwd();
+const stateRoot = path.join(root, '.omx', 'state');
+const now = new Date().toISOString();
+const staleMs = Number.parseInt(process.env.OMX_STATE_PRUNE_STALE_MS ?? `${24 * 60 * 60 * 1000}`, 10);
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function collectSkillStateFiles() {
+  const files = [path.join(stateRoot, 'skill-active-state.json')];
+  const sessionsDir = path.join(stateRoot, 'sessions');
+
+  if (!(await fileExists(sessionsDir))) {
+    return files;
+  }
+
+  const sessionEntries = await fs.readdir(sessionsDir, { withFileTypes: true });
+  for (const entry of sessionEntries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    files.push(path.join(sessionsDir, entry.name, 'skill-active-state.json'));
+  }
+
+  return files;
+}
+
+async function collectInstalledSkillNames() {
+  const names = new Set();
+  const roots = [
+    path.join(root, '.codex', 'skills'),
+    path.join(process.env.HOME ?? '', '.codex', 'skills'),
+  ];
+
+  for (const skillsRoot of roots) {
+    if (!skillsRoot || !(await fileExists(skillsRoot))) {
+      continue;
+    }
+
+    const entries = await fs.readdir(skillsRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const skillFile = path.join(skillsRoot, entry.name, 'SKILL.md');
+      if (!(await fileExists(skillFile))) {
+        continue;
+      }
+
+      const raw = await fs.readFile(skillFile, 'utf8');
+      const match = raw.match(/^name:\s*"?([^"\n]+)"?\s*$/m);
+      if (match) {
+        names.add(match[1].trim());
+      }
+    }
+  }
+
+  return names;
+}
+
+function isOlderThanStaleWindow(value) {
+  const timestamp = Date.parse(String(value ?? ''));
+  return Number.isFinite(timestamp) && Date.now() - timestamp > staleMs;
+}
+
+function shouldPruneSkillState(state) {
+  if (!state || typeof state !== 'object') {
+    return false;
+  }
+
+  const activeSkills = Array.isArray(state.active_skills) ? state.active_skills : [];
+  return state.active === false
+    && activeSkills.length === 0
+    && Boolean(state.skill || state.keyword || (state.phase && state.phase !== 'inactive'));
+}
+
+function shouldPruneUnknownStaleSkillState(state, installedSkills) {
+  if (!state || typeof state !== 'object' || state.active !== true) {
+    return false;
+  }
+
+  const activeSkills = Array.isArray(state.active_skills) ? state.active_skills : [];
+  const stateSkill = typeof state.skill === 'string' ? state.skill : '';
+  const skillNames = activeSkills
+    .map((entry) => (entry && typeof entry.skill === 'string' ? entry.skill : ''))
+    .filter(Boolean);
+  const names = new Set([stateSkill, ...skillNames].filter(Boolean));
+
+  if (names.size === 0 || [...names].some((name) => installedSkills.has(name))) {
+    return false;
+  }
+
+  const updatedAt = state.updated_at ?? activeSkills[0]?.updated_at;
+  return isOlderThanStaleWindow(updatedAt);
+}
+
+function prunedSkillState(state) {
+  return {
+    version: state.version ?? 1,
+    active: false,
+    phase: 'inactive',
+    updated_at: now,
+    source: 'prune-omx-state',
+    active_skills: [],
+  };
+}
+
+let pruned = 0;
+let checked = 0;
+const installedSkills = await collectInstalledSkillNames();
+
+for (const filePath of await collectSkillStateFiles()) {
+  if (!(await fileExists(filePath))) {
+    continue;
+  }
+
+  checked += 1;
+  const raw = await fs.readFile(filePath, 'utf8');
+  const state = JSON.parse(raw);
+
+  if (!shouldPruneSkillState(state) && !shouldPruneUnknownStaleSkillState(state, installedSkills)) {
+    continue;
+  }
+
+  pruned += 1;
+  if (write) {
+    await fs.writeFile(filePath, `${JSON.stringify(prunedSkillState(state), null, 2)}\n`);
+  }
+}
+
+console.log(JSON.stringify({ checked, pruned, write }));

--- a/scripts/run-omx-script.sh
+++ b/scripts/run-omx-script.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_path="${1:?usage: run-omx-script.sh <dist-relative-script> [args...]}"
+shift || true
+
+if [[ "$script_path" == /* || "$script_path" == *".."* ]]; then
+  echo "Refusing unsafe OMX script path: $script_path" >&2
+  exit 64
+fi
+
+node_bin="${NODE_BIN:-}"
+if [[ -z "$node_bin" ]]; then
+  node_bin="$(command -v node || true)"
+fi
+
+if [[ -z "$node_bin" ]]; then
+  echo "Unable to find node. Set NODE_BIN to the Node executable used by oh-my-codex." >&2
+  exit 127
+fi
+
+candidates=()
+
+if [[ -n "${OMX_DIST_DIR:-}" ]]; then
+  candidates+=("$OMX_DIST_DIR")
+fi
+
+if command -v npm >/dev/null 2>&1; then
+  npm_root="$(npm root -g 2>/dev/null || true)"
+  if [[ -n "$npm_root" ]]; then
+    candidates+=("$npm_root/oh-my-codex/dist")
+  fi
+fi
+
+if command -v omx >/dev/null 2>&1; then
+  omx_bin="$(command -v omx)"
+  candidates+=("$(cd "$(dirname "$omx_bin")/../lib/node_modules/oh-my-codex/dist" 2>/dev/null && pwd || true)")
+fi
+
+for version_dir in "$HOME"/.nvm/versions/node/*; do
+  candidates+=("$version_dir/lib/node_modules/oh-my-codex/dist")
+done
+
+candidates+=(
+  "/opt/homebrew/lib/node_modules/oh-my-codex/dist"
+  "/usr/local/lib/node_modules/oh-my-codex/dist"
+)
+
+for dist_dir in "${candidates[@]}"; do
+  [[ -n "$dist_dir" ]] || continue
+  target="$dist_dir/$script_path"
+  if [[ -f "$target" ]]; then
+    if [[ "${OMX_SCRIPT_DRY_RUN:-}" == "1" ]]; then
+      printf '%s\n' "$target"
+      exit 0
+    fi
+    exec "$node_bin" "$target" "$@"
+  fi
+done
+
+echo "Unable to locate oh-my-codex dist script: $script_path" >&2
+echo "Set OMX_DIST_DIR to the oh-my-codex dist directory if it is installed in a custom location." >&2
+exit 127


### PR DESCRIPTION
## Summary

로컬에서 분기되어 있던 `cad4e585` 커밋을 별도 브랜치로 분리하여 PR 생성.

원 커밋 메시지 (FLYLIKEB, 4월 24일):

> The project-level ship workflow collided with a user-level ship skill, and runtime-only OMX skills were indistinguishable from plain Codex/App-safe skills. This records deterministic routing names, marks runtime surfaces explicitly, and adds small helper scripts for resolving installed OMX dist scripts and pruning stale skill state.
>
> Constraint: .codex/config.toml and .codex/hooks.json are intentionally gitignored local runtime files, so their local wrapper wiring is not committed.
>
> Rejected: Commit ignored local Codex config with absolute paths | would make repository history machine-specific.
>
> Confidence: high | Scope-risk: narrow | Reversibility: clean
>
> Directive: Keep project-local issue delivery on \`\$project-ship\`; reserve generic \`\$ship\` for the user-level skill unless the global skill is removed.

## Changes

- `.codex/skills/*` — 런타임 표면 명시 (`autopilot`, `autoresearch`, `cancel`, `hud`, `ralph`, `ship`)
- `scripts/run-omx-script.sh` (신규) — 설치된 OMX dist 스크립트 해석 헬퍼
- `scripts/prune-omx-state.mjs` (신규) — stale skill state 정리

## Tested (원 커밋 메시지 기준)
- omx doctor
- hooks.json JSON parse
- bash -n scripts/run-omx-script.sh
- node --check scripts/prune-omx-state.mjs
- OMX_SCRIPT_DRY_RUN lookup
- prune script idempotence

## Test plan
- [ ] Frontend / Backend CI 통과 — 앱 코드 변경 없으므로 영향 없음 예상