### PR TITLE
fix: #813 기존 배송 상태 보정

### DIFF
--- a/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
+++ b/backend/src/modules/shipping/__tests__/shipping.service.spec.ts
@@ -175,6 +175,38 @@ describe('ShippingService', () => {
       expect(result.tracking).not.toBeNull();
       expect(result.tracking?.trackingNumber).toBe('1234567890');
     });
+
+    it('주문은 shipped인데 shipping이 preparing이면 shipped로 보정한다', async () => {
+      mockOrderRepo.findOne.mockResolvedValue(makeOrder({ status: OrderStatus.SHIPPED }));
+      mockShippingRepo.findOne.mockResolvedValue(
+        makeShipping({ trackingNumber: '123456', status: ShippingStatus.PREPARING }),
+      );
+
+      const result = await service.getByOrderId(1, 10);
+
+      expect(result.status).toBe(ShippingStatus.SHIPPED);
+      expect(result.shipped_at).toBeInstanceOf(Date);
+      expect(mockShippingRepo.update).toHaveBeenCalledWith(
+        { id: 1, status: ShippingStatus.PREPARING },
+        expect.objectContaining({ status: ShippingStatus.SHIPPED, shippedAt: expect.any(Date) }),
+      );
+    });
+
+    it('주문은 delivered인데 shipping이 shipped이면 delivered로 보정한다', async () => {
+      mockOrderRepo.findOne.mockResolvedValue(makeOrder({ status: OrderStatus.DELIVERED }));
+      mockShippingRepo.findOne.mockResolvedValue(
+        makeShipping({ trackingNumber: '123456', status: ShippingStatus.SHIPPED, shippedAt: new Date('2026-06-04T01:00:00Z') }),
+      );
+
+      const result = await service.getByOrderId(1, 10);
+
+      expect(result.status).toBe(ShippingStatus.DELIVERED);
+      expect(result.delivered_at).toBeInstanceOf(Date);
+      expect(mockShippingRepo.update).toHaveBeenCalledWith(
+        { id: 1, status: ShippingStatus.SHIPPED },
+        expect.objectContaining({ status: ShippingStatus.DELIVERED, deliveredAt: expect.any(Date) }),
+      );
+    });
   });
 
   describe('registerTracking', () => {

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -60,13 +60,14 @@ export class ShippingService {
     assertOwnership(order.userId, userId);
 
     const shipping = await findOrThrow(this.shippingRepository, { orderId }, '배송 정보를 찾을 수 없습니다.');
+    const normalizedShipping = await this.syncShippingStatusFromOrder(order, shipping);
 
     let tracking: TrackingResult | null = null;
-    if (shipping.trackingNumber) {
+    if (normalizedShipping.trackingNumber) {
       try {
         tracking = await this.getTrackingWithStaleFallback(
-          shipping.trackingNumber,
-          (shipping.carrier as CarrierCode) ?? 'mock',
+          normalizedShipping.trackingNumber,
+          (normalizedShipping.carrier as CarrierCode) ?? 'mock',
         );
       } catch (err) {
         this.logger.warn(`Carrier API error for orderId=${orderId}: ${String(err)}`);
@@ -77,10 +78,10 @@ export class ShippingService {
       id: Number(shipping.id),
       order_id: orderId,
       carrier: shipping.carrier,
-      tracking_number: shipping.trackingNumber,
-      status: shipping.status,
-      shipped_at: shipping.shippedAt,
-      delivered_at: shipping.deliveredAt,
+      tracking_number: normalizedShipping.trackingNumber,
+      status: normalizedShipping.status,
+      shipped_at: normalizedShipping.shippedAt,
+      delivered_at: normalizedShipping.deliveredAt,
       tracking,
     };
   }
@@ -226,6 +227,29 @@ export class ShippingService {
 
   validateTransition(current: ShippingStatus, next: ShippingStatus): void {
     assertShippingStatusTransition(current, next);
+  }
+
+  private async syncShippingStatusFromOrder(order: Order, shipping: Shipping): Promise<Shipping> {
+    if (order.status === OrderStatus.SHIPPED && shipping.status === ShippingStatus.PREPARING) {
+      const shippedAt = shipping.shippedAt ?? new Date();
+      await this.shippingRepository.update(
+        { id: shipping.id, status: ShippingStatus.PREPARING },
+        { status: ShippingStatus.SHIPPED, shippedAt },
+      );
+      return { ...shipping, status: ShippingStatus.SHIPPED, shippedAt };
+    }
+
+    if (order.status === OrderStatus.DELIVERED && shipping.status !== ShippingStatus.DELIVERED) {
+      const deliveredAt = shipping.deliveredAt ?? new Date();
+      const shippedAt = shipping.shippedAt ?? deliveredAt;
+      await this.shippingRepository.update(
+        { id: shipping.id, status: shipping.status },
+        { status: ShippingStatus.DELIVERED, shippedAt, deliveredAt },
+      );
+      return { ...shipping, status: ShippingStatus.DELIVERED, shippedAt, deliveredAt };
+    }
+
+    return shipping;
   }
 
   private resolveProvider(carrier: CarrierCode): ShippingProvider {


### PR DESCRIPTION
## Summary
- Closes follow-up for #813
- 기존 운영 데이터처럼 `orders.status`는 shipped/delivered인데 `shipping.status`가 preparing/shipped로 남아있는 경우를 조회 시 보정
- 주문 상세 배송추적 응답이 보정된 배송 상태와 timestamp를 반환하도록 수정
- stale shipping 상태 회귀 테스트 추가

## Test plan
- [x] cd backend && npm test -- src/modules/shipping/__tests__/shipping.service.spec.ts
- [x] cd backend && npm run lint && npm run build && npm run test
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run