### PR TITLE
fix: #771 상품 목록 attrs 필터 값 통일

### DIFF
--- a/backend/src/database/migrations/1776500000000-RefactorToDynamicAttributes.ts
+++ b/backend/src/database/migrations/1776500000000-RefactorToDynamicAttributes.ts
@@ -49,8 +49,8 @@ export class RefactorToDynamicAttributes1776500000000 implements MigrationInterf
     // 3. Insert default attribute types for the tea shop
     await queryRunner.query(`
       INSERT INTO \`attribute_types\` (\`code\`, \`name\`, \`name_ko\`, \`input_type\`, \`is_filterable\`, \`is_searchable\`, \`valid_values\`, \`sort_order\`) VALUES
-      ('clay_type', 'Clay Type', '니료', 'select', TRUE, FALSE, '["zhuni","zisha","duanni","heini","qinghuini"]', 1),
-      ('teapot_shape', 'Shape', '모양', 'select', TRUE, FALSE, '["zhuxing","shipiao","xishi","bianping"]', 2)
+      ('clay_type', 'Clay Type', '니료', 'select', TRUE, FALSE, '["junni","danji","jani","heugni","cheongsu","nokni"]', 1),
+      ('teapot_shape', 'Shape', '모양', 'select', TRUE, FALSE, '["seoshi","seokpyo","juhu","bianping","inwang","deokjong","supeong"]', 2)
     `);
 
     // 4. Drop old clay_type and teapot_shape columns from products

--- a/backend/src/database/migrations/1783900000001-AlignProductAttributeFilterValues.ts
+++ b/backend/src/database/migrations/1783900000001-AlignProductAttributeFilterValues.ts
@@ -1,0 +1,101 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlignProductAttributeFilterValues1783900000001 implements MigrationInterface {
+  name = 'AlignProductAttributeFilterValues1783900000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE \`attribute_types\`
+      SET \`valid_values\` = '["junni","danji","jani","heugni","cheongsu","nokni"]'
+      WHERE \`code\` = 'clay_type'
+    `);
+    await queryRunner.query(`
+      UPDATE \`attribute_types\`
+      SET \`valid_values\` = '["seoshi","seokpyo","juhu","bianping","inwang","deokjong","supeong"]'
+      WHERE \`code\` = 'teapot_shape'
+    `);
+
+    await queryRunner.query(`
+      UPDATE \`product_attributes\` pa
+      INNER JOIN \`attribute_types\` at ON at.id = pa.attribute_type_id AND at.code = 'clay_type'
+      SET pa.value = CASE pa.value
+        WHEN 'zhuni' THEN 'junni'
+        WHEN 'zisha' THEN 'jani'
+        WHEN 'duanni' THEN 'danji'
+        WHEN 'heini' THEN 'heugni'
+        WHEN 'qinghuini' THEN 'cheongsu'
+        ELSE pa.value
+      END
+      WHERE pa.value IN ('zhuni', 'zisha', 'duanni', 'heini', 'qinghuini')
+    `);
+    await queryRunner.query(`
+      UPDATE \`product_attributes\` pa
+      INNER JOIN \`attribute_types\` at ON at.id = pa.attribute_type_id AND at.code = 'teapot_shape'
+      SET pa.value = CASE pa.value
+        WHEN 'xishi' THEN 'seoshi'
+        WHEN 'shipiao' THEN 'seokpyo'
+        WHEN 'zhuxing' THEN 'juhu'
+        ELSE pa.value
+      END
+      WHERE pa.value IN ('xishi', 'shipiao', 'zhuxing')
+    `);
+    await queryRunner.query(`
+      UPDATE \`collections\`
+      SET \`product_url\` = CASE
+        WHEN \`type\` = 'clay' THEN CONCAT('/products?attrs=clay_type:', \`name\`)
+        WHEN \`type\` = 'shape' THEN CONCAT('/products?attrs=teapot_shape:', \`name\`)
+        ELSE \`product_url\`
+      END
+      WHERE (\`type\` = 'clay' AND \`product_url\` LIKE '/products?clayType=%')
+         OR (\`type\` = 'shape' AND \`product_url\` LIKE '/products?teapotShape=%')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE \`collections\`
+      SET \`product_url\` = CASE
+        WHEN \`type\` = 'clay' THEN CONCAT('/products?clayType=', \`name\`)
+        WHEN \`type\` = 'shape' THEN CONCAT('/products?teapotShape=', \`name\`)
+        ELSE \`product_url\`
+      END
+      WHERE (\`type\` = 'clay' AND \`product_url\` LIKE '/products?attrs=clay_type:%')
+         OR (\`type\` = 'shape' AND \`product_url\` LIKE '/products?attrs=teapot_shape:%')
+    `);
+    await queryRunner.query(`
+      UPDATE \`product_attributes\` pa
+      INNER JOIN \`attribute_types\` at ON at.id = pa.attribute_type_id AND at.code = 'teapot_shape'
+      SET pa.value = CASE pa.value
+        WHEN 'seoshi' THEN 'xishi'
+        WHEN 'seokpyo' THEN 'shipiao'
+        WHEN 'juhu' THEN 'zhuxing'
+        ELSE pa.value
+      END
+      WHERE pa.value IN ('seoshi', 'seokpyo', 'juhu')
+    `);
+    await queryRunner.query(`
+      UPDATE \`product_attributes\` pa
+      INNER JOIN \`attribute_types\` at ON at.id = pa.attribute_type_id AND at.code = 'clay_type'
+      SET pa.value = CASE pa.value
+        WHEN 'junni' THEN 'zhuni'
+        WHEN 'jani' THEN 'zisha'
+        WHEN 'danji' THEN 'duanni'
+        WHEN 'heugni' THEN 'heini'
+        WHEN 'cheongsu' THEN 'qinghuini'
+        ELSE pa.value
+      END
+      WHERE pa.value IN ('junni', 'jani', 'danji', 'heugni', 'cheongsu')
+    `);
+
+    await queryRunner.query(`
+      UPDATE \`attribute_types\`
+      SET \`valid_values\` = '["zhuni","zisha","duanni","heini","qinghuini"]'
+      WHERE \`code\` = 'clay_type'
+    `);
+    await queryRunner.query(`
+      UPDATE \`attribute_types\`
+      SET \`valid_values\` = '["zhuxing","shipiao","xishi","bianping"]'
+      WHERE \`code\` = 'teapot_shape'
+    `);
+  }
+}

