### PR TITLE
fix: #814 상품 목록 이미지 fallback 개선

### DIFF
--- a/src/app/[locale]/my/recently-viewed/__tests__/RecentlyViewedPage.test.tsx
+++ b/src/app/[locale]/my/recently-viewed/__tests__/RecentlyViewedPage.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RecentlyViewedPage from '../page';
+import type { RecentlyViewedProduct } from '@/components/shared/hooks/useRecentlyViewed';
+
+const mockClear = vi.fn();
+let mockItems: RecentlyViewedProduct[] = [];
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) =>
+    ({
+      title: '최근 본 상품',
+      clearAll: '전체 삭제',
+      clearSuccess: '삭제되었습니다.',
+      noItems: '최근 본 상품이 없습니다.',
+    }[key] ?? key),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn() },
+}));
+
+vi.mock('@/components/shared/hooks/useRecentlyViewed', () => ({
+  useRecentlyViewed: () => ({ items: mockItems, clear: mockClear }),
+}));
+
+const recentItem: RecentlyViewedProduct = {
+  id: 1,
+  name: '자사호',
+  price: 50000,
+  salePrice: null,
+  thumbnail: 'https://example.com/broken.jpg',
+  slug: 'zisha-pot',
+  viewedAt: '2026-06-04T00:00:00.000Z',
+};
+
+describe('RecentlyViewedPage product image presentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockItems = [recentItem];
+  });
+
+  it('renders recently viewed product image frame without rounded corners', () => {
+    render(<RecentlyViewedPage />);
+
+    expect(screen.getByTestId('recently-viewed-product-image-frame')).not.toHaveClass('rounded-md');
+  });
+
+  it('replaces a failed recently viewed product image with the Okhwadang logo fallback on a neutral gray background', () => {
+    render(<RecentlyViewedPage />);
+
+    fireEvent.error(screen.getByAltText('자사호'));
+
+    const fallback = screen.getByTestId('recently-viewed-product-image-fallback');
+    expect(fallback).toHaveClass('bg-neutral-200');
+    expect(screen.getByAltText('옥화당')).toHaveAttribute('src', '/logo-okhwadang.png');
+    expect(screen.queryByAltText('자사호')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/my/recently-viewed/page.tsx
+++ b/src/app/[locale]/my/recently-viewed/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { toast } from 'sonner';
@@ -7,6 +8,40 @@ import { useTranslations } from 'next-intl';
 import { useRecentlyViewed } from '@/components/shared/hooks/useRecentlyViewed';
 import EmptyState from '@/components/shared/EmptyState';
 import { formatCurrency } from '@/utils/currency';
+
+interface RecentlyViewedProductImageProps {
+  thumbnail: string | null;
+  name: string;
+}
+
+function RecentlyViewedProductImage({ thumbnail, name }: RecentlyViewedProductImageProps) {
+  const [hasImageError, setHasImageError] = useState(false);
+
+  return (
+    <div data-testid="recently-viewed-product-image-frame" className="relative aspect-square overflow-hidden bg-muted">
+      {thumbnail && !hasImageError ? (
+        <Image
+          src={thumbnail}
+          alt={name}
+          fill
+          sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
+          className="object-cover transition-transform group-hover:scale-105"
+          onError={() => setHasImageError(true)}
+        />
+      ) : (
+        <div data-testid="recently-viewed-product-image-fallback" className="flex h-full w-full items-center justify-center bg-neutral-200">
+          <Image
+            src="/logo-okhwadang.png"
+            alt="옥화당"
+            width={120}
+            height={34}
+            className="object-contain opacity-70 grayscale"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function RecentlyViewedPage() {
   const t = useTranslations('recentlyViewed');
@@ -41,21 +76,7 @@ export default function RecentlyViewedPage() {
               href={`/products/${item.slug}`}
               className="group flex flex-col overflow-hidden rounded-lg border bg-card hover:shadow-md transition-shadow"
             >
-              <div className="relative aspect-square overflow-hidden bg-muted">
-                {item.thumbnail ? (
-                  <Image
-                    src={item.thumbnail}
-                    alt={item.name}
-                    fill
-                    sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
-                    className="object-cover transition-transform group-hover:scale-105"
-                  />
-                ) : (
-                  <div className="flex h-full w-full items-center justify-center text-muted-foreground text-sm">
-                    No Image
-                  </div>
-                )}
-              </div>
+              <RecentlyViewedProductImage thumbnail={item.thumbnail} name={item.name} />
               <div className="p-3">
                 <p className="line-clamp-2 text-sm font-medium">{item.name}</p>
                 <p className="mt-1 text-sm font-semibold">

--- a/src/app/[locale]/my/wishlist/__tests__/WishlistPage.test.tsx
+++ b/src/app/[locale]/my/wishlist/__tests__/WishlistPage.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import WishlistPage from '../page';
+
+const mockPush = vi.fn();
+const mockGetList = vi.fn();
+const mockRemove = vi.fn();
+const mockAddCart = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) =>
+    ({
+      title: '위시리스트',
+      loadError: '위시리스트를 불러오지 못했습니다.',
+      removeSuccess: '삭제되었습니다.',
+      removeError: '삭제하지 못했습니다.',
+      addCartSuccess: '장바구니에 담았습니다.',
+      addCartError: '장바구니에 담지 못했습니다.',
+      noItems: '위시리스트가 비었습니다.',
+      noItemsDescription: '상품을 담아보세요.',
+      goShopping: '쇼핑하러 가기',
+      soldout: '품절',
+      addToCart: '장바구니 담기',
+      delete: '삭제',
+    }[key] ?? key),
+}));
+
+vi.mock('@/components/shared/hooks/useRequireAuth', () => ({
+  useRequireAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  wishlistApi: {
+    getList: (...args: unknown[]) => mockGetList(...args),
+    remove: (...args: unknown[]) => mockRemove(...args),
+  },
+  cartApi: {
+    add: (...args: unknown[]) => mockAddCart(...args),
+  },
+}));
+
+const wishlistItem = {
+  id: 1,
+  productId: 10,
+  createdAt: '2026-06-04T00:00:00.000Z',
+  product: {
+    id: 10,
+    name: '자사호',
+    slug: 'zisha-pot',
+    price: 50000,
+    salePrice: null,
+    status: 'soldout',
+    images: [{ url: 'https://example.com/broken.jpg', alt: null, isThumbnail: true }],
+  },
+};
+
+describe('WishlistPage product image presentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetList.mockResolvedValue({ data: [wishlistItem] });
+  });
+
+  it('renders wishlist product image frame and in-image badge without rounded corners', async () => {
+    render(<WishlistPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('자사호')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('wishlist-product-image-frame')).not.toHaveClass('rounded-md');
+    expect(screen.getByText('품절')).not.toHaveClass('rounded-md');
+  });
+
+  it('replaces a failed wishlist product image with the Okhwadang logo fallback on a neutral gray background', async () => {
+    render(<WishlistPage />);
+
+    const image = await screen.findByAltText('자사호');
+    fireEvent.error(image);
+
+    const fallback = screen.getByTestId('wishlist-product-image-fallback');
+    expect(fallback).toHaveClass('bg-neutral-200');
+    expect(screen.getByAltText('옥화당')).toHaveAttribute('src', '/logo-okhwadang.png');
+    expect(screen.queryByAltText('자사호')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/my/wishlist/page.tsx
+++ b/src/app/[locale]/my/wishlist/page.tsx
@@ -14,6 +14,50 @@ import { cn } from '@/components/ui/utils';
 import PriceDisplay from '@/components/shared/common/PriceDisplay';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 
+interface WishlistProductImageProps {
+  thumbnail?: string;
+  name: string;
+  isSoldout: boolean;
+  soldoutLabel: string;
+}
+
+function WishlistProductImage({ thumbnail, name, isSoldout, soldoutLabel }: WishlistProductImageProps) {
+  const [hasImageError, setHasImageError] = useState(false);
+
+  return (
+    <div data-testid="wishlist-product-image-frame" className="relative aspect-square overflow-hidden bg-muted">
+      {thumbnail && !hasImageError ? (
+        <Image
+          src={thumbnail}
+          alt={name}
+          fill
+          sizes="(max-width: 768px) 50vw, 25vw"
+          className="object-cover"
+          loading="lazy"
+          onError={() => setHasImageError(true)}
+        />
+      ) : (
+        <div data-testid="wishlist-product-image-fallback" className="flex h-full w-full items-center justify-center bg-neutral-200">
+          <Image
+            src="/logo-okhwadang.png"
+            alt="옥화당"
+            width={120}
+            height={34}
+            className="object-contain opacity-70 grayscale"
+          />
+        </div>
+      )}
+      {isSoldout && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+          <span className="bg-black/70 px-3 py-1 text-sm font-semibold text-white">
+            {soldoutLabel}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function WishlistPage() {
   const t = useTranslations('wishlist');
   const tProduct = useTranslations('product');
@@ -86,31 +130,14 @@ export default function WishlistPage() {
 
             return (
               <li key={item.id} className="flex flex-col overflow-hidden rounded-lg border border-border bg-card">
-                <div className="relative aspect-square overflow-hidden bg-muted">
-                  <Link href={`/products/${item.productId}`} className="block h-full w-full">
-                    {thumbnail ? (
-                      <Image
-                        src={thumbnail}
-                        alt={product?.name ?? ''}
-                        fill
-                        sizes="(max-width: 768px) 50vw, 25vw"
-                        className="object-cover"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-                        <span className="text-sm">No Image</span>
-                      </div>
-                    )}
-                    {isSoldout && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-black/40">
-                        <span className="rounded-md bg-black/70 px-3 py-1 text-sm font-semibold text-white">
-                          {tProduct('soldout')}
-                        </span>
-                      </div>
-                    )}
-                  </Link>
-                </div>
+                <Link href={`/products/${item.productId}`} className="block">
+                  <WishlistProductImage
+                    thumbnail={thumbnail}
+                    name={product?.name ?? ''}
+                    isSoldout={isSoldout}
+                    soldoutLabel={tProduct('soldout')}
+                  />
+                </Link>
 
                 <div className="flex flex-1 flex-col gap-2 p-3">
                   <Link href={`/products/${item.productId}`} className="line-clamp-2 text-sm font-medium hover:underline">

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -110,9 +110,9 @@ describe('ProductCard', () => {
     expect(screen.getByText('SOLD OUT')).toBeInTheDocument();
   });
 
-  it('renders without crashing when images are empty', () => {
+  it('renders the Okhwadang logo fallback when images are empty', () => {
     render(<ProductCard {...baseProps} images={[]} />);
-    expect(screen.getByText('No Image')).toBeInTheDocument();
+    expect(screen.getByAltText('옥화당')).toHaveAttribute('src', '/logo-okhwadang.png');
   });
 
   it('links to the product detail page', () => {

--- a/src/components/shared/products/ProductCard.tsx
+++ b/src/components/shared/products/ProductCard.tsx
@@ -77,6 +77,7 @@ function ProductCard({
   const { addItem } = useCart();
   const { isWishlisted, loading: isWishlistLoading, toggle: handleToggleWishlist } = useWishlistToggle(id);
   const [isCartLoading, setIsCartLoading] = useState(false);
+  const [hasImageError, setHasImageError] = useState(false);
 
   const handleAddToCart = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -97,8 +98,8 @@ function ProductCard({
       )}
     >
       {/* ── 이미지 영역 — 오버레이 액션은 hover 시에만 노출 ── */}
-      <div className="relative aspect-square overflow-hidden bg-secondary rounded-md">
-        {thumbnail ? (
+      <div data-testid="product-card-image-frame" className="relative aspect-square overflow-hidden bg-secondary">
+        {thumbnail && !hasImageError ? (
           <Image
             src={thumbnail}
             alt={name}
@@ -106,10 +107,17 @@ function ProductCard({
             sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
             className="object-cover transition-transform duration-500 group-hover:scale-105"
             priority={priority}
+            onError={() => setHasImageError(true)}
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-            <span className="data-label">No Image</span>
+          <div data-testid="product-card-image-fallback" className="flex h-full w-full items-center justify-center bg-neutral-200">
+            <Image
+              src="/logo-okhwadang.png"
+              alt="옥화당"
+              width={120}
+              height={34}
+              className="object-contain opacity-70 grayscale"
+            />
           </div>
         )}
 
@@ -122,7 +130,7 @@ function ProductCard({
         {categoryName && (
           <span
             className={cn(
-              'absolute left-2 bottom-2 z-10 px-2 py-0.5 rounded-sm tag-clay',
+              'absolute left-2 bottom-2 z-10 px-2 py-0.5 tag-clay',
               clayTagClass ?? 'tag-generic',
             )}
           >
@@ -156,7 +164,7 @@ function ProductCard({
         </button>
 
         {isFreeShipping && (
-          <span className="tag-clay absolute bottom-2 right-2 z-10 rounded-sm bg-foreground/85 px-2 py-0.5 text-background backdrop-blur-sm">
+          <span className="tag-clay absolute bottom-2 right-2 z-10 bg-foreground/85 px-2 py-0.5 text-background backdrop-blur-sm">
             {t('badgeFreeShipping')}
           </span>
         )}

--- a/src/components/shared/products/ProductListItem.tsx
+++ b/src/components/shared/products/ProductListItem.tsx
@@ -39,6 +39,7 @@ function ProductListItem({
   const t = useTranslations('product');
   const thumbnail = images[0]?.url;
   const isSoldout = status === 'soldout';
+  const [hasImageError, setHasImageError] = React.useState(false);
 
   return (
     <Link
@@ -48,8 +49,8 @@ function ProductListItem({
         isSoldout && 'opacity-75',
       )}
     >
-      <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-md bg-muted">
-        {thumbnail ? (
+      <div data-testid="product-list-item-image-frame" className="relative h-24 w-24 shrink-0 overflow-hidden bg-muted">
+        {thumbnail && !hasImageError ? (
           <Image
             src={thumbnail}
             alt={name}
@@ -57,10 +58,17 @@ function ProductListItem({
             sizes="96px"
             className="object-cover"
             loading="lazy"
+            onError={() => setHasImageError(true)}
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-            <span className="text-xs">No Image</span>
+          <div data-testid="product-list-item-image-fallback" className="flex h-full w-full items-center justify-center bg-neutral-200">
+            <Image
+              src="/logo-okhwadang.png"
+              alt="옥화당"
+              width={72}
+              height={21}
+              className="object-contain opacity-70 grayscale"
+            />
           </div>
         )}
         {isSoldout && (
@@ -75,7 +83,7 @@ function ProductListItem({
         <div className="flex items-center gap-2">
           <PriceDisplay price={price} salePrice={salePrice} locale={locale} />
           {isFreeShipping && (
-            <span className="tag-clay rounded-sm bg-foreground/85 px-2 py-0.5 text-background">
+            <span className="tag-clay bg-foreground/85 px-2 py-0.5 text-background">
               {t('badgeFreeShipping')}
             </span>
           )}

--- a/src/components/shared/products/__tests__/ProductCard.test.tsx
+++ b/src/components/shared/products/__tests__/ProductCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import ProductCard from '@/components/shared/products/ProductCard';
 import type { ProductImage } from '@/lib/api';
@@ -55,5 +55,28 @@ describe('ProductCard free-shipping badge', () => {
     renderCard();
 
     expect(screen.queryByText('무료배송')).not.toBeInTheDocument();
+  });
+});
+
+describe('ProductCard image presentation', () => {
+  it('renders the image frame and image badges without rounded corners', () => {
+    renderCard({ categoryName: '자사호', isFreeShipping: true });
+
+    const imageFrame = screen.getByTestId('product-card-image-frame');
+
+    expect(imageFrame).not.toHaveClass('rounded-md');
+    expect(imageFrame.querySelector('.tag-clay')).not.toHaveClass('rounded-sm');
+    expect(screen.getByText('무료배송')).not.toHaveClass('rounded-sm');
+  });
+
+  it('replaces a failed product image with the Okhwadang logo fallback on a neutral gray background', () => {
+    renderCard();
+
+    fireEvent.error(screen.getByAltText('자사호'));
+
+    const fallback = screen.getByTestId('product-card-image-fallback');
+    expect(fallback).toHaveClass('bg-neutral-200');
+    expect(screen.getByAltText('옥화당')).toHaveAttribute('src', '/logo-okhwadang.png');
+    expect(screen.queryByAltText('자사호')).not.toBeInTheDocument();
   });
 });

--- a/src/components/shared/products/__tests__/ProductListItem.test.tsx
+++ b/src/components/shared/products/__tests__/ProductListItem.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import ProductListItem from '@/components/shared/products/ProductListItem';
 import type { ProductImage } from '@/lib/api';
@@ -37,5 +37,25 @@ describe('ProductListItem free-shipping badge', () => {
     renderItem({ isFreeShipping: false });
 
     expect(screen.queryByText('무료배송')).not.toBeInTheDocument();
+  });
+});
+
+describe('ProductListItem image presentation', () => {
+  it('renders the image frame and image badges without rounded corners', () => {
+    renderItem({ isFreeShipping: true });
+
+    expect(screen.getByTestId('product-list-item-image-frame')).not.toHaveClass('rounded-md');
+    expect(screen.getByText('무료배송')).not.toHaveClass('rounded-sm');
+  });
+
+  it('replaces a failed product image with the Okhwadang logo fallback on a neutral gray background', () => {
+    renderItem();
+
+    fireEvent.error(screen.getByAltText('자사호'));
+
+    const fallback = screen.getByTestId('product-list-item-image-fallback');
+    expect(fallback).toHaveClass('bg-neutral-200');
+    expect(screen.getByAltText('옥화당')).toHaveAttribute('src', '/logo-okhwadang.png');
+    expect(screen.queryByAltText('자사호')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Closes #814
- 상품 목록/리스트 이미지 프레임과 이미지 내부 뱃지의 둥근 모서리 제거
- 이미지 로딩 실패 및 이미지 없음 상태에서 깨진 이미지/No Image 대신 옥화당 로고 fallback 표시
- 위시리스트/최근 본 상품의 상품 카드 이미지 UI도 동일한 fallback으로 정리

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test