### PR TITLE
feat: #846 상품고시정보 영역 추가

### DIFF
--- a/backend/src/database/migrations/1784700000000-AddProductNoticeInfo.ts
+++ b/backend/src/database/migrations/1784700000000-AddProductNoticeInfo.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductNoticeInfo1784700000000 implements MigrationInterface {
+  name = 'AddProductNoticeInfo1784700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`products\`
+      ADD COLUMN \`notice_info\` JSON NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`products\`
+      DROP COLUMN \`notice_info\`
+    `);
+  }
+}

--- a/backend/src/modules/products/dto/create-product.dto.ts
+++ b/backend/src/modules/products/dto/create-product.dto.ts
@@ -5,6 +5,103 @@ import { ProductStatus } from '../entities/product.entity';
 
 export { ProductStatus };
 
+export enum ProductNoticeInfoType {
+  TEAWARE = 'teaware',
+  TEA = 'tea',
+}
+
+export class ProductNoticeInfoDto {
+  @ApiPropertyOptional({ example: ProductNoticeInfoType.TEA, enum: ProductNoticeInfoType, description: '고시정보 유형' })
+  @IsOptional()
+  @IsEnum(ProductNoticeInfoType, { message: '고시정보 유형은 teaware 또는 tea여야 합니다.' })
+  type?: ProductNoticeInfoType;
+
+  @ApiPropertyOptional({ example: '옥화당 자사호', description: '품명 및 모델명' })
+  @IsOptional()
+  @IsString()
+  productName?: string;
+
+  @ApiPropertyOptional({ example: '자사니', description: '재질' })
+  @IsOptional()
+  @IsString()
+  material?: string;
+
+  @ApiPropertyOptional({ example: '자사호 1점, 보관함 1점', description: '구성품' })
+  @IsOptional()
+  @IsString()
+  components?: string;
+
+  @ApiPropertyOptional({ example: '150ml', description: '크기/용량' })
+  @IsOptional()
+  @IsString()
+  sizeCapacity?: string;
+
+  @ApiPropertyOptional({ example: '옥화당', description: '제조자/수입자' })
+  @IsOptional()
+  @IsString()
+  manufacturer?: string;
+
+  @ApiPropertyOptional({ example: '중국', description: '제조국' })
+  @IsOptional()
+  @IsString()
+  countryOfOrigin?: string;
+
+  @ApiPropertyOptional({ example: '강한 충격을 피해주세요.', description: '취급 시 주의사항' })
+  @IsOptional()
+  @IsString()
+  handlingPrecautions?: string;
+
+  @ApiPropertyOptional({ example: '관련 법 및 소비자분쟁해결기준에 따름', description: '품질보증기준' })
+  @IsOptional()
+  @IsString()
+  warrantyPolicy?: string;
+
+  @ApiPropertyOptional({ example: '고객센터 010-2908-0393', description: 'A/S 책임자와 전화번호' })
+  @IsOptional()
+  @IsString()
+  asContact?: string;
+
+  @ApiPropertyOptional({ example: '침출차', description: '식품 유형' })
+  @IsOptional()
+  @IsString()
+  foodType?: string;
+
+  @ApiPropertyOptional({ example: '옥화당', description: '생산자/수입자' })
+  @IsOptional()
+  @IsString()
+  producer?: string;
+
+  @ApiPropertyOptional({ example: '중국 운남성', description: '원산지' })
+  @IsOptional()
+  @IsString()
+  origin?: string;
+
+  @ApiPropertyOptional({ example: '별도 표기', description: '제조연월일' })
+  @IsOptional()
+  @IsString()
+  manufactureDate?: string;
+
+  @ApiPropertyOptional({ example: '별도 표기', description: '소비기한' })
+  @IsOptional()
+  @IsString()
+  expirationDate?: string;
+
+  @ApiPropertyOptional({ example: '직사광선을 피하고 서늘한 곳에 보관', description: '보관방법' })
+  @IsOptional()
+  @IsString()
+  storageMethod?: string;
+
+  @ApiPropertyOptional({ example: '차엽 100%', description: '원재료명' })
+  @IsOptional()
+  @IsString()
+  ingredients?: string;
+
+  @ApiPropertyOptional({ example: '010-2908-0393', description: '소비자상담 전화번호' })
+  @IsOptional()
+  @IsString()
+  customerServicePhone?: string;
+}
+
 export class ProductImageInputDto {
   @ApiProperty({ example: 'https://cdn.example.com/image.jpg', description: '이미지 URL' })
   @IsString()
@@ -135,6 +232,12 @@ export class CreateProductDto {
   @IsString({ message: '모양은 문자열이어야 합니다.' })
   @MaxLength(50, { message: '모양은 최대 50자까지 입력 가능합니다.' })
   teapotShape?: string;
+
+  @ApiPropertyOptional({ type: ProductNoticeInfoDto, description: '상품고시정보' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ProductNoticeInfoDto)
+  noticeInfo?: ProductNoticeInfoDto;
 
   @ApiPropertyOptional({ type: [ProductImageInputDto], description: '갤러리 이미지 목록' })
   @IsOptional()

--- a/backend/src/modules/products/dto/update-product.dto.ts
+++ b/backend/src/modules/products/dto/update-product.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsNumber, IsOptional, IsBoolean, IsEnum, MaxLength, Min, IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ProductStatus } from '../entities/product.entity';
-import { ProductImageInputDto, ProductDetailImageInputDto } from './create-product.dto';
+import { ProductImageInputDto, ProductDetailImageInputDto, ProductNoticeInfoDto } from './create-product.dto';
 
 export class UpdateProductDto {
   @ApiProperty({ example: 1, description: '카테고리 ID', required: false })
@@ -100,6 +100,12 @@ export class UpdateProductDto {
   @IsString()
   @MaxLength(50)
   teapotShape?: string;
+
+  @ApiPropertyOptional({ type: ProductNoticeInfoDto, description: '상품고시정보' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ProductNoticeInfoDto)
+  noticeInfo?: ProductNoticeInfoDto;
 
   @ApiPropertyOptional({ type: [ProductImageInputDto], description: '갤러리 이미지 목록' })
   @IsOptional()

--- a/backend/src/modules/products/entities/product.entity.ts
+++ b/backend/src/modules/products/entities/product.entity.ts
@@ -23,6 +23,27 @@ export enum ProductStatus {
   HIDDEN = 'hidden',
 }
 
+export interface ProductNoticeInfo {
+  type?: 'teaware' | 'tea';
+  productName?: string;
+  material?: string;
+  components?: string;
+  sizeCapacity?: string;
+  manufacturer?: string;
+  countryOfOrigin?: string;
+  handlingPrecautions?: string;
+  warrantyPolicy?: string;
+  asContact?: string;
+  foodType?: string;
+  producer?: string;
+  origin?: string;
+  manufactureDate?: string;
+  expirationDate?: string;
+  storageMethod?: string;
+  ingredients?: string;
+  customerServicePhone?: string;
+}
+
 @Entity('products')
 @Index(['categoryId'])
 @Index(['status'])
@@ -115,6 +136,9 @@ export class Product {
 
   @Column({ name: 'avg_rating', type: 'decimal', precision: 3, scale: 2, default: 0 })
   avgRating!: number;
+
+  @Column({ name: 'notice_info', type: 'json', nullable: true })
+  noticeInfo!: ProductNoticeInfo | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/src/app/[locale]/products/preview/page.tsx
+++ b/src/app/[locale]/products/preview/page.tsx
@@ -94,6 +94,18 @@ const DUMMY_PRODUCT: ProductDetail = {
       isThumbnail: false, isDescriptionImage: false,
     },
   ],
+  noticeInfo: {
+    type: 'teaware',
+    productName: '주니 서시호',
+    material: '원광주니',
+    components: '자사호 1점',
+    sizeCapacity: '120ml',
+    manufacturer: '홍상설',
+    countryOfOrigin: '중국',
+    handlingPrecautions: '강한 충격과 세제 사용을 피해주세요.',
+    warrantyPolicy: '관련 법 및 소비자분쟁해결기준에 따름',
+    asContact: '옥화당 고객센터',
+  },
   detailImages: [
     {
       id: 1,

--- a/src/components/__tests__/ProductTabs.test.tsx
+++ b/src/components/__tests__/ProductTabs.test.tsx
@@ -81,6 +81,27 @@ describe('ProductTabs', () => {
     expect(detailContent).toBeInTheDocument()
   })
 
+  it('shows product notice info in details tab', () => {
+    render(
+      <ProductTabs
+        description="<p>상품 상세 내용입니다.</p>"
+        descriptionImages={[]}
+        noticeInfo={{
+          type: 'tea',
+          foodType: '침출차',
+          producer: '옥화당',
+          storageMethod: '서늘한 곳 보관',
+        }}
+      />,
+    )
+
+    expect(screen.getByText('상품고시정보')).toBeInTheDocument()
+    expect(screen.getByText('식품 유형')).toBeInTheDocument()
+    expect(screen.getByText('침출차')).toBeInTheDocument()
+    expect(screen.getByText('보관방법')).toBeInTheDocument()
+    expect(screen.getByText('서늘한 곳 보관')).toBeInTheDocument()
+  })
+
   it('clicking 리뷰 tab shows 준비 중입니다', async () => {
     const user = userEvent.setup()
     render(<ProductTabs description={null} descriptionImages={[]} />)

--- a/src/components/shared/admin/ProductFormPage.tsx
+++ b/src/components/shared/admin/ProductFormPage.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
 import { adminProductsApi } from '@/lib/api';
-import type { ProductDetail } from '@/lib/api';
+import type { ProductDetail, ProductNoticeInfo } from '@/lib/api';
 import MultiImageUploader from './MultiImageUploader';
 import ProductOptionsEditor, { type ProductOptionDraft } from './ProductOptionsEditor';
 import { CheckboxField, SelectField, TextAreaField, TextField } from './FormField';
@@ -39,6 +39,7 @@ interface ProductFormData {
   options: ProductOptionDraft[];
   nameEn: string;
   descriptionEn: string;
+  noticeInfo: ProductNoticeInfo;
 }
 
 interface ProductFormPageProps {
@@ -53,7 +54,117 @@ const STATUS_OPTIONS = [
   { value: 'hidden', label: '숨김' },
 ] as const;
 
+const NOTICE_TYPE_OPTIONS = [
+  { value: '', label: '선택 안 함' },
+  { value: 'teaware', label: '자사호/다구' },
+  { value: 'tea', label: '차류/식품류' },
+] as const;
+
+const EMPTY_NOTICE_INFO: ProductNoticeInfo = {
+  type: undefined,
+  productName: '',
+  material: '',
+  components: '',
+  sizeCapacity: '',
+  manufacturer: '',
+  countryOfOrigin: '',
+  handlingPrecautions: '',
+  warrantyPolicy: '',
+  asContact: '',
+  foodType: '',
+  producer: '',
+  origin: '',
+  manufactureDate: '',
+  expirationDate: '',
+  storageMethod: '',
+  ingredients: '',
+  customerServicePhone: '',
+};
+
 type Setter = <K extends keyof ProductFormData>(key: K, value: ProductFormData[K]) => void;
+
+type NoticeInfoKey = keyof ProductNoticeInfo;
+
+function buildNoticeInfoPayload(noticeInfo: ProductNoticeInfo, hadNoticeInfo: boolean): ProductNoticeInfo | null | undefined {
+  const entries = Object.entries(noticeInfo).filter(([, value]) => typeof value === 'string' && value.trim().length > 0);
+  if (entries.length === 0) return hadNoticeInfo ? null : undefined;
+  return Object.fromEntries(entries.map(([key, value]) => [key, typeof value === 'string' ? value.trim() : value])) as ProductNoticeInfo;
+}
+
+function NoticeInfoSection({
+  noticeInfo,
+  set,
+}: {
+  noticeInfo: ProductNoticeInfo;
+  set: Setter;
+}) {
+  const updateNoticeInfo = (key: NoticeInfoKey, value: string) => {
+    if (key === 'type') {
+      set('noticeInfo', {
+        ...EMPTY_NOTICE_INFO,
+        productName: noticeInfo.productName,
+        manufacturer: noticeInfo.manufacturer,
+        countryOfOrigin: noticeInfo.countryOfOrigin,
+        handlingPrecautions: noticeInfo.handlingPrecautions,
+        type: value === '' ? undefined : value as ProductNoticeInfo['type'],
+      });
+      return;
+    }
+
+    set('noticeInfo', {
+      ...noticeInfo,
+      [key]: value,
+    });
+  };
+
+  const commonFields = [
+    ['productName', '품명 및 모델명', '옥화당 자사호'] as const,
+    ['manufacturer', '제조자/수입자', '옥화당'] as const,
+    ['countryOfOrigin', '제조국', '중국'] as const,
+    ['handlingPrecautions', '취급 시 주의사항', '강한 충격을 피해주세요.'] as const,
+  ];
+  const teawareFields = [
+    ['material', '재질', '자사니'] as const,
+    ['components', '구성품', '자사호 1점, 보관함 1점'] as const,
+    ['sizeCapacity', '크기/용량', '150ml'] as const,
+    ['warrantyPolicy', '품질보증기준', '관련 법 및 소비자분쟁해결기준에 따름'] as const,
+    ['asContact', 'A/S 책임자와 전화번호', '고객센터 010-2908-0393'] as const,
+  ];
+  const teaFields = [
+    ['foodType', '식품 유형', '침출차'] as const,
+    ['producer', '생산자/수입자', '옥화당'] as const,
+    ['origin', '원산지', '중국 운남성'] as const,
+    ['manufactureDate', '제조연월일', '별도 표기'] as const,
+    ['expirationDate', '소비기한', '별도 표기'] as const,
+    ['storageMethod', '보관방법', '직사광선을 피하고 서늘한 곳에 보관'] as const,
+    ['ingredients', '원재료명', '차엽 100%'] as const,
+    ['customerServicePhone', '소비자상담 전화번호', '010-2908-0393'] as const,
+  ];
+  const typedFields = noticeInfo.type === 'tea' ? teaFields : teawareFields;
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-sm font-semibold">상품고시정보</h2>
+      <SelectField
+        label="고시정보 유형"
+        value={noticeInfo.type ?? ''}
+        onChange={(value) => updateNoticeInfo('type', value)}
+        options={NOTICE_TYPE_OPTIONS}
+      />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {[...commonFields, ...typedFields].map(([key, label, placeholder]) => (
+          <TextField
+            key={key}
+            label={label}
+            value={noticeInfo[key] ?? ''}
+            onChange={(value) => updateNoticeInfo(key, value)}
+            placeholder={placeholder}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
 
 function ImagesSection({
   images,
@@ -247,6 +358,7 @@ function VisibilitySection({
 export default function ProductFormPage({ mode, product }: ProductFormPageProps) {
   const router = useRouter();
   const [submitting, setSubmitting] = useState(false);
+  const hadNoticeInfo = product?.noticeInfo != null;
   const [form, setForm] = useState<ProductFormData>({
     name: product?.name ?? '',
     slug: product?.slug ?? '',
@@ -269,6 +381,7 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
     })) ?? [],
     nameEn: '',
     descriptionEn: '',
+    noticeInfo: { ...EMPTY_NOTICE_INFO, ...(product?.noticeInfo ?? {}) },
   });
 
   const set = <K extends keyof ProductFormData>(key: K, value: ProductFormData[K]) =>
@@ -306,6 +419,7 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
         isFreeShipping: form.isFreeShipping,
         nameEn: form.nameEn.trim() || undefined,
         descriptionEn: form.descriptionEn.trim() || undefined,
+        noticeInfo: buildNoticeInfoPayload(form.noticeInfo, hadNoticeInfo),
         images: form.images.map((img, index) => ({
           url: img.url,
           alt: img.alt,
@@ -346,6 +460,7 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
         <MultilingualSection form={form} set={set} />
         <PricingSection form={form} set={set} />
         <VisibilitySection form={form} set={set} />
+        <NoticeInfoSection noticeInfo={form.noticeInfo} set={set} />
 
         <section>
           <ProductOptionsEditor

--- a/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
@@ -157,6 +157,58 @@ describe('ProductFormPage', () => {
       });
     });
 
+    it('상품고시정보 입력 시 빈 값은 제외하고 noticeInfo를 전송한다', async () => {
+      const { adminProductsApi } = await import('@/lib/api');
+      vi.mocked(adminProductsApi.create).mockResolvedValue({
+        id: 1,
+        name: '테스트 상품',
+        slug: 'test-product',
+        price: 10000,
+        salePrice: null,
+        status: 'draft',
+        isFeatured: false,
+        viewCount: 0,
+        category: null,
+        images: [],
+        description: null,
+        shortDescription: null,
+        rating: 0,
+        reviewCount: 0,
+        stock: 0,
+        sku: null,
+        options: [],
+        detailImages: [],
+        noticeInfo: null,
+      });
+
+      render(<ProductFormPage mode="create" />);
+
+      fireEvent.change(screen.getByPlaceholderText('상품명을 입력하세요'), {
+        target: { value: '테스트 상품' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('url-friendly-slug'), {
+        target: { value: 'test-product' },
+      });
+      fireEvent.change(screen.getAllByRole('spinbutton')[0], { target: { value: '10000' } });
+      fireEvent.change(screen.getByDisplayValue('선택 안 함'), { target: { value: 'tea' } });
+      fireEvent.change(screen.getByPlaceholderText('침출차'), { target: { value: '잎차' } });
+      fireEvent.change(screen.getByPlaceholderText('직사광선을 피하고 서늘한 곳에 보관'), {
+        target: { value: '냉암소 보관' },
+      });
+
+      fireEvent.click(screen.getByText('등록하기'));
+
+      await waitFor(() => expect(adminProductsApi.create).toHaveBeenCalled());
+      expect(adminProductsApi.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          noticeInfo: {
+            type: 'tea',
+            foodType: '잎차',
+            storageMethod: '냉암소 보관',
+          },
+        }),
+      );
+    });
 
     it('다국어 입력은 영어만 노출하고 ja/zh 필드를 전송하지 않는다', async () => {
       const { adminProductsApi } = await import('@/lib/api');
@@ -201,12 +253,78 @@ describe('ProductFormPage', () => {
       fireEvent.click(screen.getByText('등록하기'));
 
       await waitFor(() => expect(adminProductsApi.create).toHaveBeenCalled());
-      const payload = vi.mocked(adminProductsApi.create).mock.calls[0][0] as Record<string, unknown>;
+      const payload = vi.mocked(adminProductsApi.create).mock.calls[0][0] as unknown as Record<string, unknown>;
       expect(payload.nameEn).toBe('Test product');
       expect(payload).not.toHaveProperty('nameJa');
       expect(payload).not.toHaveProperty('nameZh');
       expect(payload).not.toHaveProperty('descriptionJa');
       expect(payload).not.toHaveProperty('descriptionZh');
+    });
+    it('수정 모드에서 기존 상품고시정보를 모두 비우면 noticeInfo=null을 전송한다', async () => {
+      const { adminProductsApi } = await import('@/lib/api');
+      vi.mocked(adminProductsApi.update).mockResolvedValue({
+        id: 1,
+        name: '테스트 상품',
+        slug: 'test-product',
+        price: 10000,
+        salePrice: null,
+        status: 'draft',
+        isFeatured: false,
+        viewCount: 0,
+        category: null,
+        images: [],
+        description: null,
+        shortDescription: null,
+        rating: 0,
+        reviewCount: 0,
+        stock: 0,
+        sku: null,
+        options: [],
+        detailImages: [],
+        noticeInfo: null,
+      });
+
+      render(
+        <ProductFormPage
+          mode="edit"
+          product={{
+            id: 1,
+            name: '테스트 상품',
+            slug: 'test-product',
+            price: 10000,
+            salePrice: null,
+            status: 'draft',
+            isFeatured: false,
+            viewCount: 0,
+            category: null,
+            images: [],
+            description: null,
+            shortDescription: null,
+            rating: 0,
+            reviewCount: 0,
+            stock: 0,
+            sku: null,
+            options: [],
+            detailImages: [],
+            noticeInfo: {
+              type: 'tea',
+              foodType: '침출차',
+              storageMethod: '서늘한 곳 보관',
+            },
+          }}
+        />,
+      );
+
+      fireEvent.change(screen.getByDisplayValue('침출차'), { target: { value: '' } });
+      fireEvent.change(screen.getByDisplayValue('서늘한 곳 보관'), { target: { value: '' } });
+      fireEvent.change(screen.getByDisplayValue('차류/식품류'), { target: { value: '' } });
+      fireEvent.click(screen.getByText('수정하기'));
+
+      await waitFor(() => expect(adminProductsApi.update).toHaveBeenCalled());
+      expect(adminProductsApi.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ noticeInfo: null }),
+      );
     });
   });
 });

--- a/src/components/shared/products/ProductDetailClient.tsx
+++ b/src/components/shared/products/ProductDetailClient.tsx
@@ -392,6 +392,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
           descriptionImages={descriptionImages}
           productId={Number(product.id)}
           locale={locale}
+          noticeInfo={product.noticeInfo}
         />
       </div>
 

--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -7,7 +7,7 @@ import { usePathname } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import { inquiriesApi } from '@/lib/api'
-import type { Inquiry, ProductDetailImage } from '@/lib/api'
+import type { Inquiry, ProductDetailImage, ProductNoticeInfo } from '@/lib/api'
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction'
 import { useAuth } from '@/contexts/AuthContext'
 import { cn } from '@/components/ui/utils'
@@ -18,11 +18,83 @@ interface ProductTabsProps {
   descriptionImages: ProductDetailImage[]
   productId?: number
   locale?: string
+  noticeInfo?: ProductNoticeInfo | null
 }
 
 const TABS = ['details', 'reviews', 'inquiry'] as const
 type Tab = (typeof TABS)[number]
 const INQUIRY_TYPE_PRODUCT = '상품'
+
+const NOTICE_INFO_LABELS: Record<keyof Omit<ProductNoticeInfo, 'type'>, string> = {
+  productName: '품명 및 모델명',
+  material: '재질',
+  components: '구성품',
+  sizeCapacity: '크기/용량',
+  manufacturer: '제조자/수입자',
+  countryOfOrigin: '제조국',
+  handlingPrecautions: '취급 시 주의사항',
+  warrantyPolicy: '품질보증기준',
+  asContact: 'A/S 책임자와 전화번호',
+  foodType: '식품 유형',
+  producer: '생산자/수입자',
+  origin: '원산지',
+  manufactureDate: '제조연월일',
+  expirationDate: '소비기한',
+  storageMethod: '보관방법',
+  ingredients: '원재료명',
+  customerServicePhone: '소비자상담 전화번호',
+}
+
+const TEA_NOTICE_FIELDS: Array<keyof Omit<ProductNoticeInfo, 'type'>> = [
+  'foodType',
+  'producer',
+  'origin',
+  'manufactureDate',
+  'expirationDate',
+  'storageMethod',
+  'ingredients',
+  'customerServicePhone',
+]
+
+const TEAWARE_NOTICE_FIELDS: Array<keyof Omit<ProductNoticeInfo, 'type'>> = [
+  'productName',
+  'material',
+  'components',
+  'sizeCapacity',
+  'manufacturer',
+  'countryOfOrigin',
+  'handlingPrecautions',
+  'warrantyPolicy',
+  'asContact',
+]
+
+function ProductNoticeInfoGuide({ noticeInfo }: { noticeInfo?: ProductNoticeInfo | null }) {
+  if (!noticeInfo) return null
+
+  const keys = noticeInfo.type === 'tea' ? TEA_NOTICE_FIELDS : TEAWARE_NOTICE_FIELDS
+  const rows = keys
+    .map((key) => ({ key, label: NOTICE_INFO_LABELS[key], value: noticeInfo[key] }))
+    .filter((row): row is { key: keyof Omit<ProductNoticeInfo, 'type'>; label: string; value: string } => typeof row.value === 'string' && row.value.trim().length > 0)
+
+  if (rows.length === 0) return null
+
+  return (
+    <section className="rounded-lg border border-border bg-muted/20 p-5" aria-labelledby="product-notice-info-title">
+      <div className="mb-4">
+        <p className="typo-label text-muted-foreground">Product information</p>
+        <h2 id="product-notice-info-title" className="typo-h2 text-foreground">상품고시정보</h2>
+      </div>
+      <dl className="grid gap-3 md:grid-cols-2">
+        {rows.map((row) => (
+          <div key={row.key} className="rounded-md bg-background/70 p-3">
+            <dt className="typo-label text-muted-foreground">{row.label}</dt>
+            <dd className="mt-1 typo-body-sm text-foreground">{row.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  )
+}
 
 function ProductPolicyGuide({ namespace, titleId }: { namespace: 'deliveryGuide' | 'exchangeRefundGuide'; titleId: string }) {
   const t = useTranslations(`product.tabs.${namespace}`)
@@ -50,7 +122,7 @@ function ProductPolicyGuide({ namespace, titleId }: { namespace: 'deliveryGuide'
   )
 }
 
-export default function ProductTabs({ description, descriptionImages, productId, locale = 'ko' }: ProductTabsProps) {
+export default function ProductTabs({ description, descriptionImages, productId, locale = 'ko', noticeInfo }: ProductTabsProps) {
   const t = useTranslations('product')
   const pathname = usePathname()
   const { isAuthenticated } = useAuth()
@@ -181,6 +253,7 @@ export default function ProductTabs({ description, descriptionImages, productId,
               className="prose prose-sm max-w-none"
               dangerouslySetInnerHTML={{ __html: sanitized }}
             />
+            <ProductNoticeInfoGuide noticeInfo={noticeInfo} />
             <ProductPolicyGuide namespace="deliveryGuide" titleId="delivery-guide-title" />
             <ProductPolicyGuide namespace="exchangeRefundGuide" titleId="exchange-refund-guide-title" />
           </div>

--- a/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
+++ b/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
@@ -175,6 +175,7 @@ const productWithOptions: ProductDetail = {
   description: '<p>본문</p>',
   stock: 12,
   sku: 'TP-001',
+  noticeInfo: null,
   options: [
     { id: 11, name: '크기', value: '대', priceAdjustment: 0, stock: 12, sortOrder: 0 },
     { id: 12, name: '크기', value: '소', priceAdjustment: -10000, stock: 5, sortOrder: 1 },

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '../core';
-import type { ProductDetail, ProductListResponse } from '../products';
+import type { ProductDetail, ProductListResponse, ProductNoticeInfo } from '../products';
 
 export interface AdminProductsParams {
   page?: number;
@@ -21,6 +21,7 @@ export interface CreateProductData {
   isFreeShipping?: boolean;
   nameEn?: string;
   descriptionEn?: string;
+  noticeInfo?: ProductNoticeInfo | null;
   images?: Array<{
     url: string;
     alt?: string;

--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -77,11 +77,33 @@ export interface ProductOption {
   sortOrder: number;
 }
 
+export interface ProductNoticeInfo {
+  type?: 'teaware' | 'tea';
+  productName?: string;
+  material?: string;
+  components?: string;
+  sizeCapacity?: string;
+  manufacturer?: string;
+  countryOfOrigin?: string;
+  handlingPrecautions?: string;
+  warrantyPolicy?: string;
+  asContact?: string;
+  foodType?: string;
+  producer?: string;
+  origin?: string;
+  manufactureDate?: string;
+  expirationDate?: string;
+  storageMethod?: string;
+  ingredients?: string;
+  customerServicePhone?: string;
+}
+
 export interface ProductDetail extends Product {
   description: string | null;
   shortDescription: string | null;
   stock: number;
   sku: string | null;
+  noticeInfo: ProductNoticeInfo | null;
   options: ProductOption[];
   detailImages: ProductDetailImage[];
 }


### PR DESCRIPTION
## Summary
- Closes #846
- 상품 엔티티/DTO에 상품고시정보 JSON 필드를 추가하고 TypeORM 마이그레이션을 작성했습니다.
- 관리자 상품 등록/수정 폼에서 자사호/다구 및 차류/식품류 고시정보를 입력할 수 있게 했습니다.
- 상품 상세 상세정보 탭에 입력된 상품고시정보를 표시합니다.

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run
- [x] cd backend && npm run lint
- [x] cd backend && npm run build
- [x] cd backend && npm run test
- [x] bash scripts/test.sh e2e