### PR TITLE
fix: #813 remove remaining brown point colors

### DIFF
--- a/backend/src/database/migrations/1783000000000-AddDarkModeColorSettings.ts
+++ b/backend/src/database/migrations/1783000000000-AddDarkModeColorSettings.ts
@@ -7,23 +7,23 @@ export class AddDarkModeColorSettings1783000000000 implements MigrationInterface
     await queryRunner.query(`
       INSERT INTO \`site_settings\` (\`setting_key\`, \`value\`, \`group\`, \`label\`, \`input_type\`, \`options\`, \`default_value\`, \`sort_order\`)
       VALUES
-        ('color_dark_primary',              '#C4956A', 'color_dark', '다크 대표색',           'color', NULL, '#C4956A', 101),
-        ('color_dark_primary_foreground',   '#141210', 'color_dark', '다크 대표색 텍스트',     'color', NULL, '#141210', 102),
-        ('color_dark_secondary',            '#1E1C18', 'color_dark', '다크 보조색',           'color', NULL, '#1E1C18', 103),
-        ('color_dark_secondary_foreground', '#E8E0D4', 'color_dark', '다크 보조색 텍스트',     'color', NULL, '#E8E0D4', 104),
-        ('color_dark_background',           '#141210', 'color_dark', '다크 배경색',           'color', NULL, '#141210', 105),
-        ('color_dark_foreground',           '#F0EDE8', 'color_dark', '다크 기본 텍스트색',     'color', NULL, '#F0EDE8', 106),
-        ('color_dark_card',                 '#1A1714', 'color_dark', '다크 카드 배경',         'color', NULL, '#1A1714', 107),
-        ('color_dark_card_foreground',      '#F0EDE8', 'color_dark', '다크 카드 텍스트',       'color', NULL, '#F0EDE8', 108),
-        ('color_dark_border',               '#2E2822', 'color_dark', '다크 테두리색',          'color', NULL, '#2E2822', 109),
-        ('color_dark_input',                '#2E2822', 'color_dark', '다크 인풋 배경',         'color', NULL, '#2E2822', 110),
-        ('color_dark_muted',                '#1E1C18', 'color_dark', '다크 음소거 배경',       'color', NULL, '#1E1C18', 111),
-        ('color_dark_muted_foreground',     '#9B8E7E', 'color_dark', '다크 음소거 텍스트',     'color', NULL, '#9B8E7E', 112),
-        ('color_dark_accent',               '#1E1C18', 'color_dark', '다크 액센트 배경',       'color', NULL, '#1E1C18', 113),
-        ('color_dark_accent_foreground',    '#E8E0D4', 'color_dark', '다크 액센트 텍스트',     'color', NULL, '#E8E0D4', 114),
-        ('color_dark_destructive',          '#ef4444', 'color_dark', '다크 삭제/경고색',       'color', NULL, '#ef4444', 115),
+        ('color_dark_primary',              '#9C9C9C', 'color_dark', '다크 대표색',           'color', NULL, '#9C9C9C', 101),
+        ('color_dark_primary_foreground',   '#121212', 'color_dark', '다크 대표색 텍스트',     'color', NULL, '#121212', 102),
+        ('color_dark_secondary',            '#1C1C1C', 'color_dark', '다크 보조색',           'color', NULL, '#1C1C1C', 103),
+        ('color_dark_secondary_foreground', '#E1E1E1', 'color_dark', '다크 보조색 텍스트',     'color', NULL, '#E1E1E1', 104),
+        ('color_dark_background',           '#121212', 'color_dark', '다크 배경색',           'color', NULL, '#121212', 105),
+        ('color_dark_foreground',           '#EDEDED', 'color_dark', '다크 기본 텍스트색',     'color', NULL, '#EDEDED', 106),
+        ('color_dark_card',                 '#171717', 'color_dark', '다크 카드 배경',         'color', NULL, '#171717', 107),
+        ('color_dark_card_foreground',      '#EDEDED', 'color_dark', '다크 카드 텍스트',       'color', NULL, '#EDEDED', 108),
+        ('color_dark_border',               '#292929', 'color_dark', '다크 테두리색',          'color', NULL, '#292929', 109),
+        ('color_dark_input',                '#292929', 'color_dark', '다크 인풋 배경',         'color', NULL, '#292929', 110),
+        ('color_dark_muted',                '#1C1C1C', 'color_dark', '다크 음소거 배경',       'color', NULL, '#1C1C1C', 111),
+        ('color_dark_muted_foreground',     '#909090', 'color_dark', '다크 음소거 텍스트',     'color', NULL, '#909090', 112),
+        ('color_dark_accent',               '#1C1C1C', 'color_dark', '다크 액센트 배경',       'color', NULL, '#1C1C1C', 113),
+        ('color_dark_accent_foreground',    '#E1E1E1', 'color_dark', '다크 액센트 텍스트',     'color', NULL, '#E1E1E1', 114),
+        ('color_dark_destructive',          '#686868', 'color_dark', '다크 삭제/경고색',       'color', NULL, '#686868', 115),
         ('color_dark_destructive_foreground','#ffffff', 'color_dark', '다크 경고 텍스트',      'color', NULL, '#ffffff', 116),
-        ('color_dark_ring',                 '#C4956A', 'color_dark', '다크 포커스 링 색',      'color', NULL, '#C4956A', 117)
+        ('color_dark_ring',                 '#9C9C9C', 'color_dark', '다크 포커스 링 색',      'color', NULL, '#9C9C9C', 117)
       ON DUPLICATE KEY UPDATE \`setting_key\` = \`setting_key\`
     `);
   }

