### PR TITLE
#818 헤더 카테고리 미리보기 장식 제거

### DIFF
--- a/src/components/shared/admin/__tests__/NavigationPreview.test.tsx
+++ b/src/components/shared/admin/__tests__/NavigationPreview.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import NavigationPreview from '@/components/shared/admin/navigation/NavigationPreview';
+import type { NavigationItem } from '@/lib/api';
+
+const gnbItems: NavigationItem[] = [
+  {
+    id: 1,
+    group: 'gnb',
+    label: '상품',
+    labelEn: 'Products',
+    url: '/products',
+    sort_order: 0,
+    is_active: true,
+    parent_id: null,
+    children: [
+      {
+        id: 2,
+        group: 'gnb',
+        label: '자사호',
+        labelEn: 'Teapots',
+        url: '/products?categoryId=1',
+        sort_order: 0,
+        is_active: true,
+        parent_id: 1,
+        children: [],
+      },
+    ],
+  },
+];
+
+describe('NavigationPreview', () => {
+  it('GNB 헤더 드롭다운 하위 카테고리에 ㄴ 모양 장식을 렌더링하지 않는다', () => {
+    render(<NavigationPreview group="gnb" items={gnbItems} />);
+
+    fireEvent.mouseEnter(screen.getByText('상품').closest('div')!);
+
+    expect(screen.getByText('자사호')).toBeInTheDocument();
+    expect(screen.queryByText('└')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/admin/navigation/NavigationPreview.tsx
+++ b/src/components/shared/admin/navigation/NavigationPreview.tsx
@@ -37,8 +37,7 @@ function GNBDropdownPreviewItem({ item }: { item: NavigationItem }) {
       {hasActiveChildren && isHovered && (
         <div className="absolute left-1/2 -translate-x-1/2 top-full mt-2 min-w-36 rounded-lg border border-slate-600 bg-slate-800 shadow-xl py-1 z-10 animate-accordion-down">
           {activeChildren.map((child: NavigationItem) => (
-            <span key={child.id} className="flex items-center gap-2 px-4 py-2 text-xs text-slate-300 hover:text-white hover:bg-slate-700/50 transition-all duration-200 cursor-default border-l-2 border-transparent hover:border-slate-400/50">
-              <span className="text-slate-500">└</span>
+            <span key={child.id} className="flex items-center px-4 py-2 text-xs text-slate-300 hover:text-white hover:bg-slate-700/50 transition-all duration-200 cursor-default border-l-2 border-transparent hover:border-slate-400/50">
               {child.label}
             </span>
           ))}


### PR DESCRIPTION
## 요약
- 관리자 내비게이션 GNB(헤더) 미리보기 드롭다운의 하위 카테고리 앞 `└` 장식 제거
- 헤더 카테고리 미리보기에서 `ㄴ` 모양 장식이 렌더링되지 않는 회귀 테스트 추가

Closes #818

## 검증
- `npx vitest run src/components/shared/admin/__tests__/NavigationPreview.test.tsx --reporter=verbose`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
