### PR TITLE
fix: #866 support 카테고리 API 429 방지

### DIFF
--- a/src/components/__tests__/HomePage.test.tsx
+++ b/src/components/__tests__/HomePage.test.tsx
@@ -262,7 +262,7 @@ describe('CategoryNavBlock', () => {
     };
     render(<CategoryNavBlock content={content} />);
     const topLink = screen.getByRole('link', { name: /상의/ });
-    expect(topLink).toHaveAttribute('href', '/products?categoryId=1');
+    expect(topLink).toHaveAttribute('href', '/ko/products?categoryId=1');
   });
 
   it('renders nothing when categories empty and not loading', () => {

--- a/src/components/shared/blocks/CategoryNavBlock.test.tsx
+++ b/src/components/shared/blocks/CategoryNavBlock.test.tsx
@@ -13,13 +13,23 @@ vi.mock('next/image', () => ({
 }));
 
 vi.mock('next/link', () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+  default: ({
+    children,
+    href,
+    prefetch,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    prefetch?: boolean;
+  }) => (
+    <a href={href} data-prefetch={String(prefetch)}>
+      {children}
+    </a>
   ),
 }));
 
 vi.mock('next/navigation', () => ({
-  useParams: () => ({ locale: 'ko' }),
+  useParams: () => ({ locale: 'en' }),
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -39,7 +49,7 @@ describe('CategoryNavBlock', () => {
     vi.clearAllMocks();
   });
 
-  it('renders categories when prefetched_categories is provided', async () => {
+  it('renders text category links with locale path and disabled prefetch', async () => {
     const content = {
       category_ids: [],
       template: 'text' as const,
@@ -51,6 +61,25 @@ describe('CategoryNavBlock', () => {
     await waitFor(() => {
       const links = screen.getAllByRole('link');
       expect(links).toHaveLength(3);
+      expect(links[0]).toHaveAttribute('href', '/en/products?categoryId=1');
+      expect(links[0]).toHaveAttribute('data-prefetch', 'false');
+    });
+  });
+
+  it('renders image category links with locale path and disabled prefetch', async () => {
+    const content = {
+      category_ids: [],
+      template: 'image' as const,
+      prefetched_categories: mockCategories,
+    };
+
+    render(<CategoryNavBlock content={content} />);
+
+    await waitFor(() => {
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(3);
+      expect(links[1]).toHaveAttribute('href', '/en/products?categoryId=2');
+      expect(links[1]).toHaveAttribute('data-prefetch', 'false');
     });
   });
 

--- a/src/components/shared/blocks/CategoryNavBlock.tsx
+++ b/src/components/shared/blocks/CategoryNavBlock.tsx
@@ -26,14 +26,15 @@ function getClayColor(slug: string): string | null {
   return null;
 }
 
-function CategoryImageCard({ cat }: { cat: Category }) {
+function CategoryImageCard({ cat, locale }: { cat: Category; locale: string }) {
   const [imgError, setImgError] = useState(false);
   const handleError = useCallback(() => setImgError(true), []);
   const clayColor = getClayColor(cat.slug);
 
   return (
     <Link
-      href={`/products?categoryId=${cat.id}`}
+      href={`/${locale}/products?categoryId=${cat.id}`}
+      prefetch={false}
       className="group relative aspect-[4/3] overflow-hidden bg-muted"
     >
       {cat.imageUrl && !imgError ? (
@@ -105,7 +106,7 @@ export default function CategoryNavBlock({ content }: Props) {
         {title && <h2 className="text-2xl font-medium mb-8 text-center">{title}</h2>}
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           {categories.map((cat) => (
-            <CategoryImageCard key={cat.id} cat={cat} />
+            <CategoryImageCard key={cat.id} cat={cat} locale={locale} />
           ))}
         </div>
       </nav>
@@ -121,7 +122,8 @@ export default function CategoryNavBlock({ content }: Props) {
           return (
             <Link
               key={cat.id}
-              href={`/products?categoryId=${cat.id}`}
+              href={`/${locale}/products?categoryId=${cat.id}`}
+              prefetch={false}
               className="group bg-background px-6 py-8 flex flex-col gap-3 hover:bg-muted/40 transition-colors duration-300"
               style={{
                 opacity: visible ? 1 : 0,


### PR DESCRIPTION
## Summary
- Closes #866
- CMS category_nav 링크를 locale-aware 경로로 변경해 `/products -> /en/products` 리다이렉트를 제거
- category_nav 링크에 `prefetch={false}`를 적용해 support 페이지 체류 중 상품 목록 RSC prefetch가 categories API를 반복 호출하지 않도록 방지
- text/image 템플릿 및 기존 홈 테스트 기대값 보강

## Test plan
- [x] npm run test:run -- src/components/shared/blocks/CategoryNavBlock.test.tsx
- [x] npm run test:run -- src/components/__tests__/HomePage.test.tsx src/components/shared/blocks/CategoryNavBlock.test.tsx
- [x] npm run lint && npm run build && npm run test:run
- [x] cd backend && npm run lint && npm run build && npm run test