### PR TITLE
Align footer copyright typography and position

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -56,6 +56,7 @@ export default function Footer() {
   const { items: footerItems, loading } = useNavigation('footer');
   const hasCmsData = !loading && footerItems.length > 0;
   const rootItems = hasCmsData ? footerItems.filter((item) => item.parent_id === null) : [];
+  const currentYear = new Date().getFullYear();
 
   const socialLabels: Record<'instagram' | 'naver', string> = {
     instagram: 'Instagram',
@@ -110,21 +111,17 @@ export default function Footer() {
           </div>
         </div>
 
-        {/* 공방 서명/낙관 영역 */}
-        <div className="mt-12 pt-8">
-          <div className="flex flex-col md:flex-row items-center justify-between gap-6">
-            <span className="font-display text-lg text-muted-foreground/50">玉華堂</span>
-            <div className="font-mono text-xs text-muted-foreground text-center md:text-right space-y-0.5 tracking-wide">
-              <p>&copy; {new Date().getFullYear()} OCKHWADANG. All rights reserved.</p>
-            </div>
-          </div>
-
-          {/* 사업자 정보 (전자상거래법 제10조) */}
-          <div className="mt-4 text-xs text-muted-foreground/70 leading-relaxed text-center md:text-left space-y-0.5">
+        {/* 사업자 정보 (전자상거래법 제10조) */}
+        <div className="mt-12 pt-8 text-center">
+          <div className="typo-body-sm text-muted-foreground/70 leading-relaxed space-y-0.5">
             <p>{t('businessInfo.companyName')} · {t('businessInfo.ceo')}</p>
             <p>{t('businessInfo.address')}</p>
             <p>{t('businessInfo.bizNo')} · {t('businessInfo.mailOrderNo')}</p>
           </div>
+
+          <p className="mt-6 typo-body-sm font-body text-muted-foreground">
+            {t('copyright', { year: currentYear })}
+          </p>
         </div>
       </div>
     </footer>

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -20,12 +20,20 @@ vi.mock('next-intl', async (importOriginal) => {
       }
       return undefined;
     }, root);
+  const format = (value: string, params?: Record<string, unknown>) => {
+    if (!params) return value;
+    return Object.entries(params).reduce(
+      (acc, [paramKey, paramValue]) => acc.replace(`{${paramKey}}`, String(paramValue)),
+      value,
+    );
+  };
+
   return {
     ...actual,
     useLocale: () => 'ko',
-    useTranslations: (namespace: string) => (key: string) => {
+    useTranslations: (namespace: string) => (key: string, params?: Record<string, unknown>) => {
       const value = resolvePath(messages[namespace], key);
-      return typeof value === 'string' ? value : key;
+      return typeof value === 'string' ? format(value, params) : key;
     },
   };
 });
@@ -69,12 +77,20 @@ describe('Footer', () => {
     expect(container.querySelector('.opacity-100')).toBeInTheDocument();
   });
 
-  it('renders copyright text containing current year', () => {
+  it('renders centered copyright text with normal Pretendard body styling', () => {
     render(<Footer />);
     const year = new Date().getFullYear().toString();
-    expect(
-      screen.getByText(new RegExp(`${year} OCKHWADANG`))
-    ).toBeInTheDocument();
+    const copyright = screen.getByText(new RegExp(`${year} OCKHWADANG`));
+
+    expect(copyright).toBeInTheDocument();
+    expect(copyright).toHaveClass('typo-body-sm', 'font-body', 'text-muted-foreground');
+    expect(copyright).not.toHaveClass('font-mono', 'font-display', 'italic');
+    expect(copyright.closest('.text-center')).toBeInTheDocument();
+  });
+
+  it('does not render the old display-font footer seal', () => {
+    render(<Footer />);
+    expect(screen.queryByText('玉華堂')).not.toBeInTheDocument();
   });
 
   it('renders required business information (상호·대표자·사업자번호·통신판매번호·소재지)', () => {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -104,7 +104,7 @@
     "collection": "Collection",
     "archive": "Archive",
     "journal": "Journal",
-    "copyright": "© {year} Ockhwadang. All rights reserved.",
+    "copyright": "© {year} OCKHWADANG. All rights reserved.",
     "businessInfo": {
       "companyName": "Seoro International",
       "ceo": "CEO: Kwon Junhyun",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -104,7 +104,7 @@
     "collection": "컬렉션",
     "archive": "아카이브",
     "journal": "Journal",
-    "copyright": "© {year} 옥화당. All rights reserved.",
+    "copyright": "© {year} OCKHWADANG. All rights reserved.",
     "businessInfo": {
       "companyName": "서로 인터내셔널",
       "ceo": "대표 권준현",


### PR DESCRIPTION
## Summary
- Move footer business/legal information into a single centered bottom block
- Replace the copyright mono/display treatment with locale-backed `typo-body-sm font-body`
- Remove the decorative footer seal that made the copyright area feel visually detached
- Keep both Korean and English locale copyright strings aligned with the requested `OCKHWADANG` casing

## Verification
- `npx vitest run src/components/__tests__/Footer.test.tsx src/__tests__/App.test.tsx --reporter=verbose`
- `npm run build`
- `npm run test:run`
- `cd backend && npm run build && npm run test`

Closes #830
