### PR TITLE
푸터 대분류 제목 시각 계층 강화

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -68,21 +68,21 @@ export default function Footer() {
       <div className="mx-auto max-w-7xl px-4 py-12">
         <div className={`grid grid-cols-2 md:grid-cols-4 gap-8 transition-opacity duration-300 ${loading ? 'opacity-0' : 'opacity-100'}`}>
           <div>
-            <p className="text-sm font-medium text-foreground mb-4">{t('customerService')}</p>
+            <p className="typo-body font-semibold text-foreground mb-4">{t('customerService')}</p>
             <nav className="flex flex-col gap-2">
               {renderNavLinks(rootItems.slice(0, 4))}
             </nav>
           </div>
 
           <div>
-            <p className="text-sm font-medium text-foreground mb-4">{t('company')}</p>
+            <p className="typo-body font-semibold text-foreground mb-4">{t('company')}</p>
             <nav className="flex flex-col gap-2">
               {renderNavLinks(rootItems.slice(4, 6))}
             </nav>
           </div>
 
           <div>
-            <p className="text-sm font-medium text-foreground mb-4">{t('shop')}</p>
+            <p className="typo-body font-semibold text-foreground mb-4">{t('shop')}</p>
             <nav className="flex flex-col gap-2">
               {renderNavLinks(rootItems.slice(6, 10))}
             </nav>

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -64,6 +64,17 @@ describe('Footer', () => {
     expect(screen.getByRole('link', { name: '고객센터' })).toBeInTheDocument();
   });
 
+  it('renders footer section headings larger and bold', () => {
+    render(<Footer />);
+
+    for (const heading of ['고객센터', '회사', '쇼핑']) {
+      const sectionHeading = screen.getAllByText(heading).find((element) => element.tagName === 'P');
+
+      expect(sectionHeading).toHaveClass('typo-body', 'font-semibold', 'text-foreground');
+      expect(sectionHeading).not.toHaveClass('text-sm', 'font-medium');
+    }
+  });
+
   it('renders footer without solid or dotted divider lines', () => {
     const { container } = render(<Footer />);
 


### PR DESCRIPTION
## Summary
- Increase footer major section heading typography from small text to the project body typography token.
- Make footer headings semibold so 고객센터/회사/쇼핑 stand apart from child links.
- Add a Footer test that locks the heading typography classes.

## Verification
- [x] `npx vitest run src/components/__tests__/Footer.test.tsx`
- [x] `npm run build && npm run test:run`
- [x] `cd backend && npm run build && npm run test`

Closes #836
