### PR TITLE
fix: #840 Footer 대표전화 및 고객센터 정보 표시

### DIFF
--- a/backend/src/database/migrations/1784600000000-AddCustomerCenterLunchHolidaySettings.ts
+++ b/backend/src/database/migrations/1784600000000-AddCustomerCenterLunchHolidaySettings.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCustomerCenterLunchHolidaySettings1784600000000 implements MigrationInterface {
+  name = 'AddCustomerCenterLunchHolidaySettings1784600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO \`site_settings\` (\`setting_key\`, \`value\`, \`value_en\`, \`group\`, \`label\`, \`input_type\`, \`options\`, \`default_value\`, \`sort_order\`)
+      VALUES
+        ('business_lunch_time', '점심시간 12:00 - 13:00', 'Lunch break 12:00 - 13:00', 'business_info', '점심시간', 'text', NULL, '점심시간 12:00 - 13:00', 208),
+        ('business_holidays', '주말·공휴일 휴무', 'Closed on weekends & holidays', 'business_info', '휴무일', 'text', NULL, '주말·공휴일 휴무', 209)
+      ON DUPLICATE KEY UPDATE \`setting_key\` = \`setting_key\`
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM \`site_settings\`
+      WHERE \`setting_key\` IN ('business_lunch_time', 'business_holidays')
+    `);
+  }
+}

--- a/src/app/[locale]/admin/settings/business/BusinessInfoEditor.tsx
+++ b/src/app/[locale]/admin/settings/business/BusinessInfoEditor.tsx
@@ -19,6 +19,8 @@ const FIELD_ORDER = [
   'business_phone',
   'business_email',
   'business_hours',
+  'business_lunch_time',
+  'business_holidays',
   'business_privacy_officer',
   'business_info_url',
 ] as const;

