### PR TITLE
feat: #852 사업자 정보 관리자 설정화

### DIFF
--- a/backend/src/database/migrations/1784500000000-AddBusinessInfoSettings.ts
+++ b/backend/src/database/migrations/1784500000000-AddBusinessInfoSettings.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddBusinessInfoSettings1784500000000 implements MigrationInterface {
+  name = 'AddBusinessInfoSettings1784500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO \`site_settings\` (\`setting_key\`, \`value\`, \`value_en\`, \`group\`, \`label\`, \`input_type\`, \`options\`, \`default_value\`, \`sort_order\`)
+      VALUES
+        ('business_company_name', '서로 인터내셔널', 'Seoro International', 'business_info', '상호명', 'text', NULL, '서로 인터내셔널', 200),
+        ('business_ceo', '권준현', 'Kwon Junhyun', 'business_info', '대표자명', 'text', NULL, '권준현', 201),
+        ('business_registration_number', '131-72-05631', '131-72-05631', 'business_info', '사업자등록번호', 'text', NULL, '131-72-05631', 202),
+        ('business_mail_order_number', '2026-서울강남-01632', '2026-서울강남-01632', 'business_info', '통신판매업신고번호', 'text', NULL, '2026-서울강남-01632', 203),
+        ('business_address', '서울특별시 강남구 역삼로 114 (현죽빌딩) 8층 8028호 (우 06252)', '8028, 8F, 114 Yeoksam-ro, Gangnam-gu, Seoul, Republic of Korea (06252)', 'business_info', '주소', 'text', NULL, '서울특별시 강남구 역삼로 114 (현죽빌딩) 8층 8028호 (우 06252)', 204),
+        ('business_phone', '010-2908-0393', '010-2908-0393', 'business_info', '대표전화', 'text', NULL, '010-2908-0393', 205),
+        ('business_email', 'seorointernational@naver.com', 'seorointernational@naver.com', 'business_info', '이메일', 'text', NULL, 'seorointernational@naver.com', 206),
+        ('business_hours', '평일 10:00 - 18:00 (주말·공휴일 휴무)', 'Weekdays 10:00 - 18:00 (Closed on weekends & holidays)', 'business_info', '운영시간', 'text', NULL, '평일 10:00 - 18:00 (주말·공휴일 휴무)', 207),
+        ('business_privacy_officer', '권준현', 'Kwon Junhyun', 'business_info', '개인정보보호책임자', 'text', NULL, '권준현', 208),
+        ('business_info_url', 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', 'business_info', '사업자정보확인 URL', 'text', NULL, 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', 209)
+      ON DUPLICATE KEY UPDATE \`setting_key\` = \`setting_key\`
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM \`site_settings\`
+      WHERE \`setting_key\` IN (
+        'business_company_name',
+        'business_ceo',
+        'business_registration_number',
+        'business_mail_order_number',
+        'business_address',
+        'business_phone',
+        'business_email',
+        'business_hours',
+        'business_privacy_officer',
+        'business_info_url'
+      )
+    `);
+  }
+}

