### PR TITLE
feat: #769 PayPal·네이버페이 결제 정책 적용

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ NEXT_PUBLIC_KAKAO_CLIENT_ID=  # REQUIRED — Kakao JavaScript/REST app key used 
 NEXT_PUBLIC_KAKAO_REDIRECT_URI=http://localhost:5173/auth/kakao/callback  # REQUIRED — must match Kakao Developers redirect URI
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 NEXT_PUBLIC_GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
+
+# PayPal uses backend-created Orders API redirect flow; no frontend SDK key is required.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -51,7 +51,7 @@ SENTRY_TRACES_SAMPLE_RATE=0.1
 # 캐시: 백엔드 프로세스 내 in-memory (CacheService).
 # Redis/ElastiCache 연결 불필요.
 # ─────────────────────────────────────────────
-PAYMENT_GATEWAY=mock  # REQUIRED — 'mock' is blocked in production. Options: mock, toss, stripe, inicis, naverpay
+PAYMENT_GATEWAY=mock  # REQUIRED — 'mock' is blocked in production. Options: mock, toss, stripe, inicis, naverpay, paypal
 TOSS_SECRET_KEY=   # Toss Payments secret key (for ko locale, default 국내 PG)
 TOSS_CLIENT_KEY=   # Toss Payments client key (for ko locale)
 STRIPE_SECRET_KEY=   # Stripe secret key (for global locale)
@@ -95,3 +95,9 @@ GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
 NOTIFICATION_PROVIDER=mock  # REQUIRED
 RESEND_API_KEY=  # REQUIRED (when NOTIFICATION_PROVIDER=resend)
 EMAIL_FROM=no-reply@okhwadang.com
+
+# PayPal (global checkout)
+PAYPAL_CLIENT_ID=
+PAYPAL_CLIENT_SECRET=
+PAYPAL_WEBHOOK_ID=
+PAYPAL_API_BASE_URL=

--- a/backend/src/config/payment.config.ts
+++ b/backend/src/config/payment.config.ts
@@ -2,12 +2,13 @@ import { Provider } from '@nestjs/common';
 
 export const PAYMENT_CONFIG = Symbol('PAYMENT_CONFIG');
 
-export type PaymentGatewayName = 'mock' | 'toss' | 'stripe' | 'inicis' | 'naverpay';
+export type PaymentGatewayName = 'mock' | 'toss' | 'stripe' | 'inicis' | 'naverpay' | 'paypal';
 
 export interface PaymentConfig {
   nodeEnv: string;
   gateway: PaymentGatewayName;
   defaultCarrier: string;
+  frontendUrl: string;
   toss: {
     secretKey: string;
     clientKey: string;
@@ -29,6 +30,12 @@ export interface PaymentConfig {
     clientSecret: string;
     chainId: string;
   };
+  paypal: {
+    clientId: string;
+    clientSecret: string;
+    webhookId: string;
+    apiBaseUrl: string;
+  };
 }
 
 function isPaymentGatewayName(value: string): value is PaymentGatewayName {
@@ -37,7 +44,8 @@ function isPaymentGatewayName(value: string): value is PaymentGatewayName {
     value === 'toss' ||
     value === 'stripe' ||
     value === 'inicis' ||
-    value === 'naverpay'
+    value === 'naverpay' ||
+    value === 'paypal'
   );
 }
 
@@ -59,6 +67,7 @@ export function createPaymentConfig(env: NodeJS.ProcessEnv = process.env): Payme
     nodeEnv,
     gateway,
     defaultCarrier: env.DEFAULT_CARRIER || 'mock',
+    frontendUrl: (env.FRONTEND_URL ?? 'http://localhost:5173').replace(/\/$/, ''),
     toss: {
       secretKey: env.TOSS_SECRET_KEY ?? '',
       clientKey: env.TOSS_CLIENT_KEY ?? '',
@@ -79,6 +88,15 @@ export function createPaymentConfig(env: NodeJS.ProcessEnv = process.env): Payme
       clientId: env.NAVERPAY_CLIENT_ID ?? '',
       clientSecret: env.NAVERPAY_CLIENT_SECRET ?? '',
       chainId: env.NAVERPAY_CHAIN_ID ?? '',
+    },
+    paypal: {
+      clientId: env.PAYPAL_CLIENT_ID ?? '',
+      clientSecret: env.PAYPAL_CLIENT_SECRET ?? '',
+      webhookId: env.PAYPAL_WEBHOOK_ID ?? '',
+      apiBaseUrl: (
+        env.PAYPAL_API_BASE_URL
+        ?? (nodeEnv === 'production' ? 'https://api-m.paypal.com' : 'https://api-m.sandbox.paypal.com')
+      ).replace(/\/$/, ''),
     },
   };
 }

--- a/backend/src/database/migrations/1783900000000-AddPaypalPaymentEnums.ts
+++ b/backend/src/database/migrations/1783900000000-AddPaypalPaymentEnums.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * PayPal 결제 gateway/method enum 추가 (#769)
+ *
+ * PayPal은 주문 생성 후 승인 redirect, confirm 단계에서 capture 하는 별도 PG로
+ * 저장되어야 하므로 기존 stripe/naverpay enum 값을 placeholder로 재사용하지 않는다.
+ */
+export class AddPaypalPaymentEnums1783900000000 implements MigrationInterface {
+  name = 'AddPaypalPaymentEnums1783900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`payments\` MODIFY COLUMN \`method\`
+       ENUM('card','bank_transfer','virtual_account','phone','mock','paypal')
+       NOT NULL DEFAULT 'mock'`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE \`payments\` MODIFY COLUMN \`gateway\`
+       ENUM('mock','toss','inicis','stripe','naverpay','paypal')
+       NOT NULL DEFAULT 'mock'`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE \`payment_webhook_events\` MODIFY COLUMN \`gateway\`
+       ENUM('mock','toss','inicis','stripe','naverpay','paypal')
+       NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`payments\` SET \`method\` = 'card' WHERE \`method\` = 'paypal'`,
+    );
+    await queryRunner.query(
+      `UPDATE \`payments\` SET \`gateway\` = 'stripe' WHERE \`gateway\` = 'paypal'`,
+    );
+    await queryRunner.query(
+      `UPDATE \`payment_webhook_events\` SET \`gateway\` = 'stripe' WHERE \`gateway\` = 'paypal'`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE \`payment_webhook_events\` MODIFY COLUMN \`gateway\`
+       ENUM('mock','toss','inicis','stripe','naverpay')
+       NOT NULL`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE \`payments\` MODIFY COLUMN \`gateway\`
+       ENUM('mock','toss','inicis','stripe','naverpay')
+       NOT NULL DEFAULT 'mock'`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE \`payments\` MODIFY COLUMN \`method\`
+       ENUM('card','bank_transfer','virtual_account','phone','mock')
+       NOT NULL DEFAULT 'mock'`,
+    );
+  }
+}

--- a/backend/src/modules/payments/__tests__/naverpay.adapter.spec.ts
+++ b/backend/src/modules/payments/__tests__/naverpay.adapter.spec.ts
@@ -28,6 +28,10 @@ describe('NaverPayPaymentAdapter', () => {
 
       expect(result.clientKey).toBe('naverpay-test-client');
       expect(result.orderId).toBe('ORDER-NAVERPAY-1');
+      expect(result.gatewayPayload).toEqual({
+        chainId: 'naverpay-chain-id',
+        mode: 'development',
+      });
     });
   });
 

--- a/backend/src/modules/payments/__tests__/payments.module.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.module.spec.ts
@@ -1,4 +1,5 @@
 import { createPaymentConfig } from '../../../config/payment.config';
+import { getAvailableGatewaysByLocale, resolveGatewayByLocale } from '../payments.module';
 
 describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
   it('NODE_ENV=production, PAYMENT_GATEWAY=mock → 시작 실패', () => {
@@ -36,5 +37,36 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
       PAYMENT_GATEWAY: 'toss',
     });
     expect(config.gateway).toBe('toss');
+  });
+
+  it('PAYMENT_GATEWAY=paypal → PayPal 설정을 읽는다', () => {
+    const config = createPaymentConfig({
+      NODE_ENV: 'development',
+      PAYMENT_GATEWAY: 'paypal',
+      PAYPAL_CLIENT_ID: 'paypal-client',
+      PAYPAL_CLIENT_SECRET: 'paypal-secret',
+      PAYPAL_WEBHOOK_ID: 'paypal-webhook',
+    });
+
+    expect(config.gateway).toBe('paypal');
+    expect(config.paypal).toMatchObject({
+      clientId: 'paypal-client',
+      clientSecret: 'paypal-secret',
+      webhookId: 'paypal-webhook',
+      apiBaseUrl: 'https://api-m.sandbox.paypal.com',
+    });
+  });
+});
+
+describe('locale gateway policy — PayPal/NaverPay ordering', () => {
+  it('ko → naverpay default, paypal fallback', () => {
+    expect(resolveGatewayByLocale('ko')).toBe('naverpay');
+    expect(getAvailableGatewaysByLocale('ko')).toEqual(['naverpay', 'paypal']);
+  });
+
+  it('en and other locales → paypal default, naverpay fallback', () => {
+    expect(resolveGatewayByLocale('en')).toBe('paypal');
+    expect(resolveGatewayByLocale('ja')).toBe('paypal');
+    expect(getAvailableGatewaysByLocale('en')).toEqual(['paypal', 'naverpay']);
   });
 });

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -13,6 +13,7 @@ import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
 import { KGInicisPaymentAdapter } from '../adapters/inicis.adapter';
 import { NaverPayPaymentAdapter } from '../adapters/naverpay.adapter';
+import { PayPalPaymentAdapter } from '../adapters/paypal.adapter';
 import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import { PAYMENT_CONFIG, createPaymentConfig } from '../../../config/payment.config';
