### PR TITLE
feat: #806 무료배송 상품 뱃지 표시 추가

### DIFF
--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -290,6 +290,7 @@ export default function AdminProductsPage() {
                 <th className="px-4 py-3 text-left">{t('columns.price')}</th>
                 <th className="px-4 py-3 text-left">{t('columns.status')}</th>
                 <th className="px-4 py-3 text-left">{t('columns.featured')}</th>
+                <th className="px-4 py-3 text-left">{t('columns.freeShipping')}</th>
                 <th className="px-4 py-3 text-right">{t('columns.action')}</th>
               </tr>
             </thead>
@@ -303,6 +304,15 @@ export default function AdminProductsPage() {
                     <ProductStatusBadge status={product.status as ProductStatus} />
                   </td>
                   <td className="px-4 py-3">{product.isFeatured ? '✓' : '-'}</td>
+                  <td className="px-4 py-3">
+                    {product.isFreeShipping ? (
+                      <span className="inline-flex rounded-sm bg-foreground/85 px-2 py-0.5 text-xs text-background">
+                        {t('columns.freeShipping')}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">-</span>
+                    )}
+                  </td>
                   <td className="px-4 py-3 text-right">
                     <div className="flex justify-end gap-2">
                       <button

--- a/src/components/shared/blocks/ProductCarouselBlock.tsx
+++ b/src/components/shared/blocks/ProductCarouselBlock.tsx
@@ -151,6 +151,7 @@ export default function ProductCarouselBlock({ content }: Props) {
                 categoryName={product.category?.name}
                 status={product.status}
                 images={product.images}
+                isFreeShipping={product.isFreeShipping}
                 priority={index === 0}
               />
             </div>

--- a/src/components/shared/blocks/ProductGridBlock.tsx
+++ b/src/components/shared/blocks/ProductGridBlock.tsx
@@ -102,6 +102,7 @@ export default function ProductGridBlock({ content }: Props) {
               categoryName={product.category?.name}
               status={product.status}
               images={product.images}
+              isFreeShipping={product.isFreeShipping}
             />
           </div>
         ))}

--- a/src/components/shared/products/ProductCard.tsx
+++ b/src/components/shared/products/ProductCard.tsx
@@ -26,6 +26,7 @@ interface ProductCardProps {
   locale?: Locale;
   priority?: boolean;
   categoryName?: string | null;
+  isFreeShipping?: boolean;
 }
 
 /** 카테고리명 → 니료 태그 CSS 클래스 매핑 */
@@ -64,6 +65,7 @@ function ProductCard({
   locale = 'ko',
   priority = false,
   categoryName,
+  isFreeShipping = false,
 }: ProductCardProps) {
   const t = useTranslations('product');
   const tWishlist = useTranslations('wishlist');
@@ -152,6 +154,12 @@ function ProductCard({
             )}
           />
         </button>
+
+        {isFreeShipping && (
+          <span className="tag-clay absolute bottom-2 right-2 z-10 rounded-sm bg-foreground/85 px-2 py-0.5 text-background backdrop-blur-sm">
+            {t('badgeFreeShipping')}
+          </span>
+        )}
       </div>
 
       {/* ── 정보 영역 — 상품명 > 가격 > 메타 위계 ── */}

--- a/src/components/shared/products/ProductGrid.tsx
+++ b/src/components/shared/products/ProductGrid.tsx
@@ -61,6 +61,7 @@ export default function ProductGrid({ products, total, locale = 'ko' }: ProductG
               images={product.images}
               locale={locale}
               categoryName={product.category?.name ?? null}
+              isFreeShipping={product.isFreeShipping}
             />
           ))}
         </div>
@@ -79,6 +80,7 @@ export default function ProductGrid({ products, total, locale = 'ko' }: ProductG
               status={product.status}
               images={product.images}
               isFeatured={product.isFeatured}
+              isFreeShipping={product.isFreeShipping}
               locale={locale}
             />
           ))}

