### PR TITLE
fix: #866 카테고리 블록 fetch 루프 방지

### DIFF
--- a/src/components/shared/blocks/CategoryNavBlock.test.tsx
+++ b/src/components/shared/blocks/CategoryNavBlock.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import CategoryNavBlock from '@/components/shared/blocks/CategoryNavBlock';
+import { categoriesApi } from '@/lib/api';
 import type { Category } from '@/lib/api';
 
 vi.mock('next/image', () => ({
@@ -81,6 +82,21 @@ describe('CategoryNavBlock', () => {
       expect(links[1]).toHaveAttribute('href', '/en/products?categoryId=2');
       expect(links[1]).toHaveAttribute('data-prefetch', 'false');
     });
+  });
+
+  it('fetches client fallback categories only once when category_ids is omitted', async () => {
+    vi.mocked(categoriesApi.getTree).mockResolvedValue(mockCategories);
+
+    render(<CategoryNavBlock content={{ template: 'text' }} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('link')).toHaveLength(3);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(categoriesApi.getTree).toHaveBeenCalledTimes(1);
+    expect(categoriesApi.getTree).toHaveBeenCalledWith('en');
   });
 
   it('returns null when prefetched_categories is empty array', () => {

--- a/src/components/shared/blocks/CategoryNavBlock.tsx
+++ b/src/components/shared/blocks/CategoryNavBlock.tsx
@@ -61,12 +61,15 @@ function CategoryImageCard({ cat, locale }: { cat: Category; locale: string }) {
   );
 }
 
+const EMPTY_CATEGORY_IDS: number[] = [];
+
 interface Props {
   content: CategoryNavContent;
 }
 
 export default function CategoryNavBlock({ content }: Props) {
-  const { title, category_ids = [], template, prefetched_categories } = content;
+  const { title, template, prefetched_categories } = content;
+  const category_ids = content.category_ids ?? EMPTY_CATEGORY_IDS;
   const { ref, visible } = useScrollAnimation<HTMLElement>();
   const params = useParams();
   const locale = params.locale as string;


### PR DESCRIPTION
## Summary
- Closes #866
- `CategoryNavBlock`에서 `category_ids` 생략 시 렌더마다 새 `[]`가 생성되어 `useBlockData` deps가 계속 바뀌던 문제 수정
- 안정적인 `EMPTY_CATEGORY_IDS`를 사용해 client fallback categories fetch가 1회만 실행되도록 고정
- 생략된 `category_ids` 케이스의 fetch 1회 보장 regression test 추가

## Test plan
- [x] npm run test:run -- src/components/shared/blocks/CategoryNavBlock.test.tsx (RED 확인 후 GREEN)
- [x] npm run lint && npm run build && npm run test:run
- [x] cd backend && npm run lint && npm run build && npm run test
- [ ] 배포 후 Chrome DevTools 네트워크에서 support 페이지 `/api/categories?locale=en` 반복 호출/429 소거 확인