### PR TITLE
fix: #813 배송 추적 상태 및 CJ 링크 수정

### DIFF
--- a/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-orders.service.spec.ts
@@ -5,7 +5,7 @@ import { DataSource } from 'typeorm';
 import { AdminOrdersService } from '../admin-orders.service';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { Payment, PaymentStatus } from '../../payments/entities/payment.entity';
-import { Shipping } from '../../payments/entities/shipping.entity';
+import { Shipping, ShippingStatus } from '../../payments/entities/shipping.entity';
 import { PaymentsService } from '../../payments/payments.service';
 import { MembershipService } from '../../membership/membership.service';
 import { PointsService } from '../../points/points.service';
@@ -128,14 +128,33 @@ describe('AdminOrdersService', () => {
         .rejects.toThrow(BadRequestException);
     });
 
-    it('preparing → shipped: allowed with tracking number', async () => {
+    it('preparing → shipped: allowed with tracking number and marks shipping as shipped', async () => {
       orderRepo.findOne
         .mockResolvedValueOnce({ id: 1, status: OrderStatus.PREPARING })
         .mockResolvedValueOnce({ id: 1, status: OrderStatus.SHIPPED });
-      shippingRepo.findOne.mockResolvedValue({ trackingNumber: '123456' });
+      shippingRepo.findOne.mockResolvedValue({ orderId: 1, status: ShippingStatus.PREPARING, trackingNumber: '123456' });
 
       await service.updateStatus(1, OrderStatus.SHIPPED);
       expect(mockManager.update).toHaveBeenCalledWith(Order, 1, { status: OrderStatus.SHIPPED });
+      expect(mockManager.update).toHaveBeenCalledWith(
+        Shipping,
+        { orderId: 1 },
+        expect.objectContaining({ status: ShippingStatus.SHIPPED, shippedAt: expect.any(Date) }),
+      );
+    });
+
+    it('shipped → delivered: allowed and marks shipping as delivered', async () => {
+      orderRepo.findOne
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.SHIPPED })
+        .mockResolvedValueOnce({ id: 1, status: OrderStatus.DELIVERED });
+
+      await service.updateStatus(1, OrderStatus.DELIVERED);
+      expect(mockManager.update).toHaveBeenCalledWith(Order, 1, { status: OrderStatus.DELIVERED });
+      expect(mockManager.update).toHaveBeenCalledWith(
+        Shipping,
+        { orderId: 1 },
+        expect.objectContaining({ status: ShippingStatus.DELIVERED, deliveredAt: expect.any(Date) }),
+      );
     });
 
     it('delivered → paid: not allowed (terminal state)', async () => {

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -94,6 +94,7 @@ export class AdminOrdersService {
 
     await this.dataSource.transaction(async (manager) => {
       await manager.update(Order, orderId, { status: nextStatus });
+      await this.syncShippingStatus(manager, orderId, nextStatus);
 
       if (this.shouldRestoreStockAndPoints(currentStatus, nextStatus)) {
         await this.restoreStock(manager, orderId);
@@ -117,6 +118,27 @@ export class AdminOrdersService {
   private shouldRestoreStockAndPoints(currentStatus: OrderStatus, nextStatus: OrderStatus): boolean {
     const restoreTargets = new Set<OrderStatus>([OrderStatus.CANCELLED, OrderStatus.REFUNDED]);
     return !restoreTargets.has(currentStatus) && restoreTargets.has(nextStatus);
+  }
+
+  private async syncShippingStatus(
+    manager: EntityManager,
+    orderId: number,
+    nextStatus: OrderStatus,
+  ): Promise<void> {
+    if (nextStatus === OrderStatus.SHIPPED) {
+      await manager.update(Shipping, { orderId }, {
+        status: ShippingStatus.SHIPPED,
+        shippedAt: new Date(),
+      });
+      return;
+    }
+
+    if (nextStatus === OrderStatus.DELIVERED) {
+      await manager.update(Shipping, { orderId }, {
+        status: ShippingStatus.DELIVERED,
+        deliveredAt: new Date(),
+      });
+    }
   }
 
   /**

--- a/src/components/__tests__/ShippingTimeline.test.tsx
+++ b/src/components/__tests__/ShippingTimeline.test.tsx
@@ -3,11 +3,73 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ShippingTimeline from '@/components/shared/ShippingTimeline';
 import type { ShippingResponse } from '@/lib/api';
 
+let mockLocale = 'ko';
+
+const shippingMessages: Record<string, Record<string, string>> = {
+  ko: {
+    title: '배송 추적',
+    payment_confirmed: '결제 완료',
+    preparing: '상품 준비중',
+    shipped: '배송 시작',
+    in_transit: '배송 중',
+    delivered: '배송 완료',
+    stepCompleted: '{status} 완료',
+    carrier: '택배사',
+    trackingNumber: '운송장',
+    trackingLink: '택배사 사이트에서 보기 →',
+    trackingLinkLabel: '{carrier} 사이트에서 배송 추적 (새 탭에서 열림)',
+    noTrackingNumber: '배송 준비 중입니다. 운송장 번호가 등록되면 알려드립니다.',
+    refresh: '새로고침',
+    refreshLabel: '배송 상태 새로고침',
+    polling: '자동 업데이트 중',
+    pollingStopped: '자동 업데이트 중단됨',
+    loadError: '배송 정보를 불러올 수 없습니다.',
+    forbidden: '접근 권한이 없습니다.',
+    estimatedDelivery: '예상 배송일: {date}',
+  },
+  en: {
+    title: 'Shipping Tracking',
+    payment_confirmed: 'Payment Confirmed',
+    preparing: 'Preparing Items',
+    shipped: 'Shipment Started',
+    in_transit: 'In Transit',
+    delivered: 'Delivered',
+    stepCompleted: '{status} completed',
+    carrier: 'Carrier',
+    trackingNumber: 'Tracking No.',
+    trackingLink: 'View on carrier site →',
+    trackingLinkLabel: 'Track shipment on {carrier} site (opens in a new tab)',
+    noTrackingNumber: 'Preparing shipment. We will show the tracking number once it is registered.',
+    refresh: 'Refresh',
+    refreshLabel: 'Refresh shipping status',
+    polling: 'Auto-updating',
+    pollingStopped: 'Auto-update stopped',
+    loadError: 'Unable to load shipping information.',
+    forbidden: 'You do not have permission to view this shipment.',
+    estimatedDelivery: 'Estimated delivery: {date}',
+  },
+};
+
+function translateShipping(key: string, vars?: Record<string, unknown>) {
+  let message = shippingMessages[mockLocale]?.[key] ?? key;
+  if (vars) {
+    for (const [name, value] of Object.entries(vars)) {
+      message = message.replace(`{${name}}`, String(value));
+    }
+  }
+  return message;
+}
+
 const mockRefresh = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ refresh: mockRefresh }),
   useParams: () => ({ id: '1' }),
   usePathname: () => '/my/orders/1',
+}));
+
+vi.mock('next-intl', () => ({
+  useLocale: () => mockLocale,
+  useTranslations: () => translateShipping,
 }));
 
 const mockGetByOrderId = vi.fn();
@@ -34,6 +96,7 @@ function makeShipping(overrides: Partial<ShippingResponse> = {}): ShippingRespon
 describe('ShippingTimeline', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLocale = 'ko';
   });
 
   it('status=payment_confirmed → 1단계만 active', async () => {
@@ -90,6 +153,34 @@ describe('ShippingTimeline', () => {
     await waitFor(() => expect(screen.getByText('1234567890123')).toBeInTheDocument());
     expect(screen.getByText('CJ대한통운')).toBeInTheDocument();
     expect(screen.getByText(/택배사 사이트에서 보기/)).toBeInTheDocument();
+  });
+
+  it('locale=en → 배송 추적 상태를 영어 문구로 표시한다', async () => {
+    mockLocale = 'en';
+    mockGetByOrderId.mockResolvedValue(
+      makeShipping({
+        status: 'shipped',
+        carrier: 'cj',
+        tracking_number: '1234567890123',
+      }),
+    );
+    render(<ShippingTimeline orderId={42} />);
+    await waitFor(() => expect(screen.getByText('Shipment Started')).toBeInTheDocument());
+    expect(screen.getByLabelText('Payment Confirmed completed')).toBeInTheDocument();
+    expect(screen.queryByText('상품 준비중')).toBeNull();
+    expect(screen.getByText(/View on carrier site/)).toBeInTheDocument();
+  });
+
+  it('carrier=cj → 공식 추적 URL에 실제 운송장 번호를 인코딩해서 붙인다', async () => {
+    mockGetByOrderId.mockResolvedValue(
+      makeShipping({ carrier: 'cj', tracking_number: '123 456' }),
+    );
+    render(<ShippingTimeline orderId={42} />);
+    await waitFor(() => expect(screen.getByText('CJ대한통운')).toBeInTheDocument());
+    const link = screen.getByRole('link', { name: /배송 추적/ });
+    expect((link as HTMLAnchorElement).href).toBe(
+      'https://trace.cjlogistics.com/next/tracking.html?wblNo=123%20456',
+    );
   });
 
   it('carrier=hanjin → 한진 추적 URL 생성', async () => {

--- a/src/components/shared/ShippingTimeline.tsx
+++ b/src/components/shared/ShippingTimeline.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
 import { shippingApi, type ShippingResponse } from '@/lib/api';
 import {
-  SHIPPING_STATUS_LABELS,
   CARRIER_NAMES,
   CARRIER_TRACKING_URLS,
 } from '@/constants/status';
@@ -17,6 +17,9 @@ interface Props {
 
 export default function ShippingTimeline({ orderId }: Props) {
   const router = useRouter();
+  const locale = useLocale();
+  const t = useTranslations('shippingTracking');
+  const dateLocale = locale === 'en' ? 'en-US' : 'ko-KR';
   const [shipping, setShipping] = useState<ShippingResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -35,18 +38,18 @@ export default function ShippingTimeline({ orderId }: Props) {
       if (status === 404) {
         setShipping(null);
       } else if (status === 403) {
-        setError('접근 권한이 없습니다.');
+        setError(t('forbidden'));
       } else {
         if (silent) {
           setPollErrorCount((c) => c + 1);
         } else {
-          setError('배송 정보를 불러올 수 없습니다.');
+          setError(t('loadError'));
         }
       }
     } finally {
       if (!silent) setLoading(false);
     }
-  }, [orderId]);
+  }, [orderId, t]);
 
   useEffect(() => {
     fetchShipping();
@@ -70,7 +73,7 @@ export default function ShippingTimeline({ orderId }: Props) {
   if (loading) {
     return (
       <section className="rounded-lg border p-6" aria-busy="true">
-        <h2 className="mb-4 text-base font-semibold">배송 추적</h2>
+        <h2 className="mb-4 text-base font-semibold">{t('title')}</h2>
         <div className="space-y-2">
           <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
           <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
@@ -82,7 +85,7 @@ export default function ShippingTimeline({ orderId }: Props) {
   if (error) {
     return (
       <section className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
-        <h2 className="mb-2 text-base font-semibold">배송 추적</h2>
+        <h2 className="mb-2 text-base font-semibold">{t('title')}</h2>
         <p className="text-sm text-destructive">{error}</p>
       </section>
     );
@@ -95,24 +98,27 @@ export default function ShippingTimeline({ orderId }: Props) {
     shipping.tracking_number && shipping.carrier !== 'mock'
       ? (CARRIER_TRACKING_URLS[shipping.carrier] ?? null)
       : null;
+  const trackingHref = trackingUrl && shipping.tracking_number
+    ? `${trackingUrl}${encodeURIComponent(shipping.tracking_number)}`
+    : null;
 
   return (
     <section className="rounded-lg border p-6">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-base font-semibold">배송 추적</h2>
+        <h2 className="text-base font-semibold">{t('title')}</h2>
         <div className="flex items-center gap-2">
           {isPolling && (
-            <span className="text-xs text-muted-foreground">자동 업데이트 중</span>
+            <span className="text-xs text-muted-foreground">{t('polling')}</span>
           )}
           {pollErrorCount >= 3 && (
-            <span className="text-xs text-destructive">자동 업데이트 중단됨</span>
+            <span className="text-xs text-destructive">{t('pollingStopped')}</span>
           )}
           <button
             onClick={() => fetchShipping()}
             className="text-xs text-muted-foreground underline hover:text-foreground"
-            aria-label="배송 상태 새로고침"
+            aria-label={t('refreshLabel')}
           >
-            새로고침
+            {t('refresh')}
           </button>
         </div>
       </div>
@@ -128,21 +134,21 @@ export default function ShippingTimeline({ orderId }: Props) {
                     ? 'bg-foreground text-background'
                     : 'bg-muted text-muted-foreground'
                 }`}
-                aria-label={index <= currentIndex ? `${SHIPPING_STATUS_LABELS[step]} 완료` : SHIPPING_STATUS_LABELS[step]}
+                aria-label={index <= currentIndex ? t('stepCompleted', { status: t(step) }) : t(step)}
               >
                 {index < currentIndex ? '✓' : index + 1}
               </div>
               <span className="text-center text-xs whitespace-nowrap">
-                {SHIPPING_STATUS_LABELS[step]}
+                {t(step)}
               </span>
               {step === 'shipped' && shipping.shipped_at && (
                 <span className="text-center text-xs text-muted-foreground">
-                  {new Date(shipping.shipped_at).toLocaleDateString('ko-KR')}
+                  {new Date(shipping.shipped_at).toLocaleDateString(dateLocale)}
                 </span>
               )}
               {step === 'delivered' && shipping.delivered_at && (
                 <span className="text-center text-xs text-muted-foreground">
-                  {new Date(shipping.delivered_at).toLocaleDateString('ko-KR')}
+                  {new Date(shipping.delivered_at).toLocaleDateString(dateLocale)}
                 </span>
               )}
             </div>
@@ -160,28 +166,28 @@ export default function ShippingTimeline({ orderId }: Props) {
       {/* Carrier info */}
       <div className="mb-4 rounded-md bg-muted/40 p-3 text-sm">
         <div className="flex items-center gap-2">
-          <span className="text-muted-foreground">택배사</span>
+          <span className="text-muted-foreground">{t('carrier')}</span>
           <span className="font-medium">{CARRIER_NAMES[shipping.carrier] ?? shipping.carrier}</span>
         </div>
         {shipping.tracking_number ? (
           <div className="mt-1 flex items-center gap-2">
-            <span className="text-muted-foreground">운송장</span>
+            <span className="text-muted-foreground">{t('trackingNumber')}</span>
             <span className="font-mono font-medium">{shipping.tracking_number}</span>
-            {trackingUrl && (
+            {trackingHref && (
               <a
-                href={`${trackingUrl}${shipping.tracking_number}`}
+                href={trackingHref}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs text-primary underline"
-                aria-label={`${CARRIER_NAMES[shipping.carrier] ?? shipping.carrier} 사이트에서 배송 추적 (새 탭에서 열림)`}
+                aria-label={t('trackingLinkLabel', { carrier: CARRIER_NAMES[shipping.carrier] ?? shipping.carrier })}
               >
-                택배사 사이트에서 보기 →
+                {t('trackingLink')}
               </a>
             )}
           </div>
         ) : (
           <p className="mt-1 text-xs text-muted-foreground">
-            배송 준비 중입니다. 운송장 번호가 등록되면 알려드립니다.
+            {t('noTrackingNumber')}
           </p>
         )}
       </div>
@@ -195,7 +201,7 @@ export default function ShippingTimeline({ orderId }: Props) {
               <div>
                 <span className="font-medium">{step.description}</span>
                 <span className="ml-2 text-xs text-muted-foreground">
-                  {new Date(step.timestamp).toLocaleString('ko-KR')}
+                  {new Date(step.timestamp).toLocaleString(dateLocale)}
                 </span>
               </div>
             </li>
@@ -205,7 +211,7 @@ export default function ShippingTimeline({ orderId }: Props) {
 
       {shipping.tracking?.estimatedDelivery && (
         <p className="mt-3 text-sm text-muted-foreground">
-          예상 배송일: {shipping.tracking.estimatedDelivery}
+          {t('estimatedDelivery', { date: shipping.tracking.estimatedDelivery })}
         </p>
       )}
     </section>

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -20,14 +20,6 @@ export const ORDER_STATUS_COLORS: Record<string, string> = {
   refunded: 'bg-red-100 text-red-800',
 };
 
-export const SHIPPING_STATUS_LABELS: Record<string, string> = {
-  payment_confirmed: '결제 완료',
-  preparing: '상품 준비중',
-  shipped: '배송 시작',
-  in_transit: '배송 중',
-  delivered: '배송 완료',
-};
-
 export const CARRIER_NAMES: Record<CarrierCode, string> = {
   mock: '테스트 택배',
   cj: 'CJ대한통운',
@@ -36,7 +28,7 @@ export const CARRIER_NAMES: Record<CarrierCode, string> = {
 };
 
 export const CARRIER_TRACKING_URLS: Partial<Record<CarrierCode, string>> = {
-  cj: 'https://www.doortodoor.co.kr/parcel/doortodoor.do?fsp_action=PARC_ACT_002&invc_no=',
+  cj: 'https://trace.cjlogistics.com/next/tracking.html?wblNo=',
   hanjin: 'https://www.hanjin.com/kor/CMS/DeliveryMgr/WaybillResult.do?mCode=MN038&schLang=KR&wbl_num=',
   lotte: 'https://www.lotteglogis.com/home/reservation/tracking/index?InvNo=',
 };

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -959,6 +959,27 @@
       "other": "Other"
     }
   },
+  "shippingTracking": {
+    "title": "Shipping Tracking",
+    "payment_confirmed": "Payment Confirmed",
+    "preparing": "Preparing Items",
+    "shipped": "Shipment Started",
+    "in_transit": "In Transit",
+    "delivered": "Delivered",
+    "stepCompleted": "{status} completed",
+    "carrier": "Carrier",
+    "trackingNumber": "Tracking No.",
+    "trackingLink": "View on carrier site →",
+    "trackingLinkLabel": "Track shipment on {carrier} site (opens in a new tab)",
+    "noTrackingNumber": "Preparing shipment. We will show the tracking number once it is registered.",
+    "refresh": "Refresh",
+    "refreshLabel": "Refresh shipping status",
+    "polling": "Auto-updating",
+    "pollingStopped": "Auto-update stopped",
+    "loadError": "Unable to load shipping information.",
+    "forbidden": "You do not have permission to view this shipment.",
+    "estimatedDelivery": "Estimated delivery: {date}"
+  },
   "orderDetail": {
     "notFound": "Order not found.",
     "backToOrders": "Back to orders",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -959,6 +959,27 @@
       "other": "기타"
     }
   },
+  "shippingTracking": {
+    "title": "배송 추적",
+    "payment_confirmed": "결제 완료",
+    "preparing": "상품 준비중",
+    "shipped": "배송 시작",
+    "in_transit": "배송 중",
+    "delivered": "배송 완료",
+    "stepCompleted": "{status} 완료",
+    "carrier": "택배사",
+    "trackingNumber": "운송장",
+    "trackingLink": "택배사 사이트에서 보기 →",
+    "trackingLinkLabel": "{carrier} 사이트에서 배송 추적 (새 탭에서 열림)",
+    "noTrackingNumber": "배송 준비 중입니다. 운송장 번호가 등록되면 알려드립니다.",
+    "refresh": "새로고침",
+    "refreshLabel": "배송 상태 새로고침",
+    "polling": "자동 업데이트 중",
+    "pollingStopped": "자동 업데이트 중단됨",
+    "loadError": "배송 정보를 불러올 수 없습니다.",
+    "forbidden": "접근 권한이 없습니다.",
+    "estimatedDelivery": "예상 배송일: {date}"
+  },
   "orderDetail": {
     "notFound": "주문을 찾을 수 없습니다.",
     "backToOrders": "주문 목록으로",


### PR DESCRIPTION
## Summary
- Closes #813
- 관리자 주문 상태가 배송 시작으로 변경될 때 배송 레코드 상태도 `shipped`로 동기화
- 배송 추적 UI 문구를 `/ko`, `/en` 로케일별 i18n으로 표시
- CJ대한통운 추적 URL을 최신 URL로 교체하고 운송장 번호를 URL 인코딩

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test