--- a/src/components/shared/products/ProductListItem.tsx
+++ b/src/components/shared/products/ProductListItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
 import type { ProductImage } from '@/lib/api';
 import PriceDisplay from '@/components/shared/common/PriceDisplay';
@@ -18,6 +19,7 @@ interface ProductListItemProps {
   status: 'active' | 'soldout' | 'inactive' | 'draft' | 'hidden';
   images: ProductImage[];
   isFeatured?: boolean;
+  isFreeShipping?: boolean;
   locale?: Locale;
 }
 
@@ -31,8 +33,10 @@ function ProductListItem({
   reviewCount,
   status,
   images,
+  isFreeShipping = false,
   locale = 'ko',
 }: ProductListItemProps) {
+  const t = useTranslations('product');
   const thumbnail = images[0]?.url;
   const isSoldout = status === 'soldout';
 
@@ -68,7 +72,14 @@ function ProductListItem({
 
       <div className="flex flex-1 flex-col justify-center gap-1">
         <p className="typo-title-sm line-clamp-1 text-card-foreground">{name}</p>
-        <PriceDisplay price={price} salePrice={salePrice} locale={locale} />
+        <div className="flex items-center gap-2">
+          <PriceDisplay price={price} salePrice={salePrice} locale={locale} />
+          {isFreeShipping && (
+            <span className="tag-clay rounded-sm bg-foreground/85 px-2 py-0.5 text-background">
+              {t('badgeFreeShipping')}
+            </span>
+          )}
+        </div>
         {rating !== undefined && (
           <div className="flex items-center gap-1.5">
             <StarRating rating={rating} size="sm" interactive={false} />

--- a/src/components/shared/products/__tests__/ProductCard.test.tsx
+++ b/src/components/shared/products/__tests__/ProductCard.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ProductCard from '@/components/shared/products/ProductCard';
+import type { ProductImage } from '@/lib/api';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) =>
+    ({
+      addToCart: '장바구니 담기',
+      addingToCart: '담는 중...',
+      badgeFreeShipping: '무료배송',
+      toggleOn: '위시리스트에 추가',
+      toggleOff: '위시리스트에서 삭제',
+    }[key] ?? key),
+}));
+
+vi.mock('@/components/shared/hooks/useWishlistToggle', () => ({
+  useWishlistToggle: () => ({ isWishlisted: false, loading: false, toggle: vi.fn() }),
+}));
+
+vi.mock('@/contexts/CartContext', () => ({
+  useCart: () => ({ addItem: vi.fn() }),
+}));
+
+const images: ProductImage[] = [{ id: 1, url: 'https://example.com/a.jpg', sortOrder: 0 } as ProductImage];
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof ProductCard>> = {}) {
+  return render(
+    <ProductCard
+      id={1}
+      name="자사호"
+      price={50000}
+      salePrice={null}
+      status="active"
+      images={images}
+      {...overrides}
+    />,
+  );
+}
+
+describe('ProductCard free-shipping badge', () => {
+  it('renders the free-shipping badge when isFreeShipping is true', () => {
+    renderCard({ isFreeShipping: true });
+
+    expect(screen.getByText('무료배송')).toBeInTheDocument();
+  });
+
+  it('does not render the badge for a regular product', () => {
+    renderCard({ isFreeShipping: false });
+
+    expect(screen.queryByText('무료배송')).not.toBeInTheDocument();
+  });
+
+  it('does not render the badge when isFreeShipping is omitted', () => {
+    renderCard();
+
+    expect(screen.queryByText('무료배송')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/products/__tests__/ProductListItem.test.tsx
+++ b/src/components/shared/products/__tests__/ProductListItem.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ProductListItem from '@/components/shared/products/ProductListItem';
+import type { ProductImage } from '@/lib/api';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) =>
+    ({
+      badgeFreeShipping: '무료배송',
+    }[key] ?? key),
+}));
+
+const images: ProductImage[] = [{ id: 1, url: 'https://example.com/a.jpg', sortOrder: 0 } as ProductImage];
+
+function renderItem(overrides: Partial<React.ComponentProps<typeof ProductListItem>> = {}) {
+  return render(
+    <ProductListItem
+      id={1}
+      name="자사호"
+      price={50000}
+      salePrice={null}
+      status="active"
+      images={images}
+      {...overrides}
+    />,
+  );
+}
+
+describe('ProductListItem free-shipping badge', () => {
+  it('renders the free-shipping badge when isFreeShipping is true', () => {
+    renderItem({ isFreeShipping: true });
+
+    expect(screen.getByText('무료배송')).toBeInTheDocument();
+  });
+
+  it('does not render the badge for a regular product', () => {
+    renderItem({ isFreeShipping: false });
+
+    expect(screen.queryByText('무료배송')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/search/SearchPage.tsx
+++ b/src/components/shared/search/SearchPage.tsx
@@ -170,6 +170,7 @@ export default function SearchPage() {
                 status={product.status}
                 images={product.images}
                 categoryName={product.category?.name ?? null}
+                isFreeShipping={product.isFreeShipping}
               />
             ))}
           </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -231,7 +231,8 @@
       "soldout": "Sold Out",
       "hidden": "Hidden"
     },
-    "lowStock": "Only {count} left"
+    "lowStock": "Only {count} left",
+    "badgeFreeShipping": "Free Shipping"
   },
   "cart": {
     "title": "Cart",
@@ -542,6 +543,7 @@
         "price": "Price",
         "status": "Status",
         "featured": "Featured",
+        "freeShipping": "Free Shipping",
         "action": "Action"
       },
       "actions": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -231,7 +231,8 @@
       "soldout": "품절",
       "hidden": "숨김"
     },
-    "lowStock": "{count}개 남음"
+    "lowStock": "{count}개 남음",
+    "badgeFreeShipping": "무료배송"
   },
   "cart": {
     "title": "장바구니",
@@ -542,6 +543,7 @@
         "price": "가격",
         "status": "상태",
         "featured": "추천",
+        "freeShipping": "무료배송",
         "action": "액션"
       },
       "actions": {


### PR DESCRIPTION
## 개요
`isFreeShipping` 상품에 대해 고객/관리자 상품 목록에서 무료배송 표시를 추가한다.

Closes #806

## 변경 사항
- **고객 상품 카드** (`ProductCard.tsx`): 무료배송 상품이면 이미지 오른쪽 아래에 `무료배송` 뱃지 표시. 기존 니료 태그(왼쪽 아래)·찜하기(오른쪽 위)·품절 오버레이와 충돌하지 않도록 우하단 배치.
- **고객 리스트 아이템** (`ProductListItem.tsx`): 가격 옆에 `무료배송` 뱃지 표시 (96px 썸네일을 가리지 않도록 정보 영역에 배치).
- **그리드/캐러셀/검색 카드**: `isFreeShipping`를 카드에 전달해 모든 고객-facing 목록에서 일관 표시.
- **관리자 상품 목록** (`admin/products/page.tsx`): `무료배송` 컬럼 추가, 상품별 뱃지 또는 `-` 표시.
- **i18n**: `product.badgeFreeShipping`, `admin.products.columns.freeShipping` ko/en 키 추가.
- 뱃지는 기존 `tag-clay` 타이포 + `bg-foreground/85 text-background` 톤으로 디자인 시스템을 따름.

## 테스트
- 신규 단위 테스트: `ProductCard.test.tsx`, `ProductListItem.test.tsx`
- `npx vitest run` → 115 files, 708 tests passed
- `npx tsc --noEmit` → 변경 소스 파일 에러 0
- `npx next lint`(변경 파일) → No ESLint warnings or errors
- `npm run build` → 성공
- DB 스키마 변경 없음 → e2e 불필요