### PR TITLE
feat: #841 상품 상세 배송 안내 추가

### DIFF
--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -24,6 +24,30 @@ const TABS = ['details', 'reviews', 'inquiry'] as const
 type Tab = (typeof TABS)[number]
 const INQUIRY_TYPE_PRODUCT = '상품'
 
+function DeliveryGuide() {
+  const t = useTranslations('product.tabs.deliveryGuide')
+  const items = ['method', 'area', 'period', 'dispatch', 'remoteArea'] as const
+
+  return (
+    <section className="rounded-lg border border-border bg-muted/20 p-5" aria-labelledby="delivery-guide-title">
+      <div className="mb-4">
+        <p className="typo-label text-muted-foreground">{t('eyebrow')}</p>
+        <h2 id="delivery-guide-title" className="typo-h2 text-foreground">
+          {t('title')}
+        </h2>
+      </div>
+      <dl className="grid gap-3 md:grid-cols-2">
+        {items.map((item) => (
+          <div key={item} className="rounded-md bg-background/70 p-3">
+            <dt className="typo-label text-muted-foreground">{t(`${item}.label`)}</dt>
+            <dd className="mt-1 typo-body-sm text-foreground">{t(`${item}.value`)}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  )
+}
+
 export default function ProductTabs({ description, descriptionImages, productId, locale = 'ko' }: ProductTabsProps) {
   const t = useTranslations('product')
   const pathname = usePathname()
@@ -155,6 +179,7 @@ export default function ProductTabs({ description, descriptionImages, productId,
               className="prose prose-sm max-w-none"
               dangerouslySetInnerHTML={{ __html: sanitized }}
             />
+            <DeliveryGuide />
           </div>
         )}
         {activeTab === 'reviews' && productId && (

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -206,6 +206,30 @@
         "statusAnswered": "Answered",
         "statusPending": "Received",
         "answerLabel": "Answer"
+      },
+      "deliveryGuide": {
+        "eyebrow": "Shipping Guide",
+        "title": "Delivery Period & Service Guide",
+        "method": {
+          "label": "Shipping method",
+          "value": "Orders are shipped safely by parcel courier."
+        },
+        "area": {
+          "label": "Service area",
+          "value": "Delivery is available throughout South Korea."
+        },
+        "period": {
+          "label": "Standard delivery period",
+          "value": "Delivery usually takes 2–5 business days after payment is completed."
+        },
+        "dispatch": {
+          "label": "Dispatch schedule",
+          "value": "Orders are dispatched within 1–2 business days after payment confirmation."
+        },
+        "remoteArea": {
+          "label": "Remote or island areas",
+          "value": "Jeju, island, and remote areas may require additional shipping fees or delivery time."
+        }
       }
     },
     "sort": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -206,6 +206,30 @@
         "statusAnswered": "답변완료",
         "statusPending": "접수",
         "answerLabel": "답변"
+      },
+      "deliveryGuide": {
+        "eyebrow": "배송 안내",
+        "title": "배송기간 및 서비스 제공 안내",
+        "method": {
+          "label": "배송 방법",
+          "value": "택배 배송으로 안전하게 발송합니다."
+        },
+        "area": {
+          "label": "배송 지역",
+          "value": "대한민국 전 지역 배송이 가능합니다."
+        },
+        "period": {
+          "label": "기본 배송기간",
+          "value": "결제 완료 후 영업일 기준 2~5일 이내 배송됩니다."
+        },
+        "dispatch": {
+          "label": "출고 안내",
+          "value": "결제 완료 확인 후 영업일 기준 1~2일 이내 출고를 진행합니다."
+        },
+        "remoteArea": {
+          "label": "산간·도서 지역",
+          "value": "제주 및 산간·도서 지역은 추가 배송비 또는 배송기간이 발생할 수 있습니다."
+        }
       }
     },
     "sort": {


### PR DESCRIPTION
## Summary
- Closes #841
- 상품 상세 상세정보 탭 하단에 배송기간 및 배송 안내 블록을 고정 노출했습니다.
- 배송 방법, 배송 지역, 기본 배송기간, 출고 안내, 산간·도서 지역 추가 안내를 한국어/영어 i18n으로 추가했습니다.

## Test plan
- [x] npm run lint
- [x] npm run test:run -- ProductTabs
- [x] npm run build