--- a/src/app/[locale]/admin/settings/business/BusinessInfoEditor.tsx
+++ b/src/app/[locale]/admin/settings/business/BusinessInfoEditor.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { adminSettingsApi } from '@/lib/api';
+import { handleApiError } from '@/utils/error';
+import type { SiteSetting } from '@/lib/api';
+import { useUnsavedChanges } from '@/components/shared/hooks/useUnsavedChanges';
+import { cn } from '@/components/ui/utils';
+import { toastMessage } from '@/utils/toastMessages';
+
+const FIELD_ORDER = [
+  'business_company_name',
+  'business_ceo',
+  'business_registration_number',
+  'business_mail_order_number',
+  'business_address',
+  'business_phone',
+  'business_email',
+  'business_hours',
+  'business_privacy_officer',
+  'business_info_url',
+] as const;
+
+interface Props {
+  initialSettings: SiteSetting[];
+}
+
+function FieldRow({
+  setting,
+  currentValue,
+  currentValueEn,
+  onChange,
+  onChangeEn,
+}: {
+  setting: SiteSetting;
+  currentValue: string;
+  currentValueEn: string;
+  onChange: (key: string, value: string) => void;
+  onChangeEn: (key: string, value: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-2 border-b py-4 last:border-0 sm:grid-cols-[1fr_2fr]">
+      <div>
+        <p className="text-sm font-medium">{setting.label}</p>
+        <p className="text-xs text-muted-foreground">{setting.key}</p>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <input
+          type="text"
+          value={currentValue}
+          onChange={(e) => onChange(setting.key, e.target.value)}
+          className="w-full rounded border px-3 py-1.5 text-sm"
+          placeholder="한국어"
+        />
+        <input
+          type="text"
+          value={currentValueEn}
+          onChange={(e) => onChangeEn(setting.key, e.target.value)}
+          className="w-full rounded border px-3 py-1.5 text-xs text-muted-foreground placeholder:text-muted-foreground/50"
+          placeholder="English"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function BusinessInfoEditor({ initialSettings }: Props) {
+  const router = useRouter();
+  const [settings, setSettings] = useState<SiteSetting[]>(initialSettings);
+  const [pendingChanges, setPendingChanges] = useState<Record<string, string>>({});
+  const [pendingEnChanges, setPendingEnChanges] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+
+  const hasChanges = Object.keys(pendingChanges).length > 0 || Object.keys(pendingEnChanges).length > 0;
+  useUnsavedChanges(hasChanges);
+
+  const getCurrentValue = useCallback(
+    (setting: SiteSetting) => pendingChanges[setting.key] ?? setting.value,
+    [pendingChanges],
+  );
+
+  const getCurrentValueEn = useCallback(
+    (setting: SiteSetting) => pendingEnChanges[setting.key] ?? (setting.valueEn ?? ''),
+    [pendingEnChanges],
+  );
+
+  const handleChange = useCallback((key: string, value: string) => {
+    setPendingChanges((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const handleChangeEn = useCallback((key: string, value: string) => {
+    setPendingEnChanges((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const handleSave = async () => {
+    if (!hasChanges) return;
+    setSaving(true);
+    try {
+      const allKeys = new Set([...Object.keys(pendingChanges), ...Object.keys(pendingEnChanges)]);
+      const items = Array.from(allKeys).map((key) => {
+        const payload: { key: string; value?: string; valueEn?: string } = { key };
+        if (pendingChanges[key] !== undefined) payload.value = pendingChanges[key];
+        if (pendingEnChanges[key] !== undefined) payload.valueEn = pendingEnChanges[key];
+        return payload;
+      });
+      await adminSettingsApi.bulkUpdate(items);
+      setSettings((prev) =>
+        prev.map((s) => ({
+          ...s,
+          ...(pendingChanges[s.key] !== undefined ? { value: pendingChanges[s.key] } : {}),
+          ...(pendingEnChanges[s.key] !== undefined ? { valueEn: pendingEnChanges[s.key] } : {}),
+        })),
+      );
+      setPendingChanges({});
+      setPendingEnChanges({});
+      toast.success(toastMessage('saved'));
+      router.refresh();
+    } catch (err) {
+      toast.error(handleApiError(err, toastMessage('saveError')));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const orderedSettings = FIELD_ORDER
+    .map((key) => settings.find((s) => s.key === key))
+    .filter((s): s is SiteSetting => s !== undefined);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">사업자 정보 설정</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Footer에 표시되는 사업자 정보를 관리합니다. (전자상거래법 제10조)
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!hasChanges || saving}
+          className={cn(
+            'rounded-md px-4 py-2 text-sm transition-colors',
+            hasChanges && !saving
+              ? 'bg-primary text-primary-foreground hover:opacity-90'
+              : 'cursor-not-allowed bg-muted text-muted-foreground',
+          )}
+        >
+          {saving ? '저장 중...' : '저장'}
+        </button>
+      </div>
+
+      <div className="rounded-lg border bg-background p-4">
+        {orderedSettings.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            사업자 정보 설정이 없습니다. DB 마이그레이션을 실행해 주세요.
+          </p>
+        ) : (
+          orderedSettings.map((setting) => (
+            <FieldRow
+              key={setting.key}
+              setting={setting}
+              currentValue={getCurrentValue(setting)}
+              currentValueEn={getCurrentValueEn(setting)}
+              onChange={handleChange}
+              onChangeEn={handleChangeEn}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/settings/business/__tests__/BusinessInfoEditor.test.tsx
+++ b/src/app/[locale]/admin/settings/business/__tests__/BusinessInfoEditor.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import BusinessInfoEditor from '../BusinessInfoEditor';
+import type { SiteSetting } from '@/lib/api';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/api', () => ({
+  adminSettingsApi: {
+    bulkUpdate: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/utils/error', () => ({
+  handleApiError: (_err: unknown, fallback: string) => fallback,
+}));
+
+vi.mock('@/utils/toastMessages', () => ({
+  toastMessage: (key: string) => `toast:${key}`,
+}));
+
+vi.mock('@/components/shared/hooks/useUnsavedChanges', () => ({
+  useUnsavedChanges: vi.fn(),
+}));
+
+const mockSettings: SiteSetting[] = [
+  { id: 1, key: 'business_company_name', value: '서로 인터내셔널', valueEn: 'Seoro International', group: 'business_info', label: '상호명', inputType: 'text', options: null, defaultValue: '서로 인터내셔널', sortOrder: 200 },
+  { id: 2, key: 'business_ceo', value: '권준현', valueEn: 'Kwon Junhyun', group: 'business_info', label: '대표자명', inputType: 'text', options: null, defaultValue: '권준현', sortOrder: 201 },
+  { id: 3, key: 'business_registration_number', value: '131-72-05631', valueEn: '131-72-05631', group: 'business_info', label: '사업자등록번호', inputType: 'text', options: null, defaultValue: '131-72-05631', sortOrder: 202 },
+  { id: 4, key: 'business_mail_order_number', value: '2026-서울강남-01632', valueEn: '2026-서울강남-01632', group: 'business_info', label: '통신판매업신고번호', inputType: 'text', options: null, defaultValue: '2026-서울강남-01632', sortOrder: 203 },
+  { id: 5, key: 'business_address', value: '서울특별시 강남구 역삼로 114 (현죽빌딩) 8층 8028호 (우 06252)', valueEn: '8028, 8F, 114 Yeoksam-ro', group: 'business_info', label: '주소', inputType: 'text', options: null, defaultValue: '서울특별시 강남구 역삼로 114', sortOrder: 204 },
+  { id: 6, key: 'business_phone', value: '010-2908-0393', valueEn: '010-2908-0393', group: 'business_info', label: '대표전화', inputType: 'text', options: null, defaultValue: '010-2908-0393', sortOrder: 205 },
+  { id: 7, key: 'business_email', value: 'seorointernational@naver.com', valueEn: 'seorointernational@naver.com', group: 'business_info', label: '이메일', inputType: 'text', options: null, defaultValue: 'seorointernational@naver.com', sortOrder: 206 },
+  { id: 8, key: 'business_hours', value: '평일 10:00 - 18:00', valueEn: 'Weekdays 10:00 - 18:00', group: 'business_info', label: '운영시간', inputType: 'text', options: null, defaultValue: '평일 10:00 - 18:00', sortOrder: 207 },
+  { id: 9, key: 'business_privacy_officer', value: '권준현', valueEn: 'Kwon Junhyun', group: 'business_info', label: '개인정보보호책임자', inputType: 'text', options: null, defaultValue: '권준현', sortOrder: 208 },
+  { id: 10, key: 'business_info_url', value: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', valueEn: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', group: 'business_info', label: '사업자정보확인 URL', inputType: 'text', options: null, defaultValue: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', sortOrder: 209 },
+];
+
+describe('BusinessInfoEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all business info fields', () => {
+    render(<BusinessInfoEditor initialSettings={mockSettings} />);
+    expect(screen.getByText('상호명')).toBeInTheDocument();
+    expect(screen.getByText('대표자명')).toBeInTheDocument();
+    expect(screen.getByText('사업자등록번호')).toBeInTheDocument();
+    expect(screen.getByText('통신판매업신고번호')).toBeInTheDocument();
+    expect(screen.getByText('주소')).toBeInTheDocument();
+    expect(screen.getByText('대표전화')).toBeInTheDocument();
+    expect(screen.getByText('이메일')).toBeInTheDocument();
+    expect(screen.getByText('운영시간')).toBeInTheDocument();
+    expect(screen.getByText('개인정보보호책임자')).toBeInTheDocument();
+    expect(screen.getByText('사업자정보확인 URL')).toBeInTheDocument();
+  });
+
+  it('displays current Korean and English values', () => {
+    render(<BusinessInfoEditor initialSettings={mockSettings} />);
+    expect(screen.getByDisplayValue('서로 인터내셔널')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Seoro International')).toBeInTheDocument();
+  });
+
+  it('save button is disabled when no changes', () => {
+    render(<BusinessInfoEditor initialSettings={mockSettings} />);
+    const saveBtn = screen.getByRole('button', { name: '저장' });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it('save button enables when field is edited', () => {
+    render(<BusinessInfoEditor initialSettings={mockSettings} />);
+    const input = screen.getByDisplayValue('서로 인터내셔널');
+    fireEvent.change(input, { target: { value: '새 상호명' } });
+    const saveBtn = screen.getByRole('button', { name: '저장' });
+    expect(saveBtn).not.toBeDisabled();
+  });
+
+  it('calls bulkUpdate with changed keys only on save', async () => {
+    const { adminSettingsApi } = await import('@/lib/api');
+    render(<BusinessInfoEditor initialSettings={mockSettings} />);
+    const input = screen.getByDisplayValue('서로 인터내셔널');
+    fireEvent.change(input, { target: { value: '새 상호명' } });
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+    await waitFor(() => {
+      expect(adminSettingsApi.bulkUpdate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ key: 'business_company_name', value: '새 상호명' }),
+        ]),
+      );
+    });
+  });
+
+  it('shows empty state when no settings provided', () => {
+    render(<BusinessInfoEditor initialSettings={[]} />);
+    expect(screen.getByText(/DB 마이그레이션을 실행해 주세요/)).toBeInTheDocument();
+  });
+
+  it('renders heading and description', () => {
+    render(<BusinessInfoEditor initialSettings={mockSettings} />);
+    expect(screen.getByText('사업자 정보 설정')).toBeInTheDocument();
+    expect(screen.getByText(/전자상거래법 제10조/)).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/admin/settings/business/error.tsx
+++ b/src/app/[locale]/admin/settings/business/error.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+export default function BusinessSettingsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-16">
+      <p className="text-sm text-destructive">사업자 정보 설정을 불러오지 못했습니다.</p>
+      <p className="text-xs text-muted-foreground">{error.message}</p>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md border px-4 py-2 text-sm hover:bg-muted"
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/settings/business/page.tsx
+++ b/src/app/[locale]/admin/settings/business/page.tsx
@@ -1,15 +1,9 @@
-import type { SiteSetting } from '@/lib/api';
 import { fetchSettings } from '@/lib/api-server';
 import BusinessInfoEditor from './BusinessInfoEditor';
 
 export const metadata = { title: '사업자 정보 설정' };
 
 export default async function BusinessInfoSettingsPage() {
-  let initialSettings: SiteSetting[] = [];
-  try {
-    initialSettings = await fetchSettings('business_info');
-  } catch {
-    // fallback to empty — BusinessInfoEditor handles empty state
-  }
+  const initialSettings = await fetchSettings('business_info');
   return <BusinessInfoEditor initialSettings={initialSettings} />;
 }

--- a/src/app/[locale]/admin/settings/business/page.tsx
+++ b/src/app/[locale]/admin/settings/business/page.tsx
@@ -1,0 +1,15 @@
+import type { SiteSetting } from '@/lib/api';
+import { fetchSettings } from '@/lib/api-server';
+import BusinessInfoEditor from './BusinessInfoEditor';
+
+export const metadata = { title: '사업자 정보 설정' };
+
+export default async function BusinessInfoSettingsPage() {
+  let initialSettings: SiteSetting[] = [];
+  try {
+    initialSettings = await fetchSettings('business_info');
+  } catch {
+    // fallback to empty — BusinessInfoEditor handles empty state
+  }
+  return <BusinessInfoEditor initialSettings={initialSettings} />;
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -82,6 +82,16 @@ export default async function LocaleLayout({
 
   const mobileBottomNavVisible = settingsMap?.mobile_bottom_nav_visible === 'true';
 
+  const businessInfo = settingsMap
+    ? {
+        companyName: settingsMap.business_company_name ?? '',
+        ceo: settingsMap.business_ceo ?? '',
+        address: settingsMap.business_address ?? '',
+        bizNo: settingsMap.business_registration_number ?? '',
+        mailOrderNo: settingsMap.business_mail_order_number ?? '',
+      }
+    : undefined;
+
   // SSR 단계에서 data-theme 기본값을 locale 기반으로 설정 — hydration mismatch 방지.
   // 클라이언트의 FOUC 스크립트가 localStorage 에 저장된 사용자 선호가 있으면 즉시 덮어씀.
   const initialTheme = safeLocale === 'ko' ? 'dark' : 'light';
@@ -116,6 +126,7 @@ export default async function LocaleLayout({
               locale={safeLocale}
               mobileBottomNavVisible={mobileBottomNavVisible}
               announcementBar={<AnnouncementBar locale={safeLocale} />}
+              businessInfo={businessInfo}
             >
               {children}
             </AppShell>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -89,6 +89,11 @@ export default async function LocaleLayout({
         address: settingsMap.business_address ?? '',
         bizNo: settingsMap.business_registration_number ?? '',
         mailOrderNo: settingsMap.business_mail_order_number ?? '',
+        phone: settingsMap.business_phone ?? '',
+        email: settingsMap.business_email ?? '',
+        hours: settingsMap.business_hours ?? '',
+        privacyOfficer: settingsMap.business_privacy_officer ?? '',
+        infoUrl: settingsMap.business_info_url ?? '',
       }
     : undefined;
 

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -73,6 +73,7 @@ const NAV_ITEMS: NavItem[] = [
     icon: Settings,
     children: [
       { label: '테마 편집', href: '/admin/settings/theme' },
+      { label: '사업자 정보', href: '/admin/settings/business' },
     ],
   },
 ];

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import { Toaster } from 'sonner';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import type { FooterBusinessInfo } from '@/components/Footer';
 import MobileBottomNavWrapper from '@/components/MobileBottomNavWrapper';
 import { MobileNavProvider } from '@/contexts/MobileNavContext';
 import RecentlyViewedWidget from '@/components/RecentlyViewedWidget';
@@ -14,6 +15,7 @@ type AppShellProps = {
   locale: Locale;
   mobileBottomNavVisible: boolean;
   announcementBar?: React.ReactNode;
+  businessInfo?: FooterBusinessInfo;
 };
 
 function isAdminPath(pathname: string): boolean {
@@ -41,6 +43,7 @@ export default function AppShell({
   locale,
   mobileBottomNavVisible,
   announcementBar,
+  businessInfo,
 }: AppShellProps) {
   const pathname = usePathname();
   const isAdminRoute = isAdminPath(pathname);
@@ -62,7 +65,7 @@ export default function AppShell({
         <main id="main-content" className="flex-1 pb-16 md:pb-0">
           {children}
         </main>
-        <Footer />
+        <Footer businessInfo={businessInfo} />
         <MobileBottomNavWrapper visible={mobileBottomNavVisible} />
         <SharedToaster />
         <RecentlyViewedWidget />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -59,7 +59,19 @@ function renderNavLinks(items: NavigationItem[]) {
   ));
 }
 
-export default function Footer() {
+export interface FooterBusinessInfo {
+  companyName: string;
+  ceo: string;
+  address: string;
+  bizNo: string;
+  mailOrderNo: string;
+}
+
+interface FooterProps {
+  businessInfo?: FooterBusinessInfo;
+}
+
+export default function Footer({ businessInfo }: FooterProps) {
   const t = useTranslations('footer');
   const { items: footerItems, loading } = useNavigation('footer');
   const hasCmsData = !loading && footerItems.length > 0;
@@ -70,6 +82,13 @@ export default function Footer() {
     instagram: 'Instagram',
     naver: 'Naver Smart Store',
   };
+
+  // Settings values take priority; fall back to i18n for safety
+  const companyName = businessInfo?.companyName ?? t('businessInfo.companyName');
+  const ceo = businessInfo?.ceo ?? t('businessInfo.ceo');
+  const address = businessInfo?.address ?? t('businessInfo.address');
+  const bizNo = businessInfo?.bizNo ?? t('businessInfo.bizNo');
+  const mailOrderNo = businessInfo?.mailOrderNo ?? t('businessInfo.mailOrderNo');
 
   return (
     <footer className="mt-auto bg-card">
@@ -122,9 +141,9 @@ export default function Footer() {
         {/* 사업자 정보 (전자상거래법 제10조) */}
         <div className="mt-12 pt-8 text-center">
           <div className="typo-body-sm text-muted-foreground/70 leading-relaxed space-y-0.5">
-            <p>{t('businessInfo.companyName')} · {t('businessInfo.ceo')}</p>
-            <p>{t('businessInfo.address')}</p>
-            <p>{t('businessInfo.bizNo')} · {t('businessInfo.mailOrderNo')}</p>
+            <p>{companyName} · {ceo}</p>
+            <p>{address}</p>
+            <p>{bizNo} · {mailOrderNo}</p>
           </div>
 
           <p className="mt-6 typo-body-sm font-body text-muted-foreground">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -65,6 +65,11 @@ export interface FooterBusinessInfo {
   address: string;
   bizNo: string;
   mailOrderNo: string;
+  phone: string;
+  email: string;
+  hours: string;
+  privacyOfficer: string;
+  infoUrl: string;
 }
 
 interface FooterProps {
@@ -86,9 +91,18 @@ export default function Footer({ businessInfo }: FooterProps) {
   // Settings values take priority; fall back to i18n for safety
   const companyName = businessInfo?.companyName ?? t('businessInfo.companyName');
   const ceo = businessInfo?.ceo ?? t('businessInfo.ceo');
-  const address = businessInfo?.address ?? t('businessInfo.address');
-  const bizNo = businessInfo?.bizNo ?? t('businessInfo.bizNo');
-  const mailOrderNo = businessInfo?.mailOrderNo ?? t('businessInfo.mailOrderNo');
+  const address = businessInfo?.address ? t('businessInfo.addressLabel', { value: businessInfo.address }) : t('businessInfo.address');
+  const bizNo = businessInfo?.bizNo ? t('businessInfo.bizNoLabel', { value: businessInfo.bizNo }) : t('businessInfo.bizNo');
+  const mailOrderNo = businessInfo?.mailOrderNo
+    ? t('businessInfo.mailOrderNoLabel', { value: businessInfo.mailOrderNo })
+    : t('businessInfo.mailOrderNo');
+  const phone = businessInfo?.phone ? t('businessInfo.phoneLabel', { value: businessInfo.phone }) : t('businessInfo.phone');
+  const email = businessInfo?.email ? t('businessInfo.emailLabel', { value: businessInfo.email }) : t('businessInfo.email');
+  const hours = businessInfo?.hours ? t('businessInfo.hoursLabel', { value: businessInfo.hours }) : t('businessInfo.hours');
+  const privacyOfficer = businessInfo?.privacyOfficer
+    ? t('businessInfo.privacyOfficerLabel', { value: businessInfo.privacyOfficer })
+    : t('businessInfo.privacyOfficer');
+  const infoUrl = businessInfo?.infoUrl ?? '';
 
   return (
     <footer className="mt-auto bg-card">
@@ -144,6 +158,16 @@ export default function Footer({ businessInfo }: FooterProps) {
             <p>{companyName} · {ceo}</p>
             <p>{address}</p>
             <p>{bizNo} · {mailOrderNo}</p>
+            <p>{phone} · {email}</p>
+            <p>{hours}</p>
+            <p>{privacyOfficer}</p>
+            {infoUrl ? (
+              <p>
+                <a href={infoUrl} target="_blank" rel="noopener noreferrer" className="underline-offset-4 hover:underline">
+                  {t('businessInfo.infoUrlLabel')}
+                </a>
+              </p>
+            ) : null}
           </div>
 
           <p className="mt-6 typo-body-sm font-body text-muted-foreground">

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -114,7 +114,7 @@ describe('Footer', () => {
   it('renders required business information (상호·대표자·사업자번호·통신판매번호·소재지)', () => {
     render(<Footer />);
     expect(screen.getByText(/서로 인터내셔널/)).toBeInTheDocument();
-    expect(screen.getByText(/권준현/)).toBeInTheDocument();
+    expect(screen.getAllByText(/권준현/).length).toBeGreaterThan(0);
     expect(screen.getByText(/131-72-05631/)).toBeInTheDocument();
     expect(screen.getByText(/2026-서울강남-01632/)).toBeInTheDocument();
     expect(screen.getByText(/역삼로 114/)).toBeInTheDocument();
@@ -125,15 +125,25 @@ describe('Footer', () => {
       companyName: '설정 회사명',
       ceo: '대표 홍길동',
       address: '서울시 종로구 1번지',
-      bizNo: '사업자등록번호: 000-00-00000',
-      mailOrderNo: '통신판매업신고번호: 2026-서울종로-0001',
+      bizNo: '000-00-00000',
+      mailOrderNo: '2026-서울종로-0001',
+      phone: '02-1234-5678',
+      email: 'support@example.com',
+      hours: '평일 09:00 - 17:00',
+      privacyOfficer: '개인정보 담당자',
+      infoUrl: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=0000000000',
     };
     render(<Footer businessInfo={businessInfo} />);
     expect(screen.getByText(/설정 회사명/)).toBeInTheDocument();
     expect(screen.getByText(/홍길동/)).toBeInTheDocument();
-    expect(screen.getByText(/000-00-00000/)).toBeInTheDocument();
-    expect(screen.getByText(/2026-서울종로-0001/)).toBeInTheDocument();
-    expect(screen.getByText(/종로구 1번지/)).toBeInTheDocument();
+    expect(screen.getByText(/사업자등록번호: 000-00-00000/)).toBeInTheDocument();
+    expect(screen.getByText(/통신판매업신고번호: 2026-서울종로-0001/)).toBeInTheDocument();
+    expect(screen.getByText('소재지: 서울시 종로구 1번지')).toBeInTheDocument();
+    expect(screen.getByText(/대표전화: 02-1234-5678/)).toBeInTheDocument();
+    expect(screen.getByText(/이메일: support@example.com/)).toBeInTheDocument();
+    expect(screen.getByText('운영시간: 평일 09:00 - 17:00')).toBeInTheDocument();
+    expect(screen.getByText('개인정보보호책임자: 개인정보 담당자')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '사업자정보확인' })).toHaveAttribute('href', businessInfo.infoUrl);
   });
 
   it('falls back to i18n when businessInfo prop is not provided', () => {
@@ -141,5 +151,8 @@ describe('Footer', () => {
     // i18n fallback values from ko.json
     expect(screen.getByText(/서로 인터내셔널/)).toBeInTheDocument();
     expect(screen.getByText(/131-72-05631/)).toBeInTheDocument();
+    expect(screen.getByText(/대표전화: 010-2908-0393/)).toBeInTheDocument();
+    expect(screen.getByText(/이메일: seorointernational@naver.com/)).toBeInTheDocument();
+    expect(screen.getByText(/개인정보보호책임자: 권준현/)).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -119,4 +119,27 @@ describe('Footer', () => {
     expect(screen.getByText(/2026-서울강남-01632/)).toBeInTheDocument();
     expect(screen.getByText(/역삼로 114/)).toBeInTheDocument();
   });
+
+  it('uses settings values when businessInfo prop is provided', () => {
+    const businessInfo = {
+      companyName: '설정 회사명',
+      ceo: '대표 홍길동',
+      address: '서울시 종로구 1번지',
+      bizNo: '사업자등록번호: 000-00-00000',
+      mailOrderNo: '통신판매업신고번호: 2026-서울종로-0001',
+    };
+    render(<Footer businessInfo={businessInfo} />);
+    expect(screen.getByText(/설정 회사명/)).toBeInTheDocument();
+    expect(screen.getByText(/홍길동/)).toBeInTheDocument();
+    expect(screen.getByText(/000-00-00000/)).toBeInTheDocument();
+    expect(screen.getByText(/2026-서울종로-0001/)).toBeInTheDocument();
+    expect(screen.getByText(/종로구 1번지/)).toBeInTheDocument();
+  });
+
+  it('falls back to i18n when businessInfo prop is not provided', () => {
+    render(<Footer />);
+    // i18n fallback values from ko.json
+    expect(screen.getByText(/서로 인터내셔널/)).toBeInTheDocument();
+    expect(screen.getByText(/131-72-05631/)).toBeInTheDocument();
+  });
 });

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -109,8 +109,20 @@
       "companyName": "Seoro International",
       "ceo": "CEO: Kwon Junhyun",
       "address": "Address: 8F 8028, Hyeonjuk Building, 114 Yeoksam-ro, Gangnam-gu, Seoul 06252, Korea",
+      "addressLabel": "Address: {value}",
       "bizNo": "Business Reg. No.: 131-72-05631",
-      "mailOrderNo": "Mail-Order Reg. No.: 2026-서울강남-01632"
+      "bizNoLabel": "Business Reg. No.: {value}",
+      "mailOrderNo": "Mail-Order Reg. No.: 2026-서울강남-01632",
+      "mailOrderNoLabel": "Mail-Order Reg. No.: {value}",
+      "phone": "Phone: 010-2908-0393",
+      "phoneLabel": "Phone: {value}",
+      "email": "Email: seorointernational@naver.com",
+      "emailLabel": "Email: {value}",
+      "hours": "Hours: Weekdays 10:00 - 18:00 (Closed on weekends & holidays)",
+      "hoursLabel": "Hours: {value}",
+      "privacyOfficer": "Privacy Officer: Kwon Junhyun",
+      "privacyOfficerLabel": "Privacy Officer: {value}",
+      "infoUrlLabel": "Verify Business Information"
     }
   },
   "auth": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -109,8 +109,20 @@
       "companyName": "서로 인터내셔널",
       "ceo": "대표 권준현",
       "address": "소재지: 서울특별시 강남구 역삼로 114 (현죽빌딩) 8층 8028호 (우 06252)",
+      "addressLabel": "소재지: {value}",
       "bizNo": "사업자등록번호: 131-72-05631",
-      "mailOrderNo": "통신판매업신고번호: 2026-서울강남-01632"
+      "bizNoLabel": "사업자등록번호: {value}",
+      "mailOrderNo": "통신판매업신고번호: 2026-서울강남-01632",
+      "mailOrderNoLabel": "통신판매업신고번호: {value}",
+      "phone": "대표전화: 010-2908-0393",
+      "phoneLabel": "대표전화: {value}",
+      "email": "이메일: seorointernational@naver.com",
+      "emailLabel": "이메일: {value}",
+      "hours": "운영시간: 평일 10:00 - 18:00 (주말·공휴일 휴무)",
+      "hoursLabel": "운영시간: {value}",
+      "privacyOfficer": "개인정보보호책임자: 권준현",
+      "privacyOfficerLabel": "개인정보보호책임자: {value}",
+      "infoUrlLabel": "사업자정보확인"
     }
   },
   "auth": {


### PR DESCRIPTION
## 개요
Footer의 사업자 정보를 i18n 하드코딩에서 site_settings DB로 이관하고, 관리자 화면에서 편집 가능하게 합니다.

## 변경 사항

### Backend
- `1784500000000-AddBusinessInfoSettings` 마이그레이션 추가
  - 10개 사업자 정보 필드를 `business_info` 그룹으로 `site_settings` 테이블에 삽입
  - 상호명, 대표자명, 사업자등록번호, 통신판매업신고번호, 주소, 대표전화, 이메일, 운영시간, 개인정보보호책임자, 사업자정보확인 URL
  - ko/en 값 포함, `ON DUPLICATE KEY UPDATE` 멱등 처리

### Frontend
- `/admin/settings/business` 페이지 신규 추가 (`BusinessInfoEditor` 컴포넌트)
  - ko/en 필드 동시 편집, 미변경 키만 전송, 저장 시 캐시 자동 무효화
  - 빈 설정 시 마이그레이션 안내 empty state
  - `error.tsx` 에러 바운더리 포함
- `AdminSidebar`: '사이트 설정' 그룹에 '사업자 정보' 메뉴 추가
- `Footer`: `businessInfo` prop으로 settings 값 우선 사용, i18n fallback 유지
- `AppShell`: `businessInfo` prop 추가
- `layout.tsx`: 기존 `settingsMap`에서 business_info 키 추출 → AppShell → Footer 전달 (추가 fetch 없음)

## 테스트 결과

### 신규 테스트
- `BusinessInfoEditor.test.tsx`: 7개 테스트 ✅
- `Footer.test.tsx` 신규 2개 추가 (settings prop 우선, i18n fallback) ✅

### 전체 테스트
- Frontend: **750 tests passed** (126 test files) ✅
- Backend: **1070 tests passed** (106 test suites) ✅
- Frontend build: ✅
- Backend build: ✅

## 캐시 무효화
- `adminSettingsApi.bulkUpdate()` 호출 시 백엔드에서 `settings:*` 자동 삭제
- DB 직접 수정 시 백엔드 프로세스 재시작 필요 (기존 규칙 동일)

Closes #852