--- a/backend/src/database/migrations/1784300000000-UpdateThemeColorsGrayscale.ts
+++ b/backend/src/database/migrations/1784300000000-UpdateThemeColorsGrayscale.ts
@@ -1,0 +1,124 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const LIGHT_THEME_COLORS: Record<string, string> = {
+  color_primary: '#353535',
+  color_primary_foreground: '#ffffff',
+  color_secondary: '#F0F0F0',
+  color_secondary_foreground: '#1a1a1a',
+  color_background: '#F9F9F9',
+  color_foreground: '#1a1a1a',
+  color_destructive: '#3D3D3D',
+  color_destructive_foreground: '#ffffff',
+  color_border: '#E1E1E1',
+  color_muted: '#F0F0F0',
+  color_muted_foreground: '#525252',
+  color_ring: '#353535',
+  color_accent: '#F0F0F0',
+  color_accent_foreground: '#1a1a1a',
+  color_card: '#F9F9F9',
+  color_card_foreground: '#1a1a1a',
+  color_input: '#E1E1E1',
+};
+
+const DARK_THEME_COLORS: Record<string, string> = {
+  color_dark_primary: '#9C9C9C',
+  color_dark_primary_foreground: '#121212',
+  color_dark_secondary: '#1C1C1C',
+  color_dark_secondary_foreground: '#E1E1E1',
+  color_dark_background: '#121212',
+  color_dark_foreground: '#EDEDED',
+  color_dark_card: '#171717',
+  color_dark_card_foreground: '#EDEDED',
+  color_dark_border: '#292929',
+  color_dark_input: '#292929',
+  color_dark_muted: '#1C1C1C',
+  color_dark_muted_foreground: '#909090',
+  color_dark_accent: '#1C1C1C',
+  color_dark_accent_foreground: '#E1E1E1',
+  color_dark_destructive: '#686868',
+  color_dark_destructive_foreground: '#ffffff',
+  color_dark_ring: '#9C9C9C',
+};
+
+const LEGACY_LIGHT_THEME_COLORS: Record<string, string> = {
+  color_primary: '#8B5A2B',
+  color_primary_foreground: '#FDFBF7',
+  color_secondary: '#F5E6D3',
+  color_secondary_foreground: '#3D2314',
+  color_background: '#FDFBF7',
+  color_foreground: '#2C1810',
+  color_destructive: '#B91C1C',
+  color_destructive_foreground: '#FFFFFF',
+  color_border: '#E8DDD4',
+  color_muted: '#F5F0EB',
+  color_muted_foreground: '#8B7355',
+  color_ring: '#8B5A2B',
+  color_accent: '#C4A77D',
+  color_accent_foreground: '#2C1810',
+  color_card: '#FDFCF9',
+  color_card_foreground: '#111111',
+  color_input: '#E8DDD4',
+};
+
+const LEGACY_DARK_THEME_COLORS: Record<string, string> = {
+  color_dark_primary: '#C4956A',
+  color_dark_primary_foreground: '#141210',
+  color_dark_secondary: '#1E1C18',
+  color_dark_secondary_foreground: '#E8E0D4',
+  color_dark_background: '#141210',
+  color_dark_foreground: '#F0EDE8',
+  color_dark_card: '#1A1714',
+  color_dark_card_foreground: '#F0EDE8',
+  color_dark_border: '#2E2822',
+  color_dark_input: '#2E2822',
+  color_dark_muted: '#1E1C18',
+  color_dark_muted_foreground: '#9B8E7E',
+  color_dark_accent: '#1E1C18',
+  color_dark_accent_foreground: '#E8E0D4',
+  color_dark_destructive: '#ef4444',
+  color_dark_destructive_foreground: '#ffffff',
+  color_dark_ring: '#C4956A',
+};
+
+function buildColorCase(colors: Record<string, string>): string {
+  return Object.entries(colors)
+    .map(([key, value]) => `WHEN '${key}' THEN '${value}'`)
+    .join('\n        ');
+}
+
+function buildKeyList(colors: Record<string, string>): string {
+  return Object.keys(colors)
+    .map((key) => `'${key}'`)
+    .join(', ');
+}
+
+export class UpdateThemeColorsGrayscale1784300000000 implements MigrationInterface {
+  name = 'UpdateThemeColorsGrayscale1784300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.updateColors(queryRunner, { ...LIGHT_THEME_COLORS, ...DARK_THEME_COLORS });
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await this.updateColors(queryRunner, { ...LEGACY_LIGHT_THEME_COLORS, ...LEGACY_DARK_THEME_COLORS });
+  }
+
+  private async updateColors(queryRunner: QueryRunner, colors: Record<string, string>): Promise<void> {
+    await queryRunner.query(`
+      UPDATE \`site_settings\`
+      SET
+        \`value\` = CASE \`setting_key\`
+          ${buildColorCase(colors)}
+          ELSE \`value\`
+        END,
+        \`default_value\` = CASE \`setting_key\`
+          ${buildColorCase(colors)}
+          ELSE \`default_value\`
+        END,
+        \`value_en\` = NULL,
+        \`value_ja\` = NULL,
+        \`value_zh\` = NULL
+      WHERE \`setting_key\` IN (${buildKeyList(colors)})
+    `);
+  }
+}

