### PR TITLE
Serve best sellers through CMS

### DIFF
--- a/backend/src/database/migrations/1783800000000-CreateBestSellersCmsPage.ts
+++ b/backend/src/database/migrations/1783800000000-CreateBestSellersCmsPage.ts
@@ -1,0 +1,83 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateBestSellersCmsPage1783800000000 implements MigrationInterface {
+  name = 'CreateBestSellersCmsPage1783800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO \`pages\` (\`slug\`, \`title\`, \`title_en\`, \`template\`, \`is_published\`)
+       VALUES ('best', '베스트', 'Best Sellers', 'default', 1)
+       ON DUPLICATE KEY UPDATE
+         \`title\` = VALUES(\`title\`),
+         \`title_en\` = COALESCE(NULLIF(\`title_en\`, ''), VALUES(\`title_en\`)),
+         \`template\` = VALUES(\`template\`),
+         \`is_published\` = VALUES(\`is_published\`)`,
+    );
+
+    const [page] = await queryRunner.query(`SELECT id FROM \`pages\` WHERE \`slug\` = 'best' LIMIT 1`);
+    if (!page) return;
+
+    const textContent = {
+      html: '<h1>베스트</h1><p>옥화당에서 가장 많은 사랑을 받은 상품을 모았습니다.</p>',
+      html_en: '<h1>Best Sellers</h1><p>Discover the most-loved pieces from Ockhwadang.</p>',
+      textAlign: 'center',
+      template: 'default',
+    };
+    const gridContent = {
+      title: '베스트 상품',
+      title_en: 'Best Sellers',
+      sort: 'popular',
+      limit: 12,
+      template: '4col',
+    };
+
+    const [existingText] = await queryRunner.query(
+      `SELECT id FROM \`page_blocks\` WHERE \`page_id\` = ? AND \`type\` = 'text_content' AND \`sort_order\` = 0 LIMIT 1`,
+      [page.id],
+    );
+    if (!existingText) {
+      await queryRunner.query(
+        `INSERT INTO \`page_blocks\` (\`page_id\`, \`type\`, \`content\`, \`sort_order\`, \`is_visible\`)
+         VALUES (?, 'text_content', ?, 0, 1)`,
+        [page.id, JSON.stringify(textContent)],
+      );
+    }
+
+    const [existingGrid] = await queryRunner.query(
+      `SELECT id FROM \`page_blocks\` WHERE \`page_id\` = ? AND \`type\` = 'product_grid' AND \`sort_order\` = 1 LIMIT 1`,
+      [page.id],
+    );
+    if (!existingGrid) {
+      await queryRunner.query(
+        `INSERT INTO \`page_blocks\` (\`page_id\`, \`type\`, \`content\`, \`sort_order\`, \`is_visible\`)
+         VALUES (?, 'product_grid', ?, 1, 1)`,
+        [page.id, JSON.stringify(gridContent)],
+      );
+    }
+
+    await queryRunner.query(
+      `INSERT INTO \`navigation_items\` (\`id\`, \`group\`, \`label\`, \`label_en\`, \`url\`, \`sort_order\`, \`is_active\`, \`parent_id\`)
+       VALUES (104, 'gnb', '베스트', 'Best Sellers', '/p/best', 3, 1, NULL)
+       ON DUPLICATE KEY UPDATE
+         \`label\` = VALUES(\`label\`),
+         \`label_en\` = VALUES(\`label_en\`),
+         \`url\` = VALUES(\`url\`),
+         \`sort_order\` = VALUES(\`sort_order\`),
+         \`is_active\` = VALUES(\`is_active\`)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`navigation_items\`
+       SET \`url\` = '/products?sort=popular'
+       WHERE \`id\` = 104 AND \`group\` = 'gnb' AND \`url\` = '/p/best'`,
+    );
+
+    const [page] = await queryRunner.query(`SELECT id FROM \`pages\` WHERE \`slug\` = 'best' LIMIT 1`);
+    if (!page) return;
+
+    await queryRunner.query(`DELETE FROM \`page_blocks\` WHERE \`page_id\` = ?`, [page.id]);
+    await queryRunner.query(`DELETE FROM \`pages\` WHERE \`id\` = ?`, [page.id]);
+  }
+}

