### PR TITLE
#825 상품 필터 라벨 간결화

### DIFF
--- a/src/components/shared/filters/ClayTypeFilter.tsx
+++ b/src/components/shared/filters/ClayTypeFilter.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import type { Collection } from '@/lib/api';
 import SegmentedOptionGroup from '@/components/shared/ui/SegmentedOptionGroup';
+import { getCompactCollectionLabel } from '@/lib/collectionDisplay';
 import { getCollectionFilterValue } from '@/lib/collectionFilters';
 
 interface ClayTypeFilterProps {
@@ -18,7 +19,10 @@ export default function ClayTypeFilter({ collections, selected, onSelect }: Clay
     <SegmentedOptionGroup
       items={[
         { label: tCommon('all'), value: '' },
-        ...collections.map((item) => ({ label: item.name, value: getCollectionFilterValue(item, 'clay_type') })),
+        ...collections.map((item) => ({
+          label: getCompactCollectionLabel(item),
+          value: getCollectionFilterValue(item, 'clay_type'),
+        })),
       ]}
       value={selected ?? ''}
       onToggle={(value) => onSelect(value === selected ? undefined : value || undefined)}

--- a/src/components/shared/filters/TeapotShapeFilter.tsx
+++ b/src/components/shared/filters/TeapotShapeFilter.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
 import type { Collection } from '@/lib/api';
+import { getCompactCollectionLabel } from '@/lib/collectionDisplay';
 import { getCollectionFilterValue } from '@/lib/collectionFilters';
 
 interface TeapotShapeFilterProps {
@@ -45,7 +46,7 @@ export default function TeapotShapeFilter({ collections, selected, onSelect }: T
               'text-sm transition-colors',
               selected === filterValue ? 'font-medium text-foreground' : 'text-muted-foreground',
             )}>
-              {item.name}
+              {getCompactCollectionLabel(item)}
             </span>
           </label>
         );

--- a/src/components/shared/filters/__tests__/FilterSidebar.test.tsx
+++ b/src/components/shared/filters/__tests__/FilterSidebar.test.tsx
@@ -63,7 +63,7 @@ const clayCollections: Collection[] = [
   {
     id: 11,
     type: CollectionType.CLAY,
-    name: '자니',
+    name: 'Zisha Collection',
     nameKo: null,
     color: null,
     description: null,
@@ -78,7 +78,7 @@ const shapeCollections: Collection[] = [
   {
     id: 21,
     type: CollectionType.SHAPE,
-    name: '원형',
+    name: 'Byeonpyeong Collection',
     nameKo: null,
     color: null,
     description: null,
@@ -140,10 +140,13 @@ describe('FilterSidebar', () => {
 
     render(<FilterSidebar categories={categories} clayCollections={clayCollections} shapeCollections={shapeCollections} />);
 
-    await userEvent.click(screen.getAllByRole('button', { name: '자니' })[0]);
+    expect(screen.queryByRole('button', { name: /Collection/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: /Collection/ })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Zisha' })[0]);
     expect(updateQueryMock).toHaveBeenCalledWith({ attrs: undefined });
 
-    await userEvent.click(screen.getAllByRole('radio', { name: '원형' })[0]);
+    await userEvent.click(screen.getAllByRole('radio', { name: 'Byeonpyeong' })[0]);
     expect(updateQueryMock).toHaveBeenCalledWith({ attrs: 'clay_type:zini,teapot_shape:round' });
 
     await userEvent.click(screen.getAllByRole('button', { name: '초기화' })[0]);

--- a/src/components/shared/products/ProductCard.tsx
+++ b/src/components/shared/products/ProductCard.tsx
@@ -11,6 +11,7 @@ import PriceDisplay from '@/components/shared/common/PriceDisplay';
 import StarRating from '@/components/shared/reviews/StarRating';
 import { useWishlistToggle } from '@/components/shared/hooks/useWishlistToggle';
 import { useCart } from '@/contexts/CartContext';
+import { compactProductSummary } from '@/lib/collectionDisplay';
 import type { Locale } from '@/utils/currency';
 
 interface ProductCardProps {
@@ -194,7 +195,7 @@ function ProductCard({
 
           {shortDescription && (
             <p className="line-clamp-1 text-xs text-muted-foreground leading-relaxed">
-              {shortDescription}
+              {compactProductSummary(shortDescription)}
             </p>
           )}
         </div>

--- a/src/components/shared/products/__tests__/ProductCard.test.tsx
+++ b/src/components/shared/products/__tests__/ProductCard.test.tsx
@@ -80,3 +80,12 @@ describe('ProductCard image presentation', () => {
     expect(screen.queryByAltText('자사호')).not.toBeInTheDocument();
   });
 });
+
+describe('ProductCard summary display', () => {
+  it('compacts long attribute wording in the card summary', () => {
+    renderCard({ shortDescription: 'Fujian Zhuni · Xishi Shape · 120ml · Gongfu Tea' });
+
+    expect(screen.getByText('Fujian Zhuni · Xishi · 120ml · Gongfu Tea')).toBeInTheDocument();
+    expect(screen.queryByText(/Xishi Shape/)).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/collectionDisplay.test.ts
+++ b/src/lib/__tests__/collectionDisplay.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { compactDisplayLabel, compactProductSummary } from '@/lib/collectionDisplay';
+
+describe('collection display compaction', () => {
+  it('removes redundant collection suffixes from filter labels', () => {
+    expect(compactDisplayLabel('Jooni Collection')).toBe('Jooni');
+    expect(compactDisplayLabel('Byeonpyeong Collection')).toBe('Byeonpyeong');
+    expect(compactDisplayLabel('청수니 컬렉션')).toBe('청수니');
+  });
+
+  it('keeps meaningful parenthetical details while removing suffix-only wording', () => {
+    expect(compactDisplayLabel('Heini (Black Clay)')).toBe('Heini (Black Clay)');
+  });
+
+  it('shortens product summaries without changing semantic parts', () => {
+    expect(compactProductSummary('Fujian Zhuni · Xishi Shape · 120ml · Gongfu Tea')).toBe('Fujian Zhuni · Xishi · 120ml · Gongfu Tea');
+    expect(compactProductSummary('Yixing Zisha · Flat shape · 200ml')).toBe('Yixing Zisha · Flat · 200ml');
+  });
+});

--- a/src/lib/collectionDisplay.ts
+++ b/src/lib/collectionDisplay.ts
@@ -1,0 +1,28 @@
+import type { Collection } from '@/lib/api';
+
+const COLLECTION_SUFFIX_PATTERN = /\s*(?:Collection|컬렉션)\s*$/i;
+const ENGLISH_SHAPE_SUFFIX_PATTERN = /\s+shape\b/gi;
+
+export function compactDisplayLabel(label: string): string {
+  return label
+    .replace(COLLECTION_SUFFIX_PATTERN, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function getCompactCollectionLabel(collection: Pick<Collection, 'name'>): string {
+  return compactDisplayLabel(collection.name);
+}
+
+export function compactProductSummary(summary: string): string {
+  return summary
+    .split('·')
+    .map((part) => (
+      compactDisplayLabel(part)
+        .replace(ENGLISH_SHAPE_SUFFIX_PATTERN, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+    ))
+    .filter(Boolean)
+    .join(' · ');
+}


### PR DESCRIPTION
## 요약
- 필터 컬렉션 표시명에서 불필요한 `Collection`/`컬렉션` 접미사를 제거했습니다.
- 상품 카드 요약의 영어 `shape` 반복 표현을 줄여 한 줄 표시 가독성을 개선했습니다.
- 표시 전용 compaction 유틸과 회귀 테스트를 추가했습니다.

## 테스트
- `npx vitest run src/lib/__tests__/collectionDisplay.test.ts src/components/shared/filters/__tests__/FilterSidebar.test.tsx src/components/shared/products/__tests__/ProductCard.test.tsx`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`

Closes #825