### PR TITLE
fix: 관리자 상품 상태 필터 적용 복구

### DIFF
--- a/backend/src/modules/products/__tests__/admin-products.controller.spec.ts
+++ b/backend/src/modules/products/__tests__/admin-products.controller.spec.ts
@@ -1,0 +1,18 @@
+import { AdminProductsController } from '../admin-products.controller';
+import { ProductsService } from '../products.service';
+
+describe('AdminProductsController', () => {
+  it('관리자 목록 조회는 status 필터를 관리자 권한으로 전달한다', async () => {
+    const productsService = {
+      findAll: jest.fn().mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 }),
+    };
+    const controller = new AdminProductsController(productsService as unknown as ProductsService);
+
+    await controller.findAll({ status: 'draft', page: 2, limit: 20 });
+
+    expect(productsService.findAll).toHaveBeenCalledWith(
+      { status: 'draft', page: 2, limit: 20 },
+      true,
+    );
+  });
+});

--- a/backend/src/modules/products/admin-products.controller.ts
+++ b/backend/src/modules/products/admin-products.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import {
+  ApiCookieAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { ProductsService } from './products.service';
+import { QueryProductsDto } from './dto/query-products.dto';
+
+@ApiTags('관리자 - 상품')
+@Controller('admin/products')
+@Roles('admin', 'super_admin')
+export class AdminProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @Get()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '관리자 상품 목록 조회', description: '모든 상태의 상품을 필터링하여 조회합니다.' })
+  @ApiResponse({ status: 200, description: '관리자 상품 목록 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: '페이지 번호' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: '페이지당 개수' })
+  @ApiQuery({ name: 'status', required: false, type: String, description: '상품 상태 필터' })
+  findAll(@Query() query: QueryProductsDto) {
+    return this.productsService.findAll(query, true);
+  }
+}

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -16,6 +16,7 @@ import { AttributesService } from './attributes.service';
 import { RecentlyViewedService } from './recently-viewed.service';
 import { SmartStoreProductImportService } from './smartstore-product-import.service';
 import { ProductsController } from './products.controller';
+import { AdminProductsController } from './admin-products.controller';
 import { CategoriesController } from './categories.controller';
 import { AttributesController } from './attributes.controller';
 import { CacheModule } from '../cache/cache.module';
@@ -47,7 +48,7 @@ import { RecentlyViewedProduct } from './entities/recently-viewed-product.entity
     RecentlyViewedService,
     SmartStoreProductImportService,
   ],
-  controllers: [ProductsController, CategoriesController, AttributesController],
+  controllers: [ProductsController, AdminProductsController, CategoriesController, AttributesController],
   exports: [
     ProductsService,
     ProductQueryService,

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -62,11 +62,8 @@ export interface SmartStoreProductImportResult {
 
 export const adminProductsApi = {
   getList: (params?: AdminProductsParams) =>
-    apiClient.get<ProductListResponse>('/products', {
-      params: {
-        ...params,
-        // admin calls include all statuses
-      } as Record<string, string | number | undefined>,
+    apiClient.get<ProductListResponse>('/admin/products', {
+      params: params as Record<string, string | number | undefined>,
     }),
   create: (data: CreateProductData) =>
     apiClient.post<ProductDetail>('/products', data),


### PR DESCRIPTION
## 요약
- 관리자 상품 목록을 공개 `/products` 대신 보호된 `/admin/products`로 분리
- 관리자 조회가 항상 `isAdmin=true`로 전달되도록 전용 컨트롤러 추가
- 관리자 상태 필터 회귀 테스트 추가

## 원인
`/products`는 공개 엔드포인트라 JWT 가드가 사용자 정보를 채우지 않았고, 관리자 화면도 이 경로를 써서 서버가 항상 비관리자 조회로 처리했습니다. 그 결과 상태 버튼을 눌러도 `active` 필터가 강제되었습니다.

## 검증
- `cd backend && npm test -- --runInBand admin-products.controller.spec.ts product-query.service.spec.ts`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`