### PR TITLE
fix: #776 필터 이름 ko 로케일 시 nameKo 우선 적용

### DIFF
--- a/backend/src/modules/collections/collections.service.ts
+++ b/backend/src/modules/collections/collections.service.ts
@@ -15,11 +15,13 @@ export class CollectionsService {
   ) {}
 
   private applyLocaleToCollection(entity: Collection, locale?: string): Collection {
+    // ko 로케일: name 컬럼이 영문 슬러그일 수 있으므로 nameKo 우선 적용
+    if (!locale || locale === 'ko') {
+      return entity.nameKo ? { ...entity, name: entity.nameKo } : entity;
+    }
     const localized = applyLocale(entity, locale, ['name', 'description']);
     // 비한국어 로케일: nameKo 에 남은 한국어가 그대로 노출되지 않도록 로컬라이즈된 name 으로 덮어씀
-    if (locale && locale !== 'ko') {
-      localized.nameKo = localized.name ?? null;
-    }
+    localized.nameKo = localized.name ?? null;
     return localized;
   }
 

--- a/backend/src/modules/products/attributes.service.ts
+++ b/backend/src/modules/products/attributes.service.ts
@@ -19,6 +19,10 @@ export class AttributesService {
   ) {}
 
   private applyLocaleToAttributeType(entity: AttributeType, locale?: string): AttributeType {
+    // ko 로케일: name 컬럼이 영문일 수 있으므로 nameKo 우선 적용
+    if (!locale || locale === 'ko') {
+      return entity.nameKo ? { ...entity, name: entity.nameKo } : entity;
+    }
     return applyLocale(entity, locale, ['name']);
   }
 


### PR DESCRIPTION
## 변경 사항

한국어 페이지에서 필터 이름이 영문 슬러그/영문명으로 표시되는 버그 수정.

### 원인
- `collections.name` 컬럼이 영문 슬러그(`junni`, `danji` 등)로 저장
- `attribute_types.name` 컬럼이 영문(`Clay Type`, `Shape`)으로 저장
- `applyLocale()`이 `ko` 로케일 시 원본 그대로 반환

### 수정
- `CollectionsService`: `ko` 로케일 시 `nameKo` 있으면 `name` 덮어쓰기
- `AttributesService`: 동일 패턴 적용

Closes #776