### PR TITLE
feat: 주문 사후처리·상품문의·정책 동의 흐름 보강

### DIFF
--- a/backend/src/database/migrations/1784900000000-AddOrderServiceRequestsAndProductInquiry.ts
+++ b/backend/src/database/migrations/1784900000000-AddOrderServiceRequestsAndProductInquiry.ts
@@ -1,0 +1,156 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderServiceRequestsAndProductInquiry1784900000000 implements MigrationInterface {
+  name = 'AddOrderServiceRequestsAndProductInquiry1784900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await this.columnExists(queryRunner, 'pages', 'policy_version'))) {
+      await queryRunner.query(
+        `ALTER TABLE \`pages\` ADD COLUMN \`policy_version\` varchar(50) NULL AFTER \`template\``,
+      );
+    }
+    if (!(await this.columnExists(queryRunner, 'pages', 'policy_effective_date'))) {
+      await queryRunner.query(
+        `ALTER TABLE \`pages\` ADD COLUMN \`policy_effective_date\` date NULL AFTER \`policy_version\``,
+      );
+    }
+    if (!(await this.columnExists(queryRunner, 'pages', 'policy_change_summary'))) {
+      await queryRunner.query(
+        `ALTER TABLE \`pages\` ADD COLUMN \`policy_change_summary\` longtext NULL AFTER \`policy_effective_date\``,
+      );
+    }
+    if (!(await this.columnExists(queryRunner, 'pages', 'is_current_policy'))) {
+      await queryRunner.query(
+        `ALTER TABLE \`pages\` ADD COLUMN \`is_current_policy\` tinyint(1) NOT NULL DEFAULT 0 AFTER \`policy_change_summary\``,
+      );
+      await queryRunner.query(
+        `UPDATE \`pages\` SET \`policy_version\` = 'v1.0', \`policy_effective_date\` = '2026-04-20', \`policy_change_summary\` = '최초 제정', \`is_current_policy\` = 1 WHERE \`slug\` IN ('terms','privacy','shipping','returns','shipping-returns')`,
+      );
+    }
+
+    if (!(await this.columnExists(queryRunner, 'inquiries', 'product_id'))) {
+      await queryRunner.query(
+        `ALTER TABLE \`inquiries\` ADD COLUMN \`product_id\` bigint NULL AFTER \`user_id\``,
+      );
+      await queryRunner.query(
+        `CREATE INDEX \`IDX_inquiries_product_id\` ON \`inquiries\` (\`product_id\`)`,
+      );
+    }
+    if (!(await this.columnExists(queryRunner, 'inquiries', 'is_secret'))) {
+      await queryRunner.query(
+        `ALTER TABLE \`inquiries\` ADD COLUMN \`is_secret\` tinyint(1) NOT NULL DEFAULT 0 AFTER \`content\``,
+      );
+    }
+
+
+    if (!(await this.tableExists(queryRunner, 'policy_consents'))) {
+      await queryRunner.query(`
+        CREATE TABLE \`policy_consents\` (
+          \`id\` bigint NOT NULL AUTO_INCREMENT,
+          \`user_id\` bigint NOT NULL,
+          \`context\` enum('signup','checkout') NOT NULL,
+          \`resource_type\` varchar(50) NULL,
+          \`resource_id\` bigint NULL,
+          \`policies\` json NOT NULL,
+          \`marketing_consent\` tinyint(1) NOT NULL DEFAULT 0,
+          \`consented_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+          INDEX \`IDX_policy_consents_user\` (\`user_id\`),
+          INDEX \`IDX_policy_consents_resource\` (\`context\`, \`resource_type\`, \`resource_id\`),
+          PRIMARY KEY (\`id\`),
+          CONSTRAINT \`FK_policy_consents_user\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE
+        ) ENGINE=InnoDB
+      `);
+    }
+
+    if (!(await this.tableExists(queryRunner, 'order_service_requests'))) {
+      await queryRunner.query(`
+        CREATE TABLE \`order_service_requests\` (
+          \`id\` bigint NOT NULL AUTO_INCREMENT,
+          \`order_id\` bigint NOT NULL,
+          \`user_id\` bigint NOT NULL,
+          \`type\` enum('cancel','return','exchange','refund') NOT NULL,
+          \`status\` enum('requested','approved','rejected','completed') NOT NULL DEFAULT 'requested',
+          \`reason\` varchar(100) NOT NULL,
+          \`detail\` longtext NULL,
+          \`image_urls\` json NULL,
+          \`use_shipping_address\` tinyint(1) NOT NULL DEFAULT 1,
+          \`pickup_name\` varchar(100) NULL,
+          \`pickup_phone\` varchar(20) NULL,
+          \`pickup_zipcode\` varchar(10) NULL,
+          \`pickup_address\` varchar(255) NULL,
+          \`pickup_address_detail\` varchar(255) NULL,
+          \`admin_note\` longtext NULL,
+          \`processed_at\` datetime NULL,
+          \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+          \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+          INDEX \`IDX_osr_order_id\` (\`order_id\`),
+          INDEX \`IDX_osr_user_id\` (\`user_id\`),
+          INDEX \`IDX_osr_type_status\` (\`type\`, \`status\`),
+          PRIMARY KEY (\`id\`)
+        ) ENGINE=InnoDB
+      `);
+      await queryRunner.query(
+        `ALTER TABLE \`order_service_requests\` ADD CONSTRAINT \`FK_osr_order\` FOREIGN KEY (\`order_id\`) REFERENCES \`orders\`(\`id\`) ON DELETE CASCADE`,
+      );
+      await queryRunner.query(
+        `ALTER TABLE \`order_service_requests\` ADD CONSTRAINT \`FK_osr_user\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE`,
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+
+    if (await this.tableExists(queryRunner, 'policy_consents')) {
+      await queryRunner.query(`DROP TABLE \`policy_consents\``);
+    }
+
+    if (await this.tableExists(queryRunner, 'order_service_requests')) {
+      await queryRunner.query(
+        `ALTER TABLE \`order_service_requests\` DROP FOREIGN KEY \`FK_osr_user\``,
+      );
+      await queryRunner.query(
+        `ALTER TABLE \`order_service_requests\` DROP FOREIGN KEY \`FK_osr_order\``,
+      );
+      await queryRunner.query(`DROP TABLE \`order_service_requests\``);
+    }
+    if (await this.columnExists(queryRunner, 'pages', 'is_current_policy')) {
+      await queryRunner.query(`ALTER TABLE \`pages\` DROP COLUMN \`is_current_policy\``);
+    }
+    if (await this.columnExists(queryRunner, 'pages', 'policy_change_summary')) {
+      await queryRunner.query(`ALTER TABLE \`pages\` DROP COLUMN \`policy_change_summary\``);
+    }
+    if (await this.columnExists(queryRunner, 'pages', 'policy_effective_date')) {
+      await queryRunner.query(`ALTER TABLE \`pages\` DROP COLUMN \`policy_effective_date\``);
+    }
+    if (await this.columnExists(queryRunner, 'pages', 'policy_version')) {
+      await queryRunner.query(`ALTER TABLE \`pages\` DROP COLUMN \`policy_version\``);
+    }
+    if (await this.columnExists(queryRunner, 'inquiries', 'is_secret')) {
+      await queryRunner.query(`ALTER TABLE \`inquiries\` DROP COLUMN \`is_secret\``);
+    }
+    if (await this.columnExists(queryRunner, 'inquiries', 'product_id')) {
+      await queryRunner.query(`DROP INDEX \`IDX_inquiries_product_id\` ON \`inquiries\``);
+      await queryRunner.query(`ALTER TABLE \`inquiries\` DROP COLUMN \`product_id\``);
+    }
+  }
+
+  private async tableExists(queryRunner: QueryRunner, tableName: string): Promise<boolean> {
+    const rows = (await queryRunner.query(
+      `SELECT COUNT(*) AS cnt FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+      [tableName],
+    )) as Array<{ cnt: string }>;
+    return Number(rows[0]?.cnt ?? 0) > 0;
+  }
+
+  private async columnExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+  ): Promise<boolean> {
+    const rows = (await queryRunner.query(
+      `SELECT COUNT(*) AS cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+      [tableName, columnName],
+    )) as Array<{ cnt: string }>;
+    return Number(rows[0]?.cnt ?? 0) > 0;
+  }
+}

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -11,6 +11,7 @@ import { AdminMembersService } from './admin-members.service';
 import { AdminExportController } from './admin-export.controller';
 import { AdminExportService } from './admin-export.service';
 import { Order } from '../orders/entities/order.entity';
+import { OrderServiceRequest } from '../orders/entities/order-service-request.entity';
 import { Payment } from '../payments/entities/payment.entity';
 import { Shipping } from '../payments/entities/shipping.entity';
 import { User } from '../users/entities/user.entity';
