### PR TITLE
fix: #866 헤더/푸터 prefetch 비활성화

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -51,6 +51,7 @@ function renderNavLinks(items: NavigationItem[]) {
     <Link
       key={item.id}
       href={getFooterHref(item)}
+      prefetch={false}
       className="text-sm text-muted-foreground hover:text-foreground transition-colors"
     >
       {item.label}

--- a/src/components/__tests__/DesktopNav.test.tsx
+++ b/src/components/__tests__/DesktopNav.test.tsx
@@ -4,8 +4,8 @@ import { DesktopNav } from '@/components/header/DesktopNav';
 import type { NavigationItem } from '@/lib/api';
 
 vi.mock('@/i18n/navigation', () => ({
-  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
-    <a href={href} {...props}>{children}</a>
+  Link: ({ href, children, prefetch, ...props }: { href: string; children: React.ReactNode; prefetch?: boolean; [key: string]: unknown }) => (
+    <a href={href} data-prefetch={String(prefetch)} {...props}>{children}</a>
   ),
 }));
 
@@ -57,8 +57,15 @@ describe('DesktopNav', () => {
 
     fireEvent.mouseEnter(screen.getByText('보이차·다구').closest('div')!);
 
-    expect(screen.getByRole('link', { name: '보이차' })).toHaveAttribute('href', '/products?categoryId=2');
-    expect(screen.getByRole('link', { name: '생차' })).toHaveAttribute('href', '/products?categoryId=3');
+    const parentLink = screen.getByRole('link', { name: '보이차·다구' });
+    const childLink = screen.getByRole('link', { name: '보이차' });
+    const grandchildLink = screen.getByRole('link', { name: '생차' });
+
+    expect(parentLink).toHaveAttribute('data-prefetch', 'false');
+    expect(childLink).toHaveAttribute('href', '/products?categoryId=2');
+    expect(childLink).toHaveAttribute('data-prefetch', 'false');
+    expect(grandchildLink).toHaveAttribute('href', '/products?categoryId=3');
+    expect(grandchildLink).toHaveAttribute('data-prefetch', 'false');
     expect(screen.queryByText('ㄴ 보이차')).not.toBeInTheDocument();
     expect(screen.queryByText('ㄴ 생차')).not.toBeInTheDocument();
     expect(container.innerHTML).not.toContain('border-divider-soft');

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -3,8 +3,8 @@ import { describe, it, expect, vi } from 'vitest';
 import Footer from '@/components/Footer';
 
 vi.mock('@/i18n/navigation', () => ({
-  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
-    <a href={href} {...props}>{children}</a>
+  Link: ({ href, children, prefetch, ...props }: { href: string; children: React.ReactNode; prefetch?: boolean; [key: string]: unknown }) => (
+    <a href={href} data-prefetch={String(prefetch)} {...props}>{children}</a>
   ),
   useRouter: () => ({ push: vi.fn() }),
   usePathname: () => '/',
@@ -62,6 +62,13 @@ describe('Footer', () => {
     expect(screen.getByRole('link', { name: '이용약관' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '개인정보처리방침' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '고객센터' })).toBeInTheDocument();
+  });
+
+  it('disables prefetch for footer navigation links', () => {
+    render(<Footer />);
+
+    expect(screen.getByRole('link', { name: '전체 상품' })).toHaveAttribute('data-prefetch', 'false');
+    expect(screen.getByRole('link', { name: '고객센터' })).toHaveAttribute('data-prefetch', 'false');
   });
 
   it('renders footer section headings larger and bold', () => {

--- a/src/components/header/DesktopNav.tsx
+++ b/src/components/header/DesktopNav.tsx
@@ -42,6 +42,7 @@ export function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
         >
           <Link
             href={item.url}
+            prefetch={false}
             className={cn(
               'group relative flex items-center gap-1 py-2 typo-body-sm transition-colors duration-200',
               fullWidth && 'w-full justify-center',
@@ -74,6 +75,7 @@ export function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
                 <div key={child.id} className="flex flex-col gap-3">
                   <Link
                     href={child.url}
+                    prefetch={false}
                     className="typo-body-sm font-semibold text-foreground hover:text-primary transition-colors tracking-wide"
                   >
                     {getHeaderNavigationLabel(child.label)}
@@ -84,6 +86,7 @@ export function DesktopNav({ items, fullWidth = false }: DesktopNavProps) {
                         <Link
                           key={grandchild.id}
                           href={grandchild.url}
+                          prefetch={false}
                           className="typo-body-sm text-muted-foreground hover:text-foreground transition-colors"
                         >
                           {getHeaderNavigationLabel(grandchild.label)}


### PR DESCRIPTION
## Summary
- Closes #866
- support 페이지에서 헤더/푸터 내비게이션 링크의 Next.js route prefetch가 `/en/products`를 미리 렌더링하며 `/api/categories?locale=en`를 반복 호출하던 문제를 추가 차단
- DesktopNav root/child/grandchild 링크에 `prefetch={false}` 적용
- Footer CMS navigation 링크에 `prefetch={false}` 적용
- prefetch 비활성화 테스트 보강

## Test plan
- [x] npm run test:run -- src/components/__tests__/DesktopNav.test.tsx src/components/__tests__/Footer.test.tsx (RED 확인 후 GREEN)
- [x] npm run lint && npm run build && npm run test:run
- [x] cd backend && npm run lint && npm run build && npm run test
- [ ] 배포 후 Chrome DevTools 네트워크에서 support 페이지 `/api/categories?locale=en` 반복 호출 소거 확인