### PR TITLE
Expose desktop admin header button

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
-import { Menu, X, Search, User, LogOut } from 'lucide-react';
+import { Menu, X, Search, User, LogOut, Shield } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import Logo from '@/components/Logo';
 import { useAuth } from '@/contexts/AuthContext';
@@ -35,6 +35,7 @@ export default function Header() {
   const menuPanel = useSlidePanel(isMenuOpen);
   const headerRef = useRef<HTMLElement>(null);
   const { isScrolled } = useHeaderScroll(headerRef);
+  const isAdmin = user?.role === 'admin' || user?.role === 'super_admin';
 
   // Global Escape: close menu + search
   useEffect(() => {
@@ -120,6 +121,12 @@ export default function Header() {
                 <button type="button" onClick={() => void logout()} aria-label={t('logout')} className="p-2 text-muted-foreground hover:text-foreground transition-colors">
                   <LogOut className="h-5 w-5" />
                 </button>
+                {isAdmin && (
+                  <Link href="/admin" aria-label={t('adminPage')} className="ml-2 inline-flex items-center gap-2 rounded-md border border-primary bg-primary px-3 py-2 typo-button text-primary-foreground shadow-sm transition-colors hover:bg-primary/90">
+                    <Shield className="h-4 w-4" />
+                    {t('adminPage')}
+                  </Link>
+                )}
               </>
             ) : (
               <Link href="/login" aria-label={t('login')} className="p-2 text-muted-foreground hover:text-foreground transition-colors">

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -173,6 +173,32 @@ describe('Header', () => {
     expect(mockSetOpen).toHaveBeenCalledWith('menu', false, 'replace');
   });
 
+  it('shows desktop admin button at the right end for admin accounts', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: 1, email: 'admin@test.com', name: 'Admin', role: 'admin' },
+      logout: vi.fn(),
+    });
+
+    render(<Header />);
+
+    const adminLink = screen.getByRole('link', { name: '관리자 페이지' });
+    expect(adminLink).toHaveAttribute('href', '/admin');
+    expect(adminLink.parentElement?.lastElementChild).toBe(adminLink);
+  });
+
+  it('does not show desktop admin button for non-admin authenticated users', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { id: 2, email: 'user@test.com', name: 'User', role: 'user' },
+      logout: vi.fn(),
+    });
+
+    render(<Header />);
+
+    expect(screen.queryByRole('link', { name: '관리자 페이지' })).not.toBeInTheDocument();
+  });
+
   it('shows admin link under order tracking for admin accounts in mobile menu', async () => {
     const user = userEvent.setup();
     mockUseAuth.mockReturnValue({

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -77,6 +77,7 @@
     "contact": "Contact Us",
     "orderTracking": "Order Tracking",
     "adminPanel": "Admin",
+    "adminPage": "Admin Page",
     "menuLabel": "Menu",
     "menuBack": "Back",
     "goBack": "Back",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -77,6 +77,7 @@
     "contact": "문의하기",
     "orderTracking": "주문조회",
     "adminPanel": "관리자",
+    "adminPage": "관리자 페이지",
     "menuLabel": "메뉴",
     "menuBack": "뒤로",
     "goBack": "뒤로가기",


### PR DESCRIPTION
## Summary\n- Show a localized "관리자 페이지" button at the far right of the desktop header for admin/super_admin users\n- Style the button as a visible primary action\n- Cover admin/non-admin visibility in Header tests\n\n## Tests\n- npx vitest run src/components/__tests__/Header.test.tsx\n- npm run build\n\n## Notes\n- Existing Next build still prints the known ESLint minimatch export warning, but exits successfully.\n