### PR TITLE
Fix checkout crash when saved zipcode is not a string

### DIFF
--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -44,6 +44,18 @@ export interface FormErrors {
   address?: string;
 }
 
+function normalizeInputValue(value: unknown): string {
+  if (value == null) return '';
+  return String(value);
+}
+
+function normalizeZipcodeInputValue(value: unknown): string {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+    return String(value).padStart(5, '0');
+  }
+  return normalizeInputValue(value);
+}
+
 export default function CheckoutPage({
   params,
 }: {
@@ -96,11 +108,11 @@ export default function CheckoutPage({
 
   const fillFormFromAddress = (addr: UserAddress) => {
     setForm({
-      recipientName: addr.recipientName,
-      recipientPhone: addr.phone,
-      zipcode: addr.zipcode,
-      address: addr.address,
-      addressDetail: addr.addressDetail ?? '',
+      recipientName: normalizeInputValue(addr.recipientName),
+      recipientPhone: normalizeInputValue(addr.phone),
+      zipcode: normalizeZipcodeInputValue(addr.zipcode),
+      address: normalizeInputValue(addr.address),
+      addressDetail: normalizeInputValue(addr.addressDetail),
       memo: '',
     });
   };

--- a/src/components/__tests__/CheckoutPage.test.tsx
+++ b/src/components/__tests__/CheckoutPage.test.tsx
@@ -314,6 +314,20 @@ describe('CheckoutPage', () => {
     expect(screen.getByLabelText(/상세 주소/)).toHaveValue('101호');
   });
 
+
+  it('숫자형 zipcode 주소도 문자열로 정규화해 폼에 채운다', async () => {
+    vi.mocked(usersApi.getAddresses).mockResolvedValue([
+      { ...defaultAddress, zipcode: 6000 as unknown as string } as UserAddress,
+    ]);
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
+    sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
+    await renderCheckoutPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/우편번호/)).toHaveValue('06000');
+    });
+  });
+
   it('shows address selection list when multiple addresses exist', async () => {
     vi.mocked(usersApi.getAddresses).mockResolvedValue([defaultAddress, secondAddress]);
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });

--- a/src/components/shared/hooks/__tests__/useCheckout.test.tsx
+++ b/src/components/shared/hooks/__tests__/useCheckout.test.tsx
@@ -178,6 +178,41 @@ describe('useCheckout - 폼 검증', () => {
     expect(mockOrdersCreate).not.toHaveBeenCalled();
   });
 
+
+  it('우편번호가 숫자로 들어와도 문자열로 정규화해 주문 생성을 진행한다', async () => {
+    mockOrdersCreate.mockResolvedValue(mockOrder);
+    mockPaymentsPrepare.mockResolvedValue({
+      paymentId: 1,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      amount: 30000,
+      gateway: 'mock',
+      clientKey: 'mock_client_key',
+    } satisfies PreparePaymentResponse);
+    mockPaymentsConfirm.mockResolvedValue({
+      paymentId: 1,
+      orderId: mockOrder.id,
+      orderNumber: mockOrder.orderNumber,
+      status: 'confirmed',
+      method: 'mock',
+      amount: 30000,
+      paidAt: '2026-04-25T00:00:00Z',
+    });
+
+    const { options } = makeOptions({
+      form: { ...validForm, zipcode: 12345 as unknown as string },
+    });
+    const { result } = renderHook(() => useCheckout(options));
+
+    await act(async () => {
+      await result.current.handleSubmit(makeFormEvent());
+    });
+
+    expect(mockOrdersCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ zipcode: '12345' }),
+    );
+  });
+
   it('주소가 비어 있으면 주문 생성을 호출하지 않는다', async () => {
     const { options } = makeOptions({
       form: { ...validForm, address: '   ' },

--- a/src/components/shared/hooks/useCheckout.ts
+++ b/src/components/shared/hooks/useCheckout.ts
@@ -30,6 +30,18 @@ export interface UseCheckoutOptions {
   refetch: () => Promise<void>;
 }
 
+function normalizeTextValue(value: unknown): string {
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+function normalizeZipcodeValue(value: unknown): string {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+    return String(value).padStart(5, '0');
+  }
+  return normalizeTextValue(value);
+}
+
 export function useCheckout(options: UseCheckoutOptions) {
   const { locale, grandTotal, refetch, form, checkoutItems } = options;
   const router = useRouter();
@@ -77,6 +89,13 @@ export function useCheckout(options: UseCheckoutOptions) {
   const handleSubmit = useCallback(async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
 
+    const recipientName = normalizeTextValue(form.recipientName);
+    const recipientPhone = normalizeTextValue(form.recipientPhone);
+    const zipcode = normalizeZipcodeValue(form.zipcode);
+    const address = normalizeTextValue(form.address);
+    const addressDetail = normalizeTextValue(form.addressDetail);
+    const memo = normalizeTextValue(form.memo);
+
     // If already prepared for a user-action gateway, trigger its confirm/redirect step.
     if (
       options.prepareResult
@@ -87,16 +106,16 @@ export function useCheckout(options: UseCheckoutOptions) {
     }
 
     const errors: FormErrors = {};
-    if (form.recipientName.trim().length < 2) {
+    if (recipientName.length < 2) {
       errors.recipientName = '이름은 2자 이상 입력해주세요.';
     }
-    if (!/^\d{3}-\d{3,4}-\d{4}$/.test(form.recipientPhone)) {
+    if (!/^\d{3}-\d{3,4}-\d{4}$/.test(recipientPhone)) {
       errors.recipientPhone = '올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)';
     }
-    if (!/^\d{5}$/.test(form.zipcode)) {
+    if (!/^\d{5}$/.test(zipcode)) {
       errors.zipcode = '우편번호는 5자리 숫자로 입력해주세요.';
     }
-    if (form.address.trim().length === 0) {
+    if (address.length === 0) {
       errors.address = '주소를 입력해주세요.';
     }
     if (Object.keys(errors).length > 0) {
@@ -112,12 +131,12 @@ export function useCheckout(options: UseCheckoutOptions) {
             productOptionId: item.productOptionId,
             quantity: item.quantity,
           })),
-          recipientName: form.recipientName.trim(),
-          recipientPhone: form.recipientPhone.trim(),
-          zipcode: form.zipcode.trim(),
-          address: form.address.trim(),
-          addressDetail: form.addressDetail.trim() || null,
-          memo: form.memo.trim() || null,
+          recipientName,
+          recipientPhone,
+          zipcode,
+          address,
+          addressDetail: addressDetail || null,
+          memo: memo || null,
         },
       );
 


### PR DESCRIPTION
## Summary\n- normalize saved-address values before filling the checkout form\n- normalize zipcode values again before validation and order submission\n- add regression tests for numeric zipcode payloads in checkout form population and submit flow\n\n## Testing\n- npm run test:run -- src/components/shared/hooks/__tests__/useCheckout.test.tsx src/components/__tests__/CheckoutPage.test.tsx\n\n## Notes\n- 
> shop-okhwadang@0.0.1 lint
> next lint is currently blocked by an existing Next/ESLint environment issue: 