### PR TITLE
스마트스토어 상품 엑셀 업로드 import 지원

### DIFF
--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -1,0 +1,175 @@
+import * as ExcelJS from 'exceljs';
+import { BadRequestException } from '@nestjs/common';
+import { ProductStatus, Product } from '../entities/product.entity';
+import { SmartStoreProductImportService } from '../smartstore-product-import.service';
+import { ProductCommandService } from '../product-command.service';
+
+function createRepositoryMock(existingProducts: Product[] = []) {
+  return {
+    find: jest.fn().mockResolvedValue(existingProducts),
+    findOne: jest.fn().mockResolvedValue(null),
+  };
+}
+
+function createCommandServiceMock() {
+  return {
+    create: jest.fn().mockImplementation(async (dto) => ({ id: 100, ...dto })),
+    update: jest.fn().mockImplementation(async (id, dto) => ({ id, ...dto })),
+  };
+}
+
+async function createWorkbookBuffer(rows: Array<Array<string | number>>) {
+  const workbook = new ExcelJS.Workbook();
+  const worksheet = workbook.addWorksheet('products');
+  rows.forEach((row) => worksheet.addRow(row));
+  return Buffer.from(await workbook.xlsx.writeBuffer());
+}
+
+function createFile(buffer: Buffer, overrides: Partial<Express.Multer.File> = {}): Express.Multer.File {
+  return {
+    fieldname: 'file',
+    originalname: 'smartstore-products.xlsx',
+    encoding: '7bit',
+    mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    size: buffer.length,
+    buffer,
+    destination: '',
+    filename: '',
+    path: '',
+    stream: undefined as unknown as Express.Multer.File['stream'],
+    ...overrides,
+  };
+}
+
+describe('SmartStoreProductImportService', () => {
+  it('previews create and update actions by SKU without saving', async () => {
+    const existing = { id: 7, sku: 'SKU-2', slug: 'old-product' } as Product;
+    const repository = createRepositoryMock([existing]);
+    const commandService = createCommandServiceMock();
+    const service = new SmartStoreProductImportService(
+      repository as never,
+      commandService as unknown as ProductCommandService,
+    );
+    const buffer = await createWorkbookBuffer([
+      ['상품번호', '판매자상품코드', '상품명', '판매가', '재고수량', '판매상태', '대표이미지 URL'],
+      ['111', 'SKU-1', '신규 상품', 12000, 3, '판매중', 'https://cdn.example.com/1.jpg'],
+      ['222', 'SKU-2', '기존 상품', '9,000', 0, '판매중', ''],
+    ]);
+
+    const result = await service.preview(createFile(buffer));
+
+    expect(result.summary).toMatchObject({ totalRows: 2, createCount: 1, updateCount: 1, skipCount: 0 });
+    expect(result.rows.map((row) => row.action)).toEqual(['create', 'update']);
+    expect(result.rows[1].productId).toBe(7);
+    expect(commandService.create).not.toHaveBeenCalled();
+    expect(commandService.update).not.toHaveBeenCalled();
+  });
+
+  it('commits valid rows and maps SmartStore fields to product DTOs', async () => {
+    const repository = createRepositoryMock([]);
+    const commandService = createCommandServiceMock();
+    const service = new SmartStoreProductImportService(
+      repository as never,
+      commandService as unknown as ProductCommandService,
+    );
+    const buffer = await createWorkbookBuffer([
+      ['상품번호', '판매자상품코드', '상품명', '판매가', '재고수량', '판매상태', '대표이미지 URL', '상세설명'],
+      ['111', 'SKU-1', '신규 상품', '12,000원', 3, '판매중', 'https://cdn.example.com/1.jpg', '<p>상세</p>'],
+    ]);
+
+    const result = await service.commit(createFile(buffer));
+
+    expect(result.summary).toMatchObject({ successCount: 1, failureCount: 0, createCount: 1 });
+    expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+      name: '신규 상품',
+      sku: 'SKU-1',
+      price: 12000,
+      stock: 3,
+      status: ProductStatus.ACTIVE,
+      description: '<p>상세</p>',
+      images: [expect.objectContaining({ url: 'https://cdn.example.com/1.jpg', isThumbnail: true })],
+    }));
+  });
+
+  it('updates existing products without changing slug or clearing omitted optional fields', async () => {
+    const existing = { id: 7, sku: 'SKU-2', slug: 'old-product' } as Product;
+    const repository = createRepositoryMock([existing]);
+    const commandService = createCommandServiceMock();
+    const service = new SmartStoreProductImportService(
+      repository as never,
+      commandService as unknown as ProductCommandService,
+    );
+    const buffer = await createWorkbookBuffer([
+      ['판매자상품코드', '상품명', '판매가', '재고수량'],
+      ['SKU-2', '기존 상품', 9000, 2],
+    ]);
+
+    await service.commit(createFile(buffer));
+
+    expect(commandService.update).toHaveBeenCalledWith(7, expect.not.objectContaining({
+      slug: expect.any(String),
+      description: undefined,
+      salePrice: undefined,
+    }));
+    expect(commandService.update).toHaveBeenCalledWith(7, expect.objectContaining({
+      name: '기존 상품',
+      sku: 'SKU-2',
+      price: 9000,
+    }));
+  });
+
+  it('uses naver product number as fallback identifier and marks zero-stock active rows as soldout', async () => {
+    const repository = createRepositoryMock([]);
+    const commandService = createCommandServiceMock();
+    const service = new SmartStoreProductImportService(
+      repository as never,
+      commandService as unknown as ProductCommandService,
+    );
+    const buffer = await createWorkbookBuffer([
+      ['상품번호', '상품명', '판매가', '재고수량', '판매상태'],
+      ['98765', '번호만 있는 상품', 5000, 0, '판매중'],
+    ]);
+
+    await service.commit(createFile(buffer));
+
+    expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+      sku: 'naver-98765',
+      status: ProductStatus.SOLDOUT,
+    }));
+  });
+
+  it('rejects invalid file types before parsing', async () => {
+    const repository = createRepositoryMock([]);
+    const commandService = createCommandServiceMock();
+    const service = new SmartStoreProductImportService(
+      repository as never,
+      commandService as unknown as ProductCommandService,
+    );
+
+    await expect(service.preview(createFile(Buffer.from('x'), {
+      originalname: 'products.csv',
+      mimetype: 'text/csv',
+    }))).rejects.toThrow(BadRequestException);
+  });
+
+  it('skips rows with missing required values or duplicate identifiers', async () => {
+    const repository = createRepositoryMock([]);
+    const commandService = createCommandServiceMock();
+    const service = new SmartStoreProductImportService(
+      repository as never,
+      commandService as unknown as ProductCommandService,
+    );
+    const buffer = await createWorkbookBuffer([
+      ['판매자상품코드', '상품명', '판매가'],
+      ['SKU-1', '', 1000],
+      ['SKU-2', '중복 A', 1000],
+      ['SKU-2', '중복 B', 1000],
+    ]);
+
+    const result = await service.preview(createFile(buffer));
+
+    expect(result.summary).toMatchObject({ totalRows: 3, skipCount: 3, failureCount: 3 });
+    expect(result.rows[0].errors).toContain('상품명이 필요합니다.');
+    expect(result.rows[1].errors[0]).toContain('중복된 상품 식별자');
+  });
+});

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -11,6 +11,8 @@ import {
   Request,
   HttpCode,
   HttpStatus,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
 import { OptionalLocalePipe } from '../../common/pipes/optional-locale.pipe';
 import {
@@ -20,6 +22,8 @@ import {
   ApiParam,
   ApiQuery,
   ApiCookieAuth,
+  ApiConsumes,
+  ApiBody,
 } from '@nestjs/swagger';
 import { ProductsService } from './products.service';
 import { QueryProductsDto } from './dto/query-products.dto';
@@ -33,6 +37,9 @@ import { RequestWithAuthUser } from '../../common/interfaces/auth-user.interface
 import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
 import { CreateRestockAlertDto } from '../restock-alerts/dto/create-restock-alert.dto';
 import { RecentlyViewedService } from './recently-viewed.service';
+import { SmartStoreProductImportService } from './smartstore-product-import.service';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
 
 @ApiTags('상품')
 @Controller('products')
@@ -41,6 +48,7 @@ export class ProductsController {
     private readonly productsService: ProductsService,
     private readonly restockAlertsService: RestockAlertsService,
     private readonly recentlyViewedService: RecentlyViewedService,
+    private readonly smartStoreProductImportService: SmartStoreProductImportService,
   ) {}
 
   @Get()
@@ -98,6 +106,43 @@ export class ProductsController {
     }
 
     return result;
+  }
+
+
+  @Post('imports/smartstore/preview')
+  @Roles('admin')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '스마트스토어 상품 엑셀 미리보기', description: '스마트스토어 상품 엑셀 파일을 검증하고 생성/수정 예정 내역을 반환합니다.' })
+  @ApiResponse({ status: 201, description: '상품 가져오기 미리보기 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 파일 또는 상품 데이터' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: ['file'] } })
+  @UseInterceptors(FileInterceptor('file', {
+    storage: memoryStorage(),
+    limits: { fileSize: 10 * 1024 * 1024 },
+  }))
+  previewSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
+    return this.smartStoreProductImportService.preview(file);
+  }
+
+  @Post('imports/smartstore/commit')
+  @Roles('admin')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '스마트스토어 상품 엑셀 반영', description: '검증된 스마트스토어 상품 엑셀 파일로 자사몰 상품을 생성하거나 수정합니다.' })
+  @ApiResponse({ status: 201, description: '상품 가져오기 반영 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 파일 또는 상품 데이터' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: ['file'] } })
+  @UseInterceptors(FileInterceptor('file', {
+    storage: memoryStorage(),
+    limits: { fileSize: 10 * 1024 * 1024 },
+  }))
+  commitSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
+    return this.smartStoreProductImportService.commit(file);
   }
 
   @Post()

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -14,6 +14,7 @@ import { ProductCommandService } from './product-command.service';
 import { CategoriesService } from './categories.service';
 import { AttributesService } from './attributes.service';
 import { RecentlyViewedService } from './recently-viewed.service';
