### PR TITLE
#818 실제 헤더 카테고리 ㄴ 장식 제거

### DIFF
--- a/src/components/__tests__/DesktopNav.test.tsx
+++ b/src/components/__tests__/DesktopNav.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DesktopNav } from '@/components/header/DesktopNav';
+import type { NavigationItem } from '@/lib/api';
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const navItems: NavigationItem[] = [
+  {
+    id: 1,
+    group: 'gnb',
+    label: '보이차·다구',
+    labelEn: 'Tea and Ware',
+    url: '/products',
+    sort_order: 0,
+    is_active: true,
+    parent_id: null,
+    children: [
+      {
+        id: 2,
+        group: 'gnb',
+        label: 'ㄴ 보이차',
+        labelEn: 'Pu-erh Tea',
+        url: '/products?categoryId=2',
+        sort_order: 0,
+        is_active: true,
+        parent_id: 1,
+        children: [
+          {
+            id: 3,
+            group: 'gnb',
+            label: 'ㄴ 생차',
+            labelEn: 'Raw Pu-erh',
+            url: '/products?categoryId=3',
+            sort_order: 0,
+            is_active: true,
+            parent_id: 2,
+            children: [],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe('DesktopNav', () => {
+  it('헤더 드롭다운 카테고리 라벨에서 선행 ㄴ 장식을 숨긴다', () => {
+    render(<DesktopNav items={navItems} />);
+
+    fireEvent.mouseEnter(screen.getByText('보이차·다구').closest('div')!);
+
+    expect(screen.getByRole('link', { name: '보이차' })).toHaveAttribute('href', '/products?categoryId=2');
+    expect(screen.getByRole('link', { name: '생차' })).toHaveAttribute('href', '/products?categoryId=3');
+    expect(screen.queryByText('ㄴ 보이차')).not.toBeInTheDocument();
+    expect(screen.queryByText('ㄴ 생차')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/headerNavigationLabel.test.ts
+++ b/src/components/__tests__/headerNavigationLabel.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { getHeaderNavigationLabel } from '@/components/header/navigationLabel';
+
+describe('getHeaderNavigationLabel', () => {
+  it('헤더 표시 라벨에서 선행 ㄴ 계층 장식을 제거한다', () => {
+    expect(getHeaderNavigationLabel('ㄴ 보이차')).toBe('보이차');
+    expect(getHeaderNavigationLabel('ㄴ 다구')).toBe('다구');
+    expect(getHeaderNavigationLabel('└ 생차')).toBe('생차');
+    expect(getHeaderNavigationLabel('보이차·다구')).toBe('보이차·다구');
+  });
+});

--- a/src/components/header/DesktopNav.tsx
+++ b/src/components/header/DesktopNav.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import { cn } from '@/components/ui/utils';
+import { getHeaderNavigationLabel } from './navigationLabel';
 import type { NavigationItem } from '@/lib/api';
 
 interface DesktopNavProps {
@@ -48,7 +49,7 @@ export function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
             )}
           >
             <span className="relative">
-              {item.label}
+              {getHeaderNavigationLabel(item.label)}
               <span
                 className={cn(
                   'absolute -bottom-0.5 left-0 h-px bg-foreground transition-all duration-300 ease-out',
@@ -75,7 +76,7 @@ export function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
                     href={child.url}
                     className="typo-body-sm font-semibold text-foreground hover:text-primary transition-colors tracking-wide"
                   >
-                    {child.label}
+                    {getHeaderNavigationLabel(child.label)}
                   </Link>
                   {child.children && child.children.length > 0 && (
                     <div className="flex flex-col gap-2">
@@ -85,7 +86,7 @@ export function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
                           href={grandchild.url}
                           className="typo-body-sm text-muted-foreground hover:text-foreground transition-colors"
                         >
-                          {grandchild.label}
+                          {getHeaderNavigationLabel(grandchild.label)}
                         </Link>
                       ))}
                     </div>

--- a/src/components/header/MobileMenu.tsx
+++ b/src/components/header/MobileMenu.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/components/ui/utils';
 import Logo from '@/components/Logo';
 import LanguageSelector from '@/components/LanguageSelector';
 import ThemeToggle from '@/components/ThemeToggle';
+import { getHeaderNavigationLabel } from './navigationLabel';
 import type { NavigationItem } from '@/lib/api';
 
 interface MobileMenuProps {
@@ -65,7 +66,7 @@ function MobileMenuHeader({ historyLength, currentTitle, onClose, onBack }: Mobi
             </svg>
           </button>
           <span className="typo-body-sm font-medium ml-3">
-            {currentTitle}
+            {getHeaderNavigationLabel(currentTitle)}
           </span>
         </div>
       )}
@@ -94,7 +95,7 @@ function MobileMenuContent({ items, history, onItemClick, onLinkClick }: MobileM
                 onClick={() => onItemClick(item)}
                 className="w-full min-h-11 py-3 text-left typo-body-sm text-foreground hover:text-muted-foreground transition-colors flex items-center justify-between"
               >
-                {item.label}
+                {getHeaderNavigationLabel(item.label)}
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-muted-foreground">
                   <path d="M6 4l4 4-4 4" />
                 </svg>
@@ -105,7 +106,7 @@ function MobileMenuContent({ items, history, onItemClick, onLinkClick }: MobileM
                 onClick={onLinkClick}
                 className="block min-h-11 py-3 typo-body-sm text-foreground hover:text-muted-foreground transition-colors"
               >
-                {item.label}
+                {getHeaderNavigationLabel(item.label)}
               </Link>
             )}
           </div>
@@ -224,7 +225,7 @@ export function MobileMenu({ isAuthenticated, userName, userRole, navItems, side
 
   const handleItemClick = (item: NavigationItem) => {
     if (item.children && item.children.length > 0) {
-      setHistory(h => [...h, { title: item.label, items: item.children }]);
+      setHistory(h => [...h, { title: getHeaderNavigationLabel(item.label), items: item.children }]);
     } else {
       handleNavigateClose();
     }

--- a/src/components/header/navigationLabel.ts
+++ b/src/components/header/navigationLabel.ts
@@ -1,0 +1,5 @@
+const LEADING_HIERARCHY_MARKER_PATTERN = /^(?:\s*[ㄴ└]\s*)+/;
+
+export function getHeaderNavigationLabel(label: string): string {
+  return label.replace(LEADING_HIERARCHY_MARKER_PATTERN, '').trimStart();
+}


### PR DESCRIPTION
## 요약
- 실제 상단 헤더 드롭다운/모바일 메뉴가 DB 내비게이션 라벨의 선행 `ㄴ`/`└` 계층 장식을 표시하지 않도록 헤더 표시 전용 정규화 추가
- 링크 href와 저장된 내비게이션 데이터는 변경하지 않음
- 실제 재현 케이스(`ㄴ 보이차`, `ㄴ 생차`) 회귀 테스트 추가

Closes #818

## 검증
- `npx vitest run src/components/__tests__/DesktopNav.test.tsx src/components/__tests__/headerNavigationLabel.test.ts --reporter=verbose`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
