### PR TITLE
Fix navigation edit modal text input reset

### DIFF
--- a/src/components/shared/admin/navigation/NavigationFormModal.test.tsx
+++ b/src/components/shared/admin/navigation/NavigationFormModal.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import NavigationFormModal from './NavigationFormModal';
+import type { NavigationItem } from '@/lib/api';
+
+const initialItem: NavigationItem = {
+  id: 2,
+  group: 'gnb',
+  label: '자사호',
+  labelEn: 'JISAHO (Yixing Teapots)',
+  url: '/products?categoryId=1',
+  sort_order: 1,
+  is_active: true,
+  parent_id: null,
+  children: [],
+};
+
+describe('NavigationFormModal', () => {
+  it('수정 모달 입력값을 사용자가 바꿀 수 있다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <NavigationFormModal
+        open
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        initial={initialItem}
+        group="gnb"
+        flatItems={[initialItem]}
+      />,
+    );
+
+    const labelInput = screen.getByLabelText(/^메뉴명/) as HTMLInputElement;
+    const labelEnInput = screen.getByLabelText(/영문 메뉴명/) as HTMLInputElement;
+    const urlInput = screen.getByLabelText(/URL/) as HTMLInputElement;
+
+    await user.clear(labelInput);
+    await user.type(labelInput, '보이차');
+    await user.clear(labelEnInput);
+    await user.type(labelEnInput, 'Boischa');
+    await user.clear(urlInput);
+    await user.type(urlInput, '/products?categoryId=2');
+
+    expect(labelInput).toHaveValue('보이차');
+    expect(labelEnInput).toHaveValue('Boischa');
+    expect(urlInput).toHaveValue('/products?categoryId=2');
+  });
+});

--- a/src/components/shared/admin/navigation/NavigationFormModal.tsx
+++ b/src/components/shared/admin/navigation/NavigationFormModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { X } from 'lucide-react';
 import { useFormModal } from '@/components/shared/hooks/useFormModal';
 import type { NavigationItem } from '@/lib/api';
@@ -31,17 +32,20 @@ export default function NavigationFormModal({
   group,
   flatItems,
 }: NavigationFormModalProps) {
-  const defaults: NavigationFormData = {
+  const defaults = useMemo<NavigationFormData>(() => ({
     label: '',
     labelEn: '',
     url: '',
     group,
     parent_id: null,
     is_active: true,
-  };
-  const modalInitial: NavigationFormData | null = initial
-    ? { label: initial.label, labelEn: initial.labelEn ?? '', url: initial.url, group, parent_id: initial.parent_id, is_active: initial.is_active }
-    : null;
+  }), [group]);
+
+  const modalInitial = useMemo<NavigationFormData | null>(() => (
+    initial
+      ? { label: initial.label, labelEn: initial.labelEn ?? '', url: initial.url, group, parent_id: initial.parent_id, is_active: initial.is_active }
+      : null
+  ), [group, initial]);
   const { formData, setFormData, loading, handleSubmit } = useFormModal(defaults, modalInitial, open);
 
   if (!open) return null;


### PR DESCRIPTION
## Summary
- Fixes navigation edit modal inputs resetting after each keystroke by memoizing the form default/initial snapshots passed into `useFormModal`.
- Adds a regression test that edits the Korean label, English label, and URL fields in the edit modal.

## Verification
- `npx vitest run src/components/shared/admin/navigation/NavigationFormModal.test.tsx --reporter=verbose`
- `npx vitest run src/components/shared/admin/__tests__/NavigationEditor.test.tsx src/components/shared/admin/navigation/NavigationFormModal.test.tsx --reporter=verbose`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`

Closes #831
