### PR TITLE
Remove redundant product-search placeholder copy

### DIFF
--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -106,6 +106,14 @@ describe('Header', () => {
     expect(screen.getAllByRole('link', { name: '로그인' }).length).toBeGreaterThan(0);
   });
 
+  it('renders search inputs without product-search placeholder copy', () => {
+    render(<Header />);
+
+    screen.getAllByRole('searchbox').forEach((input) => {
+      expect(input).not.toHaveAttribute('placeholder', '상품 검색...');
+    });
+  });
+
   it('search form: type query + submit → push called with /search?q=검색어', async () => {
     const user = userEvent.setup();
     render(<Header />);

--- a/src/components/shared/search/SearchInput.tsx
+++ b/src/components/shared/search/SearchInput.tsx
@@ -14,7 +14,7 @@ interface SearchInputProps {
   placeholder?: string;
 }
 
-export default function SearchInput({ className, placeholder = '상품 검색...' }: SearchInputProps) {
+export default function SearchInput({ className, placeholder = '' }: SearchInputProps) {
   const router = useRouter();
   const [value, setValue] = useState('');
   const [isOpen, setIsOpen] = useUrlModal('searchDropdown');

--- a/src/components/shared/search/__tests__/SearchInput.test.tsx
+++ b/src/components/shared/search/__tests__/SearchInput.test.tsx
@@ -68,6 +68,12 @@ describe('SearchInput', () => {
     });
   });
 
+  it('does not show product-search helper copy in the input placeholder', () => {
+    render(<SearchInput />);
+
+    expect(screen.getByLabelText('상품 검색')).toHaveAttribute('placeholder', '');
+  });
+
   it('submits a trimmed query, stores it, and navigates to search', async () => {
     render(<SearchInput />);
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -63,7 +63,7 @@
     "next": "Next announcement"
   },
   "header": {
-    "searchPlaceholder": "Search products...",
+    "searchPlaceholder": "",
     "searchLabel": "Search products",
     "searchButton": "Search",
     "searchShort": "Search...",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -63,7 +63,7 @@
     "next": "다음 공지"
   },
   "header": {
-    "searchPlaceholder": "상품 검색...",
+    "searchPlaceholder": "",
     "searchLabel": "상품 검색",
     "searchButton": "검색",
     "searchShort": "검색...",


### PR DESCRIPTION
## Summary
- Remove visible product-search placeholder copy from the header search input translations.
- Remove the shared search input's default visible "상품 검색..." helper copy while keeping its accessible label.
- Add regression coverage for both header and shared search inputs.

## Code Review Pass
- Checked that search submission behavior remains covered and unchanged.
- Kept search purpose in `aria-label`/role names, so removing visual placeholder text does not remove the accessible name.
- No raw API calls, new dependencies, schema changes, or new hardcoded user-facing Korean strings were introduced.

## Verification
- `npx vitest run src/components/shared/search/__tests__/SearchInput.test.tsx src/components/__tests__/Header.test.tsx --reporter=verbose`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`

Closes #835
