### PR TITLE
feat: #791 상품별 무료배송 설정 추가

### DIFF
--- a/backend/src/database/migrations/1784100000000-AddProductFreeShipping.ts
+++ b/backend/src/database/migrations/1784100000000-AddProductFreeShipping.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductFreeShipping1784100000000 implements MigrationInterface {
+  name = 'AddProductFreeShipping1784100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `products` ADD `is_free_shipping` tinyint NOT NULL DEFAULT 0',
+    );
+    await queryRunner.query(
+      'CREATE INDEX `IDX_products_is_free_shipping` ON `products` (`is_free_shipping`)',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `order_items` ADD `is_free_shipping` tinyint NOT NULL DEFAULT 0',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `order_items` DROP COLUMN `is_free_shipping`',
+    );
+    await queryRunner.query('DROP INDEX `IDX_products_is_free_shipping` ON `products`');
+    await queryRunner.query(
+      'ALTER TABLE `products` DROP COLUMN `is_free_shipping`',
+    );
+  }
+}

--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -280,6 +280,86 @@ describe('OrdersService', () => {
       expect(mockDeleteQb.execute).toHaveBeenCalled();
     });
 
+    it('무료배송 상품 단독 주문은 상품 정책을 배송비 계산에 전달하고 주문상품에 스냅샷을 저장한다', async () => {
+      const dto: CreateOrderDto = {
+        items: [{ productId: 1, quantity: 2 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+        address: '서울시 강남구',
+      };
+
+      const mockProduct = {
+        id: 1,
+        name: '무료배송상품',
+        price: 10000,
+        salePrice: null,
+        stock: 5,
+        isFreeShipping: true,
+      };
+      const mockSavedOrder = {
+        id: 42,
+        orderNumber: 'ORD-20240101-FREE1',
+        userId: 1,
+        status: OrderStatus.PENDING,
+        totalAmount: 20000,
+        shippingFee: 0,
+        items: [],
+      } as unknown as Order;
+
+      const mockProductQb = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockProduct),
+      };
+      const mockDeleteQb = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({}),
+      };
+
+      mockManager.createQueryBuilder
+        .mockReturnValueOnce(mockProductQb)
+        .mockReturnValueOnce(mockDeleteQb);
+      mockManager.update.mockResolvedValue({});
+      mockManager.create.mockReturnValue(mockSavedOrder);
+      mockManager.save
+        .mockResolvedValueOnce(mockSavedOrder)
+        .mockResolvedValue([]);
+      mockShippingFeeCalculator.calculate.mockResolvedValueOnce({
+        subtotal: 20000,
+        zipcode: '12345',
+        shippingFee: 0,
+        isFreeShipping: true,
+        isRemoteArea: false,
+        isProductFreeShipping: true,
+        threshold: 50000,
+        baseFee: 3000,
+        remoteAreaSurcharge: 3000,
+      });
+      mockOrderRepository.createQueryBuilder.mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockSavedOrder),
+      });
+
+      await service.create(1, dto);
+
+      expect(mockShippingFeeCalculator.calculate).toHaveBeenCalledWith(20000, '12345', [
+        { isFreeShipping: true },
+      ]);
+      expect(mockManager.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ isFreeShipping: true }),
+      );
+      expect(mockManager.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ shippingFee: 0 }),
+      );
+    });
+
     it('valid dto with userCouponId → applies coupon discount, sets discountAmount, calls useCoupon', async () => {
       const dto: CreateOrderDto = {
         items: [{ productId: 1, quantity: 2 }],

--- a/backend/src/modules/orders/entities/order-item.entity.ts
+++ b/backend/src/modules/orders/entities/order-item.entity.ts
@@ -33,6 +33,9 @@ export class OrderItem {
   @Column({ type: 'int' })
   quantity!: number;
 
+  @Column({ name: 'is_free_shipping', default: false })
+  isFreeShipping!: boolean;
+
   @ManyToOne(() => Order, (order) => order.items, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'order_id' })
   order!: Order;

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -25,6 +25,7 @@ import { applyLocale } from '../../common/utils/locale.util';
 interface OrderItemBuildResult {
   orderItems: Partial<OrderItem>[];
   subtotalAmount: number;
+  shippingItemPolicies: { isFreeShipping: boolean }[];
 }
 
 interface OrderPriceResult {
@@ -118,13 +119,14 @@ export class OrdersService {
   ): Promise<OrderPostCommitPayload> {
     await this.ensureSufficientPoints(manager, userId, pointsToUse);
 
-    const { orderItems, subtotalAmount } = await this.validateAndReserveStock(manager, dto);
+    const { orderItems, subtotalAmount, shippingItemPolicies } = await this.validateAndReserveStock(manager, dto);
 
     const pricing = await this.calculateDiscountAndShipping(
       userId,
       dto,
       subtotalAmount,
       pointsToUse,
+      shippingItemPolicies,
     );
 
     const savedOrder = await this.persistOrder(manager, userId, dto, pointsToUse, pricing);
@@ -167,6 +169,7 @@ export class OrdersService {
     dto: CreateOrderDto,
   ): Promise<OrderItemBuildResult> {
     const orderItems: Partial<OrderItem>[] = [];
+    const shippingItemPolicies: { isFreeShipping: boolean }[] = [];
     let subtotalAmount = 0;
 
     for (const item of dto.items) {
@@ -230,10 +233,12 @@ export class OrdersService {
         optionName,
         price: unitPrice,
         quantity: item.quantity,
+        isFreeShipping: product.isFreeShipping,
       });
+      shippingItemPolicies.push({ isFreeShipping: product.isFreeShipping });
     }
 
-    return { orderItems, subtotalAmount };
+    return { orderItems, subtotalAmount, shippingItemPolicies };
   }
 
   private async calculateDiscountAndShipping(
@@ -241,6 +246,7 @@ export class OrdersService {
     dto: CreateOrderDto,
     subtotalAmount: number,
     pointsToUse: number,
+    shippingItemPolicies: { isFreeShipping: boolean }[],
   ): Promise<OrderPriceResult> {
     let discountAmount = 0;
     let discountedAmount = subtotalAmount;
@@ -256,7 +262,11 @@ export class OrdersService {
       discountedAmount = discountResult.finalAmount;
     }
 
-    const shippingQuote = await this.shippingFeeCalculator.calculate(subtotalAmount, dto.zipcode);
+    const shippingQuote = await this.shippingFeeCalculator.calculate(
+      subtotalAmount,
+      dto.zipcode,
+      shippingItemPolicies,
+    );
     const shippingFee = shippingQuote.shippingFee;
     const totalPayable = discountedAmount + shippingFee;
 

--- a/backend/src/modules/products/__tests__/product-command.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-command.service.spec.ts
@@ -99,6 +99,19 @@ describe('ProductCommandService', () => {
       );
     });
 
+    it('isFreeShipping 값을 상품 생성 데이터에 포함한다', async () => {
+      const created = { id: 1, isFreeShipping: true } as Product;
+      manager.create.mockReturnValue(created);
+      manager.save.mockResolvedValue(created);
+
+      await service.create({ name: 'p', slug: 'free-shipping', price: 100, isFreeShipping: true });
+
+      expect(manager.create).toHaveBeenCalledWith(
+        Product,
+        expect.objectContaining({ isFreeShipping: true }),
+      );
+    });
+
     it('이미지 함께 생성하면 ProductImage 도 저장', async () => {
       const created = { id: 5 } as Product;
       manager.create.mockReturnValue(created);

--- a/backend/src/modules/products/dto/create-product.dto.ts
+++ b/backend/src/modules/products/dto/create-product.dto.ts
@@ -102,6 +102,11 @@ export class CreateProductDto {
   @IsBoolean({ message: '추천 상품 여부는 불리언이어야 합니다.' })
   isFeatured?: boolean;
 
+  @ApiProperty({ example: false, description: '상품별 무료배송 여부', required: false })
+  @IsOptional()
+  @IsBoolean({ message: '무료배송 상품 여부는 불리언이어야 합니다.' })
+  isFreeShipping?: boolean;
+
   @ApiPropertyOptional({ example: 'Ockhwadang Pu-erh Tea', description: '상품명 (영문)' })
   @IsOptional()
   @IsString({ message: '영문 상품명은 문자열이어야 합니다.' })

--- a/backend/src/modules/products/dto/update-product.dto.ts
+++ b/backend/src/modules/products/dto/update-product.dto.ts
@@ -67,6 +67,11 @@ export class UpdateProductDto {
   @IsBoolean()
   isFeatured?: boolean;
 
+  @ApiProperty({ example: false, description: '상품별 무료배송 여부', required: false })
+  @IsOptional()
+  @IsBoolean()
+  isFreeShipping?: boolean;
+
   @ApiPropertyOptional({ example: 'Ockhwadang Pu-erh Tea', description: '상품명 (영문)' })
   @IsOptional()
   @IsString()

--- a/backend/src/modules/products/entities/product.entity.ts
+++ b/backend/src/modules/products/entities/product.entity.ts
@@ -27,6 +27,7 @@ export enum ProductStatus {
 @Index(['categoryId'])
 @Index(['status'])
 @Index(['isFeatured'])
+@Index(['isFreeShipping'])
 @Index(['reviewCount'])
 @Index(['avgRating'])
 export class Product {
@@ -102,6 +103,9 @@ export class Product {
 
   @Column({ name: 'is_featured', default: false })
   isFeatured!: boolean;
+
+  @Column({ name: 'is_free_shipping', default: false })
+  isFreeShipping!: boolean;
 
   @Column({ name: 'view_count', default: 0 })
   viewCount!: number;

--- a/backend/src/modules/shipping/__tests__/shipping-fee-calculator.service.spec.ts
+++ b/backend/src/modules/shipping/__tests__/shipping-fee-calculator.service.spec.ts
@@ -34,6 +34,7 @@ describe('ShippingFeeCalculatorService', () => {
     expect(result.shippingFee).toBe(3000);
     expect(result.isFreeShipping).toBe(false);
     expect(result.isRemoteArea).toBe(false);
+    expect(result.isProductFreeShipping).toBe(false);
   });
 
   it('제주(63 prefix) 우편번호는 도서산간 추가비를 부과한다', async () => {
@@ -41,6 +42,7 @@ describe('ShippingFeeCalculatorService', () => {
 
     expect(result.shippingFee).toBe(7000);
     expect(result.isRemoteArea).toBe(true);
+    expect(result.isProductFreeShipping).toBe(false);
   });
 
   it('무료배송 임계 이상이면 기본 배송비를 0으로 처리한다', async () => {
@@ -48,5 +50,39 @@ describe('ShippingFeeCalculatorService', () => {
 
     expect(result.shippingFee).toBe(0);
     expect(result.isFreeShipping).toBe(true);
+    expect(result.isProductFreeShipping).toBe(false);
+  });
+
+  it('모든 주문 상품이 무료배송 상품이면 기본 배송비만 면제한다', async () => {
+    const result = await service.calculate(30000, '04524', [
+      { isFreeShipping: true },
+      { isFreeShipping: true },
+    ]);
+
+    expect(result.shippingFee).toBe(0);
+    expect(result.isFreeShipping).toBe(true);
+    expect(result.isProductFreeShipping).toBe(true);
+  });
+
+  it('무료배송 상품이어도 도서산간 추가비는 유지한다', async () => {
+    const result = await service.calculate(30000, '63124', [
+      { isFreeShipping: true },
+    ]);
+
+    expect(result.shippingFee).toBe(4000);
+    expect(result.isFreeShipping).toBe(true);
+    expect(result.isProductFreeShipping).toBe(true);
+    expect(result.isRemoteArea).toBe(true);
+  });
+
+  it('무료배송 상품과 일반 상품이 섞이면 기존 금액 기준 정책을 적용한다', async () => {
+    const result = await service.calculate(30000, '04524', [
+      { isFreeShipping: true },
+      { isFreeShipping: false },
+    ]);
+
+    expect(result.shippingFee).toBe(3000);
+    expect(result.isFreeShipping).toBe(false);
+    expect(result.isProductFreeShipping).toBe(false);
   });
 });

--- a/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
+++ b/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
@@ -9,6 +9,8 @@ import { NotificationDispatchHelper } from '../../notification/notification-disp
 import { MockShippingAdapter } from '../adapters/mock-shipping.adapter';
 import { CjShippingAdapter } from '../adapters/cj-shipping.adapter';
 import { ShippingFeeCalculatorService } from '../services/shipping-fee-calculator.service';
+import { Product } from '../../products/entities/product.entity';
+import { ProductOption } from '../../products/entities/product-option.entity';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order =>
   ({ id: 1, userId: 10, status: OrderStatus.PAID, ...overrides } as unknown as Order);
@@ -35,6 +37,12 @@ describe('ShippingService', () => {
   const mockOrderRepo = {
     findOne: jest.fn(),
     update: jest.fn(),
+  };
+  const mockProductRepo = {
+    find: jest.fn(),
+  };
+  const mockProductOptionRepo = {
+    find: jest.fn(),
   };
   const mockAdapter = {
     registerTrackingNumber: jest.fn(),
@@ -73,6 +81,8 @@ describe('ShippingService', () => {
         ShippingService,
         { provide: getRepositoryToken(Shipping), useValue: mockShippingRepo },
         { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
+        { provide: getRepositoryToken(Product), useValue: mockProductRepo },
+        { provide: getRepositoryToken(ProductOption), useValue: mockProductOptionRepo },
         { provide: NotificationService, useValue: { sendShippingUpdate: jest.fn() } },
         { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
         { provide: MockShippingAdapter, useValue: mockAdapter },
@@ -230,6 +240,41 @@ describe('ShippingService', () => {
 
       expect(mockCalculator.calculate).toHaveBeenCalledWith(10000, '12345');
       expect(result.shippingFee).toBe(3000);
+    });
+
+    it('items가 있으면 서버 상품 가격과 무료배송 정책으로 계산한다', async () => {
+      mockProductRepo.find.mockResolvedValue([
+        { id: 1, price: 10000, salePrice: null, isFreeShipping: true },
+        { id: 2, price: 20000, salePrice: 15000, isFreeShipping: true },
+      ]);
+      mockProductOptionRepo.find.mockResolvedValue([]);
+
+      await service.quote(1, '12345', [
+        { productId: 1, quantity: 2 },
+        { productId: 2, quantity: 1 },
+      ]);
+
+      expect(mockCalculator.calculate).toHaveBeenCalledWith(35000, '12345', [
+        { isFreeShipping: true },
+        { isFreeShipping: true },
+      ]);
+    });
+
+    it('옵션이 있으면 해당 상품 옵션인지 검증하고 옵션 가격을 포함한다', async () => {
+      mockProductRepo.find.mockResolvedValue([
+        { id: 1, price: 10000, salePrice: null, isFreeShipping: false },
+      ]);
+      mockProductOptionRepo.find.mockResolvedValue([
+        { id: 7, productId: 1, priceAdjustment: 2500 },
+      ]);
+
+      await service.quote(1, '12345', [
+        { productId: 1, productOptionId: 7, quantity: 2 },
+      ]);
+
+      expect(mockCalculator.calculate).toHaveBeenCalledWith(25000, '12345', [
+        { isFreeShipping: false },
+      ]);
     });
   });
 });

--- a/backend/src/modules/shipping/dto/shipping-quote.dto.ts
+++ b/backend/src/modules/shipping/dto/shipping-quote.dto.ts
@@ -1,5 +1,23 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsString, Min, Length } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsInt, IsNumber, IsOptional, IsString, Length, Min, ValidateIf, ValidateNested } from 'class-validator';
+
+export class ShippingQuoteItemDto {
+  @ApiProperty({ example: 1, description: '상품 ID' })
+  @IsInt({ message: '상품 ID는 정수여야 합니다.' })
+  productId!: number;
+
+  @ApiPropertyOptional({ example: null, description: '상품 옵션 ID' })
+  @IsOptional()
+  @ValidateIf((o: ShippingQuoteItemDto) => o.productOptionId !== null)
+  @IsInt({ message: '상품 옵션 ID는 정수여야 합니다.' })
+  productOptionId?: number | null;
+
+  @ApiProperty({ example: 2, description: '수량' })
+  @IsInt({ message: '수량은 정수여야 합니다.' })
+  @Min(1, { message: '수량은 최소 1개 이상이어야 합니다.' })
+  quantity!: number;
+}
 
 export class ShippingQuoteDto {
   @ApiProperty({ example: 42000, description: '상품 소계 금액(원)' })
@@ -11,4 +29,11 @@ export class ShippingQuoteDto {
   @IsString()
   @Length(3, 10)
   zipcode!: string;
+
+  @ApiPropertyOptional({ type: [ShippingQuoteItemDto], description: '서버 기준 배송비 계산용 상품 목록' })
+  @IsOptional()
+  @IsArray({ message: '상품 목록은 배열이어야 합니다.' })
+  @ValidateNested({ each: true })
+  @Type(() => ShippingQuoteItemDto)
+  items?: ShippingQuoteItemDto[];
 }

--- a/backend/src/modules/shipping/services/shipping-fee-calculator.service.ts
+++ b/backend/src/modules/shipping/services/shipping-fee-calculator.service.ts
@@ -6,12 +6,17 @@ const DEFAULT_FREE_SHIPPING_THRESHOLD = 50000;
 const DEFAULT_BASE_SHIPPING_FEE = 3000;
 const DEFAULT_REMOTE_AREA_SURCHARGE = 3000;
 
+export interface ShippingFeeItemPolicy {
+  isFreeShipping: boolean;
+}
+
 export interface ShippingFeeQuote {
   subtotal: number;
   zipcode: string;
   shippingFee: number;
   isFreeShipping: boolean;
   isRemoteArea: boolean;
+  isProductFreeShipping: boolean;
   threshold: number;
   baseFee: number;
   remoteAreaSurcharge: number;
@@ -21,7 +26,11 @@ export interface ShippingFeeQuote {
 export class ShippingFeeCalculatorService {
   constructor(private readonly settingsService: SettingsService) {}
 
-  async calculate(subtotal: number, zipcode: string): Promise<ShippingFeeQuote> {
+  async calculate(
+    subtotal: number,
+    zipcode: string,
+    itemPolicies?: ShippingFeeItemPolicy[],
+  ): Promise<ShippingFeeQuote> {
     const safeSubtotal = Math.max(0, Math.floor(subtotal));
 
     const [threshold, baseFee, remoteAreaSurcharge] = await Promise.all([
@@ -30,7 +39,12 @@ export class ShippingFeeCalculatorService {
       this.settingsService.getNumber('remote_area_surcharge', DEFAULT_REMOTE_AREA_SURCHARGE),
     ]);
 
-    const isFreeShipping = safeSubtotal >= threshold;
+    const isThresholdFreeShipping = safeSubtotal >= threshold;
+    const isProductFreeShipping =
+      itemPolicies !== undefined &&
+      itemPolicies.length > 0 &&
+      itemPolicies.every((item) => item.isFreeShipping);
+    const isFreeShipping = isThresholdFreeShipping || isProductFreeShipping;
     const isRemoteArea = isRemoteAreaZipcode(zipcode);
 
     const shippingFee = (isFreeShipping ? 0 : baseFee) + (isRemoteArea ? remoteAreaSurcharge : 0);
@@ -41,6 +55,7 @@ export class ShippingFeeCalculatorService {
       shippingFee,
       isFreeShipping,
       isRemoteArea,
+      isProductFreeShipping,
       threshold,
       baseFee,
       remoteAreaSurcharge,

--- a/backend/src/modules/shipping/shipping.controller.ts
+++ b/backend/src/modules/shipping/shipping.controller.ts
@@ -45,6 +45,6 @@ export class ShippingController {
   @ApiOperation({ summary: '배송비 사전 견적', description: '체크아웃 전에 배송비를 계산합니다.' })
   @ApiResponse({ status: 200, description: '배송비 견적 성공' })
   quote(@Body() dto: ShippingQuoteDto) {
-    return this.shippingService.quote(dto.subtotal, dto.zipcode);
+    return this.shippingService.quote(dto.subtotal, dto.zipcode, dto.items);
   }
 }

--- a/backend/src/modules/shipping/shipping.module.ts
+++ b/backend/src/modules/shipping/shipping.module.ts
@@ -8,9 +8,11 @@ import { MockShippingAdapter } from './adapters/mock-shipping.adapter';
 import { CjShippingAdapter } from './adapters/cj-shipping.adapter';
 import { ShippingFeeCalculatorService } from './services/shipping-fee-calculator.service';
 import { SettingsModule } from '../settings/settings.module';
+import { Product } from '../products/entities/product.entity';
+import { ProductOption } from '../products/entities/product-option.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Shipping, Order]), SettingsModule],
+  imports: [TypeOrmModule.forFeature([Shipping, Order, Product, ProductOption]), SettingsModule],
   controllers: [ShippingController],
   providers: [ShippingService, ShippingFeeCalculatorService, MockShippingAdapter, CjShippingAdapter],
   exports: [ShippingService, ShippingFeeCalculatorService],

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -3,7 +3,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Shipping, ShippingStatus } from '../payments/entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
 import { MockShippingAdapter } from './adapters/mock-shipping.adapter';
@@ -20,6 +20,9 @@ import { assertOwnership } from '../../common/utils/ownership.util';
 import { NotificationService } from '../notification/notification.service';
 import { NotificationDispatchHelper } from '../notification/notification-dispatch.helper';
 import { ShippingFeeCalculatorService, ShippingFeeQuote } from './services/shipping-fee-calculator.service';
+import { ShippingQuoteItemDto } from './dto/shipping-quote.dto';
+import { Product } from '../products/entities/product.entity';
+import { ProductOption } from '../products/entities/product-option.entity';
 import { assertShippingStatusTransition } from './policies/shipping-status-transition.policy';
 
 @Injectable()
@@ -32,6 +35,10 @@ export class ShippingService {
     private readonly shippingRepository: Repository<Shipping>,
     @InjectRepository(Order)
     private readonly orderRepository: Repository<Order>,
+    @InjectRepository(Product)
+    private readonly productRepository: Repository<Product>,
+    @InjectRepository(ProductOption)
+    private readonly productOptionRepository: Repository<ProductOption>,
     private readonly notificationService: NotificationService,
     private readonly notificationDispatchHelper: NotificationDispatchHelper,
     private readonly mockAdapter: MockShippingAdapter,
@@ -127,8 +134,70 @@ export class ShippingService {
     return this.shippingRepository.findOne({ where: { orderId } });
   }
 
-  async quote(subtotal: number, zipcode: string): Promise<ShippingFeeQuote> {
-    return this.shippingFeeCalculator.calculate(subtotal, zipcode);
+  async quote(
+    subtotal: number,
+    zipcode: string,
+    items?: ShippingQuoteItemDto[],
+  ): Promise<ShippingFeeQuote> {
+    if (!items || items.length === 0) {
+      return this.shippingFeeCalculator.calculate(subtotal, zipcode);
+    }
+
+    const quoteContext = await this.buildQuoteContext(items);
+    return this.shippingFeeCalculator.calculate(
+      quoteContext.subtotal,
+      zipcode,
+      quoteContext.itemPolicies,
+    );
+  }
+
+  private async buildQuoteContext(items: ShippingQuoteItemDto[]): Promise<{
+    subtotal: number;
+    itemPolicies: { isFreeShipping: boolean }[];
+  }> {
+    const productIds = [...new Set(items.map((item) => item.productId))];
+    const optionIds = [
+      ...new Set(
+        items
+          .map((item) => item.productOptionId)
+          .filter((id): id is number => id != null),
+      ),
+    ];
+
+    const [products, options] = await Promise.all([
+      this.productRepository.find({ where: { id: In(productIds) } }),
+      optionIds.length > 0
+        ? this.productOptionRepository.find({ where: { id: In(optionIds) } })
+        : Promise.resolve([]),
+    ]);
+
+    const productMap = new Map(products.map((product) => [Number(product.id), product]));
+    const optionMap = new Map(options.map((option) => [Number(option.id), option]));
+
+    let subtotal = 0;
+    const itemPolicies: { isFreeShipping: boolean }[] = [];
+
+    for (const item of items) {
+      const product = productMap.get(Number(item.productId));
+      if (!product) {
+        throw new BadRequestException('상품을 찾을 수 없습니다.');
+      }
+
+      let priceAdjustment = 0;
+      if (item.productOptionId != null) {
+        const option = optionMap.get(Number(item.productOptionId));
+        if (!option || Number(option.productId) !== Number(item.productId)) {
+          throw new BadRequestException('해당 상품의 옵션을 찾을 수 없습니다.');
+        }
+        priceAdjustment = Number(option.priceAdjustment);
+      }
+
+      const unitPrice = Number(product.salePrice ?? product.price) + priceAdjustment;
+      subtotal += unitPrice * item.quantity;
+      itemPolicies.push({ isFreeShipping: product.isFreeShipping });
+    }
+
+    return { subtotal, itemPolicies };
   }
 
   private async notifyShippingUpdate(

--- a/backend/test/setup-env.js
+++ b/backend/test/setup-env.js
@@ -20,6 +20,7 @@ process.env.NODE_ENV = 'test';
 process.env.FRONTEND_URL = 'http://localhost:5173';
 process.env.PAYMENT_GATEWAY = 'mock';
 process.env.STORAGE_PROVIDER = 'local';
+process.env.NOTIFICATION_PROVIDER = 'mock';
 process.env.THROTTLE_GLOBAL_LIMIT = '10000';
 process.env.THROTTLE_AUTH_LIMIT = '10000';
 process.env.THROTTLE_FORGOT_PASSWORD_LIMIT = '10000';

--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -54,7 +54,16 @@ export default function CartPage() {
     }
 
     let cancelled = false;
-    shippingApi.quote(selectedTotal, '00000')
+    const selectedItems = items.filter((item) => selectedIds.has(item.id));
+    shippingApi.quote(
+      selectedTotal,
+      '00000',
+      selectedItems.map((item) => ({
+        productId: item.productId,
+        productOptionId: item.productOptionId,
+        quantity: item.quantity,
+      })),
+    )
       .then((quote) => {
         if (!cancelled) setShippingQuote(quote);
       })
@@ -65,7 +74,7 @@ export default function CartPage() {
     return () => {
       cancelled = true;
     };
-  }, [selectedTotal]);
+  }, [items, selectedIds, selectedTotal]);
 
   const handleSelectAll = (checked: boolean) => {
     setSelectedIds(checked ? new Set(items.map((i) => i.id)) : new Set());

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -156,7 +156,15 @@ export default function CheckoutPage({
 
     let cancelled = false;
     const zipcode = /^\d{3,10}$/.test(form.zipcode.trim()) ? form.zipcode.trim() : '00000';
-    shippingApi.quote(totalAmount, zipcode)
+    shippingApi.quote(
+      totalAmount,
+      zipcode,
+      checkoutItems.map((item) => ({
+        productId: item.productId,
+        productOptionId: item.productOptionId,
+        quantity: item.quantity,
+      })),
+    )
       .then((quote) => {
         if (!cancelled) setShippingQuote(quote);
       })
@@ -167,7 +175,7 @@ export default function CheckoutPage({
     return () => {
       cancelled = true;
     };
-  }, [totalAmount, form.zipcode]);
+  }, [checkoutItems, totalAmount, form.zipcode]);
 
   useEffect(() => {
     if (isLoading || !isAuthenticated) return;

--- a/src/components/shared/admin/ProductFormPage.tsx
+++ b/src/components/shared/admin/ProductFormPage.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
 import { adminProductsApi } from '@/lib/api';
@@ -31,6 +32,7 @@ interface ProductFormData {
   sku: string;
   status: 'draft' | 'active' | 'soldout' | 'hidden';
   isFeatured: boolean;
+  isFreeShipping: boolean;
   images: GalleryImage[];
   detailImages: DetailImage[];
   options: ProductOptionDraft[];
@@ -210,9 +212,11 @@ function VisibilitySection({
   form,
   set,
 }: {
-  form: Pick<ProductFormData, 'status' | 'isFeatured'>;
+  form: Pick<ProductFormData, 'status' | 'isFeatured' | 'isFreeShipping'>;
   set: Setter;
 }) {
+  const t = useTranslations('admin.productForm');
+
   return (
     <section className="space-y-4">
       <h2 className="text-sm font-semibold">노출 설정</h2>
@@ -228,6 +232,12 @@ function VisibilitySection({
         label="추천 상품으로 표시"
         checked={form.isFeatured}
         onChange={(v) => set('isFeatured', v)}
+      />
+
+      <CheckboxField
+        label={t('freeShippingProduct')}
+        checked={form.isFreeShipping}
+        onChange={(v) => set('isFreeShipping', v)}
       />
     </section>
   );
@@ -247,6 +257,7 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
     sku: product?.sku ?? '',
     status: (product?.status as ProductFormData['status']) ?? 'draft',
     isFeatured: product?.isFeatured ?? false,
+    isFreeShipping: product?.isFreeShipping ?? false,
     images: product?.images?.map((img) => ({ url: img.url, alt: img.alt ?? undefined })) ?? [],
     detailImages: product?.detailImages?.map((img) => ({ url: img.url, alt: img.alt ?? undefined })) ?? [],
     options: product?.options?.map((o) => ({
@@ -291,6 +302,7 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
         sku: form.sku || undefined,
         status: form.status,
         isFeatured: form.isFeatured,
+        isFreeShipping: form.isFreeShipping,
         nameEn: form.nameEn.trim() || undefined,
         descriptionEn: form.descriptionEn.trim() || undefined,
         images: form.images.map((img, index) => ({

--- a/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
@@ -10,6 +10,10 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => (key === 'freeShippingProduct' ? '무료배송 상품' : key),
+}));
+
 vi.mock('@/lib/api', () => ({
   adminProductsApi: {
     create: vi.fn(),
@@ -106,6 +110,49 @@ describe('ProductFormPage', () => {
             slug: 'test-product',
             price: 10000,
           }),
+        );
+      });
+    });
+
+    it('무료배송 상품 체크 시 create payload에 isFreeShipping=true를 포함한다', async () => {
+      const { adminProductsApi } = await import('@/lib/api');
+      vi.mocked(adminProductsApi.create).mockResolvedValue({
+        id: 1,
+        name: '테스트 상품',
+        slug: 'test-product',
+        price: 10000,
+        salePrice: null,
+        status: 'draft',
+        isFeatured: false,
+        isFreeShipping: true,
+        viewCount: 0,
+        category: null,
+        images: [],
+        description: null,
+        shortDescription: null,
+        rating: 0,
+        reviewCount: 0,
+        stock: 0,
+        sku: null,
+        options: [],
+        detailImages: [],
+      });
+
+      render(<ProductFormPage mode="create" />);
+
+      fireEvent.change(screen.getByPlaceholderText('상품명을 입력하세요'), {
+        target: { value: '테스트 상품' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('url-friendly-slug'), {
+        target: { value: 'test-product' },
+      });
+      fireEvent.change(screen.getAllByRole('spinbutton')[0], { target: { value: '10000' } });
+      fireEvent.click(screen.getByLabelText('무료배송 상품'));
+      fireEvent.click(screen.getByText('등록하기'));
+
+      await waitFor(() => {
+        expect(adminProductsApi.create).toHaveBeenCalledWith(
+          expect.objectContaining({ isFreeShipping: true }),
         );
       });
     });

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -643,7 +643,8 @@
         "nameRequired": "Please enter a product name.",
         "slugRequired": "Please enter a slug.",
         "priceRequired": "Please enter a valid price."
-      }
+      },
+      "freeShippingProduct": "Free-shipping product"
     },
     "members": {
       "title": "Member Management",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -643,7 +643,8 @@
         "nameRequired": "상품명을 입력해주세요.",
         "slugRequired": "슬러그를 입력해주세요.",
         "priceRequired": "가격을 올바르게 입력해주세요."
-      }
+      },
+      "freeShippingProduct": "무료배송 상품"
     },
     "members": {
       "title": "회원 관리",

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -18,6 +18,7 @@ export interface CreateProductData {
   sku?: string;
   status?: string;
   isFeatured?: boolean;
+  isFreeShipping?: boolean;
   nameEn?: string;
   descriptionEn?: string;
   images?: Array<{

--- a/src/lib/api/cart.ts
+++ b/src/lib/api/cart.ts
@@ -15,6 +15,7 @@ export interface CartItemProduct {
   price: number;
   salePrice: number | null;
   status: string;
+  isFreeShipping?: boolean;
   images: ProductImage[];
 }
 

--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -40,6 +40,7 @@ export interface Product {
   reviewCount: number;
   status: 'active' | 'soldout' | 'inactive' | 'draft' | 'hidden';
   isFeatured: boolean;
+  isFreeShipping?: boolean;
   viewCount: number;
   category: Category | null;
   images: ProductImage[];

--- a/src/lib/api/shipping.ts
+++ b/src/lib/api/shipping.ts
@@ -29,6 +29,7 @@ export interface ShippingQuoteResponse {
   shippingFee: number;
   isFreeShipping: boolean;
   isRemoteArea: boolean;
+  isProductFreeShipping: boolean;
   threshold: number;
   baseFee: number;
   remoteAreaSurcharge: number;
@@ -53,6 +54,10 @@ export const shippingApi = {
       '/shipping/track',
       { carrier, trackingNumber },
     ),
-  quote: (subtotal: number, zipcode: string) =>
-    apiClient.post<ShippingQuoteResponse>('/shipping/quote', { subtotal, zipcode }),
+  quote: (
+    subtotal: number,
+    zipcode: string,
+    items?: Array<{ productId: number; productOptionId?: number | null; quantity: number }>,
+  ) =>
+    apiClient.post<ShippingQuoteResponse>('/shipping/quote', { subtotal, zipcode, items }),
 };


### PR DESCRIPTION
## Summary
- Adds product-level `isFreeShipping` support across product entity/DTO/API types and admin product form.
- Extends shipping quote/order pricing to evaluate server-side product policies: all-shipping-items-free waives base shipping, mixed carts use existing global/base policy, and remote-area surcharge remains separate.
- Stores `order_items.is_free_shipping` as the order-time product policy snapshot and adds the paired TypeORM migration.
- Forces e2e notification provider to mock so local e2e assertions are not affected by `.env` notification settings.

Closes #791

## Verification
- `npm run build`
- `npm run test:run`
- `npm --prefix backend run build`
- `npm --prefix backend test -- --runInBand`
- `bash scripts/test.sh e2e`