--- a/src/app/[locale]/admin/settings/theme/ThemeEditor.tsx
+++ b/src/app/[locale]/admin/settings/theme/ThemeEditor.tsx
@@ -122,11 +122,11 @@ function ThemePreviewPanel({ isDark }: { isDark: boolean }) {
   return (
     <div
       className="space-y-4 rounded-lg border p-4"
-      style={{ background: isDark ? 'var(--db-color-dark-background, #141210)' : 'var(--color-background)' }}
+      style={{ background: isDark ? 'var(--db-color-dark-background, #121212)' : 'var(--color-background)' }}
     >
       <h3
         className="text-sm font-semibold uppercase tracking-wide"
-        style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #9B8E7E)' : 'var(--color-muted-foreground)' }}
+        style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #909090)' : 'var(--color-muted-foreground)' }}
       >
         라이브 프리뷰 {isDark ? '(다크)' : '(라이트)'}
       </h3>
@@ -134,8 +134,8 @@ function ThemePreviewPanel({ isDark }: { isDark: boolean }) {
         <button
           className="rounded-md px-4 py-2 text-sm hover:opacity-90"
           style={{
-            background: isDark ? 'var(--db-color-dark-primary, #C4956A)' : 'var(--color-primary)',
-            color: isDark ? 'var(--db-color-dark-primary-foreground, #141210)' : 'var(--color-primary-foreground)',
+            background: isDark ? 'var(--db-color-dark-primary, #9C9C9C)' : 'var(--color-primary)',
+            color: isDark ? 'var(--db-color-dark-primary-foreground, #121212)' : 'var(--color-primary-foreground)',
           }}
         >
           Primary 버튼
@@ -143,8 +143,8 @@ function ThemePreviewPanel({ isDark }: { isDark: boolean }) {
         <button
           className="rounded-md px-4 py-2 text-sm hover:opacity-90"
           style={{
-            background: isDark ? 'var(--db-color-dark-secondary, #1E1C18)' : 'var(--color-secondary)',
-            color: isDark ? 'var(--db-color-dark-secondary-foreground, #E8E0D4)' : 'var(--color-secondary-foreground)',
+            background: isDark ? 'var(--db-color-dark-secondary, #1C1C1C)' : 'var(--color-secondary)',
+            color: isDark ? 'var(--db-color-dark-secondary-foreground, #E1E1E1)' : 'var(--color-secondary-foreground)',
           }}
         >
           Secondary 버튼
@@ -159,19 +159,19 @@ function ThemePreviewPanel({ isDark }: { isDark: boolean }) {
       <div
         className="rounded-lg border p-4 shadow-sm"
         style={{
-          background: isDark ? 'var(--db-color-dark-card, #1A1714)' : 'var(--color-card)',
-          borderColor: isDark ? 'var(--db-color-dark-border, #2E2822)' : 'var(--color-border)',
+          background: isDark ? 'var(--db-color-dark-card, #171717)' : 'var(--color-card)',
+          borderColor: isDark ? 'var(--db-color-dark-border, #292929)' : 'var(--color-border)',
         }}
       >
         <h4
           className="font-semibold"
-          style={{ color: isDark ? 'var(--db-color-dark-card-foreground, #F0EDE8)' : 'var(--color-card-foreground)' }}
+          style={{ color: isDark ? 'var(--db-color-dark-card-foreground, #EDEDED)' : 'var(--color-card-foreground)' }}
         >
           카드 제목
         </h4>
         <p
           className="mt-1 text-sm"
-          style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #9B8E7E)' : 'var(--color-muted-foreground)' }}
+          style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #909090)' : 'var(--color-muted-foreground)' }}
         >
           카드 본문 텍스트 예시입니다.
         </p>
@@ -179,19 +179,19 @@ function ThemePreviewPanel({ isDark }: { isDark: boolean }) {
       <div className="space-y-1">
         <p
           className="text-lg font-bold"
-          style={{ color: isDark ? 'var(--db-color-dark-foreground, #F0EDE8)' : 'var(--color-foreground)' }}
+          style={{ color: isDark ? 'var(--db-color-dark-foreground, #EDEDED)' : 'var(--color-foreground)' }}
         >
           Heading 텍스트
         </p>
         <p
           className="text-sm"
-          style={{ color: isDark ? 'var(--db-color-dark-foreground, #F0EDE8)' : 'var(--color-foreground)' }}
+          style={{ color: isDark ? 'var(--db-color-dark-foreground, #EDEDED)' : 'var(--color-foreground)' }}
         >
           Body 텍스트 예시입니다.
         </p>
         <p
           className="text-sm"
-          style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #9B8E7E)' : 'var(--color-muted-foreground)' }}
+          style={{ color: isDark ? 'var(--db-color-dark-muted-foreground, #909090)' : 'var(--color-muted-foreground)' }}
         >
           Muted 텍스트 예시입니다.
         </p>
@@ -201,9 +201,9 @@ function ThemePreviewPanel({ isDark }: { isDark: boolean }) {
         value="Input 필드 예시"
         className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none"
         style={{
-          background: isDark ? 'var(--db-color-dark-background, #141210)' : 'var(--color-background)',
-          borderColor: isDark ? 'var(--db-color-dark-input, #2E2822)' : 'var(--color-input)',
-          color: isDark ? 'var(--db-color-dark-foreground, #F0EDE8)' : 'var(--color-foreground)',
+          background: isDark ? 'var(--db-color-dark-background, #121212)' : 'var(--color-background)',
+          borderColor: isDark ? 'var(--db-color-dark-input, #292929)' : 'var(--color-input)',
+          color: isDark ? 'var(--db-color-dark-foreground, #EDEDED)' : 'var(--color-foreground)',
         }}
       />
     </div>

--- a/src/components/shared/PageTransition.tsx
+++ b/src/components/shared/PageTransition.tsx
@@ -40,7 +40,7 @@ export default function PageTransition() {
       aria-hidden="true"
     >
       <div className="absolute inset-0 flex items-center justify-center">
-        <span className="font-display text-2xl tracking-widest text-[#B8976A]/60">
+        <span className="font-display text-2xl tracking-widest text-primary/60">
           茶
         </span>
       </div>

--- a/src/components/shared/blocks/HeroBannerBlock.tsx
+++ b/src/components/shared/blocks/HeroBannerBlock.tsx
@@ -86,7 +86,7 @@ function SliderHero({ slides, description, sectionRef }: SliderHeroProps) {
               <div className="absolute inset-x-0 top-0 h-32 bg-gradient-to-b from-black/60 to-transparent pointer-events-none" />
 
               <div className="relative z-10 w-full px-8 md:px-16 max-w-3xl">
-                <p className="typo-label uppercase tracking-[0.35em] text-[#B8976A] mb-4 font-body">
+                <p className="typo-label uppercase tracking-[0.35em] text-primary mb-4 font-body">
                   {slideIndex === 0 ? t('primaryLabel') : `0${slideIndex + 1}`}
                 </p>
                 <h1 className="typo-h0 font-display text-white leading-tight">
@@ -94,12 +94,12 @@ function SliderHero({ slides, description, sectionRef }: SliderHeroProps) {
                 </h1>
                 {slide.subtitle && (
                   <div className="mt-5 typo-body text-white/85 font-display leading-relaxed">
-                    <SafeHtml html={slide.subtitle} className="[&_p]:mt-1 [&_strong]:text-white [&_b]:text-white [&_a]:text-[#B8976A] hover:[&_a]:underline" />
+                    <SafeHtml html={slide.subtitle} className="[&_p]:mt-1 [&_strong]:text-white [&_b]:text-white [&_a]:text-primary hover:[&_a]:underline" />
                   </div>
                 )}
                 {slideIndex === 0 && description && (
                   <div className="mt-4 text-white/75">
-                    <SafeHtml html={description} className="[&_p]:mt-1 [&_strong]:text-white [&_b]:text-white [&_a]:text-[#B8976A] hover:[&_a]:underline" />
+                    <SafeHtml html={description} className="[&_p]:mt-1 [&_strong]:text-white [&_b]:text-white [&_a]:text-primary hover:[&_a]:underline" />
                   </div>
                 )}
                 {slide.cta_text && slide.cta_url && (
@@ -157,7 +157,7 @@ function SliderHero({ slides, description, sectionRef }: SliderHeroProps) {
                 aria-label={t('goToSlide', { index: idx + 1 })}
                 className={cn(
                   'h-1.5 rounded-full transition-all duration-300',
-                  idx === selectedIndex ? 'w-6 bg-[#B8976A]' : 'w-1.5 bg-white/40 hover:bg-white/60',
+                  idx === selectedIndex ? 'w-6 bg-primary' : 'w-1.5 bg-white/40 hover:bg-white/60',
                 )}
               />
             ))}
@@ -286,7 +286,7 @@ export default function HeroBannerBlock({ content }: Props) {
           {description && (
             <SafeHtml
               html={description}
-              className={cn('mt-4 [&_p]:mt-1', image_url ? 'text-white/75 [&_strong]:text-white [&_b]:text-white [&_a]:text-[#B8976A] hover:[&_a]:underline' : 'text-muted-foreground [&_strong]:text-foreground [&_b]:text-foreground')}
+              className={cn('mt-4 [&_p]:mt-1', image_url ? 'text-white/75 [&_strong]:text-white [&_b]:text-white [&_a]:text-primary hover:[&_a]:underline' : 'text-muted-foreground [&_strong]:text-foreground [&_b]:text-foreground')}
             />
           )}
           {cta_text && cta_url && (

--- a/src/components/shared/blocks/PromotionBannerBlock.tsx
+++ b/src/components/shared/blocks/PromotionBannerBlock.tsx
@@ -21,7 +21,7 @@ export default function PromotionBannerBlock({ content }: Props) {
   if (template === 'timer') {
     return (
       <section className="py-16 md:py-24 border-y border-divider-soft text-center">
-        <p className="text-sm tracking-widest text-[#B8976A] uppercase mb-3">{t('limitedTime')}</p>
+        <p className="text-sm tracking-widest text-primary uppercase mb-3">{t('limitedTime')}</p>
         <h2 className="text-2xl font-display font-medium">{title}</h2>
         {subtitle && <p className="mt-2 text-muted-foreground">{subtitle}</p>}
         {countdownEndDate && <CountdownTimer endDate={countdownEndDate} />}
@@ -97,7 +97,7 @@ export default function PromotionBannerBlock({ content }: Props) {
       )}
       <div className="relative z-10 text-center px-8">
         <p
-          className={`text-sm tracking-widest text-[#B8976A] uppercase mb-3 transition-all duration-600 ease-out ${
+          className={`text-sm tracking-widest text-primary uppercase mb-3 transition-all duration-600 ease-out ${
             visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
           }`}
         >

--- a/src/styles/__tests__/theme-runtime-tokens.test.ts
+++ b/src/styles/__tests__/theme-runtime-tokens.test.ts
@@ -6,6 +6,73 @@ const globals = readFileSync(join(process.cwd(), 'src/styles/globals.css'), 'utf
 const lightTokens = readFileSync(join(process.cwd(), 'src/styles/tokens-light.css'), 'utf8');
 const darkTokens = readFileSync(join(process.cwd(), 'src/styles/tokens-dark.css'), 'utf8');
 
+const grayscaleMigration = readFileSync(join(process.cwd(), 'backend/src/database/migrations/1784300000000-UpdateThemeColorsGrayscale.ts'), 'utf8');
+const darkSettingsMigration = readFileSync(join(process.cwd(), 'backend/src/database/migrations/1783000000000-AddDarkModeColorSettings.ts'), 'utf8');
+
+const runtimePointColorSources = [
+  'src/components/shared/blocks/HeroBannerBlock.tsx',
+  'src/components/shared/blocks/PromotionBannerBlock.tsx',
+  'src/components/shared/PageTransition.tsx',
+  'src/app/[locale]/admin/settings/theme/ThemeEditor.tsx',
+].map((file) => [file, readFileSync(join(process.cwd(), file), 'utf8')] as const);
+
+const LEGACY_POINT_COLOR_HEXES = [
+  '#8B5A2B',
+  '#FDFBF7',
+  '#F5E6D3',
+  '#3D2314',
+  '#2C1810',
+  '#E8DDD4',
+  '#F5F0EB',
+  '#8B7355',
+  '#C4A77D',
+  '#B8976A',
+  '#C4956A',
+  '#141210',
+  '#1E1C18',
+  '#E8E0D4',
+  '#F0EDE8',
+  '#2E2822',
+  '#9B8E7E',
+] as const;
+
+const GRAYSCALE_DB_THEME_COLORS = {
+  color_primary: '#353535',
+  color_primary_foreground: '#ffffff',
+  color_secondary: '#F0F0F0',
+  color_secondary_foreground: '#1a1a1a',
+  color_background: '#F9F9F9',
+  color_foreground: '#1a1a1a',
+  color_destructive: '#3D3D3D',
+  color_destructive_foreground: '#ffffff',
+  color_border: '#E1E1E1',
+  color_muted: '#F0F0F0',
+  color_muted_foreground: '#525252',
+  color_ring: '#353535',
+  color_accent: '#F0F0F0',
+  color_accent_foreground: '#1a1a1a',
+  color_card: '#F9F9F9',
+  color_card_foreground: '#1a1a1a',
+  color_input: '#E1E1E1',
+  color_dark_primary: '#9C9C9C',
+  color_dark_primary_foreground: '#121212',
+  color_dark_secondary: '#1C1C1C',
+  color_dark_secondary_foreground: '#E1E1E1',
+  color_dark_background: '#121212',
+  color_dark_foreground: '#EDEDED',
+  color_dark_card: '#171717',
+  color_dark_card_foreground: '#EDEDED',
+  color_dark_border: '#292929',
+  color_dark_input: '#292929',
+  color_dark_muted: '#1C1C1C',
+  color_dark_muted_foreground: '#909090',
+  color_dark_accent: '#1C1C1C',
+  color_dark_accent_foreground: '#E1E1E1',
+  color_dark_destructive: '#686868',
+  color_dark_destructive_foreground: '#ffffff',
+  color_dark_ring: '#9C9C9C',
+} as const;
+
 const POINT_COLOR_TOKENS = [
   '--color-accent-zuni',
   '--color-accent-tea',
@@ -85,6 +152,32 @@ describe('runtime theme tokens', () => {
       const values = tokenSources.flatMap((source) => extractTokenHexValues(source, token));
       expect(values.length, `${token} should define at least one default color`).toBeGreaterThan(0);
       values.forEach(expectGrayscale);
+    }
+  });
+
+
+
+  it('migrates persisted DB theme colors away from legacy brown point colors', () => {
+    for (const [key, hex] of Object.entries(GRAYSCALE_DB_THEME_COLORS)) {
+      expect(grayscaleMigration, `${key} should be updated by the grayscale DB migration`).toContain(`${key}: '${hex}'`);
+      expectGrayscale(hex);
+    }
+    expect(grayscaleMigration).toContain('default_value');
+    expect(grayscaleMigration).toContain('value_en');
+  });
+
+  it('keeps fresh dark theme setting inserts grayscale', () => {
+    const upSection = darkSettingsMigration.split('public async down')[0];
+    for (const legacyHex of LEGACY_POINT_COLOR_HEXES) {
+      expect(upSection, `fresh dark settings should not insert ${legacyHex}`).not.toContain(legacyHex);
+    }
+  });
+
+  it('does not hardcode legacy brown point colors in runtime point-color components', () => {
+    for (const [file, source] of runtimePointColorSources) {
+      for (const legacyHex of LEGACY_POINT_COLOR_HEXES) {
+        expect(source, `${file} should use grayscale theme tokens instead of ${legacyHex}`).not.toContain(legacyHex);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- Add a data migration that updates persisted light/dark theme color settings and defaults from the legacy brown palette to the grayscale token palette
- Update fresh dark theme setting inserts and admin preview fallbacks so reset/new installs do not reintroduce brown accents
- Replace remaining hardcoded brown point-color usage in hero/promotion/page-transition runtime components with theme tokens

## Test plan
- [x] npx vitest run src/styles/__tests__/theme-runtime-tokens.test.ts
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run -- --reporter=dot
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test

## Notes
- Production currently returns legacy brown values from /api/settings/map, so the DB migration is required in addition to CSS token defaults.