+import { SmartStoreProductImportService } from './smartstore-product-import.service';
 import { ProductsController } from './products.controller';
 import { CategoriesController } from './categories.controller';
 import { AttributesController } from './attributes.controller';
@@ -44,6 +45,7 @@ import { RecentlyViewedProduct } from './entities/recently-viewed-product.entity
     CategoriesService,
     AttributesService,
     RecentlyViewedService,
+    SmartStoreProductImportService,
   ],
   controllers: [ProductsController, CategoriesController, AttributesController],
   exports: [
@@ -53,6 +55,7 @@ import { RecentlyViewedProduct } from './entities/recently-viewed-product.entity
     CategoriesService,
     AttributesService,
     RecentlyViewedService,
+    SmartStoreProductImportService,
   ],
 })
 export class ProductsModule {}

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -1,0 +1,380 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as ExcelJS from 'exceljs';
+import { In, Repository } from 'typeorm';
+import { Product, ProductStatus } from './entities/product.entity';
+import { ProductCommandService } from './product-command.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+
+export type SmartStoreImportAction = 'create' | 'update' | 'skip';
+
+export interface SmartStoreImportRowResult {
+  rowNumber: number;
+  identifier: string | null;
+  productName: string | null;
+  action: SmartStoreImportAction;
+  status: 'valid' | 'failed' | 'success';
+  productId?: number;
+  errors: string[];
+}
+
+export interface SmartStoreImportResult {
+  summary: {
+    totalRows: number;
+    createCount: number;
+    updateCount: number;
+    skipCount: number;
+    successCount: number;
+    failureCount: number;
+  };
+  rows: SmartStoreImportRowResult[];
+}
+
+interface ParsedSmartStoreRow {
+  rowNumber: number;
+  identifier: string | null;
+  productName: string | null;
+  dto: CreateProductDto | null;
+  errors: string[];
+}
+
+const MAX_IMPORT_ROWS = 500;
+
+const HEADER_ALIASES = {
+  productNumber: ['상품번호', '스마트스토어 상품번호', '네이버상품번호', '상품 ID', '상품ID'],
+  sellerCode: ['판매자 상품코드', '판매자상품코드', '판매자 관리코드', '자체 상품코드', 'SKU', 'sku'],
+  name: ['상품명', '상품 이름', '제품명'],
+  price: ['판매가', '상품가격', '가격', '정상가'],
+  salePrice: ['할인가', '즉시할인가', '할인 판매가'],
+  stock: ['재고수량', '재고', '재고량'],
+  status: ['판매상태', '상품상태', '전시상태'],
+  representativeImage: ['대표이미지', '대표 이미지', '대표이미지 URL', '대표 이미지 URL', '이미지 URL'],
+  additionalImages: ['추가이미지', '추가 이미지', '추가이미지 URL', '추가 이미지 URL'],
+  description: ['상세설명', '상품상세', '상품 상세', '상세페이지', '상세 HTML'],
+  shortDescription: ['요약설명', '짧은설명', '간단설명'],
+} as const;
+
+type HeaderKey = keyof typeof HEADER_ALIASES;
+
+type HeaderMap = Partial<Record<HeaderKey, number>>;
+
+@Injectable()
+export class SmartStoreProductImportService {
+  constructor(
+    @InjectRepository(Product)
+    private readonly productRepository: Repository<Product>,
+    private readonly productCommandService: ProductCommandService,
+  ) {}
+
+  async preview(file: Express.Multer.File): Promise<SmartStoreImportResult> {
+    return this.process(file, false);
+  }
+
+  async commit(file: Express.Multer.File): Promise<SmartStoreImportResult> {
+    return this.process(file, true);
+  }
+
+  private async process(file: Express.Multer.File, commit: boolean): Promise<SmartStoreImportResult> {
+    this.assertExcelFile(file);
+    const parsedRows = await this.parseWorkbook(file.buffer);
+    const identifiers = parsedRows
+      .map((row) => row.identifier)
+      .filter((identifier): identifier is string => Boolean(identifier));
+    const existingProducts = identifiers.length > 0
+      ? await this.productRepository.find({ where: { sku: In(identifiers) } })
+      : [];
+    const existingBySku = new Map(
+      existingProducts
+        .filter((product) => product.sku)
+        .map((product) => [product.sku as string, product]),
+    );
+
+    const duplicateIdentifiers = this.findDuplicates(identifiers);
+    const rows: SmartStoreImportRowResult[] = [];
+
+    for (const parsed of parsedRows) {
+      const errors = [...parsed.errors];
+      if (parsed.identifier && duplicateIdentifiers.has(parsed.identifier)) {
+        errors.push(`파일 안에서 중복된 상품 식별자입니다: ${parsed.identifier}`);
+      }
+
+      const existing = parsed.identifier ? existingBySku.get(parsed.identifier) : undefined;
+      const action: SmartStoreImportAction = errors.length > 0 ? 'skip' : existing ? 'update' : 'create';
+      const rowResult: SmartStoreImportRowResult = {
+        rowNumber: parsed.rowNumber,
+        identifier: parsed.identifier,
+        productName: parsed.productName,
+        action,
+        status: errors.length > 0 ? 'failed' : commit ? 'success' : 'valid',
+        productId: existing?.id,
+        errors,
+      };
+
+      if (commit && errors.length === 0 && parsed.dto) {
+        try {
+          const saved = existing
+            ? await this.productCommandService.update(existing.id, this.toUpdateDto(parsed.dto))
+            : await this.productCommandService.create({
+                ...parsed.dto,
+                slug: await this.generateUniqueSlug(parsed.dto.slug),
+              });
+          rowResult.productId = saved.id;
+          rowResult.status = 'success';
+        } catch (err) {
+          rowResult.status = 'failed';
+          rowResult.action = 'skip';
+          rowResult.errors.push(err instanceof Error ? err.message : '상품 저장에 실패했습니다.');
+        }
+      }
+
+      rows.push(rowResult);
+    }
+
+    return this.buildResult(rows);
+  }
+
+  private assertExcelFile(file: Express.Multer.File | undefined): asserts file is Express.Multer.File {
+    if (!file) {
+      throw new BadRequestException('업로드할 엑셀 파일을 선택해 주세요.');
+    }
+    const hasXlsxName = file.originalname.toLowerCase().endsWith('.xlsx');
+    const hasXlsxMime = [
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/octet-stream',
+    ].includes(file.mimetype);
+    if (!hasXlsxName || !hasXlsxMime) {
+      throw new BadRequestException('스마트스토어 상품 엑셀(.xlsx) 파일만 업로드할 수 있습니다.');
+    }
+  }
+
+  private async parseWorkbook(buffer: Buffer): Promise<ParsedSmartStoreRow[]> {
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer);
+    const worksheet = workbook.worksheets[0];
+    if (!worksheet) {
+      throw new BadRequestException('엑셀 파일에서 시트를 찾을 수 없습니다.');
+    }
+
+    const headerRowNumber = this.findHeaderRowNumber(worksheet);
+    const headerMap = this.buildHeaderMap(worksheet.getRow(headerRowNumber));
+    if (!headerMap.name || !headerMap.price) {
+      throw new BadRequestException('상품명과 판매가 컬럼을 찾을 수 없습니다. 스마트스토어 상품 엑셀 양식을 확인해 주세요.');
+    }
+
+    const rows: ParsedSmartStoreRow[] = [];
+    const seenDataRows = worksheet.rowCount - headerRowNumber;
+    if (seenDataRows > MAX_IMPORT_ROWS) {
+      throw new BadRequestException(`한 번에 최대 ${MAX_IMPORT_ROWS}개 상품까지만 업로드할 수 있습니다.`);
+    }
+
+    for (let rowNumber = headerRowNumber + 1; rowNumber <= worksheet.rowCount; rowNumber += 1) {
+      const row = worksheet.getRow(rowNumber);
+      if (!row.hasValues) continue;
+      const parsed = this.parseRow(row, rowNumber, headerMap);
+      if (parsed.productName || parsed.identifier || parsed.errors.length > 0) {
+        rows.push(parsed);
+      }
+    }
+
+    if (rows.length === 0) {
+      throw new BadRequestException('가져올 상품 행이 없습니다.');
+    }
+
+    return rows;
+  }
+
+  private findHeaderRowNumber(worksheet: ExcelJS.Worksheet): number {
+    for (let rowNumber = 1; rowNumber <= Math.min(10, worksheet.rowCount); rowNumber += 1) {
+      const headerMap = this.buildHeaderMap(worksheet.getRow(rowNumber));
+      if (headerMap.name && headerMap.price) {
+        return rowNumber;
+      }
+    }
+    return 1;
+  }
+
+  private buildHeaderMap(row: ExcelJS.Row): HeaderMap {
+    const headerMap: HeaderMap = {};
+    row.eachCell((cell, colNumber) => {
+      const normalized = this.normalizeHeader(this.cellToString(cell.value));
+      if (!normalized) return;
+      for (const [key, aliases] of Object.entries(HEADER_ALIASES) as Array<[HeaderKey, readonly string[]]>) {
+        if (headerMap[key]) continue;
+        if (aliases.some((alias) => this.normalizeHeader(alias) === normalized)) {
+          headerMap[key] = colNumber;
+        }
+      }
+    });
+    return headerMap;
+  }
+
+  private parseRow(row: ExcelJS.Row, rowNumber: number, headerMap: HeaderMap): ParsedSmartStoreRow {
+    const productNumber = this.getCell(row, headerMap.productNumber);
+    const sellerCode = this.getCell(row, headerMap.sellerCode);
+    const productName = this.getCell(row, headerMap.name);
+    const identifier = this.buildIdentifier(sellerCode, productNumber);
+    const errors: string[] = [];
+
+    if (!identifier) errors.push('상품번호 또는 판매자상품코드가 필요합니다.');
+    if (!productName) errors.push('상품명이 필요합니다.');
+
+    const price = this.parseMoney(this.getCell(row, headerMap.price));
+    if (price === null || price < 1) errors.push('판매가는 1원 이상이어야 합니다.');
+
+    const stock = this.parseInteger(this.getCell(row, headerMap.stock));
+    const salePrice = this.parseMoney(this.getCell(row, headerMap.salePrice));
+    const representativeImage = this.getCell(row, headerMap.representativeImage);
+    const additionalImages = this.splitImageUrls(this.getCell(row, headerMap.additionalImages));
+
+    const dto: CreateProductDto | null = errors.length > 0 || !identifier || !productName || price === null
+      ? null
+      : {
+          name: productName,
+          slug: this.slugify(identifier),
+          price,
+          salePrice: salePrice ?? undefined,
+          stock: stock ?? 0,
+          sku: identifier,
+          status: this.mapStatus(this.getCell(row, headerMap.status), stock ?? 0),
+          shortDescription: this.getCell(row, headerMap.shortDescription) || undefined,
+          description: this.getCell(row, headerMap.description) || undefined,
+          images: this.buildImages(productName, representativeImage, additionalImages),
+        };
+
+    return { rowNumber, identifier, productName, dto, errors };
+  }
+
+  private buildIdentifier(sellerCode: string, productNumber: string): string | null {
+    const raw = sellerCode || (productNumber ? `naver-${productNumber}` : '');
+    const normalized = raw.trim();
+    return normalized || null;
+  }
+
+  private buildImages(productName: string, representativeImage: string, additionalImages: string[]): CreateProductDto['images'] {
+    const urls = [representativeImage, ...additionalImages].filter(Boolean);
+    if (urls.length === 0) return undefined;
+    return urls.map((url, index) => ({
+      url,
+      alt: productName,
+      sortOrder: index,
+      isThumbnail: index === 0,
+    }));
+  }
+
+  private mapStatus(rawStatus: string, stock: number): ProductStatus {
+    const normalized = rawStatus.replace(/\s/g, '').toLowerCase();
+    if (normalized.includes('판매중') || normalized.includes('active')) {
+      return stock === 0 ? ProductStatus.SOLDOUT : ProductStatus.ACTIVE;
+    }
+    if (normalized.includes('품절') || normalized.includes('soldout')) {
+      return ProductStatus.SOLDOUT;
+    }
+    if (normalized.includes('숨김') || normalized.includes('전시중지') || normalized.includes('판매중지') || normalized.includes('hidden')) {
+      return ProductStatus.HIDDEN;
+    }
+    if (normalized.includes('임시') || normalized.includes('draft')) {
+      return ProductStatus.DRAFT;
+    }
+    return stock === 0 ? ProductStatus.SOLDOUT : ProductStatus.ACTIVE;
+  }
+
+  private toUpdateDto(dto: CreateProductDto): UpdateProductDto {
+    const rest: UpdateProductDto = { ...dto };
+    delete rest.slug;
+    return Object.fromEntries(
+      Object.entries(rest).filter(([, value]) => value !== undefined),
+    ) as UpdateProductDto;
+  }
+
+  private async generateUniqueSlug(base: string): Promise<string> {
+    let candidate = base || 'smartstore-product';
+    let suffix = 2;
+    while (await this.productRepository.findOne({ where: { slug: candidate } })) {
+      candidate = `${base}-${suffix}`;
+      suffix += 1;
+    }
+    return candidate;
+  }
+
+  private buildResult(rows: SmartStoreImportRowResult[]): SmartStoreImportResult {
+    const summary = rows.reduce(
+      (acc, row) => {
+        acc.totalRows += 1;
+        if (row.action === 'create') acc.createCount += 1;
+        if (row.action === 'update') acc.updateCount += 1;
+        if (row.action === 'skip') acc.skipCount += 1;
+        if (row.status === 'success') acc.successCount += 1;
+        if (row.status === 'failed') acc.failureCount += 1;
+        return acc;
+      },
+      { totalRows: 0, createCount: 0, updateCount: 0, skipCount: 0, successCount: 0, failureCount: 0 },
+    );
+    return { summary, rows };
+  }
+
+  private findDuplicates(values: string[]): Set<string> {
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const value of values) {
+      if (seen.has(value)) duplicates.add(value);
+      seen.add(value);
+    }
+    return duplicates;
+  }
+
+  private getCell(row: ExcelJS.Row, columnNumber: number | undefined): string {
+    if (!columnNumber) return '';
+    return this.cellToString(row.getCell(columnNumber).value).trim();
+  }
+
+  private cellToString(value: ExcelJS.CellValue): string {
+    if (value === null || value === undefined) return '';
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value === 'object') {
+      if ('text' in value && typeof value.text === 'string') return value.text;
+      if ('result' in value) return this.cellToString(value.result as ExcelJS.CellValue);
+      if ('richText' in value && Array.isArray(value.richText)) {
+        return value.richText.map((part) => part.text).join('');
+      }
+      if ('hyperlink' in value && typeof value.hyperlink === 'string') return value.hyperlink;
+      return String(value);
+    }
+    return String(value);
+  }
+
+  private normalizeHeader(header: string): string {
+    return header.replace(/[\s_()\[\]{}./-]/g, '').toLowerCase();
+  }
+
+  private parseMoney(value: string): number | null {
+    if (!value) return null;
+    const normalized = value.replace(/[^0-9.-]/g, '');
+    if (!normalized) return null;
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  private parseInteger(value: string): number | null {
+    const parsed = this.parseMoney(value);
+    return parsed === null ? null : Math.max(0, Math.trunc(parsed));
+  }
+
+  private splitImageUrls(value: string): string[] {
+    if (!value) return [];
+    return value
+      .split(/[\n,;|]/)
+      .map((url) => url.trim())
+      .filter(Boolean);
+  }
+
+  private slugify(value: string): string {
+    const slug = value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9가-힣]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 240);
+    return slug || 'smartstore-product';
+  }
+}

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -1,45 +1,52 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
 import { adminProductsApi } from '@/lib/api';
