### PR TITLE
헤더·푸터 구분선 제거

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -63,7 +63,7 @@ export default function Footer() {
   };
 
   return (
-    <footer className="mt-auto border-t border-divider-soft bg-card">
+    <footer className="mt-auto bg-card">
       <div className="mx-auto max-w-7xl px-4 py-12">
         <div className={`grid grid-cols-2 md:grid-cols-4 gap-8 transition-opacity duration-300 ${loading ? 'opacity-0' : 'opacity-100'}`}>
           <div>
@@ -111,7 +111,7 @@ export default function Footer() {
         </div>
 
         {/* 공방 서명/낙관 영역 */}
-        <div className="mt-12 border-t border-dashed border-divider-soft pt-8">
+        <div className="mt-12 pt-8">
           <div className="flex flex-col md:flex-row items-center justify-between gap-6">
             <span className="font-display text-lg text-muted-foreground/50">玉華堂</span>
             <div className="font-mono text-xs text-muted-foreground text-center md:text-right space-y-0.5 tracking-wide">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -64,8 +64,8 @@ export default function Header() {
       <header ref={headerRef} className={cn(
         'sticky top-0 z-50 transition-all duration-300 ease-in-out',
         isScrolled
-          ? 'bg-background/85 backdrop-blur-lg border-b border-divider-soft shadow-sm'
-          : 'bg-background border-b border-transparent',
+          ? 'bg-background/85 backdrop-blur-lg shadow-sm'
+          : 'bg-background',
       )}>
         {/* 2줄 헤더 — top: 로고/검색/액션 · bottom: GNB 전폭 균등 */}
         <div className="mx-auto flex h-16 items-center justify-between gap-4 px-4 md:px-20">
@@ -101,7 +101,7 @@ export default function Header() {
               onChange={(e) => setQuery(e.target.value)}
               placeholder={t('searchPlaceholder')}
               aria-label={t('searchLabel')}
-              className="w-full border-b border-divider-soft bg-transparent pl-1 pr-10 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:border-foreground transition-colors"
+              className="w-full rounded-md bg-muted/40 pl-3 pr-10 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:bg-muted/60 transition-colors"
             />
             <button type="submit" aria-label={t('searchButton')} className="absolute right-3 transition-colors text-muted-foreground hover:text-foreground">
               <Search className="h-4 w-4" />
@@ -162,7 +162,7 @@ export default function Header() {
         </div>
 
         {/* Bottom row — GNB 전폭 균등 분할 */}
-        <div className="hidden md:block border-t border-divider-soft">
+        <div className="hidden md:block">
           <div className="flex h-12 items-stretch justify-between px-4 md:px-20">
             <DesktopNav items={navItems} fullWidth />
           </div>

--- a/src/components/__tests__/DesktopNav.test.tsx
+++ b/src/components/__tests__/DesktopNav.test.tsx
@@ -53,7 +53,7 @@ const navItems: NavigationItem[] = [
 
 describe('DesktopNav', () => {
   it('헤더 드롭다운 카테고리 라벨에서 선행 ㄴ 장식을 숨긴다', () => {
-    render(<DesktopNav items={navItems} />);
+    const { container } = render(<DesktopNav items={navItems} />);
 
     fireEvent.mouseEnter(screen.getByText('보이차·다구').closest('div')!);
 
@@ -61,5 +61,6 @@ describe('DesktopNav', () => {
     expect(screen.getByRole('link', { name: '생차' })).toHaveAttribute('href', '/products?categoryId=3');
     expect(screen.queryByText('ㄴ 보이차')).not.toBeInTheDocument();
     expect(screen.queryByText('ㄴ 생차')).not.toBeInTheDocument();
+    expect(container.innerHTML).not.toContain('border-divider-soft');
   });
 });

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -56,6 +56,14 @@ describe('Footer', () => {
     expect(screen.getByRole('link', { name: '고객센터' })).toBeInTheDocument();
   });
 
+  it('renders footer without solid or dotted divider lines', () => {
+    const { container } = render(<Footer />);
+
+    expect(container.querySelector('footer')?.className).not.toContain('border-');
+    expect(container.innerHTML).not.toContain('border-divider-soft');
+    expect(container.innerHTML).not.toContain('border-dashed');
+  });
+
   it('hides nav links while loading', () => {
     const { container } = render(<Footer />);
     expect(container.querySelector('.opacity-100')).toBeInTheDocument();

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -141,6 +141,18 @@ describe('Header', () => {
     expect(screen.getByRole('button', { name: '메뉴 열기' })).toBeInTheDocument();
   });
 
+  it('renders header chrome without divider lines', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Header />);
+
+    expect(container.querySelector('header')?.className).not.toMatch(/border-[bt]/);
+    expect(container.innerHTML).not.toContain('border-divider-soft');
+
+    await user.click(screen.getByRole('button', { name: '메뉴 열기' }));
+    expect(screen.getByRole('navigation', { name: '모바일 메뉴' })).toBeInTheDocument();
+    expect(container.innerHTML).not.toContain('border-divider-soft');
+  });
+
   it('hamburger click → mobile menu appears', async () => {
     const user = userEvent.setup();
     render(<Header />);

--- a/src/components/header/DesktopNav.tsx
+++ b/src/components/header/DesktopNav.tsx
@@ -63,7 +63,7 @@ export function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
 
       {hasChildren && (
         <div
-          className="fixed left-0 right-0 z-50 bg-background border-b border-divider-soft shadow-md"
+          className="fixed left-0 right-0 z-50 bg-background shadow-md"
           style={{ top: 'var(--header-bottom)' }}
           onMouseEnter={() => setHoveredId(hoveredId)}
           onMouseLeave={() => setHoveredId(null)}

--- a/src/components/header/MobileMenu.tsx
+++ b/src/components/header/MobileMenu.tsx
@@ -40,7 +40,7 @@ function MobileMenuHeader({ historyLength, currentTitle, onClose, onBack }: Mobi
   const tHeader = useTranslations('header');
   return (
     <>
-      <div className="flex items-center px-4 h-14 border-b border-divider-soft shrink-0">
+      <div className="flex items-center px-4 h-14 shrink-0">
         <button
           type="button"
           onClick={onClose}
@@ -54,7 +54,7 @@ function MobileMenuHeader({ historyLength, currentTitle, onClose, onBack }: Mobi
         </Link>
       </div>
       {historyLength > 0 && (
-        <div className="flex items-center px-4 h-12 border-b border-divider-soft shrink-0">
+        <div className="flex items-center px-4 h-12 shrink-0">
           <button
             type="button"
             onClick={onBack}
@@ -129,7 +129,7 @@ function MobileMenuFooter({ isAuthenticated, userName, userRole, onLogout, onLin
   const orderTrackingHref = isAuthenticated ? '/my/orders' : '/login?redirect=/my/orders';
   const isAdmin = userRole === 'admin' || userRole === 'super_admin';
   return (
-    <div className="px-4 py-4 border-t border-divider-soft shrink-0">
+    <div className="px-4 py-4 shrink-0">
       <div className="flex flex-col gap-1">
         {isAuthenticated ? (
           <>

--- a/src/components/header/MobileSearchOverlay.tsx
+++ b/src/components/header/MobileSearchOverlay.tsx
@@ -54,7 +54,7 @@ export function MobileSearchOverlay({ isOpen, onClose }: MobileSearchOverlayProp
         role="search"
         aria-label={t('searchLabel')}
       >
-        <form onSubmit={handleSubmit} className="flex items-center gap-3 px-4 py-3 border-b border-divider-soft">
+        <form onSubmit={handleSubmit} className="flex items-center gap-3 px-4 py-3">
           <Search className="h-5 w-5 text-muted-foreground shrink-0" />
           <input
             ref={inputRef}


### PR DESCRIPTION
## Summary
- remove public Header solid divider classes, including desktop nav row and dropdown chrome
- remove footer top solid divider and dashed signature divider
- remove mobile header/menu/search divider utilities and add regression assertions

## Tests
- `npx vitest run src/components/__tests__/Header.test.tsx src/components/__tests__/Footer.test.tsx src/components/__tests__/DesktopNav.test.tsx`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`

Closes #827