--- a/backend/src/database/seeds/data/seed-data.ts
+++ b/backend/src/database/seeds/data/seed-data.ts
@@ -1362,18 +1362,18 @@ export interface SeedCollection {
 
 export const collections: SeedCollection[] = [
   // 니료별
-  { type: 'clay', name: 'junni', nameKo: '주니', color: '#8B4513', description: '주철질의 대표 니료로, 적색 내지 황갈색을 띱니다. 내열성과 보온성이 뛰어나며, 차의 풍미를 극대화합니다.', productUrl: '/products?clayType=junni', sortOrder: 1, isActive: true },
-  { type: 'clay', name: 'danji', nameKo: '단니', color: '#D4A574', description: '황토계열의 단단한 니료로, 밝은 황금빛을 띱니다. 은은한 향과 부드러운 맛을 표현하는 데 적합합니다.', productUrl: '/products?clayType=danji', sortOrder: 2, isActive: true },
-  { type: 'clay', name: 'jani', nameKo: '자니', color: '#2F4F4F', description: '청자질의 대표 니료로, 청록색 내지 암청색을 띱니다. 깊은 향과 시원한 맛을 자랑합니다.', productUrl: '/products?clayType=jani', sortOrder: 3, isActive: true },
-  { type: 'clay', name: 'heugni', nameKo: '흑니', color: '#1C1C1C', description: '흑색 도자기 전용 니료로, 검은색을 띱니다. 떫은맛을 줄이고 깊은 맛을내는 특성이 있습니다.', productUrl: '/products?clayType=heugni', sortOrder: 4, isActive: true },
-  { type: 'clay', name: 'cheongsu', nameKo: '청수니', color: '#4682B4', description: '청수(정선) 지역 특유의 청백색 니료입니다. 산뜻한 맛과 깨끗한 향이 특징입니다.', productUrl: '/products?clayType=cheongsu', sortOrder: 5, isActive: true },
-  { type: 'clay', name: 'nokni', nameKo: '녹니', color: '#556B2F', description: '녹토계열의 독특한 니료로, 녹색기를 띱니다. 건강과 풍미를 동시에 생각하는 이들에게 사랑받습니다.', productUrl: '/products?clayType=nokni', sortOrder: 6, isActive: true },
+  { type: 'clay', name: 'junni', nameKo: '주니', color: '#8B4513', description: '주철질의 대표 니료로, 적색 내지 황갈색을 띱니다. 내열성과 보온성이 뛰어나며, 차의 풍미를 극대화합니다.', productUrl: '/products?attrs=clay_type:junni', sortOrder: 1, isActive: true },
+  { type: 'clay', name: 'danji', nameKo: '단니', color: '#D4A574', description: '황토계열의 단단한 니료로, 밝은 황금빛을 띱니다. 은은한 향과 부드러운 맛을 표현하는 데 적합합니다.', productUrl: '/products?attrs=clay_type:danji', sortOrder: 2, isActive: true },
+  { type: 'clay', name: 'jani', nameKo: '자니', color: '#2F4F4F', description: '청자질의 대표 니료로, 청록색 내지 암청색을 띱니다. 깊은 향과 시원한 맛을 자랑합니다.', productUrl: '/products?attrs=clay_type:jani', sortOrder: 3, isActive: true },
+  { type: 'clay', name: 'heugni', nameKo: '흑니', color: '#1C1C1C', description: '흑색 도자기 전용 니료로, 검은색을 띱니다. 떫은맛을 줄이고 깊은 맛을내는 특성이 있습니다.', productUrl: '/products?attrs=clay_type:heugni', sortOrder: 4, isActive: true },
+  { type: 'clay', name: 'cheongsu', nameKo: '청수니', color: '#4682B4', description: '청수(정선) 지역 특유의 청백색 니료입니다. 산뜻한 맛과 깨끗한 향이 특징입니다.', productUrl: '/products?attrs=clay_type:cheongsu', sortOrder: 5, isActive: true },
+  { type: 'clay', name: 'nokni', nameKo: '녹니', color: '#556B2F', description: '녹토계열의 독특한 니료로, 녹색기를 띱니다. 건강과 풍미를 동시에 생각하는 이들에게 사랑받습니다.', productUrl: '/products?attrs=clay_type:nokni', sortOrder: 6, isActive: true },
   // 모양별
-  { type: 'shape', name: 'seoshi', nameKo: '서시', color: null, description: '평평하고 넓은 형태의 주전자. 뛰어난 안정감과 넓은 탕면으로 차의 풍미를 펼쳐줍니다.', productUrl: '/products?teapotShape=seoshi', sortOrder: 1, isActive: true },
-  { type: 'shape', name: 'seokpyo', nameKo: '석표', color: null, description: '곰방대 형태에서 영감을 받은 독특한 모양. 절제된 아름다움과 실용성을 겸비합니다.', productUrl: '/products?teapotShape=seokpyo', sortOrder: 2, isActive: true },
-  { type: 'shape', name: 'inwang', nameKo: '인왕', color: null, description: '인왕산의 기품을 담은 날카롭고 세련된 라인. 현대적 감각으로 재해석한 전통 형태입니다.', productUrl: '/products?teapotShape=inwang', sortOrder: 3, isActive: true },
-  { type: 'shape', name: 'deokjong', nameKo: '덕종', color: null, description: '고려 시대의 달인으로 유명한 덕종달인의 기법을 현대에 재현. 우아하고 정제된 실루엿입니다.', productUrl: '/products?teapotShape=deokjong', sortOrder: 4, isActive: true },
-  { type: 'shape', name: 'supeong', nameKo: '수평', color: null, description: '수평의 아름다운 곡선. 검소하고 담백한 아름다움으로 평온함을 선물합니다.', productUrl: '/products?teapotShape=supeong', sortOrder: 5, isActive: true },
+  { type: 'shape', name: 'seoshi', nameKo: '서시', color: null, description: '평평하고 넓은 형태의 주전자. 뛰어난 안정감과 넓은 탕면으로 차의 풍미를 펼쳐줍니다.', productUrl: '/products?attrs=teapot_shape:seoshi', sortOrder: 1, isActive: true },
+  { type: 'shape', name: 'seokpyo', nameKo: '석표', color: null, description: '곰방대 형태에서 영감을 받은 독특한 모양. 절제된 아름다움과 실용성을 겸비합니다.', productUrl: '/products?attrs=teapot_shape:seokpyo', sortOrder: 2, isActive: true },
+  { type: 'shape', name: 'inwang', nameKo: '인왕', color: null, description: '인왕산의 기품을 담은 날카롭고 세련된 라인. 현대적 감각으로 재해석한 전통 형태입니다.', productUrl: '/products?attrs=teapot_shape:inwang', sortOrder: 3, isActive: true },
+  { type: 'shape', name: 'deokjong', nameKo: '덕종', color: null, description: '고려 시대의 달인으로 유명한 덕종달인의 기법을 현대에 재현. 우아하고 정제된 실루엿입니다.', productUrl: '/products?attrs=teapot_shape:deokjong', sortOrder: 4, isActive: true },
+  { type: 'shape', name: 'supeong', nameKo: '수평', color: null, description: '수평의 아름다운 곡선. 검소하고 담백한 아름다움으로 평온함을 선물합니다.', productUrl: '/products?attrs=teapot_shape:supeong', sortOrder: 5, isActive: true },
 ];
 
 // ============================================================

--- a/backend/src/database/seeds/okhwadang-seed.sql
+++ b/backend/src/database/seeds/okhwadang-seed.sql
@@ -42,45 +42,45 @@ SET SESSION FOREIGN_KEY_CHECKS = 1;
 -- 1-5. 속성 유형 (Dynamic Attribute System)
 -- ============================================================
 INSERT INTO attribute_types (id, code, name, name_ko, input_type, is_filterable, is_searchable, valid_values, sort_order) VALUES
-(1, 'clay_type', 'Clay Type', '니료', 'select', TRUE, FALSE, '["zhuni","zisha","duanni","heini","qinghuini"]', 1),
-(2, 'teapot_shape', 'Shape', '모양', 'select', TRUE, FALSE, '["zhuxing","shipiao","xishi","bianping"]', 2);
+(1, 'clay_type', 'Clay Type', '니료', 'select', TRUE, FALSE, '["junni","danji","jani","heugni","cheongsu","nokni"]', 1),
+(2, 'teapot_shape', 'Shape', '모양', 'select', TRUE, FALSE, '["seoshi","seokpyo","juhu","bianping","inwang","deokjong","supeong"]', 2);
 
 -- ============================================================
 -- 1-6. 상품 속성 (Dynamic Attributes for Products)
 -- ============================================================
 -- 상품별 니료(clay_type)와 모양(teapot_shape) 속성
--- clay_type: category 10=주니(zhuni), 11=자사(zisha), 12=단니(duanni), 13=흑니(heini), 14=청회니(qinghuini)
--- teapot_shape: 서시(xishi), 주형(zhuxing), 석표(shipiao), 편평(bianping)
+-- clay_type: category 10=주니(junni), 11=자니(jani), 12=단니(danji), 13=흑니(heugni), 14=청수니(cheongsu)
+-- teapot_shape: 서시(seoshi), 주형(juhu), 석표(seokpyo), 편평(bianping)
 INSERT INTO product_attributes (product_id, attribute_type_id, value, display_value) VALUES
 -- 자사호 (주니) - product_id 1,2,3
-(1, 1, 'zhuni', '주니'),
-(1, 2, 'xishi', '서시'),
-(2, 1, 'zhuni', '주니'),
-(2, 2, 'zhuxing', '주형'),
-(3, 1, 'zhuni', '주니'),
-(3, 2, 'shipiao', '석표'),
+(1, 1, 'junni', '주니'),
+(1, 2, 'seoshi', '서시'),
+(2, 1, 'junni', '주니'),
+(2, 2, 'juhu', '주형'),
+(3, 1, 'junni', '주니'),
+(3, 2, 'seokpyo', '석표'),
 
 -- 자사호 (자사) - product_id 4,5,6
-(4, 1, 'zisha', '자사'),
+(4, 1, 'jani', '자니'),
 (4, 2, 'bianping', '편평'),
-(5, 1, 'zisha', '자사'),
-(5, 2, 'xishi', '서시'),
-(6, 1, 'zisha', '자사'),
-(6, 2, 'zhuxing', '주형'),
+(5, 1, 'jani', '자니'),
+(5, 2, 'seoshi', '서시'),
+(6, 1, 'jani', '자니'),
+(6, 2, 'juhu', '주형'),
 
 -- 자사호 (단니) - product_id 7,8
-(7, 1, 'duanni', '단니'),
-(7, 2, 'shipiao', '석표'),
-(8, 1, 'duanni', '단니'),
+(7, 1, 'danji', '단니'),
+(7, 2, 'seokpyo', '석표'),
+(8, 1, 'danji', '단니'),
 (8, 2, 'bianping', '편평'),
 
 -- 자사호 (흑니) - product_id 9
-(9, 1, 'heini', '흑니'),
-(9, 2, 'zhuxing', '주형'),
+(9, 1, 'heugni', '흑니'),
+(9, 2, 'juhu', '주형'),
 
 -- 자사호 (청회니) - product_id 10
-(10, 1, 'qinghuini', '청회니'),
-(10, 2, 'xishi', '서시'),
+(10, 1, 'cheongsu', '청수니'),
+(10, 2, 'seoshi', '서시'),
 
 -- 보이차 - product_id 11,12,13,14,15 (no clay_type or shape)
 -- 다구 - product_id 16,17,18,19,20,21,22 (no clay_type or shape)
@@ -792,18 +792,18 @@ VALUES ('mobile_bottom_nav_visible', 'false', 'general', '하단 네비게이션
 -- ============================================================
 INSERT INTO collections (type, name, nameKo, color, description, product_url, sort_order, is_active) VALUES
 -- 니료별 컬렉션 (Clay)
-('clay', 'junni', '주니', '#8B4513', '주철질의 대표 니료로, 적색 내지 황갈색을 띱니다. 내열성과 보온성이 뛰어나며, 차의 풍미를 극대화합니다.', '/products?clayType=junni', 1, 1),
-('clay', 'danji', '단니', '#D4A574', '황토계열의 단단한 니료로, 밝은 황금빛을 띱니다. 은은한 향과 부드러운 맛을 표현하는 데 적합합니다.', '/products?clayType=danji', 2, 1),
-('clay', 'jani', '자니', '#2F4F4F', '청자질의 대표 니료로, 청록색 내지 암청색을 띱니다. 깊은 향과 시원한 맛을 자랑합니다.', '/products?clayType=jani', 3, 1),
-('clay', 'heugni', '흑니', '#1C1C1C', '흑색 도자기 전용 니료로, 검은색을 띱니다. 떫은맛을 줄이고 깊은 맛을내는 특성이 있습니다.', '/products?clayType=heugni', 4, 1),
-('clay', 'cheongsu', '청수니', '#4682B4', '청수(정선) 지역 특유의 청백색 니료입니다. 산뜻한 맛과 깨끗한 향이 특징입니다.', '/products?clayType=cheongsu', 5, 1),
-('clay', 'nokni', '녹니', '#556B2F', '녹토계열의 독특한 니료로, 녹색기를 띱니다. 건강과 풍미를 동시에 생각하는 이들에게 사랑받습니다.', '/products?clayType=nokni', 6, 1),
+('clay', 'junni', '주니', '#8B4513', '주철질의 대표 니료로, 적색 내지 황갈색을 띱니다. 내열성과 보온성이 뛰어나며, 차의 풍미를 극대화합니다.', '/products?attrs=clay_type:junni', 1, 1),
+('clay', 'danji', '단니', '#D4A574', '황토계열의 단단한 니료로, 밝은 황금빛을 띱니다. 은은한 향과 부드러운 맛을 표현하는 데 적합합니다.', '/products?attrs=clay_type:danji', 2, 1),
+('clay', 'jani', '자니', '#2F4F4F', '청자질의 대표 니료로, 청록색 내지 암청색을 띱니다. 깊은 향과 시원한 맛을 자랑합니다.', '/products?attrs=clay_type:jani', 3, 1),
+('clay', 'heugni', '흑니', '#1C1C1C', '흑색 도자기 전용 니료로, 검은색을 띱니다. 떫은맛을 줄이고 깊은 맛을내는 특성이 있습니다.', '/products?attrs=clay_type:heugni', 4, 1),
+('clay', 'cheongsu', '청수니', '#4682B4', '청수(정선) 지역 특유의 청백색 니료입니다. 산뜻한 맛과 깨끗한 향이 특징입니다.', '/products?attrs=clay_type:cheongsu', 5, 1),
+('clay', 'nokni', '녹니', '#556B2F', '녹토계열의 독특한 니료로, 녹색기를 띱니다. 건강과 풍미를 동시에 생각하는 이들에게 사랑받습니다.', '/products?attrs=clay_type:nokni', 6, 1),
 -- 모양별 컬렉션 (Shape)
-('shape', 'seoshi', '서시', NULL, '평평하고 넓은 형태의 주전자. 뛰어난 안정감과 넓은 탕면으로 차의 풍미를 펼쳐줍니다.', '/products?teapotShape=seoshi', 1, 1),
-('shape', 'seokpyo', '석표', NULL, '곰방대 형태에서 영감을 받은 독특한 모양. 절제된 아름다움과 실용성을 겸비합니다.', '/products?teapotShape=seokpyo', 2, 1),
-('shape', 'inwang', '인왕', NULL, '인왕산의 기품을 담은 날카롭고 세련된 라인. 현대적 감각으로 재해석한 전통 형태입니다.', '/products?teapotShape=inwang', 3, 1),
-('shape', 'deokjong', '덕종', NULL, '고려 시대의 달인으로 유명한 덕종달인의 기법을 현대에 재현. 우아하고 정제된 실루엿입니다.', '/products?teapotShape=deokjong', 4, 1),
-('shape', 'supeong', '수평', NULL, '수평의 아름다운 곡선. 검소하고 담백한 아름다움으로 평온함을 선물합니다.', '/products?teapotShape=supeong', 5, 1);
+('shape', 'seoshi', '서시', NULL, '평평하고 넓은 형태의 주전자. 뛰어난 안정감과 넓은 탕면으로 차의 풍미를 펼쳐줍니다.', '/products?attrs=teapot_shape:seoshi', 1, 1),
+('shape', 'seokpyo', '석표', NULL, '곰방대 형태에서 영감을 받은 독특한 모양. 절제된 아름다움과 실용성을 겸비합니다.', '/products?attrs=teapot_shape:seokpyo', 2, 1),
+('shape', 'inwang', '인왕', NULL, '인왕산의 기품을 담은 날카롭고 세련된 라인. 현대적 감각으로 재해석한 전통 형태입니다.', '/products?attrs=teapot_shape:inwang', 3, 1),
+('shape', 'deokjong', '덕종', NULL, '고려 시대의 달인으로 유명한 덕종달인의 기법을 현대에 재현. 우아하고 정제된 실루엿입니다.', '/products?attrs=teapot_shape:deokjong', 4, 1),
+('shape', 'supeong', '수평', NULL, '수평의 아름다운 곡선. 검소하고 담백한 아름다움으로 평온함을 선물합니다.', '/products?attrs=teapot_shape:supeong', 5, 1);
 
 -- ============================================================
 -- 상품 니료/모양 데이터 설정

--- a/backend/src/modules/products/__tests__/product-query.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-query.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Logger, NotFoundException } from '@nestjs/common';
 import { ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm';
 import { ProductQueryService } from '../product-query.service';
 import { Product, ProductStatus } from '../entities/product.entity';
@@ -234,6 +234,35 @@ describe('ProductQueryService', () => {
       expect(qb.andWhere).toHaveBeenCalledWith('product.status = :status', {
         status: 'draft',
       });
+    });
+  });
+
+
+  describe('findAll - 속성 필터', () => {
+    it('attrs 값으로 product_attributes inner join 조건을 적용한다', async () => {
+      qb.getMany.mockResolvedValue([{ id: 1, code: 'clay_type' } as AttributeType]);
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ attrs: 'clay_type:junni' });
+
+      expect(qb.innerJoin).toHaveBeenCalledWith(
+        'product.attributes',
+        'pa_0',
+        'pa_0.attributeTypeId = :typeId0 AND pa_0.value = :attrValue0',
+        { typeId0: 1, attrValue0: 'junni' },
+      );
+    });
+
+    it('존재하지 않는 attrs code 는 경고 로그를 남기고 필터를 건너뛴다', async () => {
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+      qb.getMany.mockResolvedValue([]);
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ attrs: 'missing_code:value' });
+
+      expect(qb.innerJoin).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith('Unknown product attribute filter code skipped: missing_code');
+      warnSpy.mockRestore();
     });
   });
 