-import type { Product } from '@/lib/api';
+import type { Product, SmartStoreProductImportResult } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import { ProductStatusBadge } from '@/components/shared/admin/StatusBadge';
 import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
 import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
 import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
 
-const STATUS_LABELS: Record<string, string> = {
-  draft: '임시저장',
-  active: '판매중',
-  soldout: '품절',
-  hidden: '숨김',
-};
-
-const STATUS_FILTERS = [
-  { label: '전체', value: '' },
-  { label: '판매중', value: 'active' },
-  { label: '임시저장', value: 'draft' },
-  { label: '품절', value: 'soldout' },
-  { label: '숨김', value: 'hidden' },
-] as const;
-
 const PAGE_SIZE = 20;
 
+type ProductStatus = 'active' | 'soldout' | 'draft' | 'hidden';
+
 export default function AdminProductsPage() {
+  const t = useTranslations('admin.products');
   const { isAdmin } = useAdminGuard();
   const [products, setProducts] = useState<Product[]>([]);
   const [total, setTotal] = useState(0);
+  const [smartStoreFile, setSmartStoreFile] = useState<File | null>(null);
+  const [importPreview, setImportPreview] = useState<SmartStoreProductImportResult | null>(null);
+  const [importResult, setImportResult] = useState<SmartStoreProductImportResult | null>(null);
   const { page, setPage, filters, setFilter } = useAdminListPage({
     initialFilters: {
       status: '',
     },
   });
+
+  const statusLabels: Record<ProductStatus, string> = {
+    draft: t('status.draft'),
+    active: t('status.active'),
+    soldout: t('status.soldout'),
+    hidden: t('status.hidden'),
+  };
+
+  const statusFilters = [
+    { label: t('statusFilter.all'), value: '' },
+    { label: t('statusFilter.active'), value: 'active' },
+    { label: t('statusFilter.draft'), value: 'draft' },
+    { label: t('statusFilter.soldout'), value: 'soldout' },
+    { label: t('statusFilter.hidden'), value: 'hidden' },
+  ] as const;
 
   const { execute: fetchProducts, isLoading: loading } = useAsyncAction(
     async () => {
@@ -53,7 +60,7 @@ export default function AdminProductsPage() {
       setProducts(res.items);
       setTotal(res.total);
     },
-    { errorMessage: '상품 목록을 불러오지 못했습니다.' },
+    { errorMessage: t('loadError') },
   );
 
   useEffect(() => {
@@ -61,14 +68,33 @@ export default function AdminProductsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAdmin, page, filters.status]);
 
+  const { execute: previewSmartStoreImport, isLoading: previewingImport } = useAsyncAction(
+    async (file: File) => {
+      const result = await adminProductsApi.previewSmartStoreImport(file);
+      setImportPreview(result);
+      setImportResult(null);
+    },
+    { successMessage: t('import.previewSuccess'), errorMessage: t('import.previewError') },
+  );
+
+  const { execute: commitSmartStoreImport, isLoading: committingImport } = useAsyncAction(
+    async (file: File) => {
+      const result = await adminProductsApi.commitSmartStoreImport(file);
+      setImportResult(result);
+      setImportPreview(null);
+      void fetchProducts();
+    },
+    { successMessage: t('import.commitSuccess'), errorMessage: t('import.commitError') },
+  );
+
   const { execute: toggleStatus } = useAsyncAction(
     async (product: Product) => {
       const next = product.status === 'active' ? 'hidden' : 'active';
       await adminProductsApi.update(product.id, { status: next });
-      toast.success(`상품이 ${STATUS_LABELS[next]}으로 변경되었습니다.`);
+      toast.success(t('statusChanged', { status: statusLabels[next as ProductStatus] }));
       void fetchProducts();
     },
-    { errorMessage: '상태 변경에 실패했습니다.' },
+    { errorMessage: t('statusChangeError') },
   );
 
   const { execute: deleteProduct } = useAsyncAction(
@@ -76,45 +102,146 @@ export default function AdminProductsPage() {
       await adminProductsApi.remove(product.id);
       void fetchProducts();
     },
-    { successMessage: '상품이 삭제되었습니다.', errorMessage: '삭제에 실패했습니다.' },
+    { successMessage: t('deleteSuccess'), errorMessage: t('deleteError') },
   );
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    setSmartStoreFile(file);
+    setImportPreview(null);
+    setImportResult(null);
+  };
+
+  const handlePreviewImport = () => {
+    if (!smartStoreFile) {
+      toast.error(t('import.selectFileFirst'));
+      return;
+    }
+    void previewSmartStoreImport(smartStoreFile);
+  };
+
+  const handleCommitImport = () => {
+    if (!smartStoreFile) {
+      toast.error(t('import.selectFileFirst'));
+      return;
+    }
+    void commitSmartStoreImport(smartStoreFile);
+  };
 
   const handleToggleStatus = (product: Product) => void toggleStatus(product);
 
   const handleDelete = (product: Product) => {
-    if (!window.confirm(`"${product.name}"을(를) 삭제하시겠습니까?`)) return;
+    if (!window.confirm(t('deleteConfirm', { name: product.name }))) return;
     void deleteProduct(product);
   };
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
+  const importSummary = importResult?.summary ?? importPreview?.summary;
+  const importRows = (importResult?.rows ?? importPreview?.rows ?? []).slice(0, 5);
+  const isImporting = previewingImport || committingImport;
 
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
       <AdminPageHeader
-        title="상품 관리"
+        title={t('title')}
         action={(
           <Link
             href="/admin/products/new"
             className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
           >
-            + 상품 등록
+            {t('addProduct')}
           </Link>
         )}
       />
 
+      <section className="rounded-lg border bg-card p-4 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <h2 className="text-base font-semibold">{t('import.title')}</h2>
+            <p className="text-sm text-muted-foreground">{t('import.description')}</p>
+            <input
+              type="file"
+              accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              onChange={handleFileChange}
+              className="block w-full text-sm file:mr-4 file:rounded-md file:border-0 file:bg-secondary file:px-3 file:py-2 file:text-sm file:font-medium"
+              aria-label={t('import.fileLabel')}
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handlePreviewImport}
+              disabled={!smartStoreFile || isImporting}
+              className="rounded border px-4 py-2 text-sm hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {previewingImport ? t('import.previewing') : t('import.previewButton')}
+            </button>
+            <button
+              type="button"
+              onClick={handleCommitImport}
+              disabled={!smartStoreFile || isImporting || !importPreview}
+              className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {committingImport ? t('import.committing') : t('import.commitButton')}
+            </button>
+          </div>
+        </div>
+
+        {importSummary && (
+          <div className="mt-4 space-y-3 rounded-lg bg-secondary/40 p-4 text-sm">
+            <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-6">
+              <ImportSummaryItem label={t('import.summary.total')} value={importSummary.totalRows} />
+              <ImportSummaryItem label={t('import.summary.create')} value={importSummary.createCount} />
+              <ImportSummaryItem label={t('import.summary.update')} value={importSummary.updateCount} />
+              <ImportSummaryItem label={t('import.summary.skip')} value={importSummary.skipCount} />
+              <ImportSummaryItem label={t('import.summary.success')} value={importSummary.successCount} />
+              <ImportSummaryItem label={t('import.summary.failure')} value={importSummary.failureCount} />
+            </div>
+            {importRows.length > 0 && (
+              <div className="overflow-x-auto rounded border bg-background">
+                <table className="w-full text-xs">
+                  <thead className="bg-secondary">
+                    <tr>
+                      <th className="px-3 py-2 text-left">{t('import.previewColumns.row')}</th>
+                      <th className="px-3 py-2 text-left">{t('import.previewColumns.identifier')}</th>
+                      <th className="px-3 py-2 text-left">{t('import.previewColumns.productName')}</th>
+                      <th className="px-3 py-2 text-left">{t('import.previewColumns.action')}</th>
+                      <th className="px-3 py-2 text-left">{t('import.previewColumns.result')}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {importRows.map((row) => (
+                      <tr key={`${row.rowNumber}-${row.identifier ?? 'empty'}`}>
+                        <td className="px-3 py-2">{row.rowNumber}</td>
+                        <td className="px-3 py-2">{row.identifier ?? '-'}</td>
+                        <td className="px-3 py-2">{row.productName ?? '-'}</td>
+                        <td className="px-3 py-2">{t(`import.actions.${row.action}`)}</td>
+                        <td className="px-3 py-2">
+                          {row.errors.length > 0 ? row.errors.join(', ') : t(`import.status.${row.status}`)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+
       <AdminFilterChips
-        items={STATUS_FILTERS}
+        items={statusFilters}
         value={filters.status}
         onToggle={(value) => setFilter('status', value)}
-        ariaLabel="상품 상태 필터"
+        ariaLabel={t('statusFilterAria')}
         size="sm"
       />
 
       <PaginatedAdminTableShell
         loading={loading}
-        loadingMessage="불러오는 중..."
+        loadingMessage={t('loading')}
         isEmpty={products.length === 0}
-        emptyMessage="상품이 없습니다."
+        emptyMessage={t('noProducts')}
         currentPage={page}
         totalPages={totalPages}
         onPageChange={setPage}
@@ -123,12 +250,12 @@ export default function AdminProductsPage() {
           <table className="w-full text-sm">
             <thead className="bg-secondary">
               <tr>
-                <th className="px-4 py-3 text-left">ID</th>
-                <th className="px-4 py-3 text-left">상품명</th>
-                <th className="px-4 py-3 text-left">가격</th>
-                <th className="px-4 py-3 text-left">상태</th>
-                <th className="px-4 py-3 text-left">추천</th>
-                <th className="px-4 py-3 text-right">액션</th>
+                <th className="px-4 py-3 text-left">{t('columns.id')}</th>
+                <th className="px-4 py-3 text-left">{t('columns.name')}</th>
+                <th className="px-4 py-3 text-left">{t('columns.price')}</th>
+                <th className="px-4 py-3 text-left">{t('columns.status')}</th>
+                <th className="px-4 py-3 text-left">{t('columns.featured')}</th>
+                <th className="px-4 py-3 text-right">{t('columns.action')}</th>
               </tr>
             </thead>
             <tbody className="divide-y">
@@ -138,7 +265,7 @@ export default function AdminProductsPage() {
                   <td className="px-4 py-3 font-medium">{product.name}</td>
                   <td className="px-4 py-3">{formatCurrency(product.price)}</td>
                   <td className="px-4 py-3">
-                    <ProductStatusBadge status={product.status as 'active' | 'soldout' | 'draft' | 'hidden'} />
+                    <ProductStatusBadge status={product.status as ProductStatus} />
                   </td>
                   <td className="px-4 py-3">{product.isFeatured ? '✓' : '-'}</td>
                   <td className="px-4 py-3 text-right">
@@ -147,19 +274,19 @@ export default function AdminProductsPage() {
                         onClick={() => void handleToggleStatus(product)}
                         className="rounded border px-2 py-1 text-xs hover:bg-secondary"
                       >
-                        {product.status === 'active' ? '숨기기' : '노출'}
+                        {product.status === 'active' ? t('actions.hide') : t('actions.show')}
                       </button>
                       <Link
                         href={`/admin/products/${product.id}/edit`}
                         className="rounded border px-2 py-1 text-xs hover:bg-secondary"
                       >
-                        수정
+                        {t('actions.edit')}
                       </Link>
                       <button
                         onClick={() => void handleDelete(product)}
                         className="rounded border border-destructive/30 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
                       >
-                        삭제
+                        {t('actions.delete')}
                       </button>
                     </div>
                   </td>
@@ -169,6 +296,15 @@ export default function AdminProductsPage() {
           </table>
         </div>
       </PaginatedAdminTableShell>
+    </div>
+  );
+}
+
+function ImportSummaryItem({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded border bg-background p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold">{value}</div>
     </div>
   );
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -171,34 +171,34 @@
     "noProducts": "No products found",
     "noProductsDescription": "No products are listed yet.",
     "noSearchResults": "No results found for \"{query}\".",
-  "tabs": {
-    "details": "Details",
-    "reviews": "Reviews",
-    "inquiry": "Inquiry",
-    "comingSoon": "Coming soon.",
-    "detailsImageAlt": "Detail image {index}",
-    "inquiryPanel": {
-      "loginRequiredTitle": "Login required.",
-      "loginRequiredDescription": "Please log in to submit an inquiry.",
-      "loginAction": "Go to login",
-      "titleLabel": "Title",
-      "titlePlaceholder": "Enter the inquiry title",
-      "contentLabel": "Content",
-      "contentPlaceholder": "Please describe your inquiry",
-      "submit": "Submit inquiry",
-      "submitting": "Submitting...",
-      "submitSuccess": "Your inquiry has been submitted.",
-      "submitError": "Failed to submit inquiry.",
-      "validation": "Please enter both title and content.",
-      "listTitle": "My inquiries",
-      "loading": "Loading inquiries...",
-      "empty": "No inquiries yet.",
-      "loadError": "Failed to load inquiries.",
-      "statusAnswered": "Answered",
-      "statusPending": "Received",
-      "answerLabel": "Answer"
-    }
-  },
+    "tabs": {
+      "details": "Details",
+      "reviews": "Reviews",
+      "inquiry": "Inquiry",
+      "comingSoon": "Coming soon.",
+      "detailsImageAlt": "Detail image {index}",
+      "inquiryPanel": {
+        "loginRequiredTitle": "Login required.",
+        "loginRequiredDescription": "Please log in to submit an inquiry.",
+        "loginAction": "Go to login",
+        "titleLabel": "Title",
+        "titlePlaceholder": "Enter the inquiry title",
+        "contentLabel": "Content",
+        "contentPlaceholder": "Please describe your inquiry",
+        "submit": "Submit inquiry",
+        "submitting": "Submitting...",
+        "submitSuccess": "Your inquiry has been submitted.",
+        "submitError": "Failed to submit inquiry.",
+        "validation": "Please enter both title and content.",
+        "listTitle": "My inquiries",
+        "loading": "Loading inquiries...",
+        "empty": "No inquiries yet.",
+        "loadError": "Failed to load inquiries.",
+        "statusAnswered": "Answered",
+        "statusPending": "Received",
+        "answerLabel": "Answer"
+      }
+    },
     "sort": {
       "label": "Sort by",
       "latest": "Newest",
@@ -554,6 +554,47 @@
         "active": "On Sale",
         "soldout": "Sold Out",
         "hidden": "Hidden"
+      },
+      "statusChanged": "Product changed to {status}.",
+      "statusFilterAria": "Product status filter",
+      "import": {
+        "title": "Import SmartStore Product Excel",
+        "description": "Validate a .xlsx product list downloaded from SmartStore, then create new products and update existing SKU matches.",
+        "fileLabel": "SmartStore product Excel file",
+        "previewButton": "Preview upload",
+        "previewing": "Validating...",
+        "commitButton": "Apply to store",
+        "committing": "Applying...",
+        "selectFileFirst": "Select a SmartStore product Excel file first.",
+        "previewSuccess": "SmartStore product Excel validated.",
+        "previewError": "Failed to validate SmartStore product Excel.",
+        "commitSuccess": "SmartStore product Excel applied to the store.",
+        "commitError": "Failed to apply SmartStore products.",
+        "summary": {
+          "total": "Rows",
+          "create": "New",
+          "update": "Updates",
+          "skip": "Skipped",
+          "success": "Succeeded",
+          "failure": "Failed"
+        },
+        "previewColumns": {
+          "row": "Row",
+          "identifier": "Identifier",
+          "productName": "Product",
+          "action": "Action",
+          "result": "Result"
+        },
+        "actions": {
+          "create": "Create",
+          "update": "Update",
+          "skip": "Skip"
+        },
+        "status": {
+          "valid": "Valid",
+          "failed": "Failed",
+          "success": "Success"
+        }
       }
     },
     "productForm": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -171,34 +171,34 @@
     "noProducts": "상품이 없습니다",
     "noProductsDescription": "등록된 상품이 없습니다.",
     "noSearchResults": "\"{query}\"에 대한 검색 결과가 없습니다.",
-  "tabs": {
-    "details": "상세정보",
-    "reviews": "리뷰",
-    "inquiry": "문의",
-    "comingSoon": "준비 중입니다.",
-    "detailsImageAlt": "상세정보 이미지 {index}",
-    "inquiryPanel": {
-      "loginRequiredTitle": "로그인이 필요합니다.",
-      "loginRequiredDescription": "문의를 작성하려면 로그인해주세요.",
-      "loginAction": "로그인하기",
-      "titleLabel": "제목",
-      "titlePlaceholder": "문의 제목을 입력해주세요",
-      "contentLabel": "내용",
-      "contentPlaceholder": "문의 내용을 입력해주세요",
-      "submit": "문의 등록",
-      "submitting": "등록 중...",
-      "submitSuccess": "문의가 접수되었습니다.",
-      "submitError": "문의 등록에 실패했습니다.",
-      "validation": "제목과 내용을 입력해주세요.",
-      "listTitle": "내 문의 내역",
-      "loading": "문의 내역을 불러오는 중입니다.",
-      "empty": "등록된 문의가 없습니다.",
-      "loadError": "문의 내역을 불러오지 못했습니다.",
-      "statusAnswered": "답변완료",
-      "statusPending": "접수",
-      "answerLabel": "답변"
-    }
-  },
+    "tabs": {
+      "details": "상세정보",
+      "reviews": "리뷰",
+      "inquiry": "문의",
+      "comingSoon": "준비 중입니다.",
+      "detailsImageAlt": "상세정보 이미지 {index}",
+      "inquiryPanel": {
+        "loginRequiredTitle": "로그인이 필요합니다.",
+        "loginRequiredDescription": "문의를 작성하려면 로그인해주세요.",
+        "loginAction": "로그인하기",
+        "titleLabel": "제목",
+        "titlePlaceholder": "문의 제목을 입력해주세요",
+        "contentLabel": "내용",
+        "contentPlaceholder": "문의 내용을 입력해주세요",
+        "submit": "문의 등록",
+        "submitting": "등록 중...",
+        "submitSuccess": "문의가 접수되었습니다.",
+        "submitError": "문의 등록에 실패했습니다.",
+        "validation": "제목과 내용을 입력해주세요.",
+        "listTitle": "내 문의 내역",
+        "loading": "문의 내역을 불러오는 중입니다.",
+        "empty": "등록된 문의가 없습니다.",
+        "loadError": "문의 내역을 불러오지 못했습니다.",
+        "statusAnswered": "답변완료",
+        "statusPending": "접수",
+        "answerLabel": "답변"
+      }
+    },
     "sort": {
       "label": "정렬 기준",
       "latest": "최신순",
@@ -554,6 +554,47 @@
         "active": "판매중",
         "soldout": "품절",
         "hidden": "숨김"
+      },
+      "statusChanged": "상품이 {status}으로 변경되었습니다.",
+      "statusFilterAria": "상품 상태 필터",
+      "import": {
+        "title": "스마트스토어 상품 엑셀 가져오기",
+        "description": "스마트스토어에서 다운로드한 .xlsx 상품목록을 검증한 뒤 신규 상품을 추가하고 기존 SKU 상품을 수정합니다.",
+        "fileLabel": "스마트스토어 상품 엑셀 파일",
+        "previewButton": "업로드 미리보기",
+        "previewing": "검증 중...",
+        "commitButton": "자사몰에 반영",
+        "committing": "반영 중...",
+        "selectFileFirst": "먼저 스마트스토어 상품 엑셀 파일을 선택해 주세요.",
+        "previewSuccess": "스마트스토어 상품 엑셀을 검증했습니다.",
+        "previewError": "스마트스토어 상품 엑셀 검증에 실패했습니다.",
+        "commitSuccess": "스마트스토어 상품 엑셀을 자사몰에 반영했습니다.",
+        "commitError": "스마트스토어 상품 반영에 실패했습니다.",
+        "summary": {
+          "total": "전체 행",
+          "create": "신규",
+          "update": "수정",
+          "skip": "스킵",
+          "success": "성공",
+          "failure": "실패"
+        },
+        "previewColumns": {
+          "row": "행",
+          "identifier": "식별자",
+          "productName": "상품명",
+          "action": "작업",
+          "result": "결과"
+        },
+        "actions": {
+          "create": "신규 추가",
+          "update": "수정",
+          "skip": "스킵"
+        },
+        "status": {
+          "valid": "검증 완료",
+          "failed": "실패",
+          "success": "성공"
+        }
       }
     },
     "productForm": {

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -35,6 +35,31 @@ export interface CreateProductData {
 
 export type UpdateProductData = Partial<CreateProductData>;
 
+export type SmartStoreImportAction = 'create' | 'update' | 'skip';
+export type SmartStoreImportStatus = 'valid' | 'failed' | 'success';
+
+export interface SmartStoreProductImportRow {
+  rowNumber: number;
+  identifier: string | null;
+  productName: string | null;
+  action: SmartStoreImportAction;
+  status: SmartStoreImportStatus;
+  productId?: number;
+  errors: string[];
+}
+
+export interface SmartStoreProductImportResult {
+  summary: {
+    totalRows: number;
+    createCount: number;
+    updateCount: number;
+    skipCount: number;
+    successCount: number;
+    failureCount: number;
+  };
+  rows: SmartStoreProductImportRow[];
+}
+
 export const adminProductsApi = {
   getList: (params?: AdminProductsParams) =>
     apiClient.get<ProductListResponse>('/products', {
@@ -49,4 +74,8 @@ export const adminProductsApi = {
     apiClient.patch<ProductDetail>(`/products/${id}`, data),
   remove: (id: number) =>
     apiClient.delete<{ message: string }>(`/products/${id}`),
+  previewSmartStoreImport: (file: File) =>
+    apiClient.uploadFile<SmartStoreProductImportResult>('/products/imports/smartstore/preview', file),
+  commitSmartStoreImport: (file: File) =>
+    apiClient.uploadFile<SmartStoreProductImportResult>('/products/imports/smartstore/commit', file),
 };


### PR DESCRIPTION
## 요약
- 스마트스토어 상품 .xlsx 업로드를 서버에서 검증/미리보기/반영하는 관리자 전용 API 추가
- SKU/판매자상품코드 또는 상품번호 기반으로 신규 추가/기존 수정 구분
- 관리자 상품 목록 화면에 업로드, 미리보기, 반영 UI 추가 및 ko/en i18n 적용
- ExcelJS 기반 파싱/매핑/오류 처리 단위 테스트 추가

Closes #759

## 검증
- cd backend && npm test -- --runInBand src/modules/products/__tests__/smartstore-product-import.service.spec.ts
- cd backend && npm run test
- cd backend && npm run build
- cd backend && npm run lint
- npm run build
- npm run test:run -- --maxWorkers=1

## 참고
- 기본 필드와 이미지 URL 매핑 중심의 MVP입니다. 복잡한 옵션 조합과 실제 스마트스토어 export 변형은 후속 확장 대상으로 남겼습니다.