### PR TITLE
fix: 관리자 상품 상태 탭 필터 동작 보정

### DIFF
--- a/backend/src/modules/products/__tests__/product-query.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-query.service.spec.ts
@@ -235,6 +235,17 @@ describe('ProductQueryService', () => {
         status: 'draft',
       });
     });
+
+    it('관리자가 status 없이 조회하면 전체 상태를 볼 수 있도록 status 조건을 추가하지 않음', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({}, true);
+
+      expect(qb.andWhere).not.toHaveBeenCalledWith(
+        'product.status = :status',
+        expect.anything(),
+      );
+    });
   });
 
   describe('findOne', () => {

--- a/backend/src/modules/products/product-query.service.ts
+++ b/backend/src/modules/products/product-query.service.ts
@@ -306,7 +306,7 @@ export class ProductQueryService {
     isAdmin: boolean,
     status?: ProductStatus,
   ): SelectQueryBuilder<Product> {
-    return this.productRepository
+    const qb = this.productRepository
       .createQueryBuilder('product')
       .leftJoinAndSelect('product.category', 'category')
       .leftJoinAndSelect(
@@ -314,10 +314,19 @@ export class ProductQueryService {
         'image',
         'image.is_thumbnail = :isThumbnail',
         { isThumbnail: true },
-      )
-      .andWhere('product.status = :status', {
-        status: isAdmin && status ? status : ProductStatus.ACTIVE,
+      );
+
+    if (!isAdmin) {
+      return qb.andWhere('product.status = :status', {
+        status: ProductStatus.ACTIVE,
       });
+    }
+
+    if (status) {
+      return qb.andWhere('product.status = :status', { status });
+    }
+
+    return qb;
   }
 
   private applyFiltersAndSort(


### PR DESCRIPTION
## 요약
- 관리자 `전체` 조회에서 상태 조건을 제거
- 비관리자는 기존처럼 `active`만 유지
- 관리자 개별 상태 탭은 해당 상태만 필터링
- 회귀 테스트 추가

## 배경
직전 수정으로 관리자 전용 API 경로는 분리했지만, 백엔드 조회 공통 로직이 관리자 `전체` 요청까지 `active`로 강제하고 있었습니다. 이번 변경은 관리자 전체/개별 상태 탭의 의미를 쿼리 레벨에서 분리합니다.

## 검증
- `cd backend && npm test -- --runInBand product-query.service.spec.ts admin-products.controller.spec.ts`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`