### PR TITLE
feat: #855 재고 및 품절 안내 강화

### DIFF
--- a/src/components/__tests__/OptionSelector.test.tsx
+++ b/src/components/__tests__/OptionSelector.test.tsx
@@ -4,6 +4,22 @@ import { describe, it, expect, vi } from 'vitest'
 import OptionSelector from '@/components/shared/products/OptionSelector'
 import type { ProductOption } from '@/lib/api'
 
+const translations: Record<string, string> = {
+  soldout: '품절',
+  optionSoldoutReason: '해당 옵션은 품절되어 선택할 수 없습니다.',
+  optionSoldoutAria: '{option} 옵션 품절',
+  lowStock: '남은 수량 {count}개',
+  available: '구매 가능',
+}
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string | number>) => {
+    const template = translations[key] ?? key
+    if (!values) return template
+    return Object.entries(values).reduce((acc, [k, v]) => acc.replace(`{${k}}`, String(v)), template)
+  },
+}))
+
 const mockOptions: ProductOption[] = [
   { id: 1, name: '색상', value: '블랙', priceAdjustment: 0, stock: 10, sortOrder: 0 },
   { id: 2, name: '색상', value: '화이트', priceAdjustment: 0, stock: 0, sortOrder: 1 },

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -49,6 +49,8 @@ const translations: Record<string, string> = {
   discountOff: '{percent}% 할인',
   toggleOn: '찜하기',
   toggleOff: '찜 해제',
+  'stockStatus.soldout': '품절',
+  'stockStatus.soldoutReason': '현재 재고가 없어 구매할 수 없습니다.',
 };
 
 vi.mock('next-intl', () => ({
@@ -107,7 +109,7 @@ describe('ProductCard', () => {
 
   it('shows soldout badge when status is soldout', () => {
     render(<ProductCard {...baseProps} status="soldout" />);
-    expect(screen.getByText('SOLD OUT')).toBeInTheDocument();
+    expect(screen.getByText('품절')).toBeInTheDocument();
   });
 
   it('renders the Okhwadang logo fallback when images are empty', () => {
@@ -133,7 +135,7 @@ describe('ProductCard', () => {
 
   it('shows soldout overlay when status is soldout', () => {
     render(<ProductCard {...baseProps} status="soldout" />);
-    expect(screen.getByText('SOLD OUT')).toBeInTheDocument();
+    expect(screen.getByText('품절')).toBeInTheDocument();
   });
 
   it('redirects to login when unauthenticated user clicks wishlist', async () => {

--- a/src/components/shared/products/OptionSelector.tsx
+++ b/src/components/shared/products/OptionSelector.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useTranslations } from 'next-intl'
 import { cn } from '@/components/ui/utils'
 import type { ProductOption } from '@/lib/api'
 import { formatCurrency } from '@/utils/currency'
@@ -11,6 +12,7 @@ interface OptionSelectorProps {
 }
 
 export default function OptionSelector({ options, selectedOptionId, onSelect }: OptionSelectorProps) {
+  const t = useTranslations('product.stockStatus')
   const groups = options.reduce<Record<string, ProductOption[]>>((acc, option) => {
     if (!acc[option.name]) {
       acc[option.name] = []
@@ -28,28 +30,34 @@ export default function OptionSelector({ options, selectedOptionId, onSelect }: 
             {groupOptions.map((option) => {
               const isSoldout = option.stock === 0
               const isSelected = option.id === selectedOptionId
+              const isLowStock = !isSoldout && option.stock > 0 && option.stock <= 5
               return (
                 <button
                   key={option.id}
                   type="button"
                   disabled={isSoldout}
                   aria-disabled={isSoldout}
+                  aria-label={isSoldout ? t('optionSoldoutAria', { option: option.value }) : undefined}
+                  title={isSoldout ? t('optionSoldoutReason') : isLowStock ? t('lowStock', { count: option.stock }) : undefined}
                   onClick={() => onSelect(option.id)}
                   className={cn(
-                    'rounded-md border px-3 py-1.5 text-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                    'flex min-w-28 flex-col items-start gap-1 rounded-md border px-3 py-2 text-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
                     isSelected
                       ? 'ring-2 ring-foreground bg-foreground text-background border-foreground'
                       : 'border-border bg-background hover:border-foreground',
-                    isSoldout && 'line-through opacity-50 cursor-not-allowed',
+                    isSoldout && 'opacity-55 cursor-not-allowed',
                   )}
                 >
-                  {option.value}
+                  <span className={cn('font-medium', isSoldout && 'line-through')}>{option.value}</span>
                   {option.priceAdjustment !== 0 && (
-                    <span className="ml-1 text-xs">
+                    <span className="text-xs">
                       ({option.priceAdjustment > 0 ? '+' : ''}
                       {formatCurrency(option.priceAdjustment)})
                     </span>
                   )}
+                  <span className={cn('text-xs', isSelected ? 'text-background/80' : 'text-muted-foreground', isSoldout && 'text-destructive')}>
+                    {isSoldout ? t('soldout') : isLowStock ? t('lowStock', { count: option.stock }) : t('available')}
+                  </span>
                 </button>
               )
             })}

--- a/src/components/shared/products/ProductCard.tsx
+++ b/src/components/shared/products/ProductCard.tsx
@@ -124,7 +124,7 @@ function ProductCard({
 
         {isSoldout && (
           <div className="absolute inset-0 flex items-center justify-center bg-background/70">
-            <span className="data-label text-foreground tracking-widest">SOLD OUT</span>
+            <span className="data-label text-foreground tracking-widest">{t('stockStatus.soldout')}</span>
           </div>
         )}
 
@@ -199,6 +199,12 @@ function ProductCard({
             </p>
           )}
         </div>
+
+        {isSoldout && (
+          <p className="mt-auto rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-center text-xs font-medium text-destructive">
+            {t('stockStatus.soldoutReason')}
+          </p>
+        )}
 
         {/* 장바구니 담기 — 메타 아래 고정, hover 시 foreground 대비 강화 */}
         {!isSoldout && (

--- a/src/components/shared/products/ProductDetailClient.tsx
+++ b/src/components/shared/products/ProductDetailClient.tsx
@@ -99,7 +99,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
     (o) => o.id === selectedOptionId,
   )
   const maxQuantity = selectedOption?.stock ?? product.stock
-  const isSoldout = product.status === 'soldout'
+  const isSoldout = product.status === 'soldout' || maxQuantity === 0
   const isLowStock = !isSoldout && maxQuantity > 0 && maxQuantity <= 5
   const descriptionImages = product.detailImages?.filter((img) => img.isActive) ?? []
 
@@ -375,9 +375,13 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
             </Button>
           </div>
 
-          {isSoldout && (
-            <p className="typo-body-sm font-medium text-destructive">{t('outOfStockMessage')}</p>
-          )}
+          <div className="rounded-lg border border-border bg-muted/20 p-4">
+            <p className="typo-label text-muted-foreground">{t('stockStatus.title')}</p>
+            <p className={cn('mt-1 typo-body-sm font-medium', isSoldout ? 'text-destructive' : 'text-foreground')}>
+              {isSoldout ? t('stockStatus.soldoutReason') : isLowStock ? t('stockStatus.lowStock', { count: maxQuantity }) : t('stockStatus.available')}
+            </p>
+            <p className="mt-2 typo-body-sm text-muted-foreground">{t('stockStatus.restockNotice')}</p>
+          </div>
         </div>
       </div>
 

--- a/src/components/shared/products/ProductListItem.tsx
+++ b/src/components/shared/products/ProductListItem.tsx
@@ -73,7 +73,7 @@ function ProductListItem({
         )}
         {isSoldout && (
           <div className="absolute inset-0 flex items-center justify-center bg-black/40">
-            <span className="text-xs font-semibold text-white">품절</span>
+            <span className="text-xs font-semibold text-white">{t('stockStatus.soldout')}</span>
           </div>
         )}
       </div>
@@ -97,7 +97,10 @@ function ProductListItem({
             )}
           </div>
         )}
-        {shortDescription && (
+        {isSoldout && (
+          <p className="line-clamp-1 typo-body-sm font-medium text-destructive">{t('stockStatus.soldoutReason')}</p>
+        )}
+        {!isSoldout && shortDescription && (
           <p className="line-clamp-1 typo-body-sm text-muted-foreground">{shortDescription}</p>
         )}
       </div>

--- a/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
+++ b/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
@@ -56,6 +56,11 @@ vi.mock('next-intl', () => ({
       selectedQuantity: `수량 ${values?.quantity ?? 0}개`,
       totalProductPrice: '상품 합계',
       outOfStockMessage: '품절',
+      'stockStatus.title': '재고 안내',
+      'stockStatus.soldoutReason': '품절',
+      'stockStatus.lowStock': `재고 ${values?.count ?? 0}개`,
+      'stockStatus.available': '구매 가능',
+      'stockStatus.restockNotice': '재입고 알림 준비 중',
       clay: '진흙',
       shape: '모양',
     };

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -239,7 +239,17 @@
       "hidden": "Hidden"
     },
     "lowStock": "Only {count} left",
-    "badgeFreeShipping": "Free Shipping"
+    "badgeFreeShipping": "Free Shipping",
+    "stockStatus": {
+      "title": "Stock status",
+      "soldout": "Sold out",
+      "soldoutReason": "This item is currently unavailable and cannot be purchased.",
+      "optionSoldoutReason": "This option is sold out and cannot be selected.",
+      "optionSoldoutAria": "{option} option sold out",
+      "lowStock": "Only {count} left",
+      "available": "Available",
+      "restockNotice": "Restock notification support is being prepared."
+    }
   },
   "cart": {
     "title": "Cart",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -239,7 +239,17 @@
       "hidden": "숨김"
     },
     "lowStock": "{count}개 남음",
-    "badgeFreeShipping": "무료배송"
+    "badgeFreeShipping": "무료배송",
+    "stockStatus": {
+      "title": "재고 안내",
+      "soldout": "품절",
+      "soldoutReason": "현재 재고가 없어 구매할 수 없습니다.",
+      "optionSoldoutReason": "해당 옵션은 품절되어 선택할 수 없습니다.",
+      "optionSoldoutAria": "{option} 옵션 품절",
+      "lowStock": "남은 수량 {count}개",
+      "available": "구매 가능",
+      "restockNotice": "재입고 알림 기능과 연결될 수 있도록 준비 중입니다."
+    }
   },
   "cart": {
     "title": "장바구니",


### PR DESCRIPTION
## Summary
- Closes #855
- 상품 목록/리스트/상세에서 품절 상태와 구매 불가 사유를 일관되게 표시했습니다.
- 옵션별 품절/낮은 재고 안내와 접근성 라벨을 추가했습니다.
- 재입고 알림 연결을 위한 안내 문구를 추가했습니다.

## Test plan
- [x] npm run lint
- [x] npm run test:run -- ProductCard ProductDetailClient
- [x] npm run build