### PR TITLE
fix: desktop checkout CTA scrolls with sticky order summary

### DIFF
--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -292,7 +292,7 @@ export default function CheckoutPage({
             </section>
           </div>
 
-          <div className="layout-stack-md">
+          <aside className="layout-stack-md lg:sticky lg:top-24 lg:self-start">
             <OrderSummarySection checkoutItems={checkoutItems} locale={locale} />
             <div className="hidden rounded-lg border border-border p-4 lg:block">
               <div className="mb-2 flex items-end justify-between">
@@ -303,7 +303,7 @@ export default function CheckoutPage({
                 {stepLabels[step]}
               </Button>
             </div>
-          </div>
+          </aside>
         </div>
       </form>
 

--- a/src/components/__tests__/CheckoutPage.test.tsx
+++ b/src/components/__tests__/CheckoutPage.test.tsx
@@ -151,6 +151,21 @@ describe('CheckoutPage', () => {
     expect(screen.getByText('테스트 상품')).toBeInTheDocument();
   });
 
+  it('keeps desktop order summary and submit CTA inside the same sticky aside', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
+    sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
+
+    await renderCheckoutPage();
+
+    const orderSummaryHeading = await screen.findByText('주문 상품');
+    const desktopSummaryAside = orderSummaryHeading.closest('aside');
+
+    expect(desktopSummaryAside).not.toBeNull();
+    expect(desktopSummaryAside).toHaveClass('lg:sticky', 'lg:top-24', 'lg:self-start');
+    expect(desktopSummaryAside).toContainElement(screen.getByText('테스트 상품'));
+    expect(desktopSummaryAside).toContainElement(screen.getAllByRole('button', { name: '결제하기' })[0]);
+  });
+
   it('shows validation error for invalid phone on submit', async () => {
     const user = userEvent.setup();
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });

--- a/src/components/shared/checkout/OrderSummarySection.tsx
+++ b/src/components/shared/checkout/OrderSummarySection.tsx
@@ -20,7 +20,7 @@ export function OrderSummarySection({ checkoutItems, locale }: OrderSummarySecti
   const freeShippingProgress = Math.min((totalAmount / FREE_SHIPPING_THRESHOLD) * 100, 100);
 
   return (
-    <section className="rounded-lg border p-6 lg:sticky lg:top-24">
+    <section className="rounded-lg border p-6">
       <h2 className="typo-h3">{t('orderItems')}</h2>
 
       <ul className="mt-4 divide-y text-sm">


### PR DESCRIPTION
## Summary
- move desktop checkout sticky behavior from the order summary card to the shared right-side aside
- keep the order summary and desktop submit CTA in the same scrolling container to prevent overlap
- add a regression test that locks the shared sticky aside structure

## Testing
- npx vitest run src/components/__tests__/CheckoutPage.test.tsx
- npm run build && npm run test:run
- cd backend && npm run build && npm run test

Closes #781
