### PR TITLE
feat: #794 toast 위치·모션·스타일 개선

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -113,19 +113,12 @@ export default async function LocaleLayout({
               <Footer />
               <MobileBottomNavWrapper visible={mobileBottomNavVisible} />
               <Toaster
-                position="top-right"
-                richColors
+                position="top-center"
                 closeButton
                 toastOptions={{
                   style: {
                     fontFamily: 'var(--font-body)',
                     borderRadius: 'var(--radius-md)',
-                  },
-                  classNames: {
-                    toast: 'bg-card border-border shadow-md',
-                    success: 'border-l-4 border-l-[--color-tea]',
-                    error: 'border-l-4 border-l-destructive',
-                    info: 'border-l-4 border-l-[--color-primary]',
                   },
                 }}
               />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -571,35 +571,9 @@ h3 {
   background-color: var(--color-card) !important;
 }
 
-/* Slide-down entrance from top-center */
-@keyframes toast-slide-in {
-  from {
-    opacity: 0;
-    transform: translateY(-12px) scale(0.97);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes toast-slide-out {
-  from {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(-8px) scale(0.97);
-  }
-}
-
-[data-sonner-toast][data-mounted="true"] {
-  animation: toast-slide-in 0.22s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-[data-sonner-toast][data-removed="true"] {
-  animation: toast-slide-out 0.18s ease-in forwards;
+/* Smooth transition for sonner's built-in --y transform */
+[data-sonner-toast] {
+  transition: transform 0.24s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.2s ease !important;
 }
 
 /* ── Accordion animations ──────────────────────────────────────────── */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -530,15 +530,17 @@ h3 {
 
 [data-sonner-toast] {
   border-radius: var(--radius-md) !important;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06) !important;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10), 0 1px 3px rgba(0, 0, 0, 0.06) !important;
   border: 1px solid var(--color-border) !important;
   background-color: var(--color-card) !important;
-  padding: 12px 16px !important;
+  padding: 14px 18px !important;
+  color: var(--color-foreground) !important;
 }
 
 [data-sonner-toast] [data-sonner-toast-title] {
   font-family: var(--font-body) !important;
   font-weight: 500;
+  font-size: 0.9375rem;
   color: var(--color-foreground) !important;
 }
 
@@ -548,20 +550,56 @@ h3 {
   color: var(--color-muted-foreground) !important;
 }
 
+/* Neutral accent stripe — muted, not vivid */
 [data-sonner-toast][data-type="success"] {
-  border-left: 4px solid var(--color-tea) !important;
+  border-left: 3px solid var(--color-tea) !important;
+  background-color: var(--color-card) !important;
 }
 
 [data-sonner-toast][data-type="error"] {
-  border-left: 4px solid var(--color-destructive) !important;
+  border-left: 3px solid var(--color-destructive) !important;
+  background-color: var(--color-card) !important;
 }
 
 [data-sonner-toast][data-type="info"] {
-  border-left: 4px solid var(--color-primary) !important;
+  border-left: 3px solid var(--color-primary) !important;
+  background-color: var(--color-card) !important;
 }
 
 [data-sonner-toast][data-type="warning"] {
-  border-left: 4px solid var(--color-danni) !important;
+  border-left: 3px solid var(--color-danni) !important;
+  background-color: var(--color-card) !important;
+}
+
+/* Slide-down entrance from top-center */
+@keyframes toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-12px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes toast-slide-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.97);
+  }
+}
+
+[data-sonner-toast][data-mounted="true"] {
+  animation: toast-slide-in 0.22s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+[data-sonner-toast][data-removed="true"] {
+  animation: toast-slide-out 0.18s ease-in forwards;
 }
 
 /* ── Accordion animations ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Closes #794
- `Toaster` position을 `top-right` → `top-center`로 변경하여 시선 집중 위치에 표시
- `richColors` 제거 — sonner 기본 강한 상태색(초록/빨강) 비활성화
- `classNames` prop 제거 — CSS 전역 스타일(`globals.css`)에서 단일 관리
- 슬라이드 인/아웃 애니메이션 추가 (`toast-slide-in`, `toast-slide-out`) — 위에서 내려오는 자연스러운 모션
- border-left accent를 4px→3px로 축소, 배경색을 `--color-card`로 고정하여 뉴트럴 단색 스타일 통일
- 호출부(`toast.success`, `toast.error`, `toast.info`) 변경 없음 — 공통 Toaster 설정만 수정

## Test plan
- [x] npm run lint (✓ No ESLint warnings or errors)
- [x] npm run build (✓ 빌드 성공)
- [x] npm run test:run (✓ 113 test files, 694 tests passed)