### PR TITLE
fix: 한국어 페이지 Archive 메뉴명 아카이브로 변경

### DIFF
--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -52,7 +52,7 @@
     "openMenu": "메뉴 열기",
     "closeMenu": "메뉴 닫기",
     "collection": "컬렉션",
-    "archive": "Archive",
+    "archive": "아카이브",
     "journal": "Journal",
     "myPage": "마이",
     "home": "홈",
@@ -101,7 +101,7 @@
     "privacy": "개인정보처리방침",
     "allProducts": "전체 상품",
     "collection": "컬렉션",
-    "archive": "Archive",
+    "archive": "아카이브",
     "journal": "Journal",
     "copyright": "© {year} 옥화당. All rights reserved."
   },
@@ -841,7 +841,7 @@
   "nav": {
     "products": "상품목록",
     "artist": "장인",
-    "archive": "Archive",
+    "archive": "아카이브",
     "collection": "컬렉션",
     "journal": "Journal"
   },


### PR DESCRIPTION
## 변경 사항\n\n`src/i18n/messages/ko.json` 에서 `"archive": "Archive"` → `"archive": "아카이브"` 변경 (네비게이션, 푸터, nav 3곳)\n\nCloses #778