@@ -160,6 +161,14 @@ describe('PaymentsService', () => {
     verifyWebhook: jest.fn(),
   };
 
+  const mockPaypalAdapter = {
+    prepare: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    partialCancel: jest.fn(),
+    verifyWebhook: jest.fn(),
+  };
+
   let mockDataSource: ReturnType<typeof makeDataSourceMock>;
 
   beforeEach(async () => {
@@ -195,6 +204,7 @@ describe('PaymentsService', () => {
         { provide: StripePaymentAdapter, useValue: mockStripeAdapter },
         { provide: KGInicisPaymentAdapter, useValue: mockInicisAdapter },
         { provide: NaverPayPaymentAdapter, useValue: mockNaverpayAdapter },
+        { provide: PayPalPaymentAdapter, useValue: mockPaypalAdapter },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
         { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
         { provide: DataSource, useValue: mockDataSource },
@@ -232,6 +242,68 @@ describe('PaymentsService', () => {
     it('order status=paid → ConflictException', async () => {
       mockOrderRepo.findOne.mockResolvedValue(makeOrder({ status: OrderStatus.PAID }));
       await expect(service.prepare({ orderId: 1 }, 10)).rejects.toThrow(ConflictException);
+    });
+
+    it('locale=ko 기본 prepare → NAVERPAY 저장 + paypal 선택지 반환 (#769)', async () => {
+      const order = makeOrder();
+      mockOrderRepo.findOne.mockResolvedValue(order);
+      mockPaymentRepo.findOne.mockResolvedValue(null);
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.NAVERPAY });
+      mockPaymentRepo.create.mockReturnValue(savedPayment);
+      mockPaymentRepo.save.mockResolvedValue(savedPayment);
+      mockNaverpayAdapter.prepare.mockResolvedValue({ clientKey: 'naverpay-client', orderId: '1' });
+
+      const result = await service.prepare({ orderId: 1, locale: 'ko' }, 10);
+
+      expect(result.gateway).toBe('naverpay');
+      expect(result.availableGateways).toEqual(['naverpay', 'paypal']);
+      expect(mockNaverpayAdapter.prepare).toHaveBeenCalledWith('1', 30000, expect.objectContaining({ locale: 'ko' }));
+      expect(mockPaymentRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ gateway: PaymentGatewayType.NAVERPAY }),
+      );
+    });
+
+    it('locale=en 기본 prepare → PAYPAL 저장 + naverpay 선택지 반환 (#769)', async () => {
+      const order = makeOrder();
+      mockOrderRepo.findOne.mockResolvedValue(order);
+      mockPaymentRepo.findOne.mockResolvedValue(null);
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.PAYPAL });
+      mockPaymentRepo.create.mockReturnValue(savedPayment);
+      mockPaymentRepo.save.mockResolvedValue(savedPayment);
+      mockPaypalAdapter.prepare.mockResolvedValue({
+        clientKey: 'paypal-client',
+        orderId: 'paypal-order-id',
+        redirectUrl: 'https://www.paypal.com/checkoutnow?token=paypal-order-id',
+      });
+
+      const result = await service.prepare({ orderId: 1, locale: 'en' }, 10);
+
+      expect(result.gateway).toBe('paypal');
+      expect(result.availableGateways).toEqual(['paypal', 'naverpay']);
+      expect(result.redirectUrl).toBe('https://www.paypal.com/checkoutnow?token=paypal-order-id');
+      expect(mockPaypalAdapter.prepare).toHaveBeenCalledWith('1', 30000, expect.objectContaining({ locale: 'en' }));
+      expect(mockPaymentRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ gateway: PaymentGatewayType.PAYPAL }),
+      );
+    });
+
+    it('명시적 gateway=paypal → locale=ko 에서도 PAYPAL 로 저장한다 (#769)', async () => {
+      const order = makeOrder();
+      mockOrderRepo.findOne.mockResolvedValue(order);
+      mockPaymentRepo.findOne.mockResolvedValue(null);
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.PAYPAL });
+      mockPaymentRepo.create.mockReturnValue(savedPayment);
+      mockPaymentRepo.save.mockResolvedValue(savedPayment);
+      mockPaypalAdapter.prepare.mockResolvedValue({ clientKey: 'paypal-client', orderId: 'paypal-order-id' });
+
+      const result = await service.prepare({ orderId: 1, locale: 'ko', gateway: 'paypal' }, 10);
+
+      expect(result.gateway).toBe('paypal');
+      expect(mockPaypalAdapter.prepare).toHaveBeenCalled();
+      expect(mockNaverpayAdapter.prepare).not.toHaveBeenCalled();
+      expect(mockPaymentRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ gateway: PaymentGatewayType.PAYPAL }),
+      );
     });
   });
 
@@ -373,20 +445,20 @@ describe('PaymentsService', () => {
       expect(recoveryManager.increment).toHaveBeenCalled();
     });
 
