### PR TITLE
docs: #849 회원 주문조회 정책 안내

### DIFF
--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -62,6 +62,12 @@ export default function FaqPage() {
         ))}
       </div>
 
+      <section className="mb-6 rounded-lg border border-border bg-muted/20 p-5">
+        <h2 className="typo-h3 text-foreground">{t('memberOnlyOrderTitle')}</h2>
+        <p className="mt-2 typo-body text-muted-foreground">{t('memberOnlyOrderDescription')}</p>
+        <p className="mt-2 typo-body-sm text-muted-foreground">{t('memberOnlyOrderAction')}</p>
+      </section>
+
       {loading ? (
         <div className="space-y-3">
           {Array.from({ length: 5 }).map((_, i) => (

--- a/src/components/__tests__/FaqPage.test.tsx
+++ b/src/components/__tests__/FaqPage.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import FaqPage from '@/app/[locale]/faq/page';
+import { faqsApi } from '@/lib/api';
+
+function makeTranslator(namespace?: string) {
+  const dict: Record<string, string> = {
+    title: '자주 묻는 질문',
+    loadError: 'FAQ를 불러오지 못했습니다.',
+    empty: '해당 카테고리의 FAQ가 없습니다.',
+    memberOnlyOrderTitle: '주문조회는 회원 로그인 후 이용할 수 있습니다.',
+    memberOnlyOrderDescription: '옥화당은 현재 회원 주문만 지원하며, 비회원 주문조회 폼은 제공하지 않습니다.',
+    memberOnlyOrderAction: '로그인 후 마이페이지 주문 내역에서 결제 상태와 배송 상태를 확인해 주세요.',
+    'categories.all': '전체',
+    'categories.shipping': '배송',
+    'categories.payment': '결제',
+    'categories.exchange': '교환/반품',
+    'categories.member': '회원',
+    'categories.other': '기타',
+  };
+  return (key: string) => dict[key] ?? `${namespace ? `${namespace}.` : ''}${key}`;
+}
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ locale: 'ko' }),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace?: string) => makeTranslator(namespace),
+}));
+
+vi.mock('@/lib/api', () => ({
+  faqsApi: {
+    getList: vi.fn(),
+  },
+}));
+
+describe('FaqPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(faqsApi.getList).mockResolvedValue([]);
+  });
+
+  it('비회원 주문조회 대신 회원 주문 전용 정책 안내를 노출한다', async () => {
+    render(<FaqPage />);
+
+    expect(await screen.findByText('주문조회는 회원 로그인 후 이용할 수 있습니다.')).toBeInTheDocument();
+    expect(screen.getByText('옥화당은 현재 회원 주문만 지원하며, 비회원 주문조회 폼은 제공하지 않습니다.')).toBeInTheDocument();
+    expect(screen.getByText(/마이페이지 주문 내역/)).toBeInTheDocument();
+
+    await waitFor(() => expect(faqsApi.getList).toHaveBeenCalledWith(undefined, 'ko'));
+  });
+});

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1117,6 +1117,9 @@
     "title": "FAQ",
     "loadError": "Failed to load FAQ.",
     "empty": "No FAQ found in this category.",
+    "memberOnlyOrderTitle": "Order lookup is available after member login.",
+    "memberOnlyOrderDescription": "Ockhwadang currently supports member orders only and does not provide a guest order lookup form.",
+    "memberOnlyOrderAction": "After logging in, check payment and shipping status from My Page order history.",
     "categories": {
       "all": "All",
       "shipping": "Shipping",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1117,6 +1117,9 @@
     "title": "자주 묻는 질문",
     "loadError": "FAQ를 불러오지 못했습니다.",
     "empty": "해당 카테고리의 FAQ가 없습니다.",
+    "memberOnlyOrderTitle": "주문조회는 회원 로그인 후 이용할 수 있습니다.",
+    "memberOnlyOrderDescription": "옥화당은 현재 회원 주문만 지원하며, 비회원 주문조회 폼은 제공하지 않습니다.",
+    "memberOnlyOrderAction": "로그인 후 마이페이지 주문 내역에서 결제 상태와 배송 상태를 확인해 주세요.",
     "categories": {
       "all": "전체",
       "shipping": "배송",


### PR DESCRIPTION
## Summary
- Closes #849
- 현재 체크아웃이 로그인 필수 구조임을 반영해 비회원 주문조회 폼 대신 회원 주문 전용 정책 안내를 FAQ에 추가했습니다.
- 무차별 주문 조회/개인정보 노출 위험을 만들지 않고, 마이페이지 주문 내역에서 결제·배송 상태를 확인하도록 안내합니다.
- 한/영 메시지와 FAQ 페이지 테스트를 추가했습니다.

## Test plan
- [x] npm run test:run -- src/components/__tests__/FaqPage.test.tsx
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run