--- a/backend/src/database/seeds/data/seed-data.ts
+++ b/backend/src/database/seeds/data/seed-data.ts
@@ -937,7 +937,7 @@ export const navigationItems: SeedNavigationItem[] = [
   { id: 100, group: 'gnb', label: '홈', url: '/', sort_order: 0, is_active: true, parent_id: null },
   { id: 101, group: 'gnb', label: '자사호', url: '/products?categoryId=1', sort_order: 1, is_active: true, parent_id: null },
   { id: 102, group: 'gnb', label: '보이차·다구', url: '/products?categoryId=2', sort_order: 2, is_active: true, parent_id: null },
-  { id: 104, group: 'gnb', label: '베스트', url: '/products?sort=popular', sort_order: 3, is_active: true, parent_id: null },
+  { id: 104, group: 'gnb', label: '베스트', labelEn: 'Best Sellers', url: '/p/best', sort_order: 3, is_active: true, parent_id: null },
   { id: 108, group: 'gnb', label: '브랜드 소개', url: '/p/about', sort_order: 4, is_active: true, parent_id: null },
   { id: 109, group: 'gnb', label: '기획전', url: '/p/exhibition', sort_order: 5, is_active: true, parent_id: null },
 
@@ -1472,12 +1472,14 @@ export const artists: SeedArtist[] = [
 export interface SeedPage {
   slug: string;
   title: string;
+  titleEn?: string;
   template: string;
   isPublished: boolean;
 }
 
 export const pages: SeedPage[] = [
   { slug: 'home', title: '홈 메인 페이지', template: 'default', isPublished: true },
+  { slug: 'best', title: '베스트', titleEn: 'Best Sellers', template: 'default', isPublished: true },
   { slug: 'exhibition', title: '봄 기획전 — 주니 신작 입고', template: 'default', isPublished: true },
   { slug: 'about', title: '브랜드 소개', template: 'default', isPublished: true },
   { slug: 'contact', title: '문의하기', template: 'default', isPublished: true },
@@ -1630,6 +1632,33 @@ export const pageBlocks: SeedPageBlock[] = JSON.parse(JSON.stringify([
       more_href: '/journal',
     },
     sortOrder: 6,
+    isVisible: true,
+  },
+
+  // ── 베스트 페이지 ──
+  {
+    pageSlug: 'best',
+    type: 'text_content',
+    content: {
+      html: '<h1>베스트</h1><p>옥화당에서 가장 많은 사랑을 받은 상품을 모았습니다.</p>',
+      html_en: '<h1>Best Sellers</h1><p>Discover the most-loved pieces from Ockhwadang.</p>',
+      textAlign: 'center',
+      template: 'default',
+    },
+    sortOrder: 0,
+    isVisible: true,
+  },
+  {
+    pageSlug: 'best',
+    type: 'product_grid',
+    content: {
+      title: '베스트 상품',
+      title_en: 'Best Sellers',
+      sort: 'popular',
+      limit: 12,
+      template: '4col',
+    },
+    sortOrder: 1,
     isVisible: true,
   },
 

--- a/backend/src/database/seeds/seeders/page.seeder.ts
+++ b/backend/src/database/seeds/seeders/page.seeder.ts
@@ -21,6 +21,7 @@ export class PageSeeder extends Seeder {
           title: page.title,
           template: page.template,
           is_published: page.isPublished,
+          ...(page.titleEn !== undefined ? { titleEn: page.titleEn } : {}),
         },
       );
       updated += result.affected ?? 0;

--- a/src/__tests__/middleware-backend-fallback.test.ts
+++ b/src/__tests__/middleware-backend-fallback.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('next-intl/middleware', () => ({
+  default: () => () => new Response(null, { status: 200 }),
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  routing: { locales: ['ko', 'en'], defaultLocale: 'ko' },
+}));
+
+import { middleware, resetPublicKeyCache, setTestPublicKey } from '@/middleware';
+
+const ORIGINAL_BACKEND_URL = process.env.BACKEND_URL;
+const ORIGINAL_JWT_PUBLIC_KEY = process.env.JWT_PUBLIC_KEY;
+
+function makeRequest(pathname: string, cookie = 'accessToken=opaque-token'): NextRequest {
+  return new NextRequest(`http://localhost${pathname}`, {
+    headers: { cookie },
+  });
+}
+
+describe('middleware backend admin-role fallback', () => {
+  beforeEach(() => {
+    resetPublicKeyCache();
+    setTestPublicKey('');
+    process.env.BACKEND_URL = 'http://backend.test';
+    delete process.env.JWT_PUBLIC_KEY;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetPublicKeyCache();
+    setTestPublicKey('');
+    if (ORIGINAL_BACKEND_URL === undefined) {
+      delete process.env.BACKEND_URL;
+    } else {
+      process.env.BACKEND_URL = ORIGINAL_BACKEND_URL;
+    }
+    if (ORIGINAL_JWT_PUBLIC_KEY === undefined) {
+      delete process.env.JWT_PUBLIC_KEY;
+    } else {
+      process.env.JWT_PUBLIC_KEY = ORIGINAL_JWT_PUBLIC_KEY;
+    }
+  });
+
+  it('allows /admin when JWT_PUBLIC_KEY is unavailable but backend /auth/me confirms admin role', async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe('http://backend.test/api/auth/me');
+      expect(init?.headers).toEqual({ cookie: 'accessToken=opaque-token' });
+      return new Response(JSON.stringify({ id: 1, role: 'admin' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await middleware(makeRequest('/ko/admin'));
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects /admin when backend fallback returns a non-admin role', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ id: 2, role: 'user' }), { status: 200 })),
+    );
+
+    const res = await middleware(makeRequest('/ko/admin'));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://localhost/ko/');
+  });
+
+  it('does not fallback to backend when a configured public key rejects the token', async () => {
+    process.env.JWT_PUBLIC_KEY = 'configured-but-invalid-key';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await middleware(makeRequest('/ko/admin', 'accessToken=forged.token.value'));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://localhost/ko/');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/shared/admin/page-editor/block-property-panel/blocks/ProductGridFields.tsx
+++ b/src/components/shared/admin/page-editor/block-property-panel/blocks/ProductGridFields.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import type { ProductSort } from '@/lib/api';
 import { NumberField, SelectField, StringField, createContentUpdater } from '../FormFields';
-import { PRODUCT_GRID_TEMPLATE_OPTIONS } from '../blockConfig';
+import { PRODUCT_GRID_TEMPLATE_OPTIONS, PRODUCT_SORT_OPTIONS } from '../blockConfig';
 import ProductCategoryPicker from '../ProductCategoryPicker';
 
 interface ProductGridFieldsProps {
@@ -22,6 +23,12 @@ export default function ProductGridFields({ content, onChange }: ProductGridFiel
         value={(content.template as string) ?? '3col'}
         options={PRODUCT_GRID_TEMPLATE_OPTIONS}
         onChange={(v) => update('template', v)}
+      />
+      <SelectField
+        label="정렬"
+        value={(content.sort as string) ?? 'latest'}
+        options={PRODUCT_SORT_OPTIONS}
+        onChange={(v) => update('sort', v as ProductSort)}
       />
       <ProductCategoryPicker content={content} onChange={onChange} />
     </>

--- a/src/components/shared/blocks/ProductGridBlock.test.tsx
+++ b/src/components/shared/blocks/ProductGridBlock.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ProductGridBlock from '@/components/shared/blocks/ProductGridBlock';
-import type { Product } from '@/lib/api';
+import { productsApi, type Product } from '@/lib/api';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -115,5 +115,27 @@ describe('ProductGridBlock', () => {
 
     const { container } = render(<ProductGridBlock content={content} />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it('passes CMS sort setting when auto-loading products', async () => {
+    vi.mocked(productsApi.getList).mockResolvedValue({
+      items: mockProducts,
+      total: mockProducts.length,
+      page: 1,
+      limit: 12,
+    });
+
+    const content = {
+      limit: 12,
+      template: '4col' as const,
+      sort: 'popular' as const,
+      title: '베스트 상품',
+    };
+
+    render(<ProductGridBlock content={content} />);
+
+    await waitFor(() => {
+      expect(productsApi.getList).toHaveBeenCalledWith({ sort: 'popular', limit: 12, locale: 'ko' });
+    });
   });
 });

--- a/src/components/shared/blocks/ProductGridBlock.tsx
+++ b/src/components/shared/blocks/ProductGridBlock.tsx
@@ -25,7 +25,7 @@ export default function ProductGridBlock({ content }: Props) {
   const params = useParams();
   const locale = params.locale as string;
   const t = useTranslations('common');
-  const { product_ids, category_id, auto, limit, template, title, more_href, prefetched_products } = content;
+  const { product_ids, category_id, auto, sort, limit, template, title, more_href, prefetched_products } = content;
   const { ref, visible } = useScrollAnimation<HTMLElement>();
 
   const { data: products, loading } = useBlockData<Product>({
@@ -34,14 +34,14 @@ export default function ProductGridBlock({ content }: Props) {
       if (product_ids && product_ids.length > 0) {
         return productsApi.getBulk(product_ids.slice(0, limit), locale);
       } else if (category_id) {
-        const res = await productsApi.getList({ categoryId: category_id, limit, locale });
+        const res = await productsApi.getList({ categoryId: category_id, sort, limit, locale });
         return res.items;
       } else {
-        const res = await productsApi.getList({ limit, locale });
+        const res = await productsApi.getList({ sort, limit, locale });
         return res.items;
       }
     },
-    deps: [product_ids, category_id, auto, limit, locale],
+    deps: [product_ids, category_id, auto, sort, limit, locale],
   });
 
   const gridCols = gridColsMap[template] ?? gridColsMap['4col'];

--- a/src/lib/api/pages.ts
+++ b/src/lib/api/pages.ts
@@ -42,6 +42,7 @@ export interface ProductGridContent {
   product_ids?: number[];
   category_id?: number;
   auto?: boolean;
+  sort?: ProductSort;
   limit: number;
   template: '2col' | '3col' | '4col';
   title?: string;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,14 +9,16 @@ const localePattern = new RegExp(`^/(${routing.locales.join('|')})(/.*)?$`);
 
 const ADMIN_ROLES = new Set(['admin', 'super_admin']);
 
+type AdminRoleCheckResult = 'admin' | 'not-admin' | 'unverified';
+
 export function resetPublicKeyCache(): void {
-  // No-op for backwards compatibility
+  testPublicKey = null;
 }
 
 let testPublicKey: string | null = null;
 
 export function setTestPublicKey(pem: string): void {
-  testPublicKey = pem;
+  testPublicKey = pem.trim() ? pem : null;
 }
 
 async function getPublicKey(): Promise<CryptoKey | null> {
@@ -55,6 +57,10 @@ async function getPublicKey(): Promise<CryptoKey | null> {
   );
 }
 
+function hasConfiguredPublicKey(): boolean {
+  return Boolean(testPublicKey ?? process.env.JWT_PUBLIC_KEY);
+}
+
 async function verifyRS256(token: string): Promise<Record<string, unknown> | null> {
   try {
     const parts = token.split('.');
@@ -89,10 +95,49 @@ async function verifyRS256(token: string): Promise<Record<string, unknown> | nul
   }
 }
 
-async function hasAdminRole(token: string): Promise<boolean> {
+async function hasAdminRoleByJwt(token: string): Promise<AdminRoleCheckResult> {
   const payload = await verifyRS256(token);
-  if (!payload) return false;
-  return typeof payload.role === 'string' && ADMIN_ROLES.has(payload.role);
+  if (!payload) return 'unverified';
+  return typeof payload.role === 'string' && ADMIN_ROLES.has(payload.role) ? 'admin' : 'not-admin';
+}
+
+function getBackendAuthMeUrl(): string | null {
+  const backendUrl = process.env.BACKEND_URL?.trim();
+  if (!backendUrl) return null;
+
+  const normalized = backendUrl.replace(/\/$/, '');
+  return normalized.endsWith('/api') ? `${normalized}/auth/me` : `${normalized}/api/auth/me`;
+}
+
+async function hasAdminRoleByBackend(cookieHeader: string | null): Promise<boolean> {
+  const url = getBackendAuthMeUrl();
+  if (!url || !cookieHeader) return false;
+
+  try {
+    const response = await fetch(url, {
+      headers: { cookie: cookieHeader },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) return false;
+
+    const profile = await response.json() as { role?: unknown };
+    return typeof profile.role === 'string' && ADMIN_ROLES.has(profile.role);
+  } catch {
+    return false;
+  }
+}
+
+async function hasAdminRole(token: string, cookieHeader: string | null): Promise<boolean> {
+  const jwtResult = await hasAdminRoleByJwt(token);
+  if (jwtResult === 'admin') return true;
+  if (jwtResult === 'not-admin' || hasConfiguredPublicKey()) return false;
+
+  // In local/Vercel deployments the Edge middleware may not have JWT_PUBLIC_KEY,
+  // while the backend still has the private/public key pair and can validate the
+  // httpOnly cookie. Fall back to the backend profile endpoint only when local
+  // verification is impossible, not when a configured key rejects the token.
+  return hasAdminRoleByBackend(cookieHeader);
 }
 
 export async function middleware(request: NextRequest) {
@@ -113,7 +158,7 @@ export async function middleware(request: NextRequest) {
       loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
       return NextResponse.redirect(loginUrl);
     }
-    if (!(await hasAdminRole(token))) {
+    if (!(await hasAdminRole(token, request.headers.get('cookie')))) {
       return NextResponse.redirect(new URL(`${localePrefix}/`, request.url));
     }
   }


### PR DESCRIPTION
## Summary
- add a CMS-managed best sellers page and seed/migration support
- point the GNB Best Sellers link to `/p/best`
- expose product grid sort in the CMS editor and pass it through to product loading

## Tests
- npm run test:run -- src/components/shared/blocks/ProductGridBlock.test.tsx
- cd backend && npm run build

## Notes
- unrelated local uncommitted files were intentionally left out of this PR