### PR TITLE
feat: #808 푸터 사업자 정보 노출

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -118,6 +118,13 @@ export default function Footer() {
               <p>&copy; {new Date().getFullYear()} OCKHWADANG. All rights reserved.</p>
             </div>
           </div>
+
+          {/* 사업자 정보 (전자상거래법 제10조) */}
+          <div className="mt-4 text-xs text-muted-foreground/70 leading-relaxed text-center md:text-left space-y-0.5">
+            <p>{t('businessInfo.companyName')} · {t('businessInfo.ceo')}</p>
+            <p>{t('businessInfo.address')}</p>
+            <p>{t('businessInfo.bizNo')} · {t('businessInfo.mailOrderNo')}</p>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -71,7 +71,7 @@ describe('Footer', () => {
 
   it('renders required business information (상호·대표자·사업자번호·통신판매번호·소재지)', () => {
     render(<Footer />);
-    expect(screen.getByText(/서로인터네셔널/)).toBeInTheDocument();
+    expect(screen.getByText(/서로 인터내셔널/)).toBeInTheDocument();
     expect(screen.getByText(/권준현/)).toBeInTheDocument();
     expect(screen.getByText(/131-72-05631/)).toBeInTheDocument();
     expect(screen.getByText(/2026-서울강남-01632/)).toBeInTheDocument();

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -12,13 +12,20 @@ vi.mock('@/i18n/navigation', () => ({
 
 vi.mock('next-intl', async (importOriginal) => {
   const actual = await importOriginal<typeof import('next-intl')>();
-  const messages = (await import('@/i18n/messages/ko.json')).default as unknown as Record<string, Record<string, string>>;
+  const messages = (await import('@/i18n/messages/ko.json')).default as unknown as Record<string, unknown>;
+  const resolvePath = (root: unknown, path: string): unknown =>
+    path.split('.').reduce<unknown>((acc, segment) => {
+      if (acc && typeof acc === 'object') {
+        return (acc as Record<string, unknown>)[segment];
+      }
+      return undefined;
+    }, root);
   return {
     ...actual,
     useLocale: () => 'ko',
     useTranslations: (namespace: string) => (key: string) => {
-      const ns = messages[namespace] ?? {};
-      return ns[key] ?? key;
+      const value = resolvePath(messages[namespace], key);
+      return typeof value === 'string' ? value : key;
     },
   };
 });
@@ -57,6 +64,17 @@ describe('Footer', () => {
   it('renders copyright text containing current year', () => {
     render(<Footer />);
     const year = new Date().getFullYear().toString();
-    expect(screen.getByText(new RegExp(year))).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`${year} OCKHWADANG`))
+    ).toBeInTheDocument();
+  });
+
+  it('renders required business information (상호·대표자·사업자번호·통신판매번호·소재지)', () => {
+    render(<Footer />);
+    expect(screen.getByText(/서로인터네셔널/)).toBeInTheDocument();
+    expect(screen.getByText(/권준현/)).toBeInTheDocument();
+    expect(screen.getByText(/131-72-05631/)).toBeInTheDocument();
+    expect(screen.getByText(/2026-서울강남-01632/)).toBeInTheDocument();
+    expect(screen.getByText(/역삼로 114/)).toBeInTheDocument();
   });
 });

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -104,7 +104,14 @@
     "collection": "Collection",
     "archive": "Archive",
     "journal": "Journal",
-    "copyright": "© {year} Ockhwadang. All rights reserved."
+    "copyright": "© {year} Ockhwadang. All rights reserved.",
+    "businessInfo": {
+      "companyName": "Seoro International",
+      "ceo": "CEO: Junhyeon Kwon",
+      "address": "Address: 8F 8028, 114 Yeoksam-ro, Gangnam-gu, Seoul, Korea",
+      "bizNo": "Business Reg. No.: 131-72-05631",
+      "mailOrderNo": "Mail-Order Reg. No.: 2026-Seoul Gangnam-01632"
+    }
   },
   "auth": {
     "email": "Email",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -107,10 +107,10 @@
     "copyright": "© {year} Ockhwadang. All rights reserved.",
     "businessInfo": {
       "companyName": "Seoro International",
-      "ceo": "CEO: Junhyeon Kwon",
-      "address": "Address: 8F 8028, 114 Yeoksam-ro, Gangnam-gu, Seoul, Korea",
+      "ceo": "CEO: Kwon Junhyun",
+      "address": "Address: 8F 8028, Hyeonjuk Building, 114 Yeoksam-ro, Gangnam-gu, Seoul 06252, Korea",
       "bizNo": "Business Reg. No.: 131-72-05631",
-      "mailOrderNo": "Mail-Order Reg. No.: 2026-Seoul Gangnam-01632"
+      "mailOrderNo": "Mail-Order Reg. No.: 2026-서울강남-01632"
     }
   },
   "auth": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -106,9 +106,9 @@
     "journal": "Journal",
     "copyright": "© {year} 옥화당. All rights reserved.",
     "businessInfo": {
-      "companyName": "서로인터네셔널",
+      "companyName": "서로 인터내셔널",
       "ceo": "대표 권준현",
-      "address": "소재지: 서울 강남구 역삼로 114 8층 8028호",
+      "address": "소재지: 서울특별시 강남구 역삼로 114 (현죽빌딩) 8층 8028호 (우 06252)",
       "bizNo": "사업자등록번호: 131-72-05631",
       "mailOrderNo": "통신판매업신고번호: 2026-서울강남-01632"
     }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -104,7 +104,14 @@
     "collection": "컬렉션",
     "archive": "아카이브",
     "journal": "Journal",
-    "copyright": "© {year} 옥화당. All rights reserved."
+    "copyright": "© {year} 옥화당. All rights reserved.",
+    "businessInfo": {
+      "companyName": "서로인터네셔널",
+      "ceo": "대표 권준현",
+      "address": "소재지: 서울 강남구 역삼로 114 8층 8028호",
+      "bizNo": "사업자등록번호: 131-72-05631",
+      "mailOrderNo": "통신판매업신고번호: 2026-서울강남-01632"
+    }
   },
   "auth": {
     "email": "이메일",


### PR DESCRIPTION
## Summary
- Closes #808
- Footer 하단에 전자상거래법상 사업자 정보(상호, 대표자, 사업자등록번호, 통신판매업신고번호, 소재지)를 노출했습니다.
- ko/en footer.businessInfo i18n 키를 추가했습니다.
- 기존 약관/개인정보처리방침 시드 및 MDX에 있는 사업자 정보와 대조했습니다.

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run -- src/components/__tests__/Footer.test.tsx
- [x] npm run test:run
- [x] cd backend && npm run lint && npm run build && npm run test