-    it('locale=en prepare → payment.gateway 가 STRIPE 로 저장되어야 함 (#722)', async () => {
+    it('locale=en prepare → payment.gateway 가 PAYPAL 로 저장되어야 함 (#769)', async () => {
       const order = makeOrder();
       mockOrderRepo.findOne.mockResolvedValue(order);
       mockPaymentRepo.findOne.mockResolvedValue(null);
-      const savedPayment = makePayment({ gateway: PaymentGatewayType.STRIPE });
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.PAYPAL });
       mockPaymentRepo.create.mockReturnValue(savedPayment);
       mockPaymentRepo.save.mockResolvedValue(savedPayment);
-      mockStripeAdapter.prepare.mockResolvedValue({ clientKey: 'pi_secret_xyz', orderId: '1' });
+      mockPaypalAdapter.prepare.mockResolvedValue({ clientKey: 'paypal-client', orderId: 'paypal-order-id' });
 
       const result = await service.prepare({ orderId: 1, locale: 'en' }, 10);
 
-      expect(result.gateway).toBe('stripe');
+      expect(result.gateway).toBe('paypal');
       expect(mockPaymentRepo.create).toHaveBeenCalledWith(
-        expect.objectContaining({ gateway: PaymentGatewayType.STRIPE }),
+        expect.objectContaining({ gateway: PaymentGatewayType.PAYPAL }),
       );
       expect(mockPaymentRepo.create).not.toHaveBeenCalledWith(
         expect.objectContaining({ gateway: PaymentGatewayType.INICIS }),
@@ -411,31 +483,31 @@ describe('PaymentsService', () => {
       expect(mockDefaultGateway.cancel).not.toHaveBeenCalled();
     });
 
-    it('locale=ko prepare → confirm 시 Toss adapter의 confirm()이 호출되어야 함', async () => {
+    it('locale=ko prepare → confirm 시 NaverPay adapter의 confirm()이 호출되어야 함', async () => {
       const order = makeOrder();
       mockOrderRepo.findOne.mockResolvedValue(order);
       mockPaymentRepo.findOne.mockResolvedValue(null);
-      const savedPayment = makePayment({ gateway: PaymentGatewayType.TOSS });
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.NAVERPAY });
       mockPaymentRepo.create.mockReturnValue(savedPayment);
       mockPaymentRepo.save.mockResolvedValue(savedPayment);
-      mockTossAdapter.prepare.mockResolvedValue({ clientKey: 'toss_client_key', orderId: '1' });
+      mockNaverpayAdapter.prepare.mockResolvedValue({ clientKey: 'naverpay_client_key', orderId: '1' });
 
       const prepareResult = await service.prepare({ orderId: 1, locale: 'ko' }, 10);
-      expect(prepareResult.gateway).toBe('toss');
+      expect(prepareResult.gateway).toBe('naverpay');
 
-      const paymentForConfirm = makePayment({ gateway: PaymentGatewayType.TOSS });
+      const paymentForConfirm = makePayment({ gateway: PaymentGatewayType.NAVERPAY });
       mockPaymentRepo.findOne.mockResolvedValue(paymentForConfirm);
-      mockTossAdapter.confirm.mockResolvedValue({
-        paymentKey: 'pay_toss_abc',
+      mockNaverpayAdapter.confirm.mockResolvedValue({
+        paymentKey: 'pay_naverpay_abc',
         method: 'card',
         amount: 30000,
         status: 'confirmed',
-        rawResponse: { toss: true },
+        rawResponse: { naverpay: true },
       });
 
-      const confirmResult = await service.confirm({ orderId: 1, paymentKey: 'pay_toss_abc', amount: 30000 }, 10);
+      const confirmResult = await service.confirm({ orderId: 1, paymentKey: 'pay_naverpay_abc', amount: 30000 }, 10);
       expect(confirmResult.status).toBe(PaymentStatus.CONFIRMED);
-      expect(mockTossAdapter.confirm).toHaveBeenCalledWith('pay_toss_abc', 30000, 'ORD-20240101-ABCD1');
+      expect(mockNaverpayAdapter.confirm).toHaveBeenCalledWith('pay_naverpay_abc', 30000, 'ORD-20240101-ABCD1');
       expect(mockDefaultGateway.confirm).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -12,6 +12,7 @@ import { TossPaymentAdapter } from '../adapters/toss.adapter';
 import { StripePaymentAdapter } from '../adapters/stripe.adapter';
 import { KGInicisPaymentAdapter } from '../adapters/inicis.adapter';
 import { NaverPayPaymentAdapter } from '../adapters/naverpay.adapter';
+import { PayPalPaymentAdapter } from '../adapters/paypal.adapter';
 import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import { PAYMENT_CONFIG, createPaymentConfig } from '../../../config/payment.config';
@@ -70,6 +71,7 @@ describe('PaymentsService — webhook', () => {
         { provide: StripePaymentAdapter, useValue: mockGateway },
         { provide: KGInicisPaymentAdapter, useValue: mockGateway },
         { provide: NaverPayPaymentAdapter, useValue: mockGateway },
+        { provide: PayPalPaymentAdapter, useValue: mockGateway },
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
         { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
         { provide: DataSource, useValue: mockDataSource },

--- a/backend/src/modules/payments/__tests__/paypal.adapter.spec.ts
+++ b/backend/src/modules/payments/__tests__/paypal.adapter.spec.ts
@@ -1,0 +1,174 @@
+import { BadGatewayException } from '@nestjs/common';
+import { PayPalPaymentAdapter } from '../adapters/paypal.adapter';
+import { createPaymentConfig } from '../../../config/payment.config';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('PayPalPaymentAdapter', () => {
+  let adapter: PayPalPaymentAdapter;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adapter = new PayPalPaymentAdapter(
+      createPaymentConfig({
+        NODE_ENV: 'development',
+        PAYMENT_GATEWAY: 'paypal',
+        PAYPAL_CLIENT_ID: 'paypal-client',
+        PAYPAL_CLIENT_SECRET: 'paypal-secret',
+        PAYPAL_WEBHOOK_ID: 'paypal-webhook',
+        FRONTEND_URL: 'https://shop.example.com',
+      }),
+    );
+  });
+
+  function mockAccessToken(): void {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: 'access-token' }),
+    });
+  }
+
+  describe('prepare', () => {
+    it('prepare → Orders v2 create 호출 후 approve redirectUrl 반환', async () => {
+      mockAccessToken();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'PAYPAL-ORDER-1',
+          links: [
+            {
+              rel: 'self',
+              href: 'https://api-m.sandbox.paypal.com/v2/checkout/orders/PAYPAL-ORDER-1',
+            },
+            { rel: 'approve', href: 'https://www.paypal.com/checkoutnow?token=PAYPAL-ORDER-1' },
+          ],
+        }),
+      });
+
+      const result = await adapter.prepare('ORDER-123', 10000, { locale: 'en' });
+
+      expect(result).toEqual({
+        clientKey: 'paypal-client',
+        orderId: 'PAYPAL-ORDER-1',
+        redirectUrl: 'https://www.paypal.com/checkoutnow?token=PAYPAL-ORDER-1',
+      });
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        'https://api-m.sandbox.paypal.com/v2/checkout/orders',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('https://shop.example.com/en/checkout/success'),
+        }),
+      );
+    });
+  });
+
+  describe('confirm', () => {
+    it('confirm → Orders v2 capture COMPLETED 응답을 confirmed로 변환', async () => {
+      mockAccessToken();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'PAYPAL-ORDER-1',
+          status: 'COMPLETED',
+          purchase_units: [{ payments: { captures: [{ id: 'CAPTURE-1' }] } }],
+        }),
+      });
+
+      const result = await adapter.confirm('PAYPAL-ORDER-1', 10000, 'ORDER-123');
+
+      expect(result.status).toBe('confirmed');
+      expect(result.method).toBe('paypal');
+      expect(result.paymentKey).toBe('PAYPAL-ORDER-1');
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        'https://api-m.sandbox.paypal.com/v2/checkout/orders/PAYPAL-ORDER-1/capture',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('confirm → COMPLETED 외 상태는 BadGatewayException', async () => {
+      mockAccessToken();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'PAYPAL-ORDER-1', status: 'PAYER_ACTION_REQUIRED' }),
+      });
+
+      await expect(adapter.confirm('PAYPAL-ORDER-1', 10000, 'ORDER-123')).rejects.toThrow(
+        BadGatewayException,
+      );
+    });
+  });
+
+  describe('partialCancel', () => {
+    it('partialCancel → capture id 조회 후 refund endpoint 호출', async () => {
+      mockAccessToken();
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            purchase_units: [{ payments: { captures: [{ id: 'CAPTURE-1' }] } }],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ id: 'REFUND-1', create_time: '2026-01-01T00:00:00Z' }),
+        });
+
+      const result = await adapter.partialCancel({
+        paymentKey: 'PAYPAL-ORDER-1',
+        cancelAmount: 5000,
+        cancelReason: '부분 환불',
+      });
+
+      expect(result.refundId).toBe('REFUND-1');
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        'https://api-m.sandbox.paypal.com/v2/payments/captures/CAPTURE-1/refund',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  describe('verifyWebhook', () => {
+    const signature = JSON.stringify({
+      auth_algo: 'SHA256withRSA',
+      cert_url: 'https://api-m.sandbox.paypal.com/certs/test.pem',
+      transmission_id: 'transmission-1',
+      transmission_sig: 'signature-1',
+      transmission_time: '2026-01-01T00:00:00Z',
+    });
+
+    it('verify-webhook-signature SUCCESS → true', async () => {
+      mockAccessToken();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ verification_status: 'SUCCESS' }),
+      });
+
+      await expect(
+        adapter.verifyWebhook({ id: 'WH-1', event_type: 'PAYMENT.CAPTURE.COMPLETED' }, signature),
+      ).resolves.toBe(true);
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        'https://api-m.sandbox.paypal.com/v1/notifications/verify-webhook-signature',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('paypal-webhook'),
+        }),
+      );
+    });
+
+    it('verify-webhook-signature FAILURE → false', async () => {
+      mockAccessToken();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ verification_status: 'FAILURE' }),
+      });
+
+      await expect(adapter.verifyWebhook({ id: 'WH-1' }, signature)).resolves.toBe(false);
+    });
+
+    it('잘못된 signature JSON → false', async () => {
+      await expect(adapter.verifyWebhook({ id: 'WH-1' }, 'not-json')).resolves.toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/payments/adapters/naverpay.adapter.ts
+++ b/backend/src/modules/payments/adapters/naverpay.adapter.ts
@@ -14,10 +14,10 @@ import { PAYMENT_CONFIG, PaymentConfig } from '../../../config/payment.config';
 /**
  * 네이버페이 결제 어댑터 (#721 국내 PG 어댑터 확장)
  *
- * 본 어댑터는 mock contract 수준으로, 실제 네이버페이 SDK 콜이 아닌
- * fetch 기반 HTTP 호출 형태만 잡아두었다. 실 도입 시 SDK 콜로 교체.
+ * 프론트엔드는 NaverPay javascript SDK로 결제창을 열고,
+ * 본 어댑터는 SDK에서 돌아온 paymentId 승인/취소 API를 담당한다.
  *
- * - prepare: clientKey(=clientId) 반환 (FE에서 NAVER Pay JS SDK 호출에 사용)
+ * - prepare: clientKey/chainId/mode 반환 (FE에서 NAVER Pay JS SDK 호출에 사용)
  * - confirm: 결제 승인 요청
  * - cancel / partialCancel: 결제 취소 / 부분 취소
  * - verifyWebhook: HMAC-SHA256 (clientSecret 기반)
@@ -29,6 +29,7 @@ export class NaverPayPaymentAdapter implements PaymentGateway {
   private readonly clientId: string;
   private readonly clientSecret: string;
   private readonly chainId: string;
+  private readonly mode: 'development' | 'production';
 
   constructor(
     @Inject(PAYMENT_CONFIG)
@@ -38,6 +39,7 @@ export class NaverPayPaymentAdapter implements PaymentGateway {
     this.clientId = config.naverpay.clientId;
     this.clientSecret = config.naverpay.clientSecret;
     this.chainId = config.naverpay.chainId;
+    this.mode = config.nodeEnv === 'production' ? 'production' : 'development';
   }
 
   private get authHeaders(): Record<string, string> {
@@ -50,7 +52,14 @@ export class NaverPayPaymentAdapter implements PaymentGateway {
   }
 
   async prepare(orderId: string, _amount: number): Promise<PrepareResult> {
-    return { clientKey: this.clientId, orderId };
+    return {
+      clientKey: this.clientId,
+      orderId,
+      gatewayPayload: {
+        chainId: this.chainId,
+        mode: this.mode,
+      },
+    };
   }
 
   async confirm(paymentKey: string, amount: number, orderId: string): Promise<ConfirmResult> {

--- a/backend/src/modules/payments/adapters/paypal.adapter.ts
+++ b/backend/src/modules/payments/adapters/paypal.adapter.ts
@@ -1,0 +1,276 @@
+import { Inject, Injectable, Logger, BadGatewayException } from '@nestjs/common';
+import {
+  PaymentGateway,
+  PrepareContext,
+  PrepareResult,
+  ConfirmResult,
+  CancelResult,
+  PartialCancelParams,
+  PartialCancelResult,
+} from '../interfaces/payment-gateway.interface';
+import { PAYMENT_CONFIG, PaymentConfig } from '../../../config/payment.config';
+
+interface PayPalLink {
+  rel?: string;
+  href?: string;
+}
+
+interface PayPalWebhookHeaders {
+  auth_algo?: string;
+  cert_url?: string;
+  transmission_id?: string;
+  transmission_sig?: string;
+  transmission_time?: string;
+}
+
+interface PayPalOrderResponse {
+  id?: string;
+  status?: string;
+  links?: PayPalLink[];
+  create_time?: string;
+  update_time?: string;
+  purchase_units?: Array<{
+    payments?: {
+      captures?: Array<{ id?: string }>;
+    };
+  }>;
+}
+
+@Injectable()
+export class PayPalPaymentAdapter implements PaymentGateway {
+  private readonly logger = new Logger(PayPalPaymentAdapter.name);
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly webhookId: string;
+  private readonly apiBaseUrl: string;
+  private readonly frontendUrl: string;
+
+  constructor(@Inject(PAYMENT_CONFIG) config: PaymentConfig) {
+    this.clientId = config.paypal.clientId;
+    this.clientSecret = config.paypal.clientSecret;
+    this.webhookId = config.paypal.webhookId;
+    this.apiBaseUrl = config.paypal.apiBaseUrl;
+    this.frontendUrl = config.frontendUrl;
+  }
+
+  async prepare(orderId: string, amount: number, context?: PrepareContext): Promise<PrepareResult> {
+    const locale = context?.locale ?? 'en';
+    const accessToken = await this.getAccessToken();
+    const response = await this.paypalFetch('/v2/checkout/orders', accessToken, {
+      method: 'POST',
+      body: JSON.stringify({
+        intent: 'CAPTURE',
+        purchase_units: [
+          {
+            reference_id: orderId,
+            amount: {
+              currency_code: 'USD',
+              value: formatPayPalAmount(amount),
+            },
+          },
+        ],
+        application_context: {
+          user_action: 'PAY_NOW',
+          return_url: `${this.frontendUrl}/${locale}/checkout/success`,
+          cancel_url: `${this.frontendUrl}/${locale}/checkout/fail`,
+        },
+      }),
+    });
+    const body = await readJson<PayPalOrderResponse>(response);
+    const paypalOrderId = body.id;
+    const redirectUrl = body.links?.find((link) => link.rel === 'approve')?.href;
+
+    if (!paypalOrderId || !redirectUrl) {
+      this.logger.error(`PayPal prepare failed: missing approval link, orderId=${orderId}`);
+      throw new BadGatewayException('PayPal 결제 준비 실패');
+    }
+
+    return {
+      clientKey: this.clientId,
+      orderId: paypalOrderId,
+      redirectUrl,
+    };
+  }
+
+  async confirm(paymentKey: string, amount: number, orderId: string): Promise<ConfirmResult> {
+    const accessToken = await this.getAccessToken();
+    const response = await this.paypalFetch(
+      `/v2/checkout/orders/${encodeURIComponent(paymentKey)}/capture`,
+      accessToken,
+      { method: 'POST' },
+    );
+    const body = await readJson<PayPalOrderResponse>(response);
+
+    if (body.status !== 'COMPLETED') {
+      this.logger.error(
+        `PayPal capture declined: paymentKey=${paymentKey}, orderId=${orderId}, status=${String(body.status)}`,
+      );
+      throw new BadGatewayException('PayPal 결제 승인 실패');
+    }
+
+    return {
+      paymentKey,
+      method: 'paypal',
+      amount,
+      status: 'confirmed',
+      rawResponse: body as object,
+    };
+  }
+
+  async cancel(paymentKey: string, reason: string): Promise<CancelResult> {
+    const result = await this.partialCancel({
+      paymentKey,
+      cancelAmount: 0,
+      cancelReason: reason,
+    });
+    return {
+      cancelledAt: result.cancelledAt,
+      rawResponse: result.rawResponse,
+    };
+  }
+
+  async partialCancel(params: PartialCancelParams): Promise<PartialCancelResult> {
+    const accessToken = await this.getAccessToken();
+    const captureId = await this.findCaptureId(params.paymentKey, accessToken);
+    const payload: Record<string, unknown> = {
+      note_to_payer: params.cancelReason,
+    };
+    if (params.cancelAmount > 0) {
+      payload.amount = {
+        currency_code: 'USD',
+        value: formatPayPalAmount(params.cancelAmount),
+      };
+    }
+
+    const response = await this.paypalFetch(
+      `/v2/payments/captures/${encodeURIComponent(captureId)}/refund`,
+      accessToken,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      },
+    );
+    const body = await readJson<Record<string, unknown>>(response);
+    const refundId = typeof body.id === 'string' ? body.id : `paypal-${params.paymentKey}-${Date.now()}`;
+    const createdAt = typeof body.create_time === 'string' ? new Date(body.create_time) : new Date();
+
+    return {
+      refundId,
+      cancelledAt: Number.isNaN(createdAt.getTime()) ? new Date() : createdAt,
+      rawResponse: body as object,
+    };
+  }
+
+  async verifyWebhook(payload: unknown, signature: string): Promise<boolean> {
+    if (!this.webhookId || !signature || !isRecord(payload)) return false;
+
+    let headers: PayPalWebhookHeaders;
+    try {
+      headers = JSON.parse(signature) as PayPalWebhookHeaders;
+    } catch {
+      return false;
+    }
+
+    if (
+      !headers.auth_algo
+      || !headers.cert_url
+      || !headers.transmission_id
+      || !headers.transmission_sig
+      || !headers.transmission_time
+    ) {
+      return false;
+    }
+
+    try {
+      const accessToken = await this.getAccessToken();
+      const response = await this.paypalFetch(
+        '/v1/notifications/verify-webhook-signature',
+        accessToken,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            ...headers,
+            webhook_id: this.webhookId,
+            webhook_event: payload,
+          }),
+        },
+      );
+      const body = await readJson<Record<string, unknown>>(response);
+      return body.verification_status === 'SUCCESS';
+    } catch (err) {
+      this.logger.error(`PayPal webhook verification failed: ${String(err)}`);
+      return false;
+    }
+  }
+
+  private async findCaptureId(orderId: string, accessToken: string): Promise<string> {
+    const response = await this.paypalFetch(
+      `/v2/checkout/orders/${encodeURIComponent(orderId)}`,
+      accessToken,
+      { method: 'GET' },
+    );
+    const body = await readJson<PayPalOrderResponse>(response);
+    const captureId = body.purchase_units?.[0]?.payments?.captures?.[0]?.id;
+    if (!captureId) {
+      this.logger.error(`PayPal refund failed: capture id not found, orderId=${orderId}`);
+      throw new BadGatewayException('PayPal 환불 대상 거래를 찾을 수 없습니다.');
+    }
+    return captureId;
+  }
+
+  private async getAccessToken(): Promise<string> {
+    if (!this.clientId || !this.clientSecret) {
+      throw new BadGatewayException('PayPal is not configured');
+    }
+    const token = Buffer.from(`${this.clientId}:${this.clientSecret}`).toString('base64');
+    const response = await fetch(`${this.apiBaseUrl}/v1/oauth2/token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${token}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'grant_type=client_credentials',
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!response.ok) {
+      this.logger.error(`PayPal token failed: status=${response.status}`);
+      throw new BadGatewayException('PayPal 인증 오류');
+    }
+    const body = await readJson<Record<string, unknown>>(response);
+    if (typeof body.access_token !== 'string') {
+      throw new BadGatewayException('PayPal 인증 응답 오류');
+    }
+    return body.access_token;
+  }
+
+  private async paypalFetch(path: string, accessToken: string, init: RequestInit): Promise<Response> {
+    const response = await fetch(`${this.apiBaseUrl}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        ...(init.headers ?? {}),
+      },
+      signal: init.signal ?? AbortSignal.timeout(8000),
+    });
+    if (!response.ok) {
+      this.logger.error(`PayPal API failed: path=${path}, status=${response.status}`);
+      throw new BadGatewayException('PayPal API 오류');
+    }
+    return response;
+  }
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+function formatPayPalAmount(amount: number): string {
+  return Number(amount).toFixed(2);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/backend/src/modules/payments/dto/prepare-payment.dto.ts
+++ b/backend/src/modules/payments/dto/prepare-payment.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsInt, IsOptional, IsString } from 'class-validator';
 
 export class PreparePaymentDto {
@@ -11,4 +11,14 @@ export class PreparePaymentDto {
   @IsString({ message: '로케일은 문자열이어야 합니다.' })
   @IsIn(['ko', 'en'], { message: '로케일은 ko 또는 en만 지원합니다.' })
   locale?: string;
+
+  @ApiPropertyOptional({
+    example: 'paypal',
+    enum: ['naverpay', 'paypal'],
+    description: '사용자가 명시적으로 선택한 결제 게이트웨이',
+  })
+  @IsOptional()
+  @IsString({ message: '결제 게이트웨이는 문자열이어야 합니다.' })
+  @IsIn(['naverpay', 'paypal'], { message: '결제 게이트웨이는 naverpay 또는 paypal만 지원합니다.' })
+  gateway?: 'naverpay' | 'paypal';
 }

--- a/backend/src/modules/payments/entities/payment.entity.ts
+++ b/backend/src/modules/payments/entities/payment.entity.ts
@@ -19,6 +19,7 @@ export enum PaymentMethod {
   VIRTUAL_ACCOUNT = 'virtual_account',
   PHONE = 'phone',
   MOCK = 'mock',
+  PAYPAL = 'paypal',
 }
 
 export enum PaymentGatewayType {
@@ -27,6 +28,7 @@ export enum PaymentGatewayType {
   INICIS = 'inicis',
   STRIPE = 'stripe',
   NAVERPAY = 'naverpay',
+  PAYPAL = 'paypal',
 }
 
 @Entity('payments')

--- a/backend/src/modules/payments/interfaces/payment-gateway.interface.ts
+++ b/backend/src/modules/payments/interfaces/payment-gateway.interface.ts
@@ -1,6 +1,13 @@
+export interface PrepareContext {
+  locale?: string;
+  orderNumber?: string;
+}
+
 export interface PrepareResult {
   clientKey: string;
   orderId: string;
+  redirectUrl?: string;
+  gatewayPayload?: Record<string, string | number | boolean>;
 }
 
 export interface ConfirmResult {
@@ -29,9 +36,9 @@ export interface PartialCancelResult {
 }
 
 export interface PaymentGateway {
-  prepare(orderId: string, amount: number): Promise<PrepareResult>;
+  prepare(orderId: string, amount: number, context?: PrepareContext): Promise<PrepareResult>;
   confirm(paymentKey: string, amount: number, orderId: string): Promise<ConfirmResult>;
   cancel(paymentKey: string, reason: string): Promise<CancelResult>;
   partialCancel(params: PartialCancelParams): Promise<PartialCancelResult>;
-  verifyWebhook(payload: unknown, signature: string): boolean;
+  verifyWebhook(payload: unknown, signature: string): boolean | Promise<boolean>;
 }

--- a/backend/src/modules/payments/payments.controller.ts
+++ b/backend/src/modules/payments/payments.controller.ts
@@ -56,9 +56,32 @@ export class PaymentsController {
   @ApiHeader({ name: 'toss-signature', description: 'Toss 서명', required: true })
   async webhook(
     @Body() dto: WebhookPayloadDto,
-    @Headers('toss-signature') signature: string,
+    @Headers() headers: Record<string, string | string[] | undefined>,
   ): Promise<{ received: boolean }> {
-    await this.paymentsService.handleWebhook(dto, signature);
+    await this.paymentsService.handleWebhook(dto, buildPaymentWebhookSignature(headers));
     return { received: true };
   }
+}
+
+function buildPaymentWebhookSignature(headers: Record<string, string | string[] | undefined>): string {
+  const tossSignature = getHeader(headers, 'toss-signature');
+  const paypalTransmissionSig = getHeader(headers, 'paypal-transmission-sig');
+
+  if (!paypalTransmissionSig) return tossSignature ?? '';
+
+  return JSON.stringify({
+    auth_algo: getHeader(headers, 'paypal-auth-algo'),
+    cert_url: getHeader(headers, 'paypal-cert-url'),
+    transmission_id: getHeader(headers, 'paypal-transmission-id'),
+    transmission_sig: paypalTransmissionSig,
+    transmission_time: getHeader(headers, 'paypal-transmission-time'),
+  });
+}
+
+function getHeader(
+  headers: Record<string, string | string[] | undefined>,
+  name: string,
+): string | undefined {
+  const value = headers[name] ?? headers[name.toLowerCase()];
+  return Array.isArray(value) ? value[0] : value;
 }

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -14,6 +14,7 @@ import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
 import { KGInicisPaymentAdapter } from './adapters/inicis.adapter';
 import { NaverPayPaymentAdapter } from './adapters/naverpay.adapter';
+import { PayPalPaymentAdapter } from './adapters/paypal.adapter';
 import {
   PAYMENT_CONFIG,
   PaymentConfig,
@@ -24,22 +25,25 @@ export function resolvePaymentGateway(config: PaymentConfig): string {
   return config.gateway;
 }
 
+export type CheckoutGatewayName = 'naverpay' | 'paypal';
+
 /**
- * 로케일 기반 결제 게이트웨이 선택 (#721)
+ * 로케일 기반 결제 게이트웨이 노출 정책 (#769)
  *
- * 정책 결정:
- * - 한국(ko): Toss Payments — 기본값. 사용자가 별도 PG 선택 시 controller 단계에서
- *   덮어쓰기 가능 (`/api/payments/prepare` body 의 명시적 gateway 필드는 추후 확장).
- *   국내 PG(toss / inicis / naverpay) 어댑터가 모두 등록되어 있으므로 Phase 2 에서
- *   사용자 선택 UI 만 추가하면 된다.
- * - 그 외 locale: Stripe (글로벌)
- *
- * 자율 판단 근거: issue #721 본문은 "사용자 선택 / 관리자 설정 / locale fallback 중 결정"
- * 을 자율 판단 항목으로 명시. 가장 작은 변화(=기존 ko→toss 매핑 유지)를 선택하고,
- * 국내 3 PG 어댑터를 미리 등록해 둠으로써 추후 사용자 선택 UI 추가가 비파괴적이도록 설계.
+ * 두 PG를 모두 제공하되 로케일별 ordering/default만 바꾼다.
+ * - ko: 네이버페이 기본, PayPal 추가 선택지
+ * - 그 외: PayPal 기본, 네이버페이 추가 선택지
  */
-export function resolveGatewayByLocale(locale: string): string {
-  return locale === 'ko' ? 'toss' : 'stripe';
+export function getAvailableGatewaysByLocale(locale: string): CheckoutGatewayName[] {
+  return locale === 'ko' ? ['naverpay', 'paypal'] : ['paypal', 'naverpay'];
+}
+
+export function resolveGatewayByLocale(locale: string): CheckoutGatewayName {
+  return getAvailableGatewaysByLocale(locale)[0];
+}
+
+export function isCheckoutGatewayName(value: string): value is CheckoutGatewayName {
+  return value === 'naverpay' || value === 'paypal';
 }
 
 const gatewayProviders = [
@@ -49,6 +53,7 @@ const gatewayProviders = [
   StripePaymentAdapter,
   KGInicisPaymentAdapter,
   NaverPayPaymentAdapter,
+  PayPalPaymentAdapter,
   {
     provide: 'PaymentGateway',
     useFactory: (
@@ -58,6 +63,7 @@ const gatewayProviders = [
       stripe: StripePaymentAdapter,
       inicis: KGInicisPaymentAdapter,
       naverpay: NaverPayPaymentAdapter,
+      paypal: PayPalPaymentAdapter,
     ) => {
       const gateway = resolvePaymentGateway(config);
       switch (gateway) {
@@ -69,6 +75,8 @@ const gatewayProviders = [
           return inicis;
         case 'naverpay':
           return naverpay;
+        case 'paypal':
+          return paypal;
         case 'mock':
           return mock;
         default:
@@ -82,6 +90,7 @@ const gatewayProviders = [
       StripePaymentAdapter,
       KGInicisPaymentAdapter,
       NaverPayPaymentAdapter,
+      PayPalPaymentAdapter,
     ],
   },
 ];

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -19,7 +19,12 @@ import { TossPaymentAdapter } from './adapters/toss.adapter';
 import { StripePaymentAdapter } from './adapters/stripe.adapter';
 import { KGInicisPaymentAdapter } from './adapters/inicis.adapter';
 import { NaverPayPaymentAdapter } from './adapters/naverpay.adapter';
-import { resolveGatewayByLocale } from './payments.module';
+import { PayPalPaymentAdapter } from './adapters/paypal.adapter';
+import {
+  getAvailableGatewaysByLocale,
+  isCheckoutGatewayName,
+  resolveGatewayByLocale,
+} from './payments.module';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { NotificationService } from '../notification/notification.service';
@@ -55,6 +60,7 @@ export class PaymentsService {
     private readonly stripeAdapter: StripePaymentAdapter,
     private readonly inicisAdapter: KGInicisPaymentAdapter,
     private readonly naverpayAdapter: NaverPayPaymentAdapter,
+    private readonly paypalAdapter: PayPalPaymentAdapter,
     private readonly notificationService: NotificationService,
     private readonly notificationDispatchHelper: NotificationDispatchHelper,
     private readonly dataSource: DataSource,
@@ -87,13 +93,12 @@ export class PaymentsService {
     });
   }
 
-  private resolveGateway(locale?: string): PaymentGateway {
-    if (!locale) return this.gateway;
-    const name = resolveGatewayByLocale(locale);
+  private resolveGatewayByName(name: string): PaymentGateway {
     if (name === 'toss') return this.tossAdapter;
     if (name === 'stripe') return this.stripeAdapter;
     if (name === 'inicis') return this.inicisAdapter;
     if (name === 'naverpay') return this.naverpayAdapter;
+    if (name === 'paypal') return this.paypalAdapter;
     return this.gateway;
   }
 
@@ -107,6 +112,8 @@ export class PaymentsService {
         return this.inicisAdapter;
       case PaymentGatewayType.NAVERPAY:
         return this.naverpayAdapter;
+      case PaymentGatewayType.PAYPAL:
+        return this.paypalAdapter;
       case PaymentGatewayType.MOCK:
       default:
         return this.gateway;
@@ -123,6 +130,8 @@ export class PaymentsService {
         return PaymentGatewayType.INICIS;
       case 'naverpay':
         return PaymentGatewayType.NAVERPAY;
+      case 'paypal':
+        return PaymentGatewayType.PAYPAL;
       case 'mock':
       default:
         return PaymentGatewayType.MOCK;
@@ -136,6 +145,9 @@ export class PaymentsService {
     amount: number;
     gateway: string;
     clientKey: string;
+    availableGateways: string[];
+    redirectUrl?: string;
+    gatewayPayload?: Record<string, string | number | boolean>;
   }> {
     const order = await findOrThrow(this.orderRepository, { id: dto.orderId }, '주문을 찾을 수 없습니다.');
     assertOwnership(order.userId, userId);
@@ -143,8 +155,14 @@ export class PaymentsService {
       throw new ConflictException('이미 처리된 주문입니다.');
     }
 
-    const selectedGateway = this.resolveGateway(dto.locale);
-    const gatewayName = dto.locale ? resolveGatewayByLocale(dto.locale) : 'mock';
+    const locale = dto.locale ?? 'ko';
+    const availableGateways = getAvailableGatewaysByLocale(locale);
+    const gatewayName = dto.gateway && isCheckoutGatewayName(dto.gateway)
+      ? dto.gateway
+      : dto.locale
+        ? resolveGatewayByLocale(locale)
+        : this.paymentConfig.gateway;
+    const selectedGateway = this.resolveGatewayByName(gatewayName);
 
     let payment = await this.paymentRepository.findOne({ where: { orderId: dto.orderId } });
     if (!payment) {
@@ -163,7 +181,10 @@ export class PaymentsService {
       payment = await findOrThrow(this.paymentRepository, { id: payment.id }, '결제 정보를 찾을 수 없습니다.');
     }
 
-    const result = await selectedGateway.prepare(String(dto.orderId), Number(order.totalAmount));
+    const result = await selectedGateway.prepare(String(dto.orderId), Number(order.totalAmount), {
+      locale,
+      orderNumber: order.orderNumber,
+    });
 
     return {
       paymentId: Number(payment.id),
@@ -172,6 +193,9 @@ export class PaymentsService {
       amount: Number(order.totalAmount),
       gateway: gatewayName,
       clientKey: result.clientKey,
+      availableGateways,
+      ...(result.redirectUrl ? { redirectUrl: result.redirectUrl } : {}),
+      ...(result.gatewayPayload ? { gatewayPayload: result.gatewayPayload } : {}),
     };
   }
 

--- a/backend/src/modules/payments/services/payment-webhook.service.ts
+++ b/backend/src/modules/payments/services/payment-webhook.service.ts
@@ -40,7 +40,7 @@ export class PaymentWebhookService {
   constructor(private readonly deps: PaymentWebhookDependencies) {}
 
   async handleWebhook(payload: unknown, signature: string): Promise<void> {
-    if (!this.deps.gateway.verifyWebhook(payload, signature)) {
+    if (!(await this.deps.gateway.verifyWebhook(payload, signature))) {
       throw new UnauthorizedException('웹훅 서명 검증 실패');
     }
     const safe = {

--- a/backend/src/modules/payments/services/webhook-idempotency.util.spec.ts
+++ b/backend/src/modules/payments/services/webhook-idempotency.util.spec.ts
@@ -83,6 +83,27 @@ describe('extractWebhookIdempotencyKey', () => {
     });
   });
 
+
+  describe('PayPal', () => {
+    it('webhook id + event_type 사용', () => {
+      const key = extractWebhookIdempotencyKey(
+        PaymentGatewayType.PAYPAL,
+        { id: 'WH-123', event_type: 'CHECKOUT.ORDER.APPROVED' },
+      );
+      expect(key).toEqual({
+        gateway: PaymentGatewayType.PAYPAL,
+        eventId: 'WH-123',
+        eventType: 'CHECKOUT.ORDER.APPROVED',
+      });
+    });
+
+    it('id 가 없으면 null', () => {
+      expect(
+        extractWebhookIdempotencyKey(PaymentGatewayType.PAYPAL, { event_type: 'PAYMENT.CAPTURE.COMPLETED' }),
+      ).toBeNull();
+    });
+  });
+
   describe('KGInicis', () => {
     it('tid + eventType 결합', () => {
       const key = extractWebhookIdempotencyKey(

--- a/backend/src/modules/payments/services/webhook-idempotency.util.ts
+++ b/backend/src/modules/payments/services/webhook-idempotency.util.ts
@@ -10,6 +10,7 @@ import { PaymentGatewayType } from '../entities/payment.entity';
  * - Stripe: `event.id` (예: `evt_xxx`). Stripe webhook 의 표준 필드.
  * - NaverPay: `paymentId` 이지만 cancel 이벤트와 confirm 이벤트가 같은 paymentId 를 공유할 수 있어
  *   `eventType` 을 함께 묶어 분리한다 (`naverpay-paymentId:CANCEL` 등).
+ * - PayPal: webhook `id` 와 `event_type` 을 사용한다.
  * - KGInicis: `tid` 와 `eventType` 결합 (취소 / 승인 분리).
  * - Mock: `orderId + ':' + eventType` (테스트 용도).
  *
@@ -28,7 +29,7 @@ export function extractWebhookIdempotencyKey(
   if (!isRecord(payload)) return null;
 
   const eventType = String(
-    payload.eventType ?? payload.status ?? payload.type ?? '',
+    payload.eventType ?? payload.event_type ?? payload.status ?? payload.type ?? '',
   ).toUpperCase();
 
   switch (gateway) {
@@ -49,6 +50,11 @@ export function extractWebhookIdempotencyKey(
       const paymentId = stringOf(payload.paymentId);
       if (!paymentId || !eventType) return null;
       return { gateway, eventId: `${paymentId}:${eventType}`, eventType };
+    }
+    case PaymentGatewayType.PAYPAL: {
+      const id = stringOf(payload.id);
+      if (!id || !eventType) return null;
+      return { gateway, eventId: id, eventType };
     }
     case PaymentGatewayType.INICIS: {
       const tid = stringOf(payload.tid);

--- a/docs/architecture/BACKEND.md
+++ b/docs/architecture/BACKEND.md
@@ -107,7 +107,7 @@ PENDING → CONFIRMED → PARTIAL_CANCELLED / CANCELLED / REFUNDED
 
 - 서버 사이드 금액 검증 필수
 - 목표 정책: 국내 결제는 네이버페이, KG이니시스, 토스페이먼츠를 모두 지원하고 글로벌 결제는 Stripe를 우선 지원한다.
-- 현재 코드 기준 환경변수 선택지는 `PAYMENT_GATEWAY=mock|toss|stripe`다. 네이버페이/KG이니시스 어댑터와 `stripe` gateway enum 정리는 후속 구현이 필요하다.
+- 현재 코드 기준 환경변수 선택지는 `PAYMENT_GATEWAY=mock|toss|stripe|inicis|naverpay|paypal`다. 결제 준비 단계는 로케일별 기본값(ko=naverpay, 그 외=paypal)과 명시적 사용자 선택을 모두 지원한다.
 
 ---
 

--- a/docs/infrastructure/ENVIRONMENT_VARIABLES.md
+++ b/docs/infrastructure/ENVIRONMENT_VARIABLES.md
@@ -65,7 +65,7 @@
 
 | 변수 | 기본값 | 설명 |
 |------|--------|------|
-| `PAYMENT_GATEWAY` | `mock` | 현재 코드 기준 PG 어댑터 선택 (`mock`/`toss`/`stripe`). 국내 목표 지원 PG는 네이버페이/KG이니시스/토스페이먼츠, 글로벌은 Stripe |
+| `PAYMENT_GATEWAY` | `mock` | PG 어댑터 선택 (`mock`/`toss`/`stripe`/`inicis`/`naverpay`/`paypal`). `mock`은 프로덕션 차단 |
 | `TOSS_SECRET_KEY` | — | 토스페이먼츠 시크릿 키 |
 | `TOSS_CLIENT_KEY` | — | 토스페이먼츠 클라이언트 키 |
 | `STRIPE_SECRET_KEY` | — | Stripe 시크릿 키 |
@@ -137,3 +137,8 @@ backend/.env.example      # 키 목록 (커밋 O, 값 없음)
 ```
 
 > **`.env` 파일은 절대 커밋하지 않습니다.** `.env.example`에 키 목록만 기록합니다.
+
+| `PAYPAL_CLIENT_ID` | — | PayPal REST API client ID |
+| `PAYPAL_CLIENT_SECRET` | — | PayPal REST API client secret |
+| `PAYPAL_WEBHOOK_ID` | — | PayPal webhook signature verification ID |
+| `PAYPAL_API_BASE_URL` | sandbox/prod default | PayPal REST API base URL override |

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -9,7 +9,7 @@ import { useCart } from '@/contexts/CartContext';
 import { useMobileNav } from '@/contexts/MobileNavContext';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/components/ui/utils';
-import type { CartItem, PreparePaymentResponse, UserAddress } from '@/lib/api';
+import type { CartItem, CheckoutGatewayName, PreparePaymentResponse, UserAddress } from '@/lib/api';
 import { usersApi } from '@/lib/api';
 import { FREE_SHIPPING_THRESHOLD, SHIPPING_FEE } from '@/constants/shipping';
 import { SESSION_KEYS } from '@/constants/storage';
@@ -59,6 +59,9 @@ export default function CheckoutPage({
   const [checkoutItems, setCheckoutItems] = useState<CartItem[]>([]);
   const [step, setStep] = useState<PaymentStep>('idle');
   const [prepareResult, setPrepareResult] = useState<PreparePaymentResponse | null>(null);
+  const [selectedGateway, setSelectedGateway] = useState<CheckoutGatewayName>(
+    locale === 'ko' ? 'naverpay' : 'paypal',
+  );
   const [currentOrderId, setCurrentOrderId] = useState<number | null>(null);
   const [currentOrderNumber, setCurrentOrderNumber] = useState('');
   const [form, setForm] = useState<ShippingForm>({
@@ -87,6 +90,9 @@ export default function CheckoutPage({
     success: t('steps.success'),
   };
   const loadAddressErrorMessage = t('loadAddressError');
+  const gatewayOptions: CheckoutGatewayName[] = locale === 'ko'
+    ? ['naverpay', 'paypal']
+    : ['paypal', 'naverpay'];
 
   const fillFormFromAddress = (addr: UserAddress) => {
     setForm({
@@ -98,6 +104,10 @@ export default function CheckoutPage({
       memo: '',
     });
   };
+
+  useEffect(() => {
+    setSelectedGateway(locale === 'ko' ? 'naverpay' : 'paypal');
+  }, [locale]);
 
   useEffect(() => {
     if (isLoading) return;
@@ -172,6 +182,7 @@ export default function CheckoutPage({
     locale,
     paymentRef,
     prepareResult,
+    selectedGateway,
     currentOrderId,
     currentOrderNumber,
     setStep,
@@ -235,7 +246,42 @@ export default function CheckoutPage({
                     onError={handlePaymentError}
                   />
                 ) : (
-                  <p className="text-sm text-muted-foreground">{t('paymentMethodHint')}</p>
+                  <div className="layout-stack-sm">
+                    <p className="typo-body-sm text-muted-foreground">{t('paymentMethodHint')}</p>
+                    <div className="grid gap-3 md:grid-cols-2" role="radiogroup" aria-label={t('paymentMethod')}>
+                      {gatewayOptions.map((gateway) => (
+                        <label
+                          key={gateway}
+                          className={cn(
+                            'flex min-h-11 cursor-pointer items-start gap-3 rounded-md border border-border p-3 transition-colors',
+                            selectedGateway === gateway ? 'bg-muted/40' : 'bg-background',
+                          )}
+                        >
+                          <input
+                            type="radio"
+                            name="checkoutGateway"
+                            value={gateway}
+                            checked={selectedGateway === gateway}
+                            onChange={() => setSelectedGateway(gateway)}
+                            className="mt-1 accent-foreground"
+                          />
+                          <span className="layout-stack-xs">
+                            <span className="flex items-center gap-2 typo-body-sm text-foreground">
+                              {t(gateway === 'naverpay' ? 'naverpayPayment' : 'paypalPayment')}
+                              {gateway === 'naverpay' && (
+                                <span className="rounded-sm bg-muted px-2 py-0.5 typo-label text-muted-foreground" title={t('naverpayDomesticHint')}>
+                                  {t('naverpayDomesticBadge')}
+                                </span>
+                              )}
+                            </span>
+                            {gateway === 'naverpay' && (
+                              <span className="typo-label text-muted-foreground">{t('naverpayDomesticHint')}</span>
+                            )}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
                 )}
               </div>
             </section>

--- a/src/app/[locale]/checkout/success/__tests__/CheckoutSuccessPage.test.tsx
+++ b/src/app/[locale]/checkout/success/__tests__/CheckoutSuccessPage.test.tsx
@@ -148,6 +148,79 @@ describe('CheckoutSuccessPage', () => {
   });
 
   describe('결제 완료 후 동작', () => {
+
+    it('PayPal token + paypalPaymentContext가 있으면 token으로 결제 확인을 진행한다', async () => {
+      mockSearchParams.set('token', 'PAYPAL-ORDER-1');
+      sessionStorage.setItem('paypalPaymentContext', JSON.stringify(validPaymentContext));
+
+      mockConfirm.mockResolvedValue({
+        paymentId: 1,
+        orderId: 1,
+        orderNumber: 'ORD-001',
+        status: 'paid',
+        method: 'paypal',
+        amount: 40000,
+        paidAt: new Date().toISOString(),
+      });
+
+      await act(async () => {
+        render(<CheckoutSuccessPage params={makeParams()} />);
+      });
+
+      await waitFor(() => {
+        expect(mockConfirm).toHaveBeenCalledWith({
+          orderId: 1,
+          paymentKey: 'PAYPAL-ORDER-1',
+          amount: 40000,
+        });
+      });
+    });
+
+
+    it('NaverPay resultCode=Success + paymentId가 있으면 네이버페이 컨텍스트로 결제 확인을 진행한다', async () => {
+      mockSearchParams.set('resultCode', 'Success');
+      mockSearchParams.set('paymentId', 'NPAYMENT-1');
+      sessionStorage.setItem('naverpayPaymentContext', JSON.stringify(validPaymentContext));
+
+      mockConfirm.mockResolvedValue({
+        paymentId: 1,
+        orderId: 1,
+        orderNumber: 'ORD-001',
+        status: 'paid',
+        method: 'card',
+        amount: 40000,
+        paidAt: new Date().toISOString(),
+      });
+
+      await act(async () => {
+        render(<CheckoutSuccessPage params={makeParams()} />);
+      });
+
+      await waitFor(() => {
+        expect(mockConfirm).toHaveBeenCalledWith({
+          orderId: 1,
+          paymentKey: 'NPAYMENT-1',
+          amount: 40000,
+        });
+      });
+    });
+
+    it('NaverPay resultCode 실패는 결제 확인 없이 cart로 이동한다', async () => {
+      mockSearchParams.set('resultCode', 'UserCancel');
+      mockSearchParams.set('resultMessage', '사용자 취소');
+      sessionStorage.setItem('naverpayPaymentContext', JSON.stringify(validPaymentContext));
+
+      await act(async () => {
+        render(<CheckoutSuccessPage params={makeParams()} />);
+      });
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/ko/cart');
+      });
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('사용자 취소');
+      expect(mockConfirm).not.toHaveBeenCalled();
+    });
+
     it('결제 확인 성공 시 sessionStorageアイテムをクリア하고 order/complete页面로リ다이렉션한다', async () => {
       setupValidSearchParams();
       sessionStorage.setItem('tossPaymentContext', JSON.stringify(validPaymentContext));

--- a/src/app/[locale]/checkout/success/page.tsx
+++ b/src/app/[locale]/checkout/success/page.tsx
@@ -17,17 +17,32 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
   const [processing, setProcessing] = useState(true);
 
   useEffect(() => {
-    const paymentKey = searchParams.get('paymentKey');
+    const paypalToken = searchParams.get('token');
+    const naverPayResultCode = searchParams.get('resultCode');
+    const naverPayPaymentId = searchParams.get('paymentId');
+    const isNaverPayReturn = naverPayResultCode !== null || naverPayPaymentId !== null;
+    const paymentKey = paypalToken ?? naverPayPaymentId ?? searchParams.get('paymentKey');
     const tossOrderId = searchParams.get('orderId');
     const amountParam = searchParams.get('amount');
+    const contextKey = paypalToken
+      ? SESSION_KEYS.PAYPAL_CONTEXT
+      : isNaverPayReturn
+        ? SESSION_KEYS.NAVERPAY_CONTEXT
+        : SESSION_KEYS.TOSS_CONTEXT;
 
-    if (!paymentKey || !tossOrderId || !amountParam) {
+    if (isNaverPayReturn && naverPayResultCode !== 'Success') {
+      toast.error(searchParams.get('resultMessage') ?? '결제 정보가 올바르지 않습니다.');
+      router.replace(`/${locale}/cart`);
+      return;
+    }
+
+    if (!paymentKey || (!paypalToken && !isNaverPayReturn && (!tossOrderId || !amountParam))) {
       toast.error('결제 정보가 올바르지 않습니다.');
       router.replace(`/${locale}/cart`);
       return;
     }
 
-    const raw = sessionStorage.getItem(SESSION_KEYS.TOSS_CONTEXT);
+    const raw = sessionStorage.getItem(contextKey);
     if (!raw) {
       toast.error('결제 컨텍스트를 찾을 수 없습니다.');
       router.replace(`/${locale}/cart`);
@@ -40,11 +55,13 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
       amount: number;
     };
 
-    const amount = Number(amountParam);
-    if (amount !== ctx.amount) {
-      toast.error('결제 금액이 일치하지 않습니다.');
-      router.replace(`/${locale}/cart`);
-      return;
+    if (!paypalToken && !isNaverPayReturn) {
+      const amount = Number(amountParam);
+      if (amount !== ctx.amount) {
+        toast.error('결제 금액이 일치하지 않습니다.');
+        router.replace(`/${locale}/cart`);
+        return;
+      }
     }
 
     paymentsApi
@@ -53,6 +70,8 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
         toast.success('결제가 완료되었습니다.');
         sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
         sessionStorage.removeItem(SESSION_KEYS.TOSS_CONTEXT);
+        sessionStorage.removeItem(SESSION_KEYS.PAYPAL_CONTEXT);
+        sessionStorage.removeItem(SESSION_KEYS.NAVERPAY_CONTEXT);
         await refetch();
         router.replace(
           `/${locale}/order/complete?orderId=${ctx.orderId}&orderNumber=${ctx.orderNumber}`,

--- a/src/components/__tests__/CheckoutPage.test.tsx
+++ b/src/components/__tests__/CheckoutPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Suspense } from 'react';
@@ -25,6 +25,10 @@ vi.mock('next-intl', () => ({
       shippingMemo: '배송 메모',
       paymentMethod: '결제 수단',
       paymentMethodHint: '주문 정보 입력 후 결제 수단이 표시됩니다.',
+      paypalPayment: 'PayPal',
+      naverpayPayment: '네이버페이',
+      naverpayDomesticBadge: '국내 전용',
+      naverpayDomesticHint: '해외 사용자는 결제가 실패할 수 있습니다.',
       couponPoints: '쿠폰 / 적립금',
       couponPointsComingSoon: '쿠폰/적립금 적용은 추후 지원 예정입니다.',
       orderItems: '주문 상품',
@@ -153,10 +157,10 @@ describe('CheckoutPage', () => {
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
     await renderCheckoutPage();
     await screen.findByLabelText(/받는 분 이름/);
-    await user.type(screen.getByLabelText(/받는 분 이름/), '홍길동');
-    await user.type(screen.getByLabelText(/연락처/), '01012345678');
-    await user.type(screen.getByLabelText(/우편번호/), '12345');
-    await user.type(screen.getByLabelText(/^주소/), '서울시 강남구');
+    fireEvent.change(screen.getByLabelText(/받는 분 이름/), { target: { value: '홍길동' } });
+    fireEvent.change(screen.getByLabelText(/연락처/), { target: { value: '01012345678' } });
+    fireEvent.change(screen.getByLabelText(/우편번호/), { target: { value: '12345' } });
+    fireEvent.change(screen.getByLabelText(/^주소/), { target: { value: '서울시 강남구' } });
     await user.click(screen.getAllByRole('button', { name: '결제하기' })[0]);
 
     await waitFor(() => {
@@ -178,7 +182,7 @@ describe('CheckoutPage', () => {
     });
     vi.mocked(paymentsApi.prepare).mockResolvedValue({
       paymentId: 1, orderId: 1, orderNumber: 'ORD-001',
-      amount: 40000, gateway: 'mock', clientKey: 'mock_client_key',
+      amount: 40000, gateway: 'mock', clientKey: 'mock_client_key', availableGateways: ['naverpay', 'paypal'],
     });
     vi.mocked(paymentsApi.confirm).mockResolvedValue({
       paymentId: 1, orderId: 1, orderNumber: 'ORD-001',
@@ -199,6 +203,40 @@ describe('CheckoutPage', () => {
     expect(ordersApi.create).toHaveBeenCalledOnce();
     expect(paymentsApi.prepare).toHaveBeenCalledOnce();
     expect(paymentsApi.confirm).toHaveBeenCalledOnce();
+  });
+
+
+
+  it('ko checkout은 네이버페이를 기본 선택하고 PayPal로 전환하면 prepare gateway=paypal 전달', async () => {
+    const user = userEvent.setup();
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
+    sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
+
+    vi.mocked(ordersApi.create).mockResolvedValue({
+      id: 1, orderNumber: 'ORD-001', status: 'pending', totalAmount: 40000,
+      discountAmount: 0, shippingFee: 0, recipientName: '홍길동',
+      recipientPhone: '010-1234-5678', zipcode: '12345', address: '서울시',
+      addressDetail: null, memo: null, items: [], createdAt: new Date().toISOString(),
+    });
+    vi.mocked(paymentsApi.prepare).mockResolvedValue({
+      paymentId: 1, orderId: 1, orderNumber: 'ORD-001',
+      amount: 40000, gateway: 'paypal', clientKey: 'paypal-client',
+      redirectUrl: 'https://www.paypal.com/checkoutnow?token=PAYPAL-ORDER-1',
+      availableGateways: ['naverpay', 'paypal'],
+    });
+
+    await renderCheckoutPage();
+    expect(await screen.findByLabelText(/네이버페이/)).toBeChecked();
+    await user.click(screen.getByLabelText(/PayPal/));
+    await user.type(screen.getByLabelText(/받는 분 이름/), '홍길동');
+    await user.type(screen.getByLabelText(/연락처/), '010-1234-5678');
+    await user.type(screen.getByLabelText(/우편번호/), '12345');
+    await user.type(screen.getByLabelText(/^주소/), '서울시 강남구');
+    await user.click(screen.getAllByRole('button', { name: '결제하기' })[0]);
+
+    await waitFor(() => {
+      expect(paymentsApi.prepare).toHaveBeenCalledWith({ orderId: 1, locale: 'ko', gateway: 'paypal' });
+    });
   });
 
   // ---- Address loading & selection tests ----

--- a/src/components/shared/checkout/PaymentGateway.tsx
+++ b/src/components/shared/checkout/PaymentGateway.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import type { Locale } from '@/i18n/routing';
 import type { PreparePaymentResponse } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
@@ -8,6 +9,76 @@ import { SESSION_KEYS } from '@/constants/storage';
 
 export interface PaymentGatewayHandle {
   confirm: () => Promise<void>;
+}
+
+
+type NaverPayMode = 'development' | 'production';
+
+interface NaverPayObject {
+  open: (params: {
+    merchantUserKey: string;
+    merchantPayKey: string;
+    productName: string;
+    totalPayAmount: number;
+    taxScopeAmount: number;
+    taxExScopeAmount: number;
+    returnUrl: string;
+  }) => void;
+}
+
+interface NaverPayNamespace {
+  Pay?: {
+    create: (config: {
+      mode: NaverPayMode;
+      payType: 'normal';
+      clientId: string;
+      chainId: string;
+    }) => NaverPayObject;
+  };
+}
+
+declare global {
+  interface Window {
+    Naver?: NaverPayNamespace;
+  }
+}
+
+const NAVERPAY_SDK_SRC = 'https://nsp.pay.naver.com/sdk/js/naverpay.min.js';
+let naverPaySdkPromise: Promise<void> | null = null;
+
+function loadNaverPaySdk(): Promise<void> {
+  if (window.Naver?.Pay) return Promise.resolve();
+  if (naverPaySdkPromise) return naverPaySdkPromise;
+
+  naverPaySdkPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[src="${NAVERPAY_SDK_SRC}"]`);
+    const script = existing ?? document.createElement('script');
+    script.src = NAVERPAY_SDK_SRC;
+    script.async = true;
+    script.onload = () => {
+      if (window.Naver?.Pay) {
+        resolve();
+      } else {
+        naverPaySdkPromise = null;
+        reject(new Error('naverpay_sdk_init_failed'));
+      }
+    };
+    script.onerror = () => {
+      naverPaySdkPromise = null;
+      reject(new Error('naverpay_sdk_load_failed'));
+    };
+    if (!existing) document.body.appendChild(script);
+  });
+
+  return naverPaySdkPromise;
+}
+
+function getGatewayPayloadString(
+  prepareResult: PreparePaymentResponse,
+  key: string,
+): string | undefined {
+  const value = prepareResult.gatewayPayload?.[key];
+  return typeof value === 'string' ? value : undefined;
 }
 
 interface PaymentGatewayProps {
@@ -217,13 +288,112 @@ const MockPaymentGateway = forwardRef<PaymentGatewayHandle>(
   },
 );
 
+// ─── External redirect gateways (PayPal / NaverPay) ───────────────────────────
+
+const ExternalRedirectGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>(
+  function ExternalRedirectGateway(
+    { prepareResult, orderId, orderNumber, amount, locale, onError },
+    ref,
+  ) {
+    const t = useTranslations('checkout');
+    const isNaverPay = prepareResult.gateway === 'naverpay';
+
+    useImperativeHandle(ref, () => ({
+      confirm: async () => {
+        if (prepareResult.gateway === 'naverpay') {
+          const chainId = getGatewayPayloadString(prepareResult, 'chainId');
+          const mode = getGatewayPayloadString(prepareResult, 'mode') === 'production'
+            ? 'production'
+            : 'development';
+
+          if (!prepareResult.clientKey || !chainId) {
+            onError(t('externalPaymentUnavailable'));
+            return;
+          }
+
+          sessionStorage.setItem(
+            SESSION_KEYS.NAVERPAY_CONTEXT,
+            JSON.stringify({ orderId, orderNumber, amount }),
+          );
+
+          try {
+            await loadNaverPaySdk();
+            const naverPay = window.Naver?.Pay?.create({
+              mode,
+              payType: 'normal',
+              clientId: prepareResult.clientKey,
+              chainId,
+            });
+            if (!naverPay) throw new Error('naverpay_sdk_init_failed');
+
+            naverPay.open({
+              merchantUserKey: `order_${orderId}`,
+              merchantPayKey: orderNumber,
+              productName: orderNumber,
+              totalPayAmount: amount,
+              taxScopeAmount: amount,
+              taxExScopeAmount: 0,
+              returnUrl: `${window.location.origin}/${locale}/checkout/success`,
+            });
+          } catch {
+            onError(t('externalPaymentUnavailable'));
+          }
+          return;
+        }
+
+        if (!prepareResult.redirectUrl) {
+          onError(t('externalPaymentUnavailable'));
+          return;
+        }
+
+        sessionStorage.setItem(
+          SESSION_KEYS.PAYPAL_CONTEXT,
+          JSON.stringify({ orderId, orderNumber, amount }),
+        );
+        window.location.assign(prepareResult.redirectUrl);
+      },
+    }));
+
+    return (
+      <label className="flex items-start gap-3 rounded-md border border-border p-3">
+        <input
+          type="radio"
+          name="paymentMethod"
+          value={prepareResult.gateway}
+          defaultChecked
+          readOnly
+          className="mt-1 accent-foreground"
+        />
+        <span className="layout-stack-xs">
+          <span className="flex items-center gap-2 typo-body-sm text-foreground">
+            {isNaverPay ? t('naverpayPayment') : t('paypalPayment')}
+            {isNaverPay && (
+              <span className="rounded-sm bg-muted px-2 py-0.5 typo-label text-muted-foreground" title={t('naverpayDomesticHint')}>
+                {t('naverpayDomesticBadge')}
+              </span>
+            )}
+          </span>
+          <span className="typo-label text-muted-foreground">
+            {isNaverPay ? t('naverpayDomesticHint') : t('paypalRedirectHint')}
+          </span>
+        </span>
+      </label>
+    );
+  },
+);
+
 // ─── Public component ─────────────────────────────────────────────────────────
 
 const PaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>(
   function PaymentGateway(props, ref) {
     const { prepareResult, locale } = props;
 
+    if (prepareResult.gateway === 'paypal' || prepareResult.gateway === 'naverpay') {
+      return <ExternalRedirectGateway ref={ref} {...props} />;
+    }
+
     const isToss =
+      prepareResult.gateway === 'toss' &&
       locale === 'ko' &&
       prepareResult.clientKey &&
       prepareResult.clientKey !== 'mock_client_key';

--- a/src/components/shared/checkout/__tests__/PaymentGateway.test.tsx
+++ b/src/components/shared/checkout/__tests__/PaymentGateway.test.tsx
@@ -1,8 +1,25 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { createRef } from 'react';
 import PaymentGateway, { type PaymentGatewayHandle } from '@/components/shared/checkout/PaymentGateway';
 import type { PreparePaymentResponse } from '@/lib/api';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const dict: Record<string, string> = {
+      tossPayment: '토스페이먼츠 (카드)',
+      stripePayment: 'Stripe (International Card)',
+      mockPayment: '테스트 결제 (Mock)',
+      paypalPayment: 'PayPal',
+      naverpayPayment: '네이버페이',
+      naverpayDomesticBadge: '국내 전용',
+      naverpayDomesticHint: '해외 사용자는 결제가 실패할 수 있습니다.',
+      paypalRedirectHint: 'PayPal 승인 페이지로 이동합니다.',
+      externalPaymentUnavailable: '결제 페이지를 열 수 없습니다.',
+    };
+    return dict[key] ?? key;
+  },
+}));
 
 vi.mock('@tosspayments/tosspayments-sdk', () => ({
   loadTossPayments: vi.fn().mockResolvedValue({
@@ -32,6 +49,11 @@ const baseProps = {
 };
 
 describe('PaymentGateway', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    delete window.Naver;
+  });
   it('locale=ko + 유효 clientKey → Toss 라디오 표시', () => {
     const prepareResult: PreparePaymentResponse = {
       paymentId: 1,
@@ -107,6 +129,97 @@ describe('PaymentGateway', () => {
     );
     expect(screen.getByText('테스트 결제 (Mock)')).toBeInTheDocument();
     expect(screen.queryByText('Stripe (International Card)')).not.toBeInTheDocument();
+  });
+
+
+
+  it('gateway=paypal + redirectUrl → PayPal 라디오와 안내 표시', () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORDER-001',
+      amount: 50000,
+      gateway: 'paypal',
+      clientKey: 'paypal-client',
+      redirectUrl: 'https://www.paypal.com/checkoutnow?token=PAYPAL-ORDER-1',
+      availableGateways: ['paypal', 'naverpay'],
+    };
+    render(
+      <PaymentGateway
+        prepareResult={prepareResult}
+        locale="en"
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText('PayPal')).toBeInTheDocument();
+    expect(screen.getByText('PayPal 승인 페이지로 이동합니다.')).toBeInTheDocument();
+  });
+
+  it('gateway=naverpay → 국내 전용 배지를 표시', () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORDER-001',
+      amount: 50000,
+      gateway: 'naverpay',
+      clientKey: 'naverpay-client',
+      availableGateways: ['naverpay', 'paypal'],
+      gatewayPayload: { chainId: 'naverpay-chain', mode: 'development' },
+    };
+    render(
+      <PaymentGateway
+        prepareResult={prepareResult}
+        locale="ko"
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText('네이버페이')).toBeInTheDocument();
+    expect(screen.getByText('국내 전용')).toBeInTheDocument();
+    expect(screen.getByText('해외 사용자는 결제가 실패할 수 있습니다.')).toBeInTheDocument();
+  });
+
+
+  it('gateway=naverpay confirm() → NaverPay SDK open 호출', async () => {
+    const open = vi.fn();
+    const create = vi.fn().mockReturnValue({ open });
+    window.Naver = { Pay: { create } };
+    const ref = createRef<PaymentGatewayHandle>();
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORDER-001',
+      amount: 50000,
+      gateway: 'naverpay',
+      clientKey: 'naverpay-client',
+      availableGateways: ['naverpay', 'paypal'],
+      gatewayPayload: { chainId: 'naverpay-chain', mode: 'development' },
+    };
+
+    render(
+      <PaymentGateway
+        ref={ref}
+        prepareResult={prepareResult}
+        locale="ko"
+        {...baseProps}
+      />,
+    );
+
+    await act(async () => {
+      await ref.current!.confirm();
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      mode: 'development',
+      payType: 'normal',
+      clientId: 'naverpay-client',
+      chainId: 'naverpay-chain',
+    });
+    expect(open).toHaveBeenCalledWith(expect.objectContaining({
+      merchantPayKey: 'ORDER-001',
+      totalPayAmount: 50000,
+      returnUrl: 'http://localhost:3000/ko/checkout/success',
+    }));
+    expect(sessionStorage.getItem('naverpayPaymentContext')).toContain('ORDER-001');
   });
 
   it('Mock gateway: confirm() 은 no-op (resolve)', async () => {

--- a/src/components/shared/hooks/__tests__/useCheckout.test.tsx
+++ b/src/components/shared/hooks/__tests__/useCheckout.test.tsx
@@ -90,6 +90,7 @@ const mockOrder: OrderResponse = {
 interface OptionsState {
   step: PaymentStep;
   prepareResult: PreparePaymentResponse | null;
+  selectedGateway: 'naverpay' | 'paypal';
   currentOrderId: number | null;
   currentOrderNumber: string;
 }
@@ -100,6 +101,7 @@ function makeOptions(
   const state: OptionsState = {
     step: 'idle',
     prepareResult: null,
+    selectedGateway: 'naverpay',
     currentOrderId: null,
     currentOrderNumber: '',
   };
@@ -113,6 +115,7 @@ function makeOptions(
     locale: 'ko',
     paymentRef,
     prepareResult: state.prepareResult,
+    selectedGateway: state.selectedGateway,
     currentOrderId: state.currentOrderId,
     currentOrderNumber: state.currentOrderNumber,
     setStep: vi.fn((s: PaymentStep) => { state.step = s; }),
@@ -230,7 +233,7 @@ describe('useCheckout - Mock 결제 흐름', () => {
         zipcode: '12345',
       }),
     );
-    expect(mockPaymentsPrepare).toHaveBeenCalledWith({ orderId: mockOrder.id, locale: 'ko' });
+    expect(mockPaymentsPrepare).toHaveBeenCalledWith({ orderId: mockOrder.id, locale: 'ko', gateway: 'naverpay' });
     expect(mockPaymentsConfirm).toHaveBeenCalledWith({
       orderId: mockOrder.id,
       paymentKey: `mock-${mockOrder.orderNumber}`,
@@ -245,6 +248,71 @@ describe('useCheckout - Mock 결제 흐름', () => {
     expect(options.setStep).toHaveBeenCalledWith('preparing_payment');
     expect(options.setStep).toHaveBeenCalledWith('confirming_payment');
     expect(options.setStep).toHaveBeenCalledWith('success');
+  });
+});
+
+describe('useCheckout - PayPal 결제 흐름', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('selectedGateway=paypal 이면 prepare 요청에 gateway를 포함하고 redirect 대기 상태로 전환', async () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 2,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      amount: 30000,
+      gateway: 'paypal',
+      clientKey: 'paypal-client',
+      redirectUrl: 'https://www.paypal.com/checkoutnow?token=PAYPAL-ORDER-1',
+      availableGateways: ['paypal', 'naverpay'],
+    };
+    mockOrdersCreate.mockResolvedValue(mockOrder);
+    mockPaymentsPrepare.mockResolvedValue(prepareResult);
+
+    const { options } = makeOptions({ locale: 'en', selectedGateway: 'paypal' });
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(mockPaymentsPrepare).toHaveBeenCalledWith({
+      orderId: mockOrder.id,
+      locale: 'en',
+      gateway: 'paypal',
+    });
+    expect(options.setPrepareResult).toHaveBeenCalledWith(prepareResult);
+    expect(options.setStep).toHaveBeenCalledWith('idle');
+    expect(mockPaymentsConfirm).not.toHaveBeenCalled();
+  });
+
+  it('이미 prepareResult(paypal) 상태에서 submit하면 paymentRef.confirm() 호출', async () => {
+    const prepareResult: PreparePaymentResponse = {
+      paymentId: 2,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      amount: 30000,
+      gateway: 'paypal',
+      clientKey: 'paypal-client',
+      redirectUrl: 'https://www.paypal.com/checkoutnow?token=PAYPAL-ORDER-1',
+      availableGateways: ['paypal', 'naverpay'],
+    };
+    const confirmSpy = vi.fn().mockResolvedValue(undefined);
+    const { options } = makeOptions({
+      prepareResult,
+      paymentRef: { current: { confirm: confirmSpy } },
+    });
+
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(options.setStep).toHaveBeenCalledWith('confirming_payment');
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(mockOrdersCreate).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/shared/hooks/useCheckout.ts
+++ b/src/components/shared/hooks/useCheckout.ts
@@ -5,7 +5,7 @@ import { useCallback } from 'react';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
 import { SESSION_KEYS } from '@/constants/storage';
-import type { CartItem, PreparePaymentResponse } from '@/lib/api';
+import type { CartItem, CheckoutGatewayName, PreparePaymentResponse } from '@/lib/api';
 import { ordersApi, paymentsApi } from '@/lib/api';
 import type { Locale } from '@/i18n/routing';
 import type { ShippingForm, FormErrors } from '@/app/[locale]/checkout/page';
@@ -20,6 +20,7 @@ export interface UseCheckoutOptions {
   locale: Locale;
   paymentRef: React.RefObject<PaymentGatewayHandle | null>;
   prepareResult: PreparePaymentResponse | null;
+  selectedGateway: CheckoutGatewayName;
   currentOrderId: number | null;
   currentOrderNumber: string;
   setStep: (step: PaymentStep) => void;
@@ -39,7 +40,7 @@ export function useCheckout(options: UseCheckoutOptions) {
     options.setPrepareResult(null);
   }, [options]);
 
-  const handleStripeFlow = useCallback(async (): Promise<void> => {
+  const handlePreparedGatewayFlow = useCallback(async (): Promise<void> => {
     if (!options.prepareResult || !options.paymentRef.current) return;
 
     options.setStep('confirming_payment');
@@ -76,9 +77,12 @@ export function useCheckout(options: UseCheckoutOptions) {
   const handleSubmit = useCallback(async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
 
-    // If already prepared (Stripe), trigger stripe confirm
-    if (options.prepareResult && options.prepareResult.gateway === 'stripe') {
-      await handleStripeFlow();
+    // If already prepared for a user-action gateway, trigger its confirm/redirect step.
+    if (
+      options.prepareResult
+      && ['stripe', 'paypal', 'naverpay'].includes(options.prepareResult.gateway)
+    ) {
+      await handlePreparedGatewayFlow();
       return;
     }
 
@@ -119,11 +123,12 @@ export function useCheckout(options: UseCheckoutOptions) {
 
       options.setStep('preparing_payment');
       const result: PreparePaymentResponse = await paymentsApi.prepare(
-        { orderId: order.id, locale },
+        { orderId: order.id, locale, gateway: options.selectedGateway },
       );
 
       // Toss flow
       const isToss =
+        result.gateway === 'toss' &&
         locale === 'ko' &&
         result.clientKey &&
         result.clientKey !== 'mock_client_key';
@@ -148,13 +153,22 @@ export function useCheckout(options: UseCheckoutOptions) {
         return;
       }
 
+      if (result.gateway === 'paypal' || result.gateway === 'naverpay') {
+        options.setCurrentOrderId(order.id);
+        options.setCurrentOrderNumber(order.orderNumber);
+        options.setPrepareResult(result);
+        options.setStep('idle');
+        toast.info('결제 수단을 확인하고 결제하기를 눌러주세요.');
+        return;
+      }
+
       // Mock flow
       await handleMockFlow(order.id, order.orderNumber);
     } catch (err) {
       toast.error(handleApiError(err, '결제 중 오류가 발생했습니다.'));
       options.setStep('idle');
     }
-  }, [options, form, checkoutItems, locale, handleStripeFlow, handleTossFlow, handleMockFlow]);
+  }, [options, form, checkoutItems, locale, handlePreparedGatewayFlow, handleTossFlow, handleMockFlow]);
 
   return {
     handleSubmit,

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,6 +1,8 @@
 export const SESSION_KEYS = {
   CHECKOUT_ITEMS: 'checkoutItems',
   TOSS_CONTEXT: 'tossPaymentContext',
+  PAYPAL_CONTEXT: 'paypalPaymentContext',
+  NAVERPAY_CONTEXT: 'naverpayPaymentContext',
   OAUTH_STATE: 'oauth_state',
 } as const;
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -304,7 +304,13 @@
     "paymentMethodHint": "Payment methods appear after shipping info is complete.",
     "freeShipping": "Free",
     "freeShippingUnlocked": "Free shipping is now applied.",
-    "freeShippingRemaining": "Add {amount} more for free shipping"
+    "freeShippingRemaining": "Add {amount} more for free shipping",
+    "paypalPayment": "PayPal",
+    "naverpayPayment": "Naver Pay",
+    "naverpayDomesticBadge": "Korea only",
+    "naverpayDomesticHint": "Naver Pay may fail for overseas users.",
+    "paypalRedirectHint": "You will be redirected to PayPal approval.",
+    "externalPaymentUnavailable": "Unable to open the payment page."
   },
   "order": {
     "orderHistory": "Order History",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -304,7 +304,13 @@
     "paymentMethodHint": "주문 정보 입력 후 결제 수단이 표시됩니다.",
     "freeShipping": "무료",
     "freeShippingUnlocked": "무료배송이 적용되었습니다.",
-    "freeShippingRemaining": "{amount} 더 담으면 무료배송"
+    "freeShippingRemaining": "{amount} 더 담으면 무료배송",
+    "paypalPayment": "PayPal",
+    "naverpayPayment": "네이버페이",
+    "naverpayDomesticBadge": "국내 전용",
+    "naverpayDomesticHint": "해외 사용자는 네이버페이 결제가 실패할 수 있습니다.",
+    "paypalRedirectHint": "PayPal 승인 페이지로 이동합니다.",
+    "externalPaymentUnavailable": "결제 페이지를 열 수 없습니다."
   },
   "order": {
     "orderHistory": "주문 내역",

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -1,5 +1,7 @@
 import { apiClient, type RequestOptions } from './core';
 
+export type CheckoutGatewayName = 'naverpay' | 'paypal';
+
 export interface PreparePaymentResponse {
   paymentId: number;
   orderId: number;
@@ -7,6 +9,9 @@ export interface PreparePaymentResponse {
   amount: number;
   gateway: string;
   clientKey: string;
+  availableGateways?: string[];
+  redirectUrl?: string;
+  gatewayPayload?: Record<string, string | number | boolean>;
 }
 
 export interface ConfirmPaymentResponse {
@@ -20,7 +25,7 @@ export interface ConfirmPaymentResponse {
 }
 
 export const paymentsApi = {
-  prepare: (body: { orderId: number; locale?: string }, options?: RequestOptions) =>
+  prepare: (body: { orderId: number; locale?: string; gateway?: CheckoutGatewayName }, options?: RequestOptions) =>
     apiClient.post<PreparePaymentResponse>('/payments/prepare', body, options),
   confirm: (body: { orderId: number; paymentKey: string; amount: number }, options?: RequestOptions) =>
     apiClient.post<ConfirmPaymentResponse>('/payments/confirm', body, options),


### PR DESCRIPTION
## Summary
- Closes #769 by adding a persisted PayPal gateway/method enum and PayPal Orders API adapter for create/capture/refund/webhook verification.
- Adds locale-ordered checkout gateway policy: `ko` defaults to NaverPay then PayPal; non-`ko` defaults to PayPal then NaverPay.
- Adds checkout PG selection UI, NaverPay domestic badge/help text, PayPal redirect flow, and NaverPay JS SDK return/confirm flow.
- Updates env examples/docs and payment webhook idempotency for PayPal events.

## Code Review
- Local `$code-review` pass: APPROVE.
- Watch item: live PayPal sandbox capture and live NaverPay partner credentials were not available locally; adapter flows are covered with mocks and e2e migration checks.

## Tests
- `npm run lint`
- `npm run build`
- `npm run test:run`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd backend && npm run test`
- `TEST_DATABASE_URL=mysql://root:<redacted>@127.0.0.1:3308/commerce_test npm run test:e2e`
