### PR TITLE
Add admin link to the mobile sidebar footer

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -168,6 +168,7 @@ export default function Header() {
         <MobileMenu
           isAuthenticated={isAuthenticated}
           userName={user?.name}
+          userRole={user?.role}
           navItems={navItems}
           sidebarItems={sidebarItems}
           visible={menuPanel.visible}

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -74,12 +74,9 @@ vi.mock('@/contexts/ThemeContext', async (importOriginal) => {
   };
 });
 
+const mockUseAuth = vi.fn();
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({
-    isAuthenticated: false,
-    user: null,
-    logout: vi.fn(),
-  }),
+  useAuth: () => mockUseAuth(),
 }));
 
 const mockUseCart = vi.fn();
@@ -93,6 +90,11 @@ beforeEach(() => {
   mockSetOpen.mockClear();
   mockPathname = '/';
   mockUseCart.mockReturnValue({ itemCount: 0 });
+  mockUseAuth.mockReturnValue({
+    isAuthenticated: false,
+    user: null,
+    logout: vi.fn(),
+  });
 });
 
 describe('Header', () => {
@@ -169,6 +171,29 @@ describe('Header', () => {
     await user.click(loginLink);
 
     expect(mockSetOpen).toHaveBeenCalledWith('menu', false, 'replace');
+  });
+
+  it('shows admin link under order tracking for admin accounts in mobile menu', async () => {
+    const user = userEvent.setup();
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: 1, email: 'admin@test.com', name: 'Admin', role: 'admin' },
+      logout: vi.fn(),
+    });
+
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: '메뉴 열기' }));
+
+    const mobileNav = screen.getByRole('navigation', { name: '모바일 메뉴' });
+    const orderTrackingLink = mobileNav.querySelector('a[href="/my/orders"]');
+    const adminLink = mobileNav.querySelector('a[href="/admin"]');
+
+    expect(orderTrackingLink).toBeInTheDocument();
+    expect(adminLink).toBeInTheDocument();
+    expect(adminLink).toHaveTextContent('관리자');
+
+    const links = Array.from(mobileNav.querySelectorAll('a[href]'));
+    expect(links.indexOf(orderTrackingLink!)).toBeLessThan(links.indexOf(adminLink!));
   });
 
   it('Escape key → mobile menu closes', async () => {

--- a/src/components/header/MobileMenu.tsx
+++ b/src/components/header/MobileMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { X, User, LogOut, LogIn, UserPlus, MessageSquare, Package } from 'lucide-react';
+import { X, User, LogOut, LogIn, UserPlus, MessageSquare, Package, Shield } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import { cn } from '@/components/ui/utils';
@@ -13,6 +13,7 @@ import type { NavigationItem } from '@/lib/api';
 interface MobileMenuProps {
   isAuthenticated: boolean;
   userName?: string;
+  userRole?: string;
   navItems: NavigationItem[];
   sidebarItems: NavigationItem[];
   visible: boolean;
@@ -117,13 +118,15 @@ function MobileMenuContent({ items, history, onItemClick, onLinkClick }: MobileM
 interface MobileMenuFooterProps {
   isAuthenticated: boolean;
   userName?: string;
+  userRole?: string;
   onLogout: () => void;
   onLinkClick: () => void;
 }
 
-function MobileMenuFooter({ isAuthenticated, userName, onLogout, onLinkClick }: MobileMenuFooterProps) {
+function MobileMenuFooter({ isAuthenticated, userName, userRole, onLogout, onLinkClick }: MobileMenuFooterProps) {
   const t = useTranslations('header');
   const orderTrackingHref = isAuthenticated ? '/my/orders' : '/login?redirect=/my/orders';
+  const isAdmin = userRole === 'admin' || userRole === 'super_admin';
   return (
     <div className="px-4 py-4 border-t border-divider-soft shrink-0">
       <div className="flex flex-col gap-1">
@@ -162,6 +165,12 @@ function MobileMenuFooter({ isAuthenticated, userName, onLogout, onLinkClick }: 
           <Package className="h-4 w-4" />
           {t('orderTracking')}
         </Link>
+        {isAdmin && (
+          <Link href="/admin" onClick={onLinkClick} className="min-h-11 py-2 typo-body-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-3">
+            <Shield className="h-4 w-4" />
+            {t('adminPanel')}
+          </Link>
+        )}
       </div>
       <div className="mt-4 flex items-center justify-between">
         <LanguageSelector variant="inline" />
@@ -203,7 +212,7 @@ function MobileMenuNav({ visible, children }: { visible: boolean; children: Reac
   );
 }
 
-export function MobileMenu({ isAuthenticated, userName, navItems, sidebarItems, visible, onClose, onNavigate, onLogout }: MobileMenuProps) {
+export function MobileMenu({ isAuthenticated, userName, userRole, navItems, sidebarItems, visible, onClose, onNavigate, onLogout }: MobileMenuProps) {
   const t = useTranslations('header');
   const menuItems = sidebarItems.length > 0 ? sidebarItems : navItems;
   const [history, setHistory] = useState<HistoryEntry[]>([]);
@@ -248,6 +257,7 @@ export function MobileMenu({ isAuthenticated, userName, navItems, sidebarItems, 
         <MobileMenuFooter
           isAuthenticated={isAuthenticated}
           userName={userName}
+          userRole={userRole}
           onLogout={onLogout}
           onLinkClick={handleNavigateClose}
         />

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -76,6 +76,7 @@
     "createAccount": "Create Account",
     "contact": "Contact Us",
     "orderTracking": "Order Tracking",
+    "adminPanel": "Admin",
     "menuLabel": "Menu",
     "menuBack": "Back",
     "goBack": "Back",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -76,6 +76,7 @@
     "createAccount": "계정 만들기",
     "contact": "문의하기",
     "orderTracking": "주문조회",
+    "adminPanel": "관리자",
     "menuLabel": "메뉴",
     "menuBack": "뒤로",
     "goBack": "뒤로가기",


### PR DESCRIPTION
## Summary
- pass the authenticated user role into the mobile menu
- show an admin footer link below order tracking for admin/super_admin users only
- add header/mobile-menu regression coverage and localized label keys

## Testing
- npm run test:run -- src/components/__tests__/Header.test.tsx
- bash scripts/start-local.sh