@@ -22,7 +23,7 @@ import { PointsModule } from '../points/points.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Order, Payment, Shipping, User, Product]),
+    TypeOrmModule.forFeature([Order, OrderServiceRequest, Payment, Shipping, User, Product]),
     PaymentsModule,
     AuditLogModule,
     MembershipModule,

--- a/backend/src/modules/inquiries/dto/create-inquiry.dto.ts
+++ b/backend/src/modules/inquiries/dto/create-inquiry.dto.ts
@@ -1,8 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsEnum, MaxLength } from 'class-validator';
+import { IsBoolean, IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
 import { InquiryType } from '../entities/inquiry.entity';
 
 export class CreateInquiryDto {
+  @ApiProperty({ example: 1, description: '상품 ID', required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'productId는 정수여야 합니다.' })
+  productId?: number;
+
   @ApiProperty({ example: InquiryType.PRODUCT, enum: InquiryType, description: '문의 유형' })
   @IsEnum(InquiryType)
   type!: InquiryType;
@@ -17,4 +24,10 @@ export class CreateInquiryDto {
   @IsString()
   @IsNotEmpty()
   content!: string;
+
+  @ApiProperty({ example: false, description: '비밀글 여부', required: false })
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => value === true || value === 'true')
+  @IsBoolean({ message: 'isSecret은 boolean이어야 합니다.' })
+  isSecret?: boolean;
 }

--- a/backend/src/modules/inquiries/entities/inquiry.entity.ts
+++ b/backend/src/modules/inquiries/entities/inquiry.entity.ts
@@ -2,6 +2,7 @@ import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
+  Index,
   CreateDateColumn,
   UpdateDateColumn,
   ManyToOne,
@@ -23,12 +24,16 @@ export enum InquiryStatus {
 }
 
 @Entity('inquiries')
+@Index(['productId'])
 export class Inquiry {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id!: number;
 
   @Column({ name: 'user_id', type: 'bigint' })
   userId!: number;
+
+  @Column({ name: 'product_id', type: 'bigint', nullable: true })
+  productId!: number | null;
 
   @Column({ type: 'enum', enum: InquiryType })
   type!: InquiryType;
@@ -38,6 +43,9 @@ export class Inquiry {
 
   @Column({ type: 'longtext' })
   content!: string;
+
+  @Column({ name: 'is_secret', type: 'boolean', default: false })
+  isSecret!: boolean;
 
   @Column({ type: 'enum', enum: InquiryStatus, default: InquiryStatus.PENDING })
   status!: InquiryStatus;

--- a/backend/src/modules/inquiries/inquiries.controller.ts
+++ b/backend/src/modules/inquiries/inquiries.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiResponse,
   ApiParam,
   ApiCookieAuth,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { InquiriesService } from './inquiries.service';
 import { CreateInquiryDto } from './dto/create-inquiry.dto';
@@ -32,8 +33,13 @@ export class InquiriesController {
   @ApiOperation({ summary: '내 문의 목록 조회', description: '현재 사용자의 1:1 문의 목록을 조회합니다.' })
   @ApiResponse({ status: 200, description: '문의 목록 조회 성공' })
   @ApiResponse({ status: 401, description: '인증 필요' })
-  findAll(@Request() req: AuthenticatedRequestWithAuthUser) {
-    return this.inquiriesService.findAllByUser(req.user.id);
+  @ApiQuery({ name: 'productId', required: false, type: Number, description: '상품 ID 필터' })
+  findAll(
+    @Request() req: AuthenticatedRequestWithAuthUser,
+    @Query('productId') productId?: string,
+  ) {
+    const parsedProductId = productId ? Number(productId) : undefined;
+    return this.inquiriesService.findAllByUser(req.user.id, parsedProductId);
   }
 
   @Post()

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -25,9 +25,9 @@ export class InquiriesService {
     private readonly notificationDispatchHelper: NotificationDispatchHelper,
   ) {}
 
-  async findAllByUser(userId: number): Promise<Inquiry[]> {
+  async findAllByUser(userId: number, productId?: number): Promise<Inquiry[]> {
     return this.inquiryRepo.find({
-      where: { userId },
+      where: productId ? { userId, productId } : { userId },
       order: { createdAt: 'DESC' },
     });
   }
@@ -48,8 +48,10 @@ export class InquiriesService {
     const inquiry = this.inquiryRepo.create({
       userId,
       type: dto.type,
+      productId: dto.productId ?? null,
       title: dto.title,
       content: dto.content,
+      isSecret: dto.isSecret ?? false,
     });
     const saved = await this.inquiryRepo.save(inquiry);
     this.logger.log(`Inquiry created: id=${saved.id}, userId=${userId}`);

--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -19,6 +19,7 @@ const mockManager = {
   save: jest.fn(),
   update: jest.fn(),
   getRepository: jest.fn(),
+  query: jest.fn(),
 };
 
 const mockDataSource = {
@@ -60,6 +61,7 @@ describe('OrdersService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockManager.query.mockResolvedValue([]);
     mockDataSource.transaction.mockImplementation(
       (cb: (manager: typeof mockManager) => Promise<unknown>) => cb(mockManager),
     );

--- a/backend/src/modules/orders/dto/admin-order-service-request-query.dto.ts
+++ b/backend/src/modules/orders/dto/admin-order-service-request-query.dto.ts
@@ -1,0 +1,31 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { OrderServiceRequestStatus, OrderServiceRequestType } from '../entities/order-service-request.entity';
+
+export class AdminOrderServiceRequestQueryDto {
+  @ApiPropertyOptional({ enum: OrderServiceRequestType })
+  @IsOptional()
+  @IsEnum(OrderServiceRequestType)
+  type?: OrderServiceRequestType;
+
+  @ApiPropertyOptional({ enum: OrderServiceRequestStatus })
+  @IsOptional()
+  @IsEnum(OrderServiceRequestStatus)
+  status?: OrderServiceRequestStatus;
+
+  @ApiPropertyOptional({ example: 1, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ example: 20, default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/backend/src/modules/orders/dto/create-order-service-request.dto.ts
+++ b/backend/src/modules/orders/dto/create-order-service-request.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsArray, IsBoolean, IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { OrderServiceRequestType } from '../entities/order-service-request.entity';
+
+export class CreateOrderServiceRequestDto {
+  @ApiProperty({ enum: OrderServiceRequestType, example: OrderServiceRequestType.CANCEL, description: '신청 유형' })
+  @IsEnum(OrderServiceRequestType, { message: '신청 유형이 올바르지 않습니다.' })
+  type!: OrderServiceRequestType;
+
+  @ApiProperty({ example: '단순 변심', description: '신청 사유' })
+  @IsString()
+  @MaxLength(100, { message: '사유는 100자 이하여야 합니다.' })
+  reason!: string;
+
+  @ApiPropertyOptional({ example: '주문을 취소하고 싶습니다.', description: '상세 사유' })
+  @IsOptional()
+  @IsString()
+  detail?: string;
+
+  @ApiPropertyOptional({ type: [String], description: '증빙 이미지 URL 목록' })
+  @IsOptional()
+  @IsArray({ message: '이미지 URL은 배열이어야 합니다.' })
+  @IsString({ each: true })
+  imageUrls?: string[];
+
+  @ApiPropertyOptional({ example: true, description: '기존 배송지를 회수지로 사용' })
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => value === true || value === 'true')
+  @IsBoolean({ message: 'useShippingAddress는 boolean이어야 합니다.' })
+  useShippingAddress?: boolean;
+
+  @ApiPropertyOptional({ example: '홍길동' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  pickupName?: string;
+
+  @ApiPropertyOptional({ example: '010-1234-5678' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  pickupPhone?: string;
+
+  @ApiPropertyOptional({ example: '06252' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(10)
+  pickupZipcode?: string;
+
+  @ApiPropertyOptional({ example: '서울특별시 강남구 역삼로 114' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  pickupAddress?: string;
+
+  @ApiPropertyOptional({ example: '8028호' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  pickupAddressDetail?: string;
+}

--- a/backend/src/modules/orders/dto/create-order.dto.ts
+++ b/backend/src/modules/orders/dto/create-order.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   IsArray, IsInt, IsOptional, IsString, MaxLength, Min,
-  ValidateNested, ValidateIf, IsNotEmpty,
+  ValidateNested, ValidateIf, IsNotEmpty, IsBoolean,
 } from 'class-validator';
 
 export class OrderItemDto {
@@ -20,6 +20,27 @@ export class OrderItemDto {
   @IsInt({ message: '수량은 정수여야 합니다.' })
   @Min(1, { message: '수량은 최소 1개 이상이어야 합니다.' })
   quantity!: number;
+}
+
+
+export class PolicyConsentSnapshotDto {
+  @ApiProperty({ example: 'terms', description: '정책 문서 slug' })
+  @IsString({ message: '정책 문서 식별자는 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '정책 문서 식별자를 입력해 주세요.' })
+  @MaxLength(100, { message: '정책 문서 식별자는 최대 100자까지 입력 가능합니다.' })
+  slug!: string;
+
+  @ApiProperty({ example: 'v1.0', description: '동의한 정책 버전', required: false })
+  @IsOptional()
+  @IsString({ message: '정책 버전은 문자열이어야 합니다.' })
+  @MaxLength(50, { message: '정책 버전은 최대 50자까지 입력 가능합니다.' })
+  version?: string | null;
+
+  @ApiProperty({ example: '2026-04-20', description: '동의한 정책 시행일', required: false })
+  @IsOptional()
+  @IsString({ message: '정책 시행일은 문자열이어야 합니다.' })
+  @MaxLength(20, { message: '정책 시행일은 최대 20자까지 입력 가능합니다.' })
+  effectiveDate?: string | null;
 }
 
 export class CreateOrderDto {
@@ -75,4 +96,17 @@ export class CreateOrderDto {
   @IsOptional()
   @IsInt({ message: '쿠폰 ID는 정수여야 합니다.' })
   userCouponId?: number;
+
+  @ApiProperty({ type: [PolicyConsentSnapshotDto], description: '결제 동의 시점 정책 버전 스냅샷', required: false })
+  @IsOptional()
+  @IsArray({ message: '정책 동의 목록은 배열이어야 합니다.' })
+  @ValidateNested({ each: true })
+  @Type(() => PolicyConsentSnapshotDto)
+  policyConsents?: PolicyConsentSnapshotDto[];
+
+  @ApiProperty({ example: false, description: '마케팅 수신 동의 여부', required: false })
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => value === true || value === 'true')
+  @IsBoolean({ message: '마케팅 수신 동의 여부는 boolean이어야 합니다.' })
+  marketingConsent?: boolean;
 }

--- a/backend/src/modules/orders/dto/update-order-service-request.dto.ts
+++ b/backend/src/modules/orders/dto/update-order-service-request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { OrderServiceRequestStatus } from '../entities/order-service-request.entity';
+
+export class UpdateOrderServiceRequestDto {
+  @ApiProperty({ enum: OrderServiceRequestStatus, example: OrderServiceRequestStatus.APPROVED })
+  @IsEnum(OrderServiceRequestStatus, { message: '처리 상태가 올바르지 않습니다.' })
+  status!: OrderServiceRequestStatus;
+
+  @ApiPropertyOptional({ example: '고객 안내 완료' })
+  @IsOptional()
+  @IsString()
+  adminNote?: string;
+}

--- a/backend/src/modules/orders/entities/order-service-request.entity.ts
+++ b/backend/src/modules/orders/entities/order-service-request.entity.ts
@@ -1,0 +1,94 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Order } from './order.entity';
+import { User } from '../../users/entities/user.entity';
+
+export enum OrderServiceRequestType {
+  CANCEL = 'cancel',
+  RETURN = 'return',
+  EXCHANGE = 'exchange',
+  REFUND = 'refund',
+}
+
+export enum OrderServiceRequestStatus {
+  REQUESTED = 'requested',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  COMPLETED = 'completed',
+}
+
+@Entity('order_service_requests')
+@Index(['orderId'])
+@Index(['userId'])
+@Index(['type', 'status'])
+export class OrderServiceRequest {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({ name: 'order_id', type: 'bigint' })
+  orderId!: number;
+
+  @Column({ name: 'user_id', type: 'bigint' })
+  userId!: number;
+
+  @Column({ type: 'enum', enum: OrderServiceRequestType })
+  type!: OrderServiceRequestType;
+
+  @Column({ type: 'enum', enum: OrderServiceRequestStatus, default: OrderServiceRequestStatus.REQUESTED })
+  status!: OrderServiceRequestStatus;
+
+  @Column({ type: 'varchar', length: 100 })
+  reason!: string;
+
+  @Column({ type: 'longtext', nullable: true })
+  detail!: string | null;
+
+  @Column({ name: 'image_urls', type: 'json', nullable: true })
+  imageUrls!: string[] | null;
+
+  @Column({ name: 'use_shipping_address', type: 'boolean', default: true })
+  useShippingAddress!: boolean;
+
+  @Column({ name: 'pickup_name', type: 'varchar', length: 100, nullable: true })
+  pickupName!: string | null;
+
+  @Column({ name: 'pickup_phone', type: 'varchar', length: 20, nullable: true })
+  pickupPhone!: string | null;
+
+  @Column({ name: 'pickup_zipcode', type: 'varchar', length: 10, nullable: true })
+  pickupZipcode!: string | null;
+
+  @Column({ name: 'pickup_address', type: 'varchar', length: 255, nullable: true })
+  pickupAddress!: string | null;
+
+  @Column({ name: 'pickup_address_detail', type: 'varchar', length: 255, nullable: true })
+  pickupAddressDetail!: string | null;
+
+  @Column({ name: 'admin_note', type: 'longtext', nullable: true })
+  adminNote!: string | null;
+
+  @Column({ name: 'processed_at', type: 'datetime', nullable: true })
+  processedAt!: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+
+  @ManyToOne(() => Order, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'order_id' })
+  order!: Order;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user!: User;
+}

--- a/backend/src/modules/orders/order-service-requests.controller.ts
+++ b/backend/src/modules/orders/order-service-requests.controller.ts
@@ -1,0 +1,59 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { AuthUser } from '../../common/interfaces/auth-user.interface';
+import { OrderServiceRequestsService } from './order-service-requests.service';
+import { CreateOrderServiceRequestDto } from './dto/create-order-service-request.dto';
+import { UpdateOrderServiceRequestDto } from './dto/update-order-service-request.dto';
+import { AdminOrderServiceRequestQueryDto } from './dto/admin-order-service-request-query.dto';
+
+@ApiTags('주문 신청')
+@Controller('orders/:orderId/service-requests')
+export class OrderServiceRequestsController {
+  constructor(private readonly service: OrderServiceRequestsService) {}
+
+  @Get()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '내 주문 취소/교환/반품/환불 신청 목록' })
+  @ApiResponse({ status: 200, description: '신청 목록 조회 성공' })
+  @ApiParam({ name: 'orderId', type: Number })
+  findByOrder(@Param('orderId', ParseIntPipe) orderId: number, @CurrentUser() user: AuthUser) {
+    return this.service.findByOrderForUser(orderId, user.id);
+  }
+
+  @Post()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '주문 취소/교환/반품/환불 신청 생성' })
+  @ApiResponse({ status: 201, description: '신청 생성 성공' })
+  @ApiParam({ name: 'orderId', type: Number })
+  create(
+    @Param('orderId', ParseIntPipe) orderId: number,
+    @CurrentUser() user: AuthUser,
+    @Body() dto: CreateOrderServiceRequestDto,
+  ) {
+    return this.service.create(orderId, user.id, dto);
+  }
+}
+
+@ApiTags('관리자 - 주문 신청')
+@Controller('admin/order-service-requests')
+@Roles('admin', 'super_admin')
+export class AdminOrderServiceRequestsController {
+  constructor(private readonly service: OrderServiceRequestsService) {}
+
+  @Get()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '주문 취소/교환/반품/환불 신청 관리 목록' })
+  findAll(@Query() query: AdminOrderServiceRequestQueryDto) {
+    return this.service.findAllForAdmin(query);
+  }
+
+  @Patch(':id')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '주문 신청 처리 상태 변경' })
+  @ApiParam({ name: 'id', type: Number })
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateOrderServiceRequestDto) {
+    return this.service.updateForAdmin(id, dto);
+  }
+}

--- a/backend/src/modules/orders/order-service-requests.service.ts
+++ b/backend/src/modules/orders/order-service-requests.service.ts
@@ -1,0 +1,243 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { Order, OrderStatus } from './entities/order.entity';
+import {
+  OrderServiceRequest,
+  OrderServiceRequestStatus,
+  OrderServiceRequestType,
+} from './entities/order-service-request.entity';
+import { CreateOrderServiceRequestDto } from './dto/create-order-service-request.dto';
+import { UpdateOrderServiceRequestDto } from './dto/update-order-service-request.dto';
+import { AdminOrderServiceRequestQueryDto } from './dto/admin-order-service-request-query.dto';
+import { findOrThrow } from '../../common/utils/repository.util';
+import { assertOwnership } from '../../common/utils/ownership.util';
+import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
+import { NotificationService } from '../notification/notification.service';
+import { NotificationDispatchHelper } from '../notification/notification-dispatch.helper';
+import { restoreOrderStock } from './order-stock.util';
+import { PointHistory } from '../coupons/entities/point-history.entity';
+
+const CANCELLABLE_STATUSES = new Set<OrderStatus>([OrderStatus.PENDING, OrderStatus.PAID]);
+const AFTER_DELIVERY_REQUEST_STATUSES = new Set<OrderStatus>([OrderStatus.DELIVERED, OrderStatus.COMPLETED]);
+const ACTIVE_REQUEST_STATUSES = [OrderServiceRequestStatus.REQUESTED, OrderServiceRequestStatus.APPROVED];
+
+@Injectable()
+export class OrderServiceRequestsService {
+  private readonly logger = new Logger(OrderServiceRequestsService.name);
+
+  constructor(
+    @InjectRepository(OrderServiceRequest)
+    private readonly requestRepository: Repository<OrderServiceRequest>,
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+    private readonly dataSource: DataSource,
+    private readonly notificationService: NotificationService,
+    private readonly notificationDispatchHelper: NotificationDispatchHelper,
+  ) {}
+
+  async create(orderId: number, userId: number, dto: CreateOrderServiceRequestDto): Promise<OrderServiceRequest> {
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
+    assertOwnership(order.userId, userId);
+    this.assertRequestAllowed(order.status, dto.type);
+
+    const existing = await this.requestRepository.findOne({
+      where: ACTIVE_REQUEST_STATUSES.map((status) => ({ orderId, userId, type: dto.type, status })),
+    });
+    if (existing) {
+      throw new BadRequestException('이미 처리 중인 신청이 있습니다.');
+    }
+
+    const useShippingAddress = dto.useShippingAddress ?? true;
+    const request = this.requestRepository.create({
+      orderId,
+      userId,
+      type: dto.type,
+      reason: dto.reason.trim(),
+      detail: dto.detail?.trim() || null,
+      imageUrls: dto.imageUrls ?? null,
+      useShippingAddress,
+      pickupName: useShippingAddress ? order.recipientName : dto.pickupName ?? null,
+      pickupPhone: useShippingAddress ? order.recipientPhone : dto.pickupPhone ?? null,
+      pickupZipcode: useShippingAddress ? order.zipcode : dto.pickupZipcode ?? null,
+      pickupAddress: useShippingAddress ? order.address : dto.pickupAddress ?? null,
+      pickupAddressDetail: useShippingAddress ? order.addressDetail : dto.pickupAddressDetail ?? null,
+    });
+
+    const saved = await this.requestRepository.save(request);
+    this.logger.log(`Order service request created: id=${saved.id}, orderId=${orderId}, type=${dto.type}`);
+    void this.notifyRequestReceived(saved, order);
+    return this.findOneForUser(Number(saved.id), userId);
+  }
+
+  async findByOrderForUser(orderId: number, userId: number): Promise<OrderServiceRequest[]> {
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
+    assertOwnership(order.userId, userId);
+    return this.requestRepository.find({
+      where: { orderId, userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOneForUser(id: number, userId: number): Promise<OrderServiceRequest> {
+    const request = await findOrThrow(
+      this.requestRepository,
+      { id },
+      '신청 내역을 찾을 수 없습니다.',
+      ['order'],
+    );
+    assertOwnership(request.userId, userId);
+    return request;
+  }
+
+  async findAllForAdmin(query: AdminOrderServiceRequestQueryDto = {}): Promise<PaginatedResult<OrderServiceRequest>> {
+    const qb = this.requestRepository
+      .createQueryBuilder('request')
+      .leftJoinAndSelect('request.order', 'order')
+      .leftJoinAndSelect('request.user', 'user')
+      .orderBy('request.createdAt', 'DESC');
+
+    if (query.type) qb.andWhere('request.type = :type', { type: query.type });
+    if (query.status) qb.andWhere('request.status = :status', { status: query.status });
+
+    return paginate(qb, { page: query.page ?? 1, limit: query.limit ?? 20 });
+  }
+
+  async updateForAdmin(id: number, dto: UpdateOrderServiceRequestDto): Promise<OrderServiceRequest> {
+    const request = await findOrThrow(
+      this.requestRepository,
+      { id },
+      '신청 내역을 찾을 수 없습니다.',
+      ['order', 'user'],
+    );
+
+    await this.dataSource.transaction(async (manager) => {
+      await manager.update(OrderServiceRequest, id, {
+        status: dto.status,
+        adminNote: dto.adminNote?.trim() || null,
+        processedAt: dto.status === OrderServiceRequestStatus.REQUESTED ? null : new Date(),
+      });
+
+      if (dto.status === OrderServiceRequestStatus.COMPLETED) {
+        await this.applyCompletedRequest(manager, request);
+      }
+    });
+
+    const updated = await findOrThrow(
+      this.requestRepository,
+      { id },
+      '신청 내역을 찾을 수 없습니다.',
+      ['order', 'user'],
+    );
+    void this.notifyRequestStatusChanged(updated);
+    return updated;
+  }
+
+  private assertRequestAllowed(orderStatus: OrderStatus, type: OrderServiceRequestType): void {
+    if (type === OrderServiceRequestType.CANCEL) {
+      if (!CANCELLABLE_STATUSES.has(orderStatus)) {
+        throw new BadRequestException('배송 준비 이후에는 주문 취소 신청이 제한됩니다. 고객센터로 문의해주세요.');
+      }
+      return;
+    }
+
+    if (!AFTER_DELIVERY_REQUEST_STATUSES.has(orderStatus)) {
+      throw new BadRequestException('반품/교환/환불 신청은 배송 완료 후 접수할 수 있습니다.');
+    }
+  }
+
+  private async applyCompletedRequest(
+    manager: import('typeorm').EntityManager,
+    request: OrderServiceRequest,
+  ): Promise<void> {
+    const order = await manager.findOne(Order, {
+      where: { id: request.orderId },
+      relations: ['items'],
+    });
+    if (!order) throw new BadRequestException('주문을 찾을 수 없습니다.');
+
+    if (request.type === OrderServiceRequestType.CANCEL) {
+      if (![OrderStatus.PENDING, OrderStatus.PAID].includes(order.status)) return;
+      await manager.update(Order, order.id, { status: OrderStatus.CANCELLED });
+      await restoreOrderStock(manager, Number(order.id));
+      await this.restorePoints(manager, order);
+      return;
+    }
+
+    if (request.type === OrderServiceRequestType.REFUND || request.type === OrderServiceRequestType.RETURN) {
+      if (order.status === OrderStatus.DELIVERED || order.status === OrderStatus.COMPLETED) {
+        await manager.update(Order, order.id, { status: OrderStatus.REFUND_REQUESTED });
+      }
+    }
+  }
+
+  private async restorePoints(manager: import('typeorm').EntityManager, order: Order): Promise<void> {
+    if (!order.pointsUsed || order.pointsUsed <= 0) return;
+
+    const last = await manager.findOne(PointHistory, {
+      where: { userId: order.userId },
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+    const balance = Number(last?.balance ?? 0) + Number(order.pointsUsed);
+    await manager.save(PointHistory, {
+      userId: order.userId,
+      type: 'admin_adjust',
+      amount: order.pointsUsed,
+      balance,
+      orderId: Number(order.id),
+      description: `주문 ${order.orderNumber} 고객 신청 처리로 인한 적립금 복구`,
+    });
+  }
+
+  private async notifyRequestReceived(request: OrderServiceRequest, order: Order): Promise<void> {
+    await this.notificationDispatchHelper.dispatch({
+      event: 'order-service-request.received',
+      userId: request.userId,
+      resourceId: request.id,
+      mode: 'fire-and-forget',
+      logger: this.logger,
+      send: (recipient) => this.notificationService.sendEmail({
+        to: recipient.email,
+        subject: `[옥화당] ${order.orderNumber} 신청이 접수되었습니다`,
+        text: `${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청이 접수되었습니다. 처리 상태는 마이페이지 주문 상세에서 확인하실 수 있습니다.`,
+        html: `<p>${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청이 접수되었습니다.</p><p>처리 상태는 마이페이지 주문 상세에서 확인하실 수 있습니다.</p>`,
+      }),
+    });
+  }
+
+  private async notifyRequestStatusChanged(request: OrderServiceRequest): Promise<void> {
+    await this.notificationDispatchHelper.dispatch({
+      event: 'order-service-request.status-changed',
+      userId: request.userId,
+      resourceId: request.id,
+      mode: 'fire-and-forget',
+      logger: this.logger,
+      send: (recipient) => this.notificationService.sendEmail({
+        to: recipient.email,
+        subject: `[옥화당] ${request.order.orderNumber} 신청 처리 상태 안내`,
+        text: `${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청 상태가 ${this.getRequestStatusLabel(request.status)}(으)로 변경되었습니다.${request.adminNote ? `\n안내: ${request.adminNote}` : ''}`,
+        html: `<p>${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청 상태가 <strong>${this.getRequestStatusLabel(request.status)}</strong>(으)로 변경되었습니다.</p>${request.adminNote ? `<p>안내: ${request.adminNote}</p>` : ''}`,
+      }),
+    });
+  }
+
+  private getRequestTypeLabel(type: OrderServiceRequestType): string {
+    const labels: Record<OrderServiceRequestType, string> = {
+      [OrderServiceRequestType.CANCEL]: '주문 취소',
+      [OrderServiceRequestType.RETURN]: '반품',
+      [OrderServiceRequestType.EXCHANGE]: '교환',
+      [OrderServiceRequestType.REFUND]: '환불',
+    };
+    return labels[type];
+  }
+
+  private getRequestStatusLabel(status: OrderServiceRequestStatus): string {
+    const labels: Record<OrderServiceRequestStatus, string> = {
+      [OrderServiceRequestStatus.REQUESTED]: '접수',
+      [OrderServiceRequestStatus.APPROVED]: '승인',
+      [OrderServiceRequestStatus.REJECTED]: '반려',
+      [OrderServiceRequestStatus.COMPLETED]: '처리 완료',
+    };
+    return labels[status];
+  }
+}

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -1,25 +1,29 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Order } from './entities/order.entity';
+import { OrderServiceRequest } from './entities/order-service-request.entity';
 import { OrderItem } from './entities/order-item.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
+import { PolicyConsent } from '../pages/entities/policy-consent.entity';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
+import { AdminOrderServiceRequestsController, OrderServiceRequestsController } from './order-service-requests.controller';
 import { PointsModule } from '../points/points.module';
 import { CouponsModule } from '../coupons/coupons.module';
 import { ShippingModule } from '../shipping/shipping.module';
 import { OrderEventsModule } from './order-events.module';
+import { OrderServiceRequestsService } from './order-service-requests.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Order, OrderItem, PointHistory]),
+    TypeOrmModule.forFeature([Order, OrderItem, OrderServiceRequest, PointHistory, PolicyConsent]),
     PointsModule,
     CouponsModule,
     ShippingModule,
     OrderEventsModule,
   ],
-  controllers: [OrdersController],
-  providers: [OrdersService],
-  exports: [OrdersService, OrderEventsModule],
+  controllers: [OrdersController, OrderServiceRequestsController, AdminOrderServiceRequestsController],
+  providers: [OrdersService, OrderServiceRequestsService],
+  exports: [OrdersService, OrderServiceRequestsService, OrderEventsModule],
 })
 export class OrdersModule {}

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -19,6 +19,11 @@ import { CouponsService } from '../coupons/coupons.service';
 import { CalculateDiscountDto } from '../coupons/dto/calculate-discount.dto';
 import { ShippingFeeCalculatorService } from '../shipping/services/shipping-fee-calculator.service';
 import { OrderEventEmitter } from './order-event.emitter';
+import {
+  PolicyConsent,
+  PolicyConsentContext,
+  PolicyConsentSnapshot,
+} from '../pages/entities/policy-consent.entity';
 import { OrderCompletedEvent } from './events/order-completed.event';
 import { applyLocale } from '../../common/utils/locale.util';
 
@@ -131,6 +136,7 @@ export class OrdersService {
 
     const savedOrder = await this.persistOrder(manager, userId, dto, pointsToUse, pricing);
     await this.applyCouponAndPoints(manager, userId, dto, pointsToUse, savedOrder);
+    await this.savePolicyConsent(manager, userId, savedOrder, dto);
     await this.saveOrderItems(manager, orderItems, Number(savedOrder.id));
     await this.clearCartItems(manager, userId, dto);
 
@@ -323,6 +329,55 @@ export class OrdersService {
         Number(savedOrder.id),
       );
     }
+  }
+
+  private async savePolicyConsent(
+    manager: EntityManager,
+    userId: number,
+    savedOrder: Order,
+    dto: CreateOrderDto,
+  ): Promise<void> {
+    const policies = dto.policyConsents?.length
+      ? dto.policyConsents.map((policy) => ({
+        slug: policy.slug,
+        version: policy.version ?? null,
+        effectiveDate: policy.effectiveDate ?? null,
+      }))
+      : await this.loadCurrentPolicySnapshots(manager);
+
+    await manager.save(PolicyConsent, {
+      userId,
+      context: PolicyConsentContext.CHECKOUT,
+      resourceType: 'order',
+      resourceId: Number(savedOrder.id),
+      policies,
+      marketingConsent: dto.marketingConsent ?? false,
+    });
+  }
+
+  private async loadCurrentPolicySnapshots(manager: EntityManager): Promise<PolicyConsentSnapshot[]> {
+    const rows = await manager.query(`
+      SELECT slug, title, policy_version AS version, policy_effective_date AS effectiveDate
+      FROM pages
+      WHERE is_current_policy = 1
+        AND slug IN ('terms', 'privacy', 'shipping', 'returns', 'shipping-returns')
+      ORDER BY slug ASC
+    `) as Array<{ slug: string; title: string | null; version: string | null; effectiveDate: string | null }>;
+
+    if (rows.length > 0) {
+      return rows.map((row) => ({
+        slug: row.slug,
+        title: row.title,
+        version: row.version,
+        effectiveDate: row.effectiveDate,
+      }));
+    }
+
+    return [
+      { slug: 'terms', version: null, effectiveDate: null },
+      { slug: 'privacy', version: null, effectiveDate: null },
+      { slug: 'shipping-returns', version: null, effectiveDate: null },
+    ];
   }
 
   private async saveOrderItems(

--- a/backend/src/modules/pages/dto/create-page.dto.ts
+++ b/backend/src/modules/pages/dto/create-page.dto.ts
@@ -22,4 +22,26 @@ export class CreatePageDto {
   @IsOptional()
   @IsBoolean()
   is_published?: boolean;
+
+  @ApiProperty({ example: 'v1.0', description: '정책 문서 버전', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  policyVersion?: string;
+
+  @ApiProperty({ example: '2026-04-20', description: '정책 시행일', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  policyEffectiveDate?: string;
+
+  @ApiProperty({ example: '최초 제정', description: '정책 변경 이력 요약', required: false })
+  @IsOptional()
+  @IsString()
+  policyChangeSummary?: string;
+
+  @ApiProperty({ example: true, description: '현재 적용 정책 여부', required: false })
+  @IsOptional()
+  @IsBoolean()
+  isCurrentPolicy?: boolean;
 }

--- a/backend/src/modules/pages/dto/update-page.dto.ts
+++ b/backend/src/modules/pages/dto/update-page.dto.ts
@@ -24,4 +24,26 @@ export class UpdatePageDto {
   @IsOptional()
   @IsBoolean()
   is_published?: boolean;
+
+  @ApiProperty({ example: 'v1.0', description: '정책 문서 버전', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  policyVersion?: string;
+
+  @ApiProperty({ example: '2026-04-20', description: '정책 시행일', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  policyEffectiveDate?: string;
+
+  @ApiProperty({ example: '최초 제정', description: '정책 변경 이력 요약', required: false })
+  @IsOptional()
+  @IsString()
+  policyChangeSummary?: string;
+
+  @ApiProperty({ example: true, description: '현재 적용 정책 여부', required: false })
+  @IsOptional()
+  @IsBoolean()
+  isCurrentPolicy?: boolean;
 }

--- a/backend/src/modules/pages/entities/page.entity.ts
+++ b/backend/src/modules/pages/entities/page.entity.ts
@@ -47,6 +47,18 @@ export class Page {
   @Column({ type: 'boolean', default: false })
   is_published!: boolean;
 
+  @Column({ name: 'policy_version', type: 'varchar', length: 50, nullable: true })
+  policyVersion!: string | null;
+
+  @Column({ name: 'policy_effective_date', type: 'date', nullable: true })
+  policyEffectiveDate!: string | null;
+
+  @Column({ name: 'policy_change_summary', type: 'longtext', nullable: true })
+  policyChangeSummary!: string | null;
+
+  @Column({ name: 'is_current_policy', type: 'boolean', default: false })
+  isCurrentPolicy!: boolean;
+
   @CreateDateColumn()
   created_at!: Date;
 

--- a/backend/src/modules/pages/entities/policy-consent.entity.ts
+++ b/backend/src/modules/pages/entities/policy-consent.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum PolicyConsentContext {
+  SIGNUP = 'signup',
+  CHECKOUT = 'checkout',
+}
+
+export interface PolicyConsentSnapshot {
+  slug: string;
+  version: string | null;
+  effectiveDate: string | null;
+  title?: string | null;
+}
+
+@Entity('policy_consents')
+@Index(['userId'])
+@Index(['context', 'resourceType', 'resourceId'])
+export class PolicyConsent {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({ name: 'user_id', type: 'bigint' })
+  userId!: number;
+
+  @Column({ type: 'enum', enum: PolicyConsentContext })
+  context!: PolicyConsentContext;
+
+  @Column({ name: 'resource_type', type: 'varchar', length: 50, nullable: true })
+  resourceType!: string | null;
+
+  @Column({ name: 'resource_id', type: 'bigint', nullable: true })
+  resourceId!: number | null;
+
+  @Column({ type: 'json' })
+  policies!: PolicyConsentSnapshot[];
+
+  @Column({ name: 'marketing_consent', type: 'boolean', default: false })
+  marketingConsent!: boolean;
+
+  @CreateDateColumn({ name: 'consented_at' })
+  consentedAt!: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user!: User;
+}

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -5,7 +5,7 @@ import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
 import { adminOrdersApi } from '@/lib/api';
-import type { AdminOrder } from '@/lib/api';
+import type { AdminOrder, OrderServiceRequest, OrderServiceRequestStatus } from '@/lib/api';
 import { AdminOrdersTable } from '@/components/shared/admin/AdminOrdersTable';
 import { ShippingModal } from '@/components/shared/admin/ShippingModal';
 import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
@@ -31,6 +31,7 @@ export default function AdminOrdersPage() {
   const [orders, setOrders] = useState<AdminOrder[]>([]);
   const [total, setTotal] = useState(0);
   const [shippingOrder, setShippingOrder] = useState<AdminOrder | null>(null);
+  const [serviceRequests, setServiceRequests] = useState<OrderServiceRequest[]>([]);
   const {
     page,
     setPage,
@@ -59,9 +60,13 @@ export default function AdminOrdersPage() {
       if (filters.startDate) params.startDate = filters.startDate;
       if (filters.endDate) params.endDate = filters.endDate;
 
-      const res = await adminOrdersApi.getList(params);
+      const [res, requestRes] = await Promise.all([
+        adminOrdersApi.getList(params),
+        adminOrdersApi.getServiceRequests({ status: 'requested', limit: 10 }),
+      ]);
       setOrders(res.items);
       setTotal(res.total);
+      setServiceRequests(requestRes.items);
     },
     { errorMessage: '주문 목록을 불러오지 못했습니다.' },
   );
@@ -78,6 +83,13 @@ export default function AdminOrdersPage() {
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
+  const handleRequestStatus = async (id: number, status: OrderServiceRequestStatus) => {
+    await adminOrdersApi.updateServiceRequest(id, { status });
+    await fetchOrders();
+  };
+
+  const requestTypeLabels = { cancel: '취소', return: '반품', exchange: '교환', refund: '환불' };
+
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
       <AdminPageHeader title="주문 관리" />
@@ -89,6 +101,48 @@ export default function AdminOrdersPage() {
         ariaLabel="주문 상태 필터"
         size="sm"
       />
+
+
+      {serviceRequests.length > 0 && (
+        <section className="rounded-lg border bg-card p-4">
+          <h2 className="mb-3 text-base font-semibold">처리 대기 신청</h2>
+          <ul className="divide-y">
+            {serviceRequests.map((request) => (
+              <li key={request.id} className="flex flex-wrap items-center justify-between gap-3 py-3 text-sm">
+                <div>
+                  <p className="font-medium">
+                    #{request.orderId} {request.order?.orderNumber} · {requestTypeLabels[request.type]} · {request.reason}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{request.userId} · {new Date(request.createdAt).toLocaleString('ko-KR')}</p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void handleRequestStatus(request.id, 'approved')}
+                    className="rounded border px-2 py-1 text-xs hover:bg-secondary"
+                  >
+                    승인
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleRequestStatus(request.id, 'rejected')}
+                    className="rounded border px-2 py-1 text-xs hover:bg-secondary"
+                  >
+                    반려
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleRequestStatus(request.id, 'completed')}
+                    className="rounded bg-foreground px-2 py-1 text-xs text-background hover:opacity-80"
+                  >
+                    처리 완료
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       <div className="flex flex-wrap items-end gap-4">
         <AdminSearchForm

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -233,6 +233,7 @@ export default function CheckoutPage({
     currentOrderId,
     currentOrderNumber,
     requiredConsent,
+    marketingConsent,
     setStep,
     setPrepareResult,
     setCurrentOrderId,

--- a/src/app/[locale]/my/orders/[id]/page.tsx
+++ b/src/app/[locale]/my/orders/[id]/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import { ordersApi, paymentsApi } from '@/lib/api';
-import type { CheckoutGatewayName, OrderResponse, PreparePaymentResponse } from '@/lib/api';
+import type { CheckoutGatewayName, OrderResponse, OrderServiceRequest, OrderServiceRequestType, PreparePaymentResponse } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import { useRequireAuth } from '@/components/shared/hooks/useRequireAuth';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
@@ -38,6 +38,10 @@ export default function OrderDetailPage() {
   );
   const [prepareResult, setPrepareResult] = useState<PreparePaymentResponse | null>(null);
   const [paymentStep, setPaymentStep] = useState<PaymentStep>('idle');
+  const [serviceRequests, setServiceRequests] = useState<OrderServiceRequest[]>([]);
+  const [requestType, setRequestType] = useState<OrderServiceRequestType>('cancel');
+  const [requestReason, setRequestReason] = useState('');
+  const [requestDetail, setRequestDetail] = useState('');
   const paymentRef = useRef<PaymentGatewayHandle>(null);
 
   const { execute: loadOrder, isLoading: loading } = useAsyncAction(
@@ -49,6 +53,10 @@ export default function OrderDetailPage() {
       }
       const res = await ordersApi.getById(id, { params: { locale } });
       setOrder(res);
+      if (typeof ordersApi.getServiceRequests === 'function') {
+        const requests = await ordersApi.getServiceRequests(id);
+        setServiceRequests(requests);
+      }
     },
     { onError: () => setNotFound(true) },
   );
@@ -64,6 +72,17 @@ export default function OrderDetailPage() {
     void loadOrder();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, locale, params.id]);
+
+  useEffect(() => {
+    if (!order) return;
+    if (['pending', 'paid'].includes(order.status)) {
+      setRequestType('cancel');
+      return;
+    }
+    if (['delivered', 'completed'].includes(order.status) && requestType === 'cancel') {
+      setRequestType('return');
+    }
+  }, [order, requestType]);
 
   if (isLoading || loading) {
     return (
@@ -98,10 +117,48 @@ export default function OrderDetailPage() {
   const isPaymentPending = order.status === 'pending';
   const shouldShowShippingTracking = !['pending', 'cancelled', 'refunded'].includes(order.status);
   const payableAmount = Number(order.totalAmount);
+  const canCancel = ['pending', 'paid'].includes(order.status);
+  const canAfterDeliveryRequest = ['delivered', 'completed'].includes(order.status);
+  const requestTypeLabels: Record<OrderServiceRequestType, string> = {
+    cancel: t('serviceRequests.types.cancel'),
+    return: t('serviceRequests.types.return'),
+    exchange: t('serviceRequests.types.exchange'),
+    refund: t('serviceRequests.types.refund'),
+  };
+  const requestStatusLabels: Record<string, string> = {
+    requested: t('serviceRequests.status.requested'),
+    approved: t('serviceRequests.status.approved'),
+    rejected: t('serviceRequests.status.rejected'),
+    completed: t('serviceRequests.status.completed'),
+  };
 
   const handlePaymentError = (message: string) => {
     toast.error(message);
     setPaymentStep('idle');
+  };
+
+  const submitServiceRequest = async () => {
+    if (!requestReason.trim()) {
+      toast.error(t('serviceRequests.reasonRequired'));
+      return;
+    }
+
+    try {
+      await ordersApi.createServiceRequest(order.id, {
+        type: requestType,
+        reason: requestReason.trim(),
+        detail: requestDetail.trim() || undefined,
+        useShippingAddress: true,
+      });
+      toast.success(t('serviceRequests.submitSuccess'));
+      setRequestReason('');
+      setRequestDetail('');
+      const requests = await ordersApi.getServiceRequests(order.id);
+      setServiceRequests(requests);
+      void loadOrder();
+    } catch (err) {
+      toast.error(handleApiError(err, t('serviceRequests.submitError')));
+    }
   };
 
   const handlePendingPayment = async () => {
@@ -275,6 +332,73 @@ export default function OrderDetailPage() {
               </dd>
             </div>
           </dl>
+        </section>
+
+
+        {/* Cancellation / return / exchange / refund requests */}
+        <section className="rounded-lg border p-6">
+          <h2 className="mb-4 text-base font-semibold">{t('serviceRequests.title')}</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            {canCancel ? t('serviceRequests.cancelGuide') : canAfterDeliveryRequest ? t('serviceRequests.afterDeliveryGuide') : t('serviceRequests.unavailableGuide')}
+          </p>
+
+          {(canCancel || canAfterDeliveryRequest) && (
+            <div className="space-y-3 rounded-md bg-muted/30 p-4">
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="text-sm">
+                  <span className="mb-1 block font-medium">{t('serviceRequests.typeLabel')}</span>
+                  <select
+                    value={requestType}
+                    onChange={(event) => setRequestType(event.target.value as OrderServiceRequestType)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  >
+                    {canCancel && <option value="cancel">{requestTypeLabels.cancel}</option>}
+                    {canAfterDeliveryRequest && <option value="return">{requestTypeLabels.return}</option>}
+                    {canAfterDeliveryRequest && <option value="exchange">{requestTypeLabels.exchange}</option>}
+                    {canAfterDeliveryRequest && <option value="refund">{requestTypeLabels.refund}</option>}
+                  </select>
+                </label>
+                <label className="text-sm">
+                  <span className="mb-1 block font-medium">{t('serviceRequests.reasonLabel')}</span>
+                  <input
+                    value={requestReason}
+                    onChange={(event) => setRequestReason(event.target.value)}
+                    maxLength={100}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    placeholder={t('serviceRequests.reasonPlaceholder')}
+                  />
+                </label>
+              </div>
+              <label className="block text-sm">
+                <span className="mb-1 block font-medium">{t('serviceRequests.detailLabel')}</span>
+                <textarea
+                  value={requestDetail}
+                  onChange={(event) => setRequestDetail(event.target.value)}
+                  rows={3}
+                  className="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  placeholder={t('serviceRequests.detailPlaceholder')}
+                />
+              </label>
+              <Button type="button" onClick={submitServiceRequest}>
+                {t('serviceRequests.submit')}
+              </Button>
+            </div>
+          )}
+
+          {serviceRequests.length > 0 && (
+            <ul className="mt-4 space-y-2">
+              {serviceRequests.map((request) => (
+                <li key={request.id} className="rounded-md border bg-card p-3 text-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-medium">{requestTypeLabels[request.type]}</span>
+                    <span className="rounded-full bg-secondary px-2 py-0.5 text-xs">{requestStatusLabels[request.status] ?? request.status}</span>
+                  </div>
+                  <p className="mt-1 text-muted-foreground">{request.reason}</p>
+                  {request.adminNote && <p className="mt-2 text-xs text-muted-foreground">{request.adminNote}</p>}
+                </li>
+              ))}
+            </ul>
+          )}
         </section>
 
         {/* Tax receipt / invoice guide */}

--- a/src/components/__tests__/ProductTabs.test.tsx
+++ b/src/components/__tests__/ProductTabs.test.tsx
@@ -128,6 +128,8 @@ describe('ProductTabs', () => {
         {
           id: 22,
           type: '상품',
+          productId: 1,
+          isSecret: false,
           title: '기존 문의',
           content: '내용',
           status: 'pending',
@@ -153,6 +155,8 @@ describe('ProductTabs', () => {
       type: '상품',
       title: '추가 문의',
       content: '문의 내용',
+      productId: 1,
+      isSecret: false,
     })
   })
 })

--- a/src/components/shared/hooks/useCheckout.ts
+++ b/src/components/shared/hooks/useCheckout.ts
@@ -25,6 +25,7 @@ export interface UseCheckoutOptions {
   currentOrderId: number | null;
   currentOrderNumber: string;
   requiredConsent?: boolean;
+  marketingConsent?: boolean;
   setStep: (step: PaymentStep) => void;
   setPrepareResult: (result: PreparePaymentResponse | null) => void;
   setCurrentOrderId: (id: number | null) => void;
@@ -168,6 +169,7 @@ export function useCheckout(options: UseCheckoutOptions) {
           address,
           addressDetail: addressDetail || null,
           memo: memo || null,
+          marketingConsent: options.marketingConsent ?? false,
         },
       );
 

--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -131,6 +131,7 @@ export default function ProductTabs({ description, descriptionImages, productId,
   const [inquiries, setInquiries] = useState<Inquiry[]>([])
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
+  const [isSecret, setIsSecret] = useState(false)
 
   const tabLabels = useMemo(
     () => ({
@@ -148,10 +149,10 @@ export default function ProductTabs({ description, descriptionImages, productId,
 
   const { execute: loadInquiries, isLoading: isLoadingInquiries } = useAsyncAction(
     async () => {
-      const response = await inquiriesApi.getList()
+      const response = await inquiriesApi.getList(productId ? { productId } : undefined)
       const items = Array.isArray(response) ? response : response.data
       const filtered = items
-        .filter((inquiry) => inquiry.type === INQUIRY_TYPE_PRODUCT)
+        .filter((inquiry) => inquiry.type === INQUIRY_TYPE_PRODUCT && (!productId || inquiry.productId == null || inquiry.productId === productId))
         .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
       setInquiries(filtered)
     },
@@ -167,9 +168,12 @@ export default function ProductTabs({ description, descriptionImages, productId,
         type: INQUIRY_TYPE_PRODUCT,
         title: trimmedTitle,
         content: trimmedContent,
+        productId,
+        isSecret,
       })
       setTitle('')
       setContent('')
+      setIsSecret(false)
       await loadInquiries(undefined)
     },
     { successMessage: t('tabs.inquiryPanel.submitSuccess'), errorMessage: t('tabs.inquiryPanel.submitError') },
@@ -312,6 +316,15 @@ export default function ProductTabs({ description, descriptionImages, productId,
                       className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                   </div>
+                  <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={isSecret}
+                      onChange={(e) => setIsSecret(e.target.checked)}
+                      className="size-4 rounded border-input"
+                    />
+                    {t('tabs.inquiryPanel.secretLabel')}
+                  </label>
                   <div className="flex justify-end">
                     <button
                       type="submit"
@@ -334,7 +347,7 @@ export default function ProductTabs({ description, descriptionImages, productId,
                       {inquiries.map((inquiry) => (
                         <li key={inquiry.id} className="rounded-lg border border-border bg-muted/20 p-3">
                           <div className="flex flex-wrap items-center justify-between gap-2">
-                            <p className="text-sm font-medium text-foreground">{inquiry.title}</p>
+                            <p className="text-sm font-medium text-foreground">{inquiry.isSecret ? `${t('tabs.inquiryPanel.secretBadge')} ` : ''}{inquiry.title}</p>
                             <span className="text-xs text-muted-foreground">
                               {new Date(inquiry.createdAt).toLocaleDateString(locale)}
                             </span>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -221,7 +221,9 @@
         "loadError": "Failed to load inquiries.",
         "statusAnswered": "Answered",
         "statusPending": "Received",
-        "answerLabel": "Answer"
+        "answerLabel": "Answer",
+        "secretLabel": "Submit as private",
+        "secretBadge": "[Private]"
       },
       "deliveryGuide": {
         "eyebrow": "Shipping Guide",
@@ -1092,7 +1094,34 @@
     "recipient": "Recipient",
     "phone": "Phone",
     "address": "Address",
-    "deliveryMemo": "Delivery Memo"
+    "deliveryMemo": "Delivery Memo",
+    "serviceRequests": {
+      "title": "Cancellation, Exchange, Return & Refund Requests",
+      "cancelGuide": "You can request cancellation while the order is pending or paid. After preparation starts, customer support review is required.",
+      "afterDeliveryGuide": "After delivery, you can request exchange, return, or refund. Shipping-fee responsibility depends on change of mind, defect, or wrong delivery.",
+      "unavailableGuide": "Online requests are limited for the current order status. Please contact customer support for cancellation after preparation starts.",
+      "typeLabel": "Request type",
+      "reasonLabel": "Reason",
+      "reasonPlaceholder": "e.g. Change of mind, defect, wrong delivery",
+      "detailLabel": "Details",
+      "detailPlaceholder": "Describe details. Submit supporting photos as guided by customer support when needed.",
+      "submit": "Submit request",
+      "submitSuccess": "Your request has been submitted.",
+      "submitError": "Failed to submit your request.",
+      "reasonRequired": "Please enter a reason.",
+      "types": {
+        "cancel": "Cancellation",
+        "return": "Return",
+        "exchange": "Exchange",
+        "refund": "Refund"
+      },
+      "status": {
+        "requested": "Requested",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "completed": "Completed"
+      }
+    }
   },
   "checkoutResult": {
     "failedTitle": "Payment Failed",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -221,7 +221,9 @@
         "loadError": "문의 내역을 불러오지 못했습니다.",
         "statusAnswered": "답변완료",
         "statusPending": "접수",
-        "answerLabel": "답변"
+        "answerLabel": "답변",
+        "secretLabel": "비밀글로 등록",
+        "secretBadge": "[비밀글]"
       },
       "deliveryGuide": {
         "eyebrow": "배송 안내",
@@ -1092,7 +1094,34 @@
     "recipient": "받는 분",
     "phone": "연락처",
     "address": "주소",
-    "deliveryMemo": "배송 메모"
+    "deliveryMemo": "배송 메모",
+    "serviceRequests": {
+      "title": "취소/교환/반품/환불 신청",
+      "cancelGuide": "결제대기/결제완료 상태에서는 주문 취소를 신청할 수 있습니다. 배송 준비 이후에는 고객센터 확인이 필요합니다.",
+      "afterDeliveryGuide": "배송 완료 후 교환, 반품, 환불 신청을 접수할 수 있습니다. 단순 변심/상품 불량/오배송에 따라 배송비 부담 주체가 달라집니다.",
+      "unavailableGuide": "현재 주문 상태에서는 온라인 신청이 제한됩니다. 배송 준비 이후 취소는 고객센터로 문의해주세요.",
+      "typeLabel": "신청 유형",
+      "reasonLabel": "사유",
+      "reasonPlaceholder": "예: 단순 변심, 상품 불량, 오배송",
+      "detailLabel": "상세 사유",
+      "detailPlaceholder": "상세 사유와 사진 첨부가 필요한 경우 고객센터 안내에 따라 제출해주세요.",
+      "submit": "신청 접수",
+      "submitSuccess": "신청이 접수되었습니다.",
+      "submitError": "신청 접수에 실패했습니다.",
+      "reasonRequired": "신청 사유를 입력해주세요.",
+      "types": {
+        "cancel": "주문 취소",
+        "return": "반품",
+        "exchange": "교환",
+        "refund": "환불"
+      },
+      "status": {
+        "requested": "접수",
+        "approved": "승인",
+        "rejected": "반려",
+        "completed": "처리 완료"
+      }
+    }
   },
   "checkoutResult": {
     "failedTitle": "결제 실패",

--- a/src/lib/api/admin/orders.ts
+++ b/src/lib/api/admin/orders.ts
@@ -1,4 +1,5 @@
 import { apiClient, type PaginatedResponse } from '../core';
+import type { OrderServiceRequest, OrderServiceRequestStatus, OrderServiceRequestType } from '../orders';
 
 export interface AdminOrder {
   id: number;
@@ -39,6 +40,13 @@ export interface AdminShipping {
   status: string;
 }
 
+export interface AdminOrderServiceRequestQueryParams {
+  type?: OrderServiceRequestType;
+  status?: OrderServiceRequestStatus;
+  page?: number;
+  limit?: number;
+}
+
 export const adminOrdersApi = {
   getList: (params?: AdminOrderQueryParams) =>
     apiClient.get<AdminOrderListResponse>('/admin/orders', {
@@ -48,4 +56,10 @@ export const adminOrdersApi = {
     apiClient.patch<AdminOrder>(`/admin/orders/${id}`, { status }),
   registerShipping: (orderId: number, data: { carrier: string; trackingNumber: string }) =>
     apiClient.post<AdminShipping>(`/admin/shipping/${orderId}`, data),
+  getServiceRequests: (params?: AdminOrderServiceRequestQueryParams) =>
+    apiClient.get<PaginatedResponse<OrderServiceRequest>>('/admin/order-service-requests', {
+      params: params as Record<string, string | number | undefined>,
+    }),
+  updateServiceRequest: (id: number, data: { status: OrderServiceRequestStatus; adminNote?: string }) =>
+    apiClient.patch<OrderServiceRequest>(`/admin/order-service-requests/${id}`, data),
 };

--- a/src/lib/api/inquiries.ts
+++ b/src/lib/api/inquiries.ts
@@ -3,8 +3,10 @@ import { apiClient, type ListResponse } from './core';
 export interface Inquiry {
   id: number;
   type: string;
+  productId?: number;
   title: string;
   content: string;
+  isSecret: boolean;
   status: 'pending' | 'answered';
   answer: string | null;
   answeredAt: string | null;
@@ -20,12 +22,14 @@ export type InquiryListResponse = ListResponse<Inquiry>;
 
 export interface CreateInquiryBody {
   type: string;
+  productId?: number;
   title: string;
   content: string;
+  isSecret?: boolean;
 }
 
 export const inquiriesApi = {
-  getList: () => apiClient.get<InquiryListResponse>('/inquiries'),
+  getList: (params?: { productId?: number }) => apiClient.get<InquiryListResponse>('/inquiries', { params }),
   getOne: (id: number) => apiClient.get<Inquiry>(`/inquiries/${id}`),
   create: (body: CreateInquiryBody) => apiClient.post<Inquiry>('/inquiries', body),
 };

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -27,6 +27,49 @@ export interface OrderResponse {
   createdAt: string;
 }
 
+export type OrderServiceRequestType = 'cancel' | 'return' | 'exchange' | 'refund';
+export type OrderServiceRequestStatus = 'requested' | 'approved' | 'rejected' | 'completed';
+
+export interface OrderServiceRequest {
+  id: number;
+  orderId: number;
+  userId: number;
+  type: OrderServiceRequestType;
+  status: OrderServiceRequestStatus;
+  reason: string;
+  detail: string | null;
+  imageUrls: string[] | null;
+  useShippingAddress: boolean;
+  pickupName: string | null;
+  pickupPhone: string | null;
+  pickupZipcode: string | null;
+  pickupAddress: string | null;
+  pickupAddressDetail: string | null;
+  adminNote: string | null;
+  processedAt: string | null;
+  createdAt: string;
+  order?: OrderResponse;
+}
+
+export interface CreateOrderServiceRequestBody {
+  type: OrderServiceRequestType;
+  reason: string;
+  detail?: string;
+  imageUrls?: string[];
+  useShippingAddress?: boolean;
+  pickupName?: string;
+  pickupPhone?: string;
+  pickupZipcode?: string;
+  pickupAddress?: string;
+  pickupAddressDetail?: string;
+}
+
+export interface PolicyConsentSnapshot {
+  slug: string;
+  version?: string | null;
+  effectiveDate?: string | null;
+}
+
 export interface CreateOrderBody {
   items: Array<{ productId: number; productOptionId: number | null; quantity: number }>;
   recipientName: string;
@@ -35,6 +78,8 @@ export interface CreateOrderBody {
   address: string;
   addressDetail?: string | null;
   memo?: string | null;
+  policyConsents?: PolicyConsentSnapshot[];
+  marketingConsent?: boolean;
 }
 
 export const ordersApi = {
@@ -44,4 +89,8 @@ export const ordersApi = {
     apiClient.get<OrderResponse>(`/orders/${id}`, options),
   getList: (params?: { page?: number; limit?: number; locale?: string }, options?: RequestOptions) =>
     apiClient.get<PaginatedResponse<OrderResponse>>('/orders', { ...options, params }),
+  getServiceRequests: (orderId: number) =>
+    apiClient.get<OrderServiceRequest[]>(`/orders/${orderId}/service-requests`),
+  createServiceRequest: (orderId: number, body: CreateOrderServiceRequestBody) =>
+    apiClient.post<OrderServiceRequest>(`/orders/${orderId}/service-requests`, body),
 };


### PR DESCRIPTION
## 요약
- #847/#848: 마이페이지 주문 상세에서 취소·반품·교환·환불 신청을 접수하고, 관리자 주문 화면에서 처리 상태를 변경할 수 있게 했습니다.
- #851: 상품 문의를 `productId`로 연결하고 비밀글/상품별 조회/답변 알림 흐름을 보강했습니다.
- #853: 정책 CMS에 버전·시행일·변경 요약·현재 적용 플래그를 추가하고, 결제 동의 시점 정책 스냅샷을 `policy_consents`로 저장합니다.
- #854: 기존 주문/결제/배송/문의 알림 기반에 취소·반품·교환·환불 접수/상태 변경 알림을 추가했습니다.

Closes #847
Closes #848
Closes #851
Closes #853
Closes #854

## 테스트
- [x] `npm run build`
- [x] `npm run test:run`
- [x] `cd backend && npm run build`
- [x] `cd backend && npm run test -- --runInBand`
- [x] `bash scripts/test.sh e2e`
- [x] `git diff --check`

## 리뷰 메모
- 실제 PG 취소 자동 연동은 기존 관리자 결제/환불 처리 흐름과 충돌 위험이 있어 이번 변경에서는 신청·승인·완료 상태와 주문 상태 반영까지만 연결했습니다.
- 외부 SMS/알림톡 채널은 기존 알림 provider 구조 위에서 단계적으로 붙일 수 있도록 이벤트/메일 dispatch로 우선 구현했습니다.