--- a/backend/src/modules/products/product-query.service.ts
+++ b/backend/src/modules/products/product-query.service.ts
@@ -350,6 +350,7 @@ export class ProductQueryService {
       for (const [code, value] of attrFilters) {
         const typeId = attrTypeIdMap.get(code);
         if (typeId === undefined) {
+          this.logger.warn(`Unknown product attribute filter code skipped: ${code}`);
           continue;
         }
 

--- a/src/components/__tests__/FilterSidebar.test.tsx
+++ b/src/components/__tests__/FilterSidebar.test.tsx
@@ -54,8 +54,8 @@ const mockCategories: Category[] = [
 ];
 
 const mockCollections: Collection[] = [
-  { id: 1, type: CollectionType.CLAY, name: 'Sin Zhi', nameKo: '신치', color: null, description: null, imageUrl: null, productUrl: '', sortOrder: 0, isActive: true },
-  { id: 2, type: CollectionType.CLAY, name: 'Jook Jin', nameKo: '죽전', color: null, description: null, imageUrl: null, productUrl: '', sortOrder: 1, isActive: true },
+  { id: 1, type: CollectionType.CLAY, name: 'Sin Zhi', nameKo: '신치', color: null, description: null, imageUrl: null, productUrl: '/products?attrs=clay_type:sin-zhi', sortOrder: 0, isActive: true },
+  { id: 2, type: CollectionType.CLAY, name: 'Jook Jin', nameKo: '죽전', color: null, description: null, imageUrl: null, productUrl: '/products?attrs=clay_type:jook-jin', sortOrder: 1, isActive: true },
 ];
 
 describe('FilterSidebar', () => {

--- a/src/components/shared/filters/ClayTypeFilter.tsx
+++ b/src/components/shared/filters/ClayTypeFilter.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import type { Collection } from '@/lib/api';
 import SegmentedOptionGroup from '@/components/shared/ui/SegmentedOptionGroup';
+import { getCollectionFilterValue } from '@/lib/collectionFilters';
 
 interface ClayTypeFilterProps {
   collections: Collection[];
@@ -17,7 +18,7 @@ export default function ClayTypeFilter({ collections, selected, onSelect }: Clay
     <SegmentedOptionGroup
       items={[
         { label: tCommon('all'), value: '' },
-        ...collections.map((item) => ({ label: item.name, value: item.name })),
+        ...collections.map((item) => ({ label: item.name, value: getCollectionFilterValue(item, 'clay_type') })),
       ]}
       value={selected ?? ''}
       onToggle={(value) => onSelect(value === selected ? undefined : value || undefined)}

--- a/src/components/shared/filters/TeapotShapeFilter.tsx
+++ b/src/components/shared/filters/TeapotShapeFilter.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
 import type { Collection } from '@/lib/api';
+import { getCollectionFilterValue } from '@/lib/collectionFilters';
 
 interface TeapotShapeFilterProps {
   collections: Collection[];
@@ -29,23 +30,26 @@ export default function TeapotShapeFilter({ collections, selected, onSelect }: T
           {tCommon('all')}
         </span>
       </label>
-      {collections.map((item) => (
-        <label key={item.id} className="flex cursor-pointer items-center gap-2">
-          <input
-            type="radio"
-            name="teapot-shape"
-            checked={selected === item.name}
-            onChange={() => onSelect(item.name)}
-            className="h-4 w-4 border-border accent-primary"
-          />
-          <span className={cn(
-            'text-sm transition-colors',
-            selected === item.name ? 'font-medium text-foreground' : 'text-muted-foreground',
-          )}>
-            {item.name}
-          </span>
-        </label>
-      ))}
+      {collections.map((item) => {
+        const filterValue = getCollectionFilterValue(item, 'teapot_shape');
+        return (
+          <label key={item.id} className="flex cursor-pointer items-center gap-2">
+            <input
+              type="radio"
+              name="teapot-shape"
+              checked={selected === filterValue}
+              onChange={() => onSelect(filterValue)}
+              className="h-4 w-4 border-border accent-primary"
+            />
+            <span className={cn(
+              'text-sm transition-colors',
+              selected === filterValue ? 'font-medium text-foreground' : 'text-muted-foreground',
+            )}>
+              {item.name}
+            </span>
+          </label>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/shared/filters/__tests__/FilterSidebar.test.tsx
+++ b/src/components/shared/filters/__tests__/FilterSidebar.test.tsx
@@ -130,7 +130,7 @@ describe('FilterSidebar', () => {
 
   it('builds attrs for clay and shape filters and can reset active filters', async () => {
     useCatalogQueryParamsMock.mockReturnValue({
-      attrs: new Map([['clay_type', '자니']]),
+      attrs: new Map([['clay_type', 'zini']]),
       categoryId: 1,
       priceMin: 10000,
       priceMax: undefined,
@@ -144,7 +144,7 @@ describe('FilterSidebar', () => {
     expect(updateQueryMock).toHaveBeenCalledWith({ attrs: undefined });
 
     await userEvent.click(screen.getAllByRole('radio', { name: '원형' })[0]);
-    expect(updateQueryMock).toHaveBeenCalledWith({ attrs: 'clay_type:자니,teapot_shape:원형' });
+    expect(updateQueryMock).toHaveBeenCalledWith({ attrs: 'clay_type:zini,teapot_shape:round' });
 
     await userEvent.click(screen.getAllByRole('button', { name: '초기화' })[0]);
     expect(resetQueryMock).toHaveBeenCalledWith(['categoryId', 'price_min', 'price_max', 'attrs']);

--- a/src/components/shared/products/ProductDetailClient.tsx
+++ b/src/components/shared/products/ProductDetailClient.tsx
@@ -21,11 +21,12 @@ import QuantitySelector from './QuantitySelector'
 import ProductTabs from './ProductTabs'
 import StarRating from '@/components/shared/reviews/StarRating'
 import { formatCurrency, type Locale } from '@/utils/currency'
+import { getCollectionFilterValue } from '@/lib/collectionFilters'
 
-function findCollectionLabel(collections: Collection[], name: string): string {
-  const found = collections.find((c) => c.name === name)
-  if (!found) return name
-  return found.name ?? name
+function findCollectionLabel(collections: Collection[], attrCode: string, value: string): string {
+  const found = collections.find((collection) => getCollectionFilterValue(collection, attrCode) === value)
+  if (!found) return value
+  return found.name ?? value
 }
 
 function getClayTagClass(value: string): string {
@@ -206,7 +207,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
                         getClayTagClass(attr.value),
                       )}
                     >
-                      {t('clay')}: {findCollectionLabel(clayCollections, attr.value)}
+                      {t('clay')}: {findCollectionLabel(clayCollections, 'clay_type', attr.value)}
                     </Link>
                   );
                 }
@@ -217,7 +218,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
                       href={`/products?attrs=teapot_shape:${encodeURIComponent(attr.value)}`}
                       className="inline-flex items-center rounded-full border border-border bg-background px-3 py-1 text-xs font-medium text-foreground transition-colors hover:border-foreground/30"
                     >
-                      {t('shape')}: {findCollectionLabel(shapeCollections, attr.value)}
+                      {t('shape')}: {findCollectionLabel(shapeCollections, 'teapot_shape', attr.value)}
                     </Link>
                   );
                 }

--- a/src/lib/__tests__/collectionFilters.test.ts
+++ b/src/lib/__tests__/collectionFilters.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { CollectionType, type Collection } from '@/lib/api';
+import { getCollectionFilterValue } from '@/lib/collectionFilters';
+
+const baseCollection: Collection = {
+  id: 1,
+  type: CollectionType.CLAY,
+  name: '자니',
+  nameKo: null,
+  color: null,
+  description: null,
+  imageUrl: null,
+  productUrl: '/products?attrs=clay_type:jani',
+  sortOrder: 0,
+  isActive: true,
+};
+
+describe('getCollectionFilterValue', () => {
+  it('extracts the attrs value for the requested attribute code', () => {
+    expect(getCollectionFilterValue(baseCollection, 'clay_type')).toBe('jani');
+  });
+
+  it('falls back to collection.name when productUrl has no matching attrs value', () => {
+    expect(getCollectionFilterValue({ ...baseCollection, productUrl: '/products?categoryId=1' }, 'clay_type')).toBe('자니');
+  });
+});

--- a/src/lib/__tests__/products-api.test.ts
+++ b/src/lib/__tests__/products-api.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest';
+import { apiClient } from '@/lib/api/core';
+import { productsApi } from '@/lib/api/products';
+
+describe('productsApi', () => {
+  it('passes attrs to the product list request params', async () => {
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 });
+
+    await productsApi.getList({ attrs: 'clay_type:junni', price_min: 10000 });
+
+    expect(getSpy).toHaveBeenCalledWith('/products', {
+      params: { attrs: 'clay_type:junni', price_min: 10000 },
+    });
+    getSpy.mockRestore();
+  });
+});

--- a/src/lib/collectionFilters.ts
+++ b/src/lib/collectionFilters.ts
@@ -1,0 +1,20 @@
+import type { Collection } from '@/lib/api';
+
+export function getCollectionFilterValue(collection: Collection, attrCode: string): string {
+  try {
+    const url = new URL(collection.productUrl, 'http://localhost');
+    const attrs = url.searchParams.get('attrs');
+    if (!attrs) return collection.name;
+
+    for (const pair of attrs.split(',')) {
+      const [code, value] = pair.split(':');
+      if (code?.trim() === attrCode && value?.trim()) {
+        return decodeURIComponent(value.trim());
+      }
+    }
+  } catch {
+    return collection.name;
+  }
+
+  return collection.name;
+}

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -21,7 +21,7 @@ export const CLAY_COLLECTIONS: ClayCollection[] = [
     nameKo: '주니',
     color: '#8B4513',
     description: '철분 함량이 높아 소성 후 선명한 붉은색을 띠는 니료. 홍차·우롱에 최적.',
-    productUrl: '/products?attrs=clay_type:zhuni',
+    productUrl: '/products?attrs=clay_type:junni',
   },
   {
     id: 'danni',
@@ -29,7 +29,7 @@ export const CLAY_COLLECTIONS: ClayCollection[] = [
     nameKo: '단니',
     color: '#C4A882',
     description: '베이지·황토 계열의 온화한 색상. 기공이 균일하여 녹차·백차에 최적.',
-    productUrl: '/products?attrs=clay_type:danni',
+    productUrl: '/products?attrs=clay_type:danji',
   },
   {
     id: 'zini',
@@ -37,7 +37,7 @@ export const CLAY_COLLECTIONS: ClayCollection[] = [
     nameKo: '자니',
     color: '#6B3A5C',
     description: '자사호의 대표 니료. 보라빛 갈색으로 보이차·암차에 최적.',
-    productUrl: '/products?attrs=clay_type:zini',
+    productUrl: '/products?attrs=clay_type:jani',
   },
   {
     id: 'heukni',
@@ -45,7 +45,7 @@ export const CLAY_COLLECTIONS: ClayCollection[] = [
     nameKo: '흑니',
     color: '#2A2520',
     description: '희귀한 짙은 흑갈색 니료. 강한 흡착력으로 숙성 보이차에 최적.',
-    productUrl: '/products?attrs=clay_type:heini',
+    productUrl: '/products?attrs=clay_type:heugni',
   },
   {
     id: 'chunsuni',
@@ -53,7 +53,7 @@ export const CLAY_COLLECTIONS: ClayCollection[] = [
     nameKo: '청수니',
     color: '#3D6B6B',
     description: '회록색·청회색의 섬세한 질감. 깔끔한 차 맛으로 녹차·화차에 최적.',
-    productUrl: '/products?attrs=clay_type:qingshuini',
+    productUrl: '/products?attrs=clay_type:cheongsu',
   },
   {
     id: 'nokni',
@@ -61,7 +61,7 @@ export const CLAY_COLLECTIONS: ClayCollection[] = [
     nameKo: '녹니',
     color: '#4A6741',
     description: '극히 희귀한 담록색 니료. 낮은 수축률로 정밀 조형에 적합.',
-    productUrl: '/products?attrs=clay_type:lvni',
+    productUrl: '/products?attrs=clay_type:nokni',
   },
 ];
 
@@ -70,13 +70,13 @@ export const SHAPE_COLLECTIONS: ShapeCollection[] = [
     id: 'seosi',
     name: '서시형 (西施)',
     description: '둥글고 풍만한 곡선이 특징. 우아한 여성미를 담은 대표적 형태.',
-    productUrl: '/products?attrs=teapot_shape:xishi',
+    productUrl: '/products?attrs=teapot_shape:seoshi',
   },
   {
     id: 'seokpyo',
     name: '석표형 (石瓢)',
     description: '삼각 구도의 안정적 형태. 넓은 바닥과 직선적 라인이 특징.',
-    productUrl: '/products?attrs=teapot_shape:shipiao',
+    productUrl: '/products?attrs=teapot_shape:seokpyo',
   },
   {
     id: 'inwang',
@@ -94,6 +94,6 @@ export const SHAPE_COLLECTIONS: ShapeCollection[] = [
     id: 'supyeong',
     name: '수평형 (水平)',
     description: '수평으로 뜨는 구조. 기능적이며 실용적인 우림에 최적.',
-    productUrl: '/products?attrs=teapot_shape:supyeong',
+    productUrl: '/products?attrs=teapot_shape:supeong',
   },
 ];


### PR DESCRIPTION
## Summary
- Align clay/shape attribute valid values, seed URLs, and existing DB values around canonical attrs values.
- Make filter UI derive submitted attrs values from collection.productUrl instead of display names.
- Add migration backfill plus frontend/backend regression coverage for attrs propagation and query joins.

Closes #771

## Verification
- npm run build
- npm run test:run
- cd backend && npm run build && npm run test
- bash scripts/test.sh e2e
- git diff --check

## Review
- Self code-review pass completed; fixed existing collections.product_url migration coverage and migration timestamp collision before PR.