### PR TITLE
feat: #820 포인트 컬러 무채색화

### DIFF
--- a/src/styles/__tests__/theme-runtime-tokens.test.ts
+++ b/src/styles/__tests__/theme-runtime-tokens.test.ts
@@ -3,6 +3,46 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const globals = readFileSync(join(process.cwd(), 'src/styles/globals.css'), 'utf8');
+const lightTokens = readFileSync(join(process.cwd(), 'src/styles/tokens-light.css'), 'utf8');
+const darkTokens = readFileSync(join(process.cwd(), 'src/styles/tokens-dark.css'), 'utf8');
+
+const POINT_COLOR_TOKENS = [
+  '--color-accent-zuni',
+  '--color-accent-tea',
+  '--color-brand-secondary',
+  '--color-accent-danni',
+  '--color-primary',
+  '--color-ring',
+  '--color-zuni',
+  '--color-danni',
+  '--color-zini',
+  '--color-chunsuni',
+  '--color-nokni',
+  '--color-tea',
+] as const;
+
+function hexToRgb(hex: string): [number, number, number] {
+  const value = hex.slice(1);
+  const normalized = value.length === 3
+    ? value.split('').map((char) => `${char}${char}`).join('')
+    : value.slice(0, 6);
+
+  return [0, 2, 4].map((start) => Number.parseInt(normalized.slice(start, start + 2), 16)) as [
+    number,
+    number,
+    number,
+  ];
+}
+
+function extractTokenHexValues(css: string, token: string): string[] {
+  const pattern = new RegExp(`${token}\\s*:\\s*(?:var\\([^,]+,\\s*)?(#[0-9a-fA-F]{3,6})`, 'g');
+  return Array.from(css.matchAll(pattern), (match) => match[1]);
+}
+
+function expectGrayscale(hex: string): void {
+  const [red, green, blue] = hexToRgb(hex);
+  expect([red, green, blue], `${hex} should have zero saturation`).toEqual([red, red, red]);
+}
 
 describe('runtime theme tokens', () => {
   it('connects admin typography settings to live CSS tokens', () => {
@@ -23,5 +63,15 @@ describe('runtime theme tokens', () => {
     expect(globals).toContain('--layout-section-y: var(--layout-spacing-lg)');
     expect(globals).toContain('--layout-grid-gap: var(--layout-spacing-lg)');
     expect(globals).toContain('padding-inline: var(--layout-spacing-md)');
+  });
+
+  it('keeps global point color token defaults grayscale across themes', () => {
+    const tokenSources = [globals, lightTokens, darkTokens];
+
+    for (const token of POINT_COLOR_TOKENS) {
+      const values = tokenSources.flatMap((source) => extractTokenHexValues(source, token));
+      expect(values.length, `${token} should define at least one default color`).toBeGreaterThan(0);
+      values.forEach(expectGrayscale);
+    }
   });
 });

--- a/src/styles/__tests__/theme-runtime-tokens.test.ts
+++ b/src/styles/__tests__/theme-runtime-tokens.test.ts
@@ -16,9 +16,22 @@ const POINT_COLOR_TOKENS = [
   '--color-zuni',
   '--color-danni',
   '--color-zini',
+  '--color-heukni',
   '--color-chunsuni',
   '--color-nokni',
   '--color-tea',
+] as const;
+
+const DARK_BASE_COLOR_TOKENS = [
+  '--color-bg',
+  '--color-secondary',
+  '--color-muted',
+  '--color-accent',
+  '--color-background',
+  '--color-card',
+  '--color-border',
+  '--color-input',
+  '--color-surface',
 ] as const;
 
 function hexToRgb(hex: string): [number, number, number] {
@@ -71,6 +84,14 @@ describe('runtime theme tokens', () => {
     for (const token of POINT_COLOR_TOKENS) {
       const values = tokenSources.flatMap((source) => extractTokenHexValues(source, token));
       expect(values.length, `${token} should define at least one default color`).toBeGreaterThan(0);
+      values.forEach(expectGrayscale);
+    }
+  });
+
+  it('keeps dark theme base surface defaults grayscale', () => {
+    for (const token of DARK_BASE_COLOR_TOKENS) {
+      const values = extractTokenHexValues(darkTokens, token);
+      expect(values.length, `${token} should define at least one dark default color`).toBeGreaterThan(0);
       values.forEach(expectGrayscale);
     }
   });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,10 +50,10 @@
 :root {
   --color-bg: #FAFAFA;
   --color-text: #1a1a1a;
-  --color-accent-zuni: #1B3A4B;
-  --color-accent-tea: #4A6741;
-  --color-brand-secondary: #D4C5B0;
-  --color-accent-danni: #C9B8A3;
+  --color-accent-zuni: #353535;
+  --color-accent-tea: #5E5E5E;
+  --color-brand-secondary: #C7C7C7;
+  --color-accent-danni: #BABABA;
 }
 
 /* 색상 토큰은 @theme (non-inline) — 유틸리티가 var(--color-*)로 생성되어야
@@ -62,33 +62,33 @@
    런타임에 CSS 변수를 바꿔도 색상이 변경되지 않음. */
 @theme {
   /* ── shadcn/ui 호환 토큰 — light theme as :root default, dark theme in tokens-dark.css ── */
-  --color-primary: #1B3A4B;
+  --color-primary: #353535;
   --color-primary-foreground: #ffffff;
-  --color-secondary: #F2F0EC;
+  --color-secondary: #F0F0F0;
   --color-secondary-foreground: #1a1a1a;
-  --color-destructive: #b91c1c;
+  --color-destructive: #3D3D3D;
   --color-destructive-foreground: #ffffff;
-  --color-muted: #F2F0EC;
+  --color-muted: #F0F0F0;
   --color-muted-foreground: #525252;
-  --color-accent: #F2F0EC;
+  --color-accent: #F0F0F0;
   --color-accent-foreground: #1a1a1a;
-  --color-background: #FAF9F7;
+  --color-background: #F9F9F9;
   --color-foreground: #1a1a1a;
-  --color-card: #FAF9F7;
+  --color-card: #F9F9F9;
   --color-card-foreground: #1a1a1a;
-  --color-border: #E5E1DB;
-  --color-input: #E5E1DB;
-  --color-ring: #1B3A4B;
+  --color-border: #E1E1E1;
+  --color-input: #E1E1E1;
+  --color-ring: #353535;
 
   /* ── 니료(泥料) 악센트 토큰 — 카테고리 필터·배지 등 UI 악센트용 ── */
-  --color-zuni: #1B3A4B;
-  --color-danni: #C9B8A3;
-  --color-zini: #6B3A5C;
-  --color-heukni: #2A2520;
-  --color-chunsuni: #3D6B6B;
-  --color-nokni: #4A6741;
-  --color-tea: #4A6741;
-  --color-surface: #F2F0EC;
+  --color-zuni: #353535;
+  --color-danni: #BABABA;
+  --color-zini: #474747;
+  --color-heukni: #262626;
+  --color-chunsuni: #616161;
+  --color-nokni: #5E5E5E;
+  --color-tea: #5E5E5E;
+  --color-surface: #F0F0F0;
 }
 
 @theme inline {
@@ -385,12 +385,12 @@ h3 {
 }
 
 .tag-zuni  { background-color: var(--color-zuni);     color: #ffffff; }
-.tag-danni { background-color: var(--color-danni);    color: #1C1710; }
+.tag-danni { background-color: var(--color-danni);    color: #181818; }
 .tag-zini  { background-color: var(--color-zini);     color: #ffffff; }
-.tag-heukni    { background-color: var(--color-heukni);    color: #F8F5F0; }
+.tag-heukni    { background-color: var(--color-heukni);    color: #F5F5F5; }
 .tag-chunsuni  { background-color: var(--color-chunsuni);  color: #ffffff; }
 .tag-nokni { background-color: var(--color-nokni);    color: #ffffff; }
-.tag-generic { background-color: #6B5B4F; color: #ffffff; }
+.tag-generic { background-color: #5E5E5E; color: #ffffff; }
 
 /* ── 디스플레이 타이틀 ──────────────────────────────────────────── */
 .font-display {

--- a/src/styles/tokens-dark.css
+++ b/src/styles/tokens-dark.css
@@ -3,7 +3,7 @@
    ────────────────────────────────────────────────────────────────── */
 html[data-theme="dark"] {
   /* 브랜드 레거시 변수 */
-  --color-bg: #141210;
+  --color-bg: #121212;
   --color-text: #EDEDED;
   --color-accent-zuni: #505050;
   --color-accent-tea: #5E5E5E;
@@ -12,21 +12,21 @@ html[data-theme="dark"] {
 
   /* shadcn/ui 호환 시맨틱 토큰 — DB 오버라이드 우선 */
   --color-primary:               var(--db-color-dark-primary, #9C9C9C);
-  --color-primary-foreground:    var(--db-color-dark-primary-foreground, #141210);
-  --color-secondary:             var(--db-color-dark-secondary, #1E1C18);
+  --color-primary-foreground:    var(--db-color-dark-primary-foreground, #121212);
+  --color-secondary:             var(--db-color-dark-secondary, #1C1C1C);
   --color-secondary-foreground:  var(--db-color-dark-secondary-foreground, #E1E1E1);
   --color-destructive:           var(--db-color-dark-destructive, #686868);
   --color-destructive-foreground:var(--db-color-dark-destructive-foreground, #ffffff);
-  --color-muted:                 var(--db-color-dark-muted, #1E1C18);
+  --color-muted:                 var(--db-color-dark-muted, #1C1C1C);
   --color-muted-foreground:      var(--db-color-dark-muted-foreground, #909090);
-  --color-accent:                var(--db-color-dark-accent, #1E1C18);
+  --color-accent:                var(--db-color-dark-accent, #1C1C1C);
   --color-accent-foreground:     var(--db-color-dark-accent-foreground, #E1E1E1);
-  --color-background:            var(--db-color-dark-background, #141210);
+  --color-background:            var(--db-color-dark-background, #121212);
   --color-foreground:            var(--db-color-dark-foreground, #EDEDED);
-  --color-card:                  var(--db-color-dark-card, #1A1714);
+  --color-card:                  var(--db-color-dark-card, #171717);
   --color-card-foreground:       var(--db-color-dark-card-foreground, #EDEDED);
-  --color-border:                var(--db-color-dark-border, #2E2822);
-  --color-input:                 var(--db-color-dark-input, #2E2822);
+  --color-border:                var(--db-color-dark-border, #292929);
+  --color-input:                 var(--db-color-dark-input, #292929);
   --color-ring:                  var(--db-color-dark-ring, #9C9C9C);
 
   /* 니료(泥料) 악센트 토큰 */
@@ -37,5 +37,5 @@ html[data-theme="dark"] {
   --color-chunsuni: #616161;
   --color-nokni: #5E5E5E;
   --color-tea: #5E5E5E;
-  --color-surface: #1E1C18;
+  --color-surface: #1C1C1C;
 }

--- a/src/styles/tokens-dark.css
+++ b/src/styles/tokens-dark.css
@@ -1,41 +1,41 @@
-/* ── 다크 테마 토큰 (공방/工房 — 웜 차콜 팔레트) ────────────────────
+/* ── 다크 테마 토큰 (공방/工房 — 무채색 차콜 팔레트) ────────────────────
    html[data-theme="dark"] 스코프. 기본 로케일: ko
    ────────────────────────────────────────────────────────────────── */
 html[data-theme="dark"] {
   /* 브랜드 레거시 변수 */
   --color-bg: #141210;
-  --color-text: #F0EDE8;
-  --color-accent-zuni: #8B4513;
-  --color-accent-tea: #4A6741;
-  --color-brand-secondary: #D4C5B0;
-  --color-accent-danni: #C4A882;
+  --color-text: #EDEDED;
+  --color-accent-zuni: #505050;
+  --color-accent-tea: #5E5E5E;
+  --color-brand-secondary: #C7C7C7;
+  --color-accent-danni: #ABABAB;
 
   /* shadcn/ui 호환 시맨틱 토큰 — DB 오버라이드 우선 */
-  --color-primary:               var(--db-color-dark-primary, #C4956A);
+  --color-primary:               var(--db-color-dark-primary, #9C9C9C);
   --color-primary-foreground:    var(--db-color-dark-primary-foreground, #141210);
   --color-secondary:             var(--db-color-dark-secondary, #1E1C18);
-  --color-secondary-foreground:  var(--db-color-dark-secondary-foreground, #E8E0D4);
-  --color-destructive:           var(--db-color-dark-destructive, #ef4444);
+  --color-secondary-foreground:  var(--db-color-dark-secondary-foreground, #E1E1E1);
+  --color-destructive:           var(--db-color-dark-destructive, #686868);
   --color-destructive-foreground:var(--db-color-dark-destructive-foreground, #ffffff);
   --color-muted:                 var(--db-color-dark-muted, #1E1C18);
-  --color-muted-foreground:      var(--db-color-dark-muted-foreground, #9B8E7E);
+  --color-muted-foreground:      var(--db-color-dark-muted-foreground, #909090);
   --color-accent:                var(--db-color-dark-accent, #1E1C18);
-  --color-accent-foreground:     var(--db-color-dark-accent-foreground, #E8E0D4);
+  --color-accent-foreground:     var(--db-color-dark-accent-foreground, #E1E1E1);
   --color-background:            var(--db-color-dark-background, #141210);
-  --color-foreground:            var(--db-color-dark-foreground, #F0EDE8);
+  --color-foreground:            var(--db-color-dark-foreground, #EDEDED);
   --color-card:                  var(--db-color-dark-card, #1A1714);
-  --color-card-foreground:       var(--db-color-dark-card-foreground, #F0EDE8);
+  --color-card-foreground:       var(--db-color-dark-card-foreground, #EDEDED);
   --color-border:                var(--db-color-dark-border, #2E2822);
   --color-input:                 var(--db-color-dark-input, #2E2822);
-  --color-ring:                  var(--db-color-dark-ring, #C4956A);
+  --color-ring:                  var(--db-color-dark-ring, #9C9C9C);
 
   /* 니료(泥料) 악센트 토큰 */
-  --color-zuni: #8B4513;
-  --color-danni: #C4A882;
-  --color-zini: #6B3A5C;
-  --color-heukni: #2A2520;
-  --color-chunsuni: #3D6B6B;
-  --color-nokni: #4A6741;
-  --color-tea: #4A6741;
+  --color-zuni: #505050;
+  --color-danni: #ABABAB;
+  --color-zini: #474747;
+  --color-heukni: #262626;
+  --color-chunsuni: #616161;
+  --color-nokni: #5E5E5E;
+  --color-tea: #5E5E5E;
   --color-surface: #1E1C18;
 }

--- a/src/styles/tokens-light.css
+++ b/src/styles/tokens-light.css
@@ -1,37 +1,37 @@
-/* ── 라이트 테마 토큰 (Wedgwood 웨지우드 팔레트) ────────────────────
+/* ── 라이트 테마 토큰 (무채색 라이트 팔레트) ────────────────────
    html[data-theme="light"] 스코프. 기본 로케일: en
    ────────────────────────────────────────────────────────────────── */
 html[data-theme="light"] {
   /* 브랜드 레거시 변수 */
   --color-bg: #FAFAFA;
   --color-text: #1a1a1a;
-  --color-accent-zuni: #1B3A4B;
-  --color-accent-tea: #4A6741;
-  --color-brand-secondary: #D4C5B0;
-  --color-accent-danni: #C9B8A3;
+  --color-accent-zuni: #353535;
+  --color-accent-tea: #5E5E5E;
+  --color-brand-secondary: #C7C7C7;
+  --color-accent-danni: #BABABA;
 
   /* shadcn/ui 호환 시맨틱 토큰 */
-  --color-primary: var(--db-color-primary, #1B3A4B);
+  --color-primary: var(--db-color-primary, #353535);
   --color-primary-foreground: var(--db-color-primary-foreground, #ffffff);
-  --color-secondary: var(--db-color-secondary, #F2F0EC);
+  --color-secondary: var(--db-color-secondary, #F0F0F0);
   --color-secondary-foreground: var(--db-color-secondary-foreground, #1a1a1a);
-  --color-destructive: var(--db-color-destructive, #b91c1c);
+  --color-destructive: var(--db-color-destructive, #3D3D3D);
   --color-destructive-foreground: var(--db-color-destructive-foreground, #ffffff);
-  --color-muted: var(--db-color-muted, #F2F0EC);
+  --color-muted: var(--db-color-muted, #F0F0F0);
   --color-muted-foreground: var(--db-color-muted-foreground, #525252);
-  --color-accent: var(--db-color-accent, #F2F0EC);
+  --color-accent: var(--db-color-accent, #F0F0F0);
   --color-accent-foreground: var(--db-color-accent-foreground, #1a1a1a);
-  --color-background: var(--db-color-background, #FAF9F7);
+  --color-background: var(--db-color-background, #F9F9F9);
   --color-foreground: var(--db-color-foreground, #1a1a1a);
-  --color-card: var(--db-color-card, #FAF9F7);
+  --color-card: var(--db-color-card, #F9F9F9);
   --color-card-foreground: var(--db-color-card-foreground, #1a1a1a);
-  --color-border: var(--db-color-border, #E5E1DB);
-  --color-input: var(--db-color-input, #E5E1DB);
-  --color-ring: var(--db-color-ring, #1B3A4B);
+  --color-border: var(--db-color-border, #E1E1E1);
+  --color-input: var(--db-color-input, #E1E1E1);
+  --color-ring: var(--db-color-ring, #353535);
 
   /* 브랜드 확장 토큰 */
-  --color-zuni: #1B3A4B;
-  --color-tea: #4A6741;
-  --color-danni: #C9B8A3;
-  --color-surface: #F2F0EC;
+  --color-zuni: #353535;
+  --color-tea: #5E5E5E;
+  --color-danni: #BABABA;
+  --color-surface: #F0F0F0;
 }


### PR DESCRIPTION
## Summary
- Closes #820
- 전역 라이트/다크 테마 색상 토큰의 갈색·유색 포인트 컬러 기본값을 동일 명도대의 무채색으로 변경
- 니료 태그, primary/ring, surface/border 계열 기본값을 글로벌 CSS 토큰에서만 조정
- 전역 토큰 기본값이 grayscale(R=G=B)인지 검증하는 회귀 테스트 추가

## Test plan
- [x] npx vitest run src/styles/__tests__/theme-runtime-tokens.test.ts
- [x] npx vitest run src/styles/__tests__/theme-runtime-tokens.test.ts src/lib/__tests__/theme-style.test.ts
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run -- --reporter=dot
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test