--- a/src/app/[locale]/admin/settings/business/__tests__/BusinessInfoEditor.test.tsx
+++ b/src/app/[locale]/admin/settings/business/__tests__/BusinessInfoEditor.test.tsx
@@ -38,8 +38,10 @@ const mockSettings: SiteSetting[] = [
   { id: 6, key: 'business_phone', value: '010-2908-0393', valueEn: '010-2908-0393', group: 'business_info', label: '대표전화', inputType: 'text', options: null, defaultValue: '010-2908-0393', sortOrder: 205 },
   { id: 7, key: 'business_email', value: 'seorointernational@naver.com', valueEn: 'seorointernational@naver.com', group: 'business_info', label: '이메일', inputType: 'text', options: null, defaultValue: 'seorointernational@naver.com', sortOrder: 206 },
   { id: 8, key: 'business_hours', value: '평일 10:00 - 18:00', valueEn: 'Weekdays 10:00 - 18:00', group: 'business_info', label: '운영시간', inputType: 'text', options: null, defaultValue: '평일 10:00 - 18:00', sortOrder: 207 },
-  { id: 9, key: 'business_privacy_officer', value: '권준현', valueEn: 'Kwon Junhyun', group: 'business_info', label: '개인정보보호책임자', inputType: 'text', options: null, defaultValue: '권준현', sortOrder: 208 },
-  { id: 10, key: 'business_info_url', value: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', valueEn: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', group: 'business_info', label: '사업자정보확인 URL', inputType: 'text', options: null, defaultValue: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', sortOrder: 209 },
+  { id: 9, key: 'business_lunch_time', value: '점심시간 12:00 - 13:00', valueEn: 'Lunch break 12:00 - 13:00', group: 'business_info', label: '점심시간', inputType: 'text', options: null, defaultValue: '점심시간 12:00 - 13:00', sortOrder: 208 },
+  { id: 10, key: 'business_holidays', value: '주말·공휴일 휴무', valueEn: 'Closed on weekends & holidays', group: 'business_info', label: '휴무일', inputType: 'text', options: null, defaultValue: '주말·공휴일 휴무', sortOrder: 209 },
+  { id: 11, key: 'business_privacy_officer', value: '권준현', valueEn: 'Kwon Junhyun', group: 'business_info', label: '개인정보보호책임자', inputType: 'text', options: null, defaultValue: '권준현', sortOrder: 210 },
+  { id: 12, key: 'business_info_url', value: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', valueEn: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', group: 'business_info', label: '사업자정보확인 URL', inputType: 'text', options: null, defaultValue: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=1317205631', sortOrder: 211 },
 ];
 
 describe('BusinessInfoEditor', () => {
@@ -57,6 +59,8 @@ describe('BusinessInfoEditor', () => {
     expect(screen.getByText('대표전화')).toBeInTheDocument();
     expect(screen.getByText('이메일')).toBeInTheDocument();
     expect(screen.getByText('운영시간')).toBeInTheDocument();
+    expect(screen.getByText('점심시간')).toBeInTheDocument();
+    expect(screen.getByText('휴무일')).toBeInTheDocument();
     expect(screen.getByText('개인정보보호책임자')).toBeInTheDocument();
     expect(screen.getByText('사업자정보확인 URL')).toBeInTheDocument();
   });

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -92,6 +92,8 @@ export default async function LocaleLayout({
         phone: settingsMap.business_phone ?? '',
         email: settingsMap.business_email ?? '',
         hours: settingsMap.business_hours ?? '',
+        lunchTime: settingsMap.business_lunch_time ?? '',
+        holidays: settingsMap.business_holidays ?? '',
         privacyOfficer: settingsMap.business_privacy_officer ?? '',
         infoUrl: settingsMap.business_info_url ?? '',
       }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -68,6 +68,8 @@ export interface FooterBusinessInfo {
   phone: string;
   email: string;
   hours: string;
+  lunchTime: string;
+  holidays: string;
   privacyOfficer: string;
   infoUrl: string;
 }
@@ -99,6 +101,8 @@ export default function Footer({ businessInfo }: FooterProps) {
   const phone = businessInfo?.phone ? t('businessInfo.phoneLabel', { value: businessInfo.phone }) : t('businessInfo.phone');
   const email = businessInfo?.email ? t('businessInfo.emailLabel', { value: businessInfo.email }) : t('businessInfo.email');
   const hours = businessInfo?.hours ? t('businessInfo.hoursLabel', { value: businessInfo.hours }) : t('businessInfo.hours');
+  const lunchTime = businessInfo?.lunchTime ? t('businessInfo.lunchTimeLabel', { value: businessInfo.lunchTime }) : t('businessInfo.lunchTime');
+  const holidays = businessInfo?.holidays ? t('businessInfo.holidaysLabel', { value: businessInfo.holidays }) : t('businessInfo.holidays');
   const privacyOfficer = businessInfo?.privacyOfficer
     ? t('businessInfo.privacyOfficerLabel', { value: businessInfo.privacyOfficer })
     : t('businessInfo.privacyOfficer');
@@ -160,6 +164,7 @@ export default function Footer({ businessInfo }: FooterProps) {
             <p>{bizNo} · {mailOrderNo}</p>
             <p>{phone} · {email}</p>
             <p>{hours}</p>
+            <p>{lunchTime} · {holidays}</p>
             <p>{privacyOfficer}</p>
             {infoUrl ? (
               <p>

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -130,6 +130,8 @@ describe('Footer', () => {
       phone: '02-1234-5678',
       email: 'support@example.com',
       hours: '평일 09:00 - 17:00',
+      lunchTime: '점심시간 12:30 - 13:30',
+      holidays: '일요일 휴무',
       privacyOfficer: '개인정보 담당자',
       infoUrl: 'https://www.ftc.go.kr/bizCommPop.do?wrkr_no=0000000000',
     };
@@ -142,6 +144,8 @@ describe('Footer', () => {
     expect(screen.getByText(/대표전화: 02-1234-5678/)).toBeInTheDocument();
     expect(screen.getByText(/이메일: support@example.com/)).toBeInTheDocument();
     expect(screen.getByText('운영시간: 평일 09:00 - 17:00')).toBeInTheDocument();
+    expect(screen.getByText(/점심시간: 점심시간 12:30 - 13:30/)).toBeInTheDocument();
+    expect(screen.getByText(/휴무일: 일요일 휴무/)).toBeInTheDocument();
     expect(screen.getByText('개인정보보호책임자: 개인정보 담당자')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '사업자정보확인' })).toHaveAttribute('href', businessInfo.infoUrl);
   });
@@ -153,6 +157,8 @@ describe('Footer', () => {
     expect(screen.getByText(/131-72-05631/)).toBeInTheDocument();
     expect(screen.getByText(/대표전화: 010-2908-0393/)).toBeInTheDocument();
     expect(screen.getByText(/이메일: seorointernational@naver.com/)).toBeInTheDocument();
+    expect(screen.getByText(/점심시간: 12:00 - 13:00/)).toBeInTheDocument();
+    expect(screen.getByText(/휴무일: 주말·공휴일/)).toBeInTheDocument();
     expect(screen.getByText(/개인정보보호책임자: 권준현/)).toBeInTheDocument();
   });
 });

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -118,8 +118,12 @@
       "phoneLabel": "Phone: {value}",
       "email": "Email: seorointernational@naver.com",
       "emailLabel": "Email: {value}",
-      "hours": "Hours: Weekdays 10:00 - 18:00 (Closed on weekends & holidays)",
+      "hours": "Hours: Weekdays 10:00 - 18:00",
       "hoursLabel": "Hours: {value}",
+      "lunchTime": "Lunch break: 12:00 - 13:00",
+      "lunchTimeLabel": "Lunch break: {value}",
+      "holidays": "Closed: weekends & holidays",
+      "holidaysLabel": "Closed: {value}",
       "privacyOfficer": "Privacy Officer: Kwon Junhyun",
       "privacyOfficerLabel": "Privacy Officer: {value}",
       "infoUrlLabel": "Verify Business Information"

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -118,8 +118,12 @@
       "phoneLabel": "대표전화: {value}",
       "email": "이메일: seorointernational@naver.com",
       "emailLabel": "이메일: {value}",
-      "hours": "운영시간: 평일 10:00 - 18:00 (주말·공휴일 휴무)",
+      "hours": "운영시간: 평일 10:00 - 18:00",
       "hoursLabel": "운영시간: {value}",
+      "lunchTime": "점심시간: 12:00 - 13:00",
+      "lunchTimeLabel": "점심시간: {value}",
+      "holidays": "휴무일: 주말·공휴일",
+      "holidaysLabel": "휴무일: {value}",
       "privacyOfficer": "개인정보보호책임자: 권준현",
       "privacyOfficerLabel": "개인정보보호책임자: {value}",
       "infoUrlLabel": "사업자정보확인"


### PR DESCRIPTION
## Summary
- Closes #840
- Footer 사업자 정보 영역에 대표전화/이메일/운영시간/점심시간/휴무일을 명확히 표시
- business_info 설정에 점심시간/휴무일 키를 추가하고 관리자 설정 화면에 노출
- 한국어/영어 i18n fallback 메시지 추가

## Test plan
- [x] npm run lint (기존 AppShell unused locale warning만 있음)
- [x] npm run build
- [x] npm run test:run -- 'src/components/__tests__/Footer.test.tsx' 'src/app/[locale]/admin/settings/business/__tests__/BusinessInfoEditor.test.tsx'
- [x] cd backend && npm run lint
- [x] cd backend && npm run build && npm run test (1070 passed)