### PR TITLE
Keep admin sidebar clear of storefront header

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,14 +1,8 @@
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
-import { Toaster } from 'sonner';
-import Header from '@/components/Header';
-import AnnouncementBar from '@/components/shared/layout/AnnouncementBar';
-import Footer from '@/components/Footer';
-import MobileBottomNavWrapper from '@/components/MobileBottomNavWrapper';
-import { MobileNavProvider } from '@/contexts/MobileNavContext';
+import AppShell from '@/components/AppShell';
 import Providers from '@/components/Providers';
-import RecentlyViewedWidget from '@/components/RecentlyViewedWidget';
 import { routing } from '@/i18n/routing';
 import type { Locale } from '@/i18n/routing';
 import { getThemeStyle } from '@/lib/theme-style';
@@ -105,27 +99,9 @@ export default async function LocaleLayout({
         </a>
         <NextIntlClientProvider messages={messages}>
           <Providers locale={safeLocale}>
-            <MobileNavProvider initialVisible={mobileBottomNavVisible}>
-              <div className="flex min-h-screen flex-col">
-              <AnnouncementBar locale={safeLocale} />
-              <Header />
-              <main id="main-content" className="flex-1 pb-16 md:pb-0">{children}</main>
-              <Footer />
-              <MobileBottomNavWrapper visible={mobileBottomNavVisible} />
-              <Toaster
-                position="top-center"
-                closeButton
-                swipeDirections={['top', 'right', 'bottom', 'left']}
-                toastOptions={{
-                  style: {
-                    fontFamily: 'var(--font-body)',
-                    borderRadius: 'var(--radius-md)',
-                  },
-                }}
-              />
-              <RecentlyViewedWidget />
-            </div>
-            </MobileNavProvider>
+            <AppShell locale={safeLocale} mobileBottomNavVisible={mobileBottomNavVisible}>
+              {children}
+            </AppShell>
           </Providers>
         </NextIntlClientProvider>
       </body>

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import {
   LayoutDashboard,
   Package,
@@ -10,6 +11,7 @@ import {
   FileText,
   Settings,
   ChevronDown,
+  Home,
   X,
 } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
@@ -94,6 +96,7 @@ type SidebarContentProps = {
 
 function SidebarContent({ onClose }: SidebarContentProps) {
   const pathname = usePathname();
+  const t = useTranslations('admin.sidebar');
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(
     () => getInitialOpenGroups(pathname),
   );
@@ -105,7 +108,7 @@ function SidebarContent({ onClose }: SidebarContentProps) {
   return (
     <aside className="flex h-full w-60 shrink-0 flex-col border-r bg-background">
       <div className="flex h-14 items-center justify-between border-b px-4">
-        <span className="text-sm font-semibold">관리자 패널</span>
+        <span className="typo-body-sm font-semibold">{t('adminPanel')}</span>
         {onClose && (
           <button
             onClick={onClose}
@@ -115,6 +118,16 @@ function SidebarContent({ onClose }: SidebarContentProps) {
             <X className="h-4 w-4" />
           </button>
         )}
+      </div>
+      <div className="border-b px-2 py-3">
+        <Link
+          href="/"
+          onClick={onClose}
+          className="flex items-center gap-3 rounded-md px-3 py-2 typo-body-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Home className="h-4 w-4 shrink-0" />
+          {t('backToShop')}
+        </Link>
       </div>
       <nav className="flex-1 overflow-y-auto py-4">
         <ul className="space-y-1 px-2">

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { Toaster } from 'sonner';
+import Header from '@/components/Header';
+import AnnouncementBar from '@/components/shared/layout/AnnouncementBar';
+import Footer from '@/components/Footer';
+import MobileBottomNavWrapper from '@/components/MobileBottomNavWrapper';
+import { MobileNavProvider } from '@/contexts/MobileNavContext';
+import RecentlyViewedWidget from '@/components/RecentlyViewedWidget';
+import type { Locale } from '@/i18n/routing';
+
+type AppShellProps = {
+  children: React.ReactNode;
+  locale: Locale;
+  mobileBottomNavVisible: boolean;
+};
+
+function isAdminPath(pathname: string): boolean {
+  return /^\/(?:[a-z]{2}(?:-[A-Z]{2})?\/)?admin(?:\/|$)/.test(pathname);
+}
+
+function SharedToaster() {
+  return (
+    <Toaster
+      position="top-center"
+      closeButton
+      swipeDirections={['top', 'right', 'bottom', 'left']}
+      toastOptions={{
+        style: {
+          fontFamily: 'var(--font-body)',
+          borderRadius: 'var(--radius-md)',
+        },
+      }}
+    />
+  );
+}
+
+export default function AppShell({
+  children,
+  locale,
+  mobileBottomNavVisible,
+}: AppShellProps) {
+  const pathname = usePathname();
+  const isAdminRoute = isAdminPath(pathname);
+
+  if (isAdminRoute) {
+    return (
+      <>
+        <main id="main-content">{children}</main>
+        <SharedToaster />
+      </>
+    );
+  }
+
+  return (
+    <MobileNavProvider initialVisible={mobileBottomNavVisible}>
+      <div className="flex min-h-screen flex-col">
+        <AnnouncementBar locale={locale} />
+        <Header />
+        <main id="main-content" className="flex-1 pb-16 md:pb-0">
+          {children}
+        </main>
+        <Footer />
+        <MobileBottomNavWrapper visible={mobileBottomNavVisible} />
+        <SharedToaster />
+        <RecentlyViewedWidget />
+      </div>
+    </MobileNavProvider>
+  );
+}
+

--- a/src/components/__tests__/AdminLayout.test.tsx
+++ b/src/components/__tests__/AdminLayout.test.tsx
@@ -14,6 +14,28 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => mockUseAuth(),
 }));
 
+vi.mock('next-intl', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next-intl')>();
+  const messages = (await import('@/i18n/messages/ko.json')).default as Record<string, unknown>;
+  return {
+    ...actual,
+    useTranslations: (namespace: string) => (key: string) => {
+      const value = namespace.split('.').reduce<unknown>((acc, part) => {
+        if (acc && typeof acc === 'object' && part in acc) {
+          return (acc as Record<string, unknown>)[part];
+        }
+        return undefined;
+      }, messages);
+
+      if (value && typeof value === 'object' && key in value) {
+        return String((value as Record<string, unknown>)[key]);
+      }
+
+      return key;
+    },
+  };
+});
+
 beforeEach(() => {
   mockReplace.mockClear();
 });
@@ -65,6 +87,8 @@ describe('AdminSidebar', () => {
       logout: vi.fn(),
     });
     render(<AdminLayout><span /></AdminLayout>);
+    const homeLink = screen.getByRole('link', { name: '쇼핑몰로 돌아가기' });
+    expect(homeLink).toHaveAttribute('href', '/');
     expect(screen.getByText('대시보드')).toBeInTheDocument();
 
     // Nav groups are collapsed by default — open each to reveal children

--- a/src/components/__tests__/AppShell.test.tsx
+++ b/src/components/__tests__/AppShell.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AppShell from '@/components/AppShell';
+
+let mockPathname = '/';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('@/components/Header', () => ({
+  default: () => <header data-testid="global-header">Global Header</header>,
+}));
+
+vi.mock('@/components/shared/layout/AnnouncementBar', () => ({
+  default: () => <div data-testid="announcement-bar" />,
+}));
+
+vi.mock('@/components/Footer', () => ({
+  default: () => <footer data-testid="footer" />,
+}));
+
+vi.mock('@/components/MobileBottomNavWrapper', () => ({
+  default: () => <nav data-testid="mobile-bottom-nav" />,
+}));
+
+vi.mock('@/components/RecentlyViewedWidget', () => ({
+  default: () => <aside data-testid="recently-viewed" />,
+}));
+
+vi.mock('@/contexts/MobileNavContext', () => ({
+  MobileNavProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="mobile-nav-provider">{children}</div>
+  ),
+}));
+
+vi.mock('sonner', () => ({
+  Toaster: () => <div data-testid="toaster" />,
+}));
+
+describe('AppShell', () => {
+  it('renders public chrome on storefront routes', () => {
+    mockPathname = '/ko/products';
+
+    render(
+      <AppShell locale="ko" mobileBottomNavVisible>
+        storefront content
+      </AppShell>,
+    );
+
+    expect(screen.getByTestId('global-header')).toBeInTheDocument();
+    expect(screen.getByTestId('announcement-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('footer')).toBeInTheDocument();
+    expect(screen.getByText('storefront content')).toBeInTheDocument();
+  });
+
+  it('hides public chrome on admin routes', () => {
+    mockPathname = '/ko/admin/dashboard';
+
+    render(
+      <AppShell locale="ko" mobileBottomNavVisible>
+        admin content
+      </AppShell>,
+    );
+
+    expect(screen.queryByTestId('global-header')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('announcement-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('footer')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mobile-bottom-nav')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('recently-viewed')).not.toBeInTheDocument();
+    expect(screen.getByText('admin content')).toBeInTheDocument();
+    expect(screen.getByTestId('toaster')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary\n- Hide storefront chrome on admin routes so the global header no longer overlaps the admin sidebar\n- Keep admin toasts available while removing public header/footer/mobile chrome on admin pages\n- Add a sidebar link back to the shop home using existing admin sidebar i18n keys\n\n## Verification\n- npx vitest run src/components/__tests__/AppShell.test.tsx src/components/__tests__/AdminLayout.test.tsx\n- npm run build && npm run test:run\n- cd backend && npm run build && npm run test\n\nCloses #834