### PR TITLE
fix: #793 PayPal 첫 클릭 승인 이동 보장

### DIFF
--- a/src/components/__tests__/CheckoutPage.test.tsx
+++ b/src/components/__tests__/CheckoutPage.test.tsx
@@ -1,12 +1,13 @@
 import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Suspense } from 'react';
+import { forwardRef, Suspense, useImperativeHandle } from 'react';
 import CheckoutPage from '@/app/[locale]/checkout/page';
 import { ordersApi, paymentsApi, usersApi } from '@/lib/api';
 import type { CartItem, UserAddress } from '@/lib/api';
 
 const makeParams = () => Promise.resolve({ locale: 'ko' as const });
+const mockPaymentGatewayConfirm = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => {
@@ -65,7 +66,7 @@ vi.mock('next/navigation', () => ({
 
 // ---- sonner ----
 vi.mock('sonner', () => ({
-  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() },
 }));
 
 // ---- contexts ----
@@ -96,7 +97,10 @@ vi.mock('@/i18n/routing', () => ({
 
 // ---- PaymentGateway ----
 vi.mock('@/components/shared/checkout/PaymentGateway', () => ({
-  default: () => <div data-testid="payment-gateway">PaymentGateway</div>,
+  default: forwardRef(function MockPaymentGateway(_props: unknown, ref) {
+    useImperativeHandle(ref, () => ({ confirm: mockPaymentGatewayConfirm }));
+    return <div data-testid="payment-gateway">PaymentGateway</div>;
+  }),
 }));
 
 // ---- api ----
@@ -252,6 +256,11 @@ describe('CheckoutPage', () => {
 
     await waitFor(() => {
       expect(paymentsApi.prepare).toHaveBeenCalledWith({ orderId: 1, locale: 'ko', gateway: 'paypal' });
+      expect(screen.getByTestId('payment-gateway')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(mockPaymentGatewayConfirm).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/shared/hooks/__tests__/useCheckout.test.tsx
+++ b/src/components/shared/hooks/__tests__/useCheckout.test.tsx
@@ -290,9 +290,10 @@ describe('useCheckout - Mock 결제 흐름', () => {
 describe('useCheckout - PayPal 결제 흐름', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
-  it('selectedGateway=paypal 이면 prepare 요청에 gateway를 포함하고 redirect 대기 상태로 전환', async () => {
+  it('selectedGateway=paypal 이면 prepare 요청에 gateway를 포함하고 첫 submit에서 redirect confirm을 예약', async () => {
     const prepareResult: PreparePaymentResponse = {
       paymentId: 2,
       orderId: mockOrder.id,
@@ -306,7 +307,13 @@ describe('useCheckout - PayPal 결제 흐름', () => {
     mockOrdersCreate.mockResolvedValue(mockOrder);
     mockPaymentsPrepare.mockResolvedValue(prepareResult);
 
-    const { options } = makeOptions({ locale: 'en', selectedGateway: 'paypal' });
+    vi.useFakeTimers();
+    const confirmSpy = vi.fn().mockResolvedValue(undefined);
+    const { options } = makeOptions({
+      locale: 'en',
+      selectedGateway: 'paypal',
+      paymentRef: { current: { confirm: confirmSpy } },
+    });
     const { result } = renderHook(() => useCheckout(options));
 
     await act(async () => {
@@ -319,7 +326,14 @@ describe('useCheckout - PayPal 결제 흐름', () => {
       gateway: 'paypal',
     });
     expect(options.setPrepareResult).toHaveBeenCalledWith(prepareResult);
-    expect(options.setStep).toHaveBeenCalledWith('idle');
+    expect(options.setStep).toHaveBeenCalledWith('confirming_payment');
+    expect(confirmSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect(mockPaymentsConfirm).not.toHaveBeenCalled();
   });
 

--- a/src/components/shared/hooks/useCheckout.ts
+++ b/src/components/shared/hooks/useCheckout.ts
@@ -74,6 +74,29 @@ export function useCheckout(options: UseCheckoutOptions) {
     }, 100);
   }, [options]);
 
+  const handleExternalRedirectFlow = useCallback(async (orderId: number, orderNumber: string, result: PreparePaymentResponse): Promise<void> => {
+    options.setCurrentOrderId(orderId);
+    options.setCurrentOrderNumber(orderNumber);
+    options.setPrepareResult(result);
+    options.setStep('confirming_payment');
+
+    // PaymentGateway renders after state update; give it a tick before invoking the redirect/open gateway.
+    setTimeout(async () => {
+      const gateway = options.paymentRef.current;
+      if (!gateway) {
+        options.setStep('idle');
+        toast.info('결제 수단을 확인하고 결제하기를 눌러주세요.');
+        return;
+      }
+
+      try {
+        await gateway.confirm();
+      } catch (err) {
+        handlePaymentError(handleApiError(err, '결제에 실패했습니다.'));
+      }
+    }, 100);
+  }, [options, handlePaymentError]);
+
   const handleMockFlow = useCallback(async (orderId: number, orderNumber: string): Promise<void> => {
     options.setStep('confirming_payment');
     await paymentsApi.confirm(
@@ -177,11 +200,7 @@ export function useCheckout(options: UseCheckoutOptions) {
       }
 
       if (result.gateway === 'paypal' || result.gateway === 'naverpay') {
-        options.setCurrentOrderId(order.id);
-        options.setCurrentOrderNumber(order.orderNumber);
-        options.setPrepareResult(result);
-        options.setStep('idle');
-        toast.info('결제 수단을 확인하고 결제하기를 눌러주세요.');
+        await handleExternalRedirectFlow(order.id, order.orderNumber, result);
         return;
       }
 
@@ -191,7 +210,7 @@ export function useCheckout(options: UseCheckoutOptions) {
       toast.error(handleApiError(err, '결제 중 오류가 발생했습니다.'));
       options.setStep('idle');
     }
-  }, [options, form, checkoutItems, locale, handlePreparedGatewayFlow, handleTossFlow, handleMockFlow]);
+  }, [options, form, checkoutItems, locale, handlePreparedGatewayFlow, handleTossFlow, handleExternalRedirectFlow, handleMockFlow]);
 
   return {
     handleSubmit,


### PR DESCRIPTION
## Summary\n- PayPal/NaverPay external redirect prepare 후 다음 tick에 PaymentGateway confirm을 예약해 첫 결제 클릭에서 승인 페이지 이동을 시작합니다.\n- Stripe 카드 입력 흐름은 prepare 후 idle 대기를 유지합니다.\n- Checkout hook/page 테스트에 PayPal single-click redirect confirm 회귀 검증을 추가했습니다.\n\n## Verification\n- npm run build && npm run test:run\n- cd backend && npm run build && npm run test\n\nCloses #793