### PR TITLE
fix: #879 remove Korean text from English customer UI

### DIFF
--- a/src/__tests__/english-locale-no-korean.test.ts
+++ b/src/__tests__/english-locale-no-korean.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import enMessages from '@/i18n/messages/en.json';
+import { handleApiError } from '@/utils/error';
+
+const HANGUL_PATTERN = /[가-힣]/;
+
+function collectHangulStrings(value: unknown, path = ''): string[] {
+  if (typeof value === 'string') {
+    return HANGUL_PATTERN.test(value) ? [`${path}: ${value}`] : [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => collectHangulStrings(item, `${path}[${index}]`));
+  }
+  if (value && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, nested]) =>
+      collectHangulStrings(nested, path ? `${path}.${key}` : key),
+    );
+  }
+  return [];
+}
+
+describe('English locale Korean text guard', () => {
+  const originalPathname = window.location.pathname;
+  const originalLang = document.documentElement.lang;
+
+  beforeEach(() => {
+    document.documentElement.lang = 'en';
+    window.history.replaceState(null, '', '/en/products');
+  });
+
+  afterEach(() => {
+    document.documentElement.lang = originalLang;
+    window.history.replaceState(null, '', originalPathname);
+  });
+
+  it('keeps en.json free of Hangul strings', () => {
+    expect(collectHangulStrings(enMessages)).toEqual([]);
+  });
+
+  it('does not expose Korean backend/API errors on English pages', () => {
+    expect(handleApiError(new Error('접근 권한이 없습니다.'), 'Failed to load data.')).toBe(
+      'You do not have permission to access this.',
+    );
+    expect(handleApiError(new Error('서버에서 발생한 한국어 오류'), 'Failed to load data.')).toBe(
+      'Failed to load data.',
+    );
+    expect(handleApiError(new Error('서버에서 발생한 한국어 오류'))).toBe('An error occurred.');
+  });
+});

--- a/src/app/[locale]/artist/[slug]/page.tsx
+++ b/src/app/[locale]/artist/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { getArtistBySlug, ARTISTS } from '@/lib/artists';
+import { getTranslations } from 'next-intl/server';
+import { getArtistBySlug, ARTISTS, localizeArtist } from '@/lib/artists';
 
 interface ArtistDetailProps {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ locale: string; slug: string }>;
 }
 
 export async function generateStaticParams() {
@@ -12,21 +13,24 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: ArtistDetailProps): Promise<Metadata> {
-  const { slug } = await params;
-  const artist = getArtistBySlug(slug);
-  if (!artist) return { title: '장인을 찾을 수 없습니다' };
+  const { locale, slug } = await params;
+  const baseArtist = getArtistBySlug(slug);
+  if (!baseArtist) return { title: locale === 'en' ? 'Artisan not found' : '장인을 찾을 수 없습니다' };
+  const artist = localizeArtist(baseArtist, locale);
 
   return {
-    title: `${artist.nameKo} ${artist.name} | 옥화당 장인`,
-    description: artist.bio,
+    title: locale === 'en' ? `${artist.displayName} | Ockhwadang Artisan` : `${artist.displayName} ${artist.name} | 옥화당 장인`,
+    description: artist.displayBio,
   };
 }
 
 export default async function ArtistDetailPage({ params }: ArtistDetailProps) {
-  const { slug } = await params;
-  const artist = getArtistBySlug(slug);
+  const { locale, slug } = await params;
+  const t = await getTranslations({ locale, namespace: 'artistPage' });
+  const baseArtist = getArtistBySlug(slug);
 
-  if (!artist) notFound();
+  if (!baseArtist) notFound();
+  const artist = localizeArtist(baseArtist, locale);
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-10">
@@ -35,7 +39,7 @@ export default async function ArtistDetailPage({ params }: ArtistDetailProps) {
         href="/artist"
         className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8"
       >
-        ← 장인 목록
+        {t('backToList')}
       </Link>
 
       {/* 에디토리얼 헤더 */}
@@ -49,29 +53,29 @@ export default async function ArtistDetailPage({ params }: ArtistDetailProps) {
 
         <div className="flex flex-col justify-center">
           <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground mb-2">
-            {artist.workshop} 공방
+            {t('workshop', { workshop: artist.displayWorkshop })}
           </p>
           <h1 className="text-3xl font-bold text-foreground md:text-4xl">
-            {artist.nameKo}
+            {artist.displayName}
           </h1>
           <p className="mt-1 text-xl text-muted-foreground">{artist.name}</p>
 
           <dl className="mt-6 grid grid-cols-2 gap-4 border-t border-border pt-6">
             <div>
-              <dt className="text-xs text-muted-foreground">대표 니료</dt>
-              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.clay}</dd>
+              <dt className="text-xs text-muted-foreground">{t('representativeClay')}</dt>
+              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.displayClay}</dd>
             </div>
             <div>
-              <dt className="text-xs text-muted-foreground">전문 분야</dt>
-              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.specialty}</dd>
+              <dt className="text-xs text-muted-foreground">{t('specialty')}</dt>
+              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.displaySpecialty}</dd>
             </div>
             <div>
-              <dt className="text-xs text-muted-foreground">작품 수</dt>
-              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.productCount}점</dd>
+              <dt className="text-xs text-muted-foreground">{t('works')}</dt>
+              <dd className="mt-0.5 text-sm font-medium text-foreground">{t('worksCount', { count: artist.productCount })}</dd>
             </div>
             <div>
-              <dt className="text-xs text-muted-foreground">공방 소재지</dt>
-              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.workshop}</dd>
+              <dt className="text-xs text-muted-foreground">{t('workshopLocation')}</dt>
+              <dd className="mt-0.5 text-sm font-medium text-foreground">{artist.displayWorkshop}</dd>
             </div>
           </dl>
         </div>
@@ -80,10 +84,10 @@ export default async function ArtistDetailPage({ params }: ArtistDetailProps) {
       {/* 장인 스토리 */}
       <section aria-labelledby="story-heading" className="mt-14">
         <h2 id="story-heading" className="text-lg font-bold text-foreground mb-6">
-          장인 이야기
+          {t('storyTitle')}
         </h2>
         <div className="space-y-4 border-l-2 border-border pl-6">
-          {artist.story.map((paragraph, index) => (
+          {artist.displayStory.map((paragraph, index) => (
             <p key={index} className="text-sm leading-relaxed text-muted-foreground">
               {paragraph}
             </p>
@@ -94,12 +98,12 @@ export default async function ArtistDetailPage({ params }: ArtistDetailProps) {
       {/* 대표 작품 갤러리 */}
       <section aria-labelledby="gallery-heading" className="mt-14">
         <h2 id="gallery-heading" className="text-lg font-bold text-foreground mb-6">
-          대표 작품
+          {t('galleryTitle')}
         </h2>
         <ul className="grid grid-cols-2 gap-4 md:grid-cols-3">
           {Array.from({ length: 6 }, (_, i) => (
             <li key={i} className="aspect-square rounded-lg bg-muted flex items-center justify-center">
-              <span className="text-xs text-muted-foreground/50">작품 {i + 1}</span>
+              <span className="text-xs text-muted-foreground/50">{t('workLabel', { index: i + 1 })}</span>
             </li>
           ))}
         </ul>
@@ -108,16 +112,16 @@ export default async function ArtistDetailPage({ params }: ArtistDetailProps) {
       {/* CTA */}
       <section className="mt-14 rounded-lg border border-border bg-muted/40 p-8 text-center">
         <h2 className="text-base font-bold text-foreground">
-          {artist.nameKo}의 작품 컬렉션
+          {t('collectionTitle', { name: artist.displayName })}
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
-          {artist.nameKo} 장인이 빚은 {artist.clay} 자사호를 만나보세요.
+          {t('collectionDescription', { name: artist.displayName, clay: artist.displayClay })}
         </p>
         <Link
-          href={`/products?artist=${encodeURIComponent(artist.nameKo)}`}
+          href={`/products?artist=${encodeURIComponent(artist.displayName)}`}
           className="mt-6 inline-flex items-center justify-center rounded-md bg-foreground px-6 py-2.5 text-sm font-medium text-background hover:opacity-90 transition-opacity"
         >
-          이 장인의 작품 보기
+          {t('viewWorks')}
         </Link>
       </section>
     </div>

--- a/src/app/[locale]/artist/page.tsx
+++ b/src/app/[locale]/artist/page.tsx
@@ -1,36 +1,46 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { ARTISTS, CLAY_FILTERS } from '@/lib/artists';
+import { getTranslations } from 'next-intl/server';
+import { ARTISTS, CLAY_FILTERS, localizeArtist } from '@/lib/artists';
 import type { ClayFilter } from '@/lib/artists';
 
 export const metadata: Metadata = {
-  title: '장인 | 옥화당',
-  description: '옥화당 자사호를 빚는 장인들을 만나보세요.',
+  title: 'Artisans | Ockhwadang',
+  description: 'Meet the Yixing artisans who craft Ockhwadang teapots.',
 };
 
 interface ArtistPageProps {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{ clay?: string }>;
 }
 
-export default async function ArtistPage({ searchParams }: ArtistPageProps) {
-  const params = await searchParams;
-  const clay = (CLAY_FILTERS as readonly string[]).includes(params.clay ?? '')
-    ? (params.clay as ClayFilter)
+export default async function ArtistPage({ params, searchParams }: ArtistPageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'artistPage' });
+  const query = await searchParams;
+  const selectedClay = query.clay ?? '';
+  const clay = (CLAY_FILTERS as readonly string[]).includes(selectedClay)
+    ? (selectedClay as ClayFilter)
     : '전체';
 
   const filtered = clay === '전체' ? ARTISTS : ARTISTS.filter((a) => a.clay === clay);
+  const clayFilterLabel = (filter: ClayFilter) => {
+    if (filter === '전체') return t('all');
+    const artist = ARTISTS.find((item) => item.clay === filter);
+    return locale === 'en' ? (artist?.clayEn ?? filter) : filter;
+  };
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-10">
       <header className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground md:text-3xl">장인</h1>
+        <h1 className="text-2xl font-bold text-foreground md:text-3xl">{t('title')}</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          옥화당의 자사호를 빚는 의흥 장인들
+          {t('description')}
         </p>
       </header>
 
       {/* 니료 필터 */}
-      <nav aria-label="니료 필터" className="mb-8 flex flex-wrap gap-2">
+      <nav aria-label={t('clayFilter')} className="mb-8 flex flex-wrap gap-2">
         {CLAY_FILTERS.map((filter) => {
           const isActive = clay === filter;
           const href = filter === '전체' ? '/artist' : `/artist?clay=${encodeURIComponent(filter)}`;
@@ -44,7 +54,7 @@ export default async function ArtistPage({ searchParams }: ArtistPageProps) {
                   : 'rounded-full border border-border bg-background px-4 py-1.5 text-sm font-medium text-muted-foreground hover:border-foreground hover:text-foreground transition-colors'
               }
             >
-              {filter}
+              {clayFilterLabel(filter)}
             </Link>
           );
         })}
@@ -52,8 +62,9 @@ export default async function ArtistPage({ searchParams }: ArtistPageProps) {
 
       {/* 장인 카드 그리드 */}
       <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        {filtered.map((artist) => (
-          <li key={artist.slug}>
+        {filtered.map((baseArtist) => {
+          const artist = localizeArtist(baseArtist, locale);
+          return <li key={artist.slug}>
             <Link
               href={`/artist/${artist.slug}`}
               className="group block overflow-hidden rounded-lg border border-border bg-background transition-shadow hover:shadow-md"
@@ -67,25 +78,25 @@ export default async function ArtistPage({ searchParams }: ArtistPageProps) {
 
               <div className="p-4">
                 <div className="flex items-baseline gap-2">
-                  <span className="text-lg font-bold text-foreground">{artist.nameKo}</span>
+                  <span className="text-lg font-bold text-foreground">{artist.displayName}</span>
                   <span className="text-sm text-muted-foreground">{artist.name}</span>
                 </div>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  {artist.clay} · {artist.workshop}
+                  {artist.displayClay} · {artist.displayWorkshop}
                 </p>
-                <p className="mt-2 text-sm text-foreground">{artist.specialty}</p>
+                <p className="mt-2 text-sm text-foreground">{artist.displaySpecialty}</p>
                 <p className="mt-3 text-xs text-muted-foreground">
-                  작품 {artist.productCount}점
+                  {t('worksCount', { count: artist.productCount })}
                 </p>
               </div>
             </Link>
-          </li>
-        ))}
+          </li>;
+        })}
       </ul>
 
       {filtered.length === 0 && (
         <p className="mt-12 text-center text-sm text-muted-foreground">
-          해당 니료의 장인이 없습니다.
+          {t('noArtists')}
         </p>
       )}
     </div>

--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -12,7 +12,7 @@ import { useMobileNav } from '@/contexts/MobileNavContext';
 import { Button } from '@/components/ui/button';
 import EmptyState from '@/components/shared/EmptyState';
 import CartItemRow from '@/components/shared/cart/CartItemRow';
-import { formatCurrency } from '@/utils/currency';
+import { formatCurrency, type Locale } from '@/utils/currency';
 import { SESSION_KEYS } from '@/constants/storage';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { shippingApi, type ShippingQuoteResponse } from '@/lib/api';
@@ -22,7 +22,7 @@ export default function CartPage() {
   const t = useTranslations('cart');
   const router = useRouter();
   const params = useParams<{ locale?: string }>();
-  const locale = params?.locale ?? 'ko';
+  const locale = (params?.locale ?? 'ko') as Locale;
   const { isVisible: isNavVisible } = useMobileNav();
   const { isAuthenticated } = useAuth();
   const { items, isLoading, updateQuantity, removeItem } = useCart();
@@ -156,11 +156,11 @@ export default function CartPage() {
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">{t('productAmount')}</span>
-          <span className="typo-price">{formatCurrency(selectedTotal)}</span>
+          <span className="typo-price">{formatCurrency(selectedTotal, locale)}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">{t('shippingFee')}</span>
-          <span className="typo-price">{selectedShippingFee === 0 ? t('freeShipping') : formatCurrency(selectedShippingFee)}</span>
+          <span className="typo-price">{selectedShippingFee === 0 ? t('freeShipping') : formatCurrency(selectedShippingFee, locale)}</span>
         </div>
       </div>
 
@@ -168,7 +168,7 @@ export default function CartPage() {
         <p className="text-xs text-muted-foreground">
           {remainingForFreeShipping === 0
             ? t('freeShippingUnlocked')
-            : t('freeShippingRemaining', { amount: formatCurrency(remainingForFreeShipping) })}
+            : t('freeShippingRemaining', { amount: formatCurrency(remainingForFreeShipping, locale) })}
         </p>
         <div className="mt-2 h-1.5 w-full rounded-full bg-background">
           <div
@@ -182,7 +182,7 @@ export default function CartPage() {
       <div className="mt-4 border-t border-divider-soft pt-4">
         <div className="flex items-end justify-between">
           <span className="typo-title">{t('total')}</span>
-          <span className="typo-price-lg text-foreground">{formatCurrency(grandTotal)}</span>
+          <span className="typo-price-lg text-foreground">{formatCurrency(grandTotal, locale)}</span>
         </div>
       </div>
     </>
@@ -226,7 +226,7 @@ export default function CartPage() {
                     <div>
                       <p className="typo-h3">{t('orderSummary')}</p>
                       <p className="mt-1 text-xs text-muted-foreground">
-                        {t('total')} · {formatCurrency(grandTotal)}
+                        {t('total')} · {formatCurrency(grandTotal, locale)}
                       </p>
                     </div>
                     <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
@@ -259,7 +259,7 @@ export default function CartPage() {
         <div className="mobile-sticky-inner">
           <div className="mb-2 flex items-end justify-between">
             <p className="text-xs text-muted-foreground">{t('total')}</p>
-            <p className="typo-price text-foreground">{formatCurrency(grandTotal)}</p>
+            <p className="typo-price text-foreground">{formatCurrency(grandTotal, locale)}</p>
           </div>
           <Button type="button" className="w-full" onClick={handleOrder}>
             {t('orderSelected')}

--- a/src/app/[locale]/journal/[slug]/page.tsx
+++ b/src/app/[locale]/journal/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { JOURNAL_ENTRIES, getJournalBySlug } from '@/lib/journal';
+import { getTranslations } from 'next-intl/server';
+import { JOURNAL_ENTRIES, getLocalizedJournalBySlug } from '@/lib/journal';
 
 interface PageProps {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ locale: 'ko' | 'en'; slug: string }>;
 }
 
 export async function generateStaticParams() {
@@ -12,9 +13,9 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { slug } = await params;
-  const entry = getJournalBySlug(slug);
-  if (!entry) return { title: 'Journal — 옥화당' };
+  const { locale, slug } = await params;
+  const entry = getLocalizedJournalBySlug(slug, locale);
+  if (!entry) return { title: locale === 'en' ? 'Journal — Ockhwadang' : 'Journal — 옥화당' };
 
   return {
     title: `${entry.title} — Journal`,
@@ -29,8 +30,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function JournalDetailPage({ params }: PageProps) {
-  const { slug } = await params;
-  const entry = getJournalBySlug(slug);
+  const { locale, slug } = await params;
+  const t = await getTranslations({ locale, namespace: 'journalPage' });
+  const entry = getLocalizedJournalBySlug(slug, locale);
 
   if (!entry) {
     notFound();
@@ -44,7 +46,7 @@ export default async function JournalDetailPage({ params }: PageProps) {
     datePublished: entry.date,
     publisher: {
       '@type': 'Organization',
-      name: '옥화당',
+      name: locale === 'en' ? 'Ockhwadang' : '옥화당',
     },
   };
 
@@ -65,7 +67,7 @@ export default async function JournalDetailPage({ params }: PageProps) {
             <span className="text-xs text-background/40">·</span>
             <time className="text-xs text-background/60">{entry.date}</time>
             <span className="text-xs text-background/40">·</span>
-            <span className="text-xs text-background/60">{entry.readTime} 읽기</span>
+            <span className="text-xs text-background/60">{entry.readTime} {t('readSuffix')}</span>
           </div>
           <h1 className="font-display typo-h1 tracking-tight mb-3">
             {entry.title}
@@ -96,7 +98,7 @@ export default async function JournalDetailPage({ params }: PageProps) {
           href="/journal"
           className="inline-flex items-center gap-2 text-sm font-medium text-foreground hover:underline"
         >
-          ← 저널 목록으로 돌아가기
+          {t('backToList')}
         </Link>
       </section>
     </div>

--- a/src/app/[locale]/my/coupons/page.tsx
+++ b/src/app/[locale]/my/coupons/page.tsx
@@ -7,7 +7,7 @@ import type { CouponItem } from '@/lib/api';
 import { useRequireAuth } from '@/components/shared/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { cn } from '@/components/ui/utils';
-import { formatCurrency } from '@/utils/currency';
+import { formatCurrency, type Locale } from '@/utils/currency';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 
 type TabStatus = 'available' | 'used' | 'expired';
@@ -18,7 +18,7 @@ function CouponCard({
   t,
 }: {
   coupon: CouponItem;
-  locale: string;
+  locale: Locale;
   t: (key: string, values?: Record<string, string | number>) => string;
 }) {
   const discountText =
@@ -26,10 +26,10 @@ function CouponCard({
       ? coupon.maxDiscount
         ? t('discountPercentWithMax', {
           value: coupon.value,
-          max: formatCurrency(coupon.maxDiscount),
+          max: formatCurrency(coupon.maxDiscount, locale),
         })
         : t('discountPercent', { value: coupon.value })
-      : t('discountFixed', { value: formatCurrency(coupon.value) });
+      : t('discountFixed', { value: formatCurrency(coupon.value, locale) });
 
   return (
     <div
@@ -54,7 +54,7 @@ function CouponCard({
       <p className="text-sm font-medium text-primary">{discountText}</p>
       {coupon.minOrderAmount > 0 && (
         <p className="text-xs text-muted-foreground">
-          {t('minOrderAmount', { amount: formatCurrency(coupon.minOrderAmount) })}
+          {t('minOrderAmount', { amount: formatCurrency(coupon.minOrderAmount, locale) })}
         </p>
       )}
       <p className="text-xs text-muted-foreground">
@@ -66,7 +66,7 @@ function CouponCard({
 
 export default function MyCouponsPage() {
   const t = useTranslations('myCoupons');
-  const locale = useLocale();
+  const locale = useLocale() as Locale;
   const { isAuthenticated, isLoading } = useRequireAuth();
   const [tab, setTab] = useState<TabStatus>('available');
   const [coupons, setCoupons] = useState<CouponItem[]>([]);
@@ -101,7 +101,7 @@ export default function MyCouponsPage() {
       {/* 적립금 잔액 */}
       <div className="mb-6 rounded-lg border p-4 flex items-center justify-between">
         <span className="text-sm font-medium">{t('pointBalance')}</span>
-        <span className="text-lg font-bold">{formatCurrency(pointBalance)}</span>
+        <span className="text-lg font-bold">{formatCurrency(pointBalance, locale)}</span>
       </div>
 
       {/* 탭 */}

--- a/src/app/[locale]/my/orders/[id]/page.tsx
+++ b/src/app/[locale]/my/orders/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import { ordersApi, paymentsApi } from '@/lib/api';
 import type { CheckoutGatewayName, OrderResponse, OrderServiceRequest, OrderServiceRequestType, PreparePaymentResponse } from '@/lib/api';
-import { formatCurrency } from '@/utils/currency';
+import { formatCurrency, type Locale as CurrencyLocale } from '@/utils/currency';
 import { useRequireAuth } from '@/components/shared/hooks/useRequireAuth';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { SkeletonBox } from '@/components/ui/Skeleton';
@@ -24,7 +24,7 @@ const STATUS_TIMELINE = ['pending', 'paid', 'preparing', 'shipped', 'delivered']
 
 export default function OrderDetailPage() {
   const params = useParams();
-  const locale = useLocale();
+  const locale = useLocale() as CurrencyLocale;
   const tOrder = useTranslations('order');
   const tMy = useTranslations('myPage');
   const t = useTranslations('orderDetail');
@@ -289,11 +289,11 @@ export default function OrderDetailPage() {
                       <p className="text-xs text-muted-foreground">{item.optionName}</p>
                     )}
                     <p className="text-xs text-muted-foreground">
-                      {formatCurrency(item.price)} × {t('quantity', { count: item.quantity })}
+                      {formatCurrency(item.price, locale)} × {t('quantity', { count: item.quantity })}
                     </p>
                   </div>
                   <p className="font-medium shrink-0">
-                    {formatCurrency(Number(item.price) * item.quantity)}
+                    {formatCurrency(Number(item.price) * item.quantity, locale)}
                   </p>
                 </div>
               </li>
@@ -307,18 +307,18 @@ export default function OrderDetailPage() {
           <dl className="space-y-2 text-sm">
             <div className="flex justify-between">
               <dt className="text-muted-foreground">{t('productAmount')}</dt>
-              <dd>{formatCurrency(order.totalAmount)}</dd>
+              <dd>{formatCurrency(order.totalAmount, locale)}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-muted-foreground">{t('discountAmount')}</dt>
-              <dd>-{formatCurrency(order.discountAmount)}</dd>
+              <dd>-{formatCurrency(order.discountAmount, locale)}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-muted-foreground">{t('shippingFee')}</dt>
               <dd>
                 {Number(order.shippingFee) === 0
                   ? t('freeShipping')
-                  : formatCurrency(order.shippingFee)}
+                  : formatCurrency(order.shippingFee, locale)}
               </dd>
             </div>
             <div className="flex justify-between border-t pt-2 font-bold">
@@ -327,7 +327,8 @@ export default function OrderDetailPage() {
                 {formatCurrency(
                   Number(order.totalAmount) -
                   Number(order.discountAmount) +
-                  Number(order.shippingFee)
+                  Number(order.shippingFee),
+                  locale,
                 )}
               </dd>
             </div>

--- a/src/app/[locale]/my/orders/page.tsx
+++ b/src/app/[locale]/my/orders/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
-import { formatCurrency } from '@/utils/currency';
+import { formatCurrency, type Locale } from '@/utils/currency';
 import { handleApiError } from '@/utils/error';
 import { useRequireAuth } from '@/components/shared/hooks/useRequireAuth';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
@@ -17,7 +17,7 @@ const PAGE_LIMIT = 10;
 export default function OrdersPage() {
   const t = useTranslations('order');
   const tMy = useTranslations('myPage');
-  const locale = useLocale();
+  const locale = useLocale() as Locale;
   const { isAuthenticated, isLoading } = useRequireAuth();
   const [orders, setOrders] = useState<OrderResponse[]>([]);
   const [total, setTotal] = useState(0);
@@ -118,7 +118,7 @@ export default function OrdersPage() {
                       </p>
                     </div>
                     <div className="text-right shrink-0">
-                      <p className="font-semibold">{formatCurrency(order.totalAmount)}</p>
+                      <p className="font-semibold">{formatCurrency(order.totalAmount, locale)}</p>
                     </div>
                   </div>
                 </Link>

--- a/src/app/[locale]/my/page.tsx
+++ b/src/app/[locale]/my/page.tsx
@@ -9,7 +9,7 @@ import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
 import { useRequireAuth } from '@/components/shared/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
-import { formatCurrency } from '@/utils/currency';
+import { formatCurrency, type Locale } from '@/utils/currency';
 import { handleApiError } from '@/utils/error';
 import {
   Package,
@@ -35,7 +35,7 @@ const QUICK_LINKS = [
 export default function MyPage() {
   const t = useTranslations('myPage');
   const tOrder = useTranslations('order');
-  const locale = useLocale();
+  const locale = useLocale() as Locale;
   const { isAuthenticated, isLoading } = useRequireAuth();
   const { user } = useAuth();
   const [recentOrders, setRecentOrders] = useState<OrderResponse[]>([]);
@@ -143,7 +143,7 @@ export default function MyPage() {
                   </div>
                   <div className="text-right shrink-0 ml-4">
                     <p className="typo-body-sm font-medium">
-                      {formatCurrency(Number(order.totalAmount))}
+                      {formatCurrency(Number(order.totalAmount), locale)}
                     </p>
                     <p className="typo-label text-muted-foreground mt-0.5">
                       {tOrder.has(`status.${order.status}`) ? tOrder(`status.${order.status}`) : order.status}

--- a/src/app/[locale]/my/recently-viewed/page.tsx
+++ b/src/app/[locale]/my/recently-viewed/page.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl';
 import { useRecentlyViewed } from '@/components/shared/hooks/useRecentlyViewed';
 import EmptyState from '@/components/shared/EmptyState';
 import { formatCurrency } from '@/utils/currency';
+import { getClientLocale } from '@/utils/clientLocale';
 
 interface RecentlyViewedProductImageProps {
   thumbnail: string | null;
@@ -45,6 +46,7 @@ function RecentlyViewedProductImage({ thumbnail, name }: RecentlyViewedProductIm
 
 export default function RecentlyViewedPage() {
   const t = useTranslations('recentlyViewed');
+  const locale = getClientLocale();
   const { items, clear } = useRecentlyViewed();
 
   const handleClear = () => {
@@ -80,7 +82,7 @@ export default function RecentlyViewedPage() {
               <div className="p-3">
                 <p className="line-clamp-2 text-sm font-medium">{item.name}</p>
                 <p className="mt-1 text-sm font-semibold">
-                  {formatCurrency(item.salePrice ?? item.price)}
+                  {formatCurrency(item.salePrice ?? item.price, locale)}
                 </p>
               </div>
             </Link>

--- a/src/app/[locale]/notice/[id]/page.tsx
+++ b/src/app/[locale]/notice/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import dynamic from 'next/dynamic';
 import { noticesApi } from '@/lib/api';
 import type { Notice } from '@/lib/api';
@@ -17,6 +18,7 @@ const DOMPurifyContent = dynamic(
 export default function NoticeDetailPage() {
   const { id, locale } = useParams<{ id: string; locale: string }>();
   const router = useRouter();
+  const t = useTranslations('notice');
   const [notice, setNotice] = useState<Notice | null>(null);
   const [notFound, setNotFound] = useState(false);
 
@@ -46,7 +48,7 @@ export default function NoticeDetailPage() {
   if (notFound || !notice) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-8 text-center text-gray-500">
-        공지사항을 찾을 수 없습니다.
+        {t('notFound')}
       </div>
     );
   }
@@ -57,14 +59,14 @@ export default function NoticeDetailPage() {
         onClick={() => router.back()}
         className="text-sm text-gray-500 hover:text-gray-700 mb-6 flex items-center gap-1"
       >
-        ← 목록으로
+        ← {t('backToList')}
       </button>
       <h1 className="text-xl font-bold text-gray-900 mb-2">{notice.title}</h1>
       <div className="flex items-center gap-3 text-xs text-gray-400 mb-6 pb-4 border-b">
-        <span>{new Date(notice.createdAt).toLocaleDateString('ko-KR')}</span>
-        <span>조회 {notice.viewCount.toLocaleString()}</span>
+        <span>{new Date(notice.createdAt).toLocaleDateString(locale === 'en' ? 'en-US' : 'ko-KR')}</span>
+        <span>{t('views', { count: notice.viewCount.toLocaleString(locale === 'en' ? 'en-US' : 'ko-KR') })}</span>
         {notice.isPinned && (
-          <span className="text-blue-600 font-semibold">필독</span>
+          <span className="text-blue-600 font-semibold">{t('pinned')}</span>
         )}
       </div>
       <div className="prose prose-sm max-w-none text-gray-700">

--- a/src/app/[locale]/order/complete/page.tsx
+++ b/src/app/[locale]/order/complete/page.tsx
@@ -91,7 +91,7 @@ function OrderCompleteContent({ locale }: { locale: string }) {
                 <p className="text-muted-foreground">{t('quantity', { quantity: item.quantity })}</p>
               </div>
               <p className="font-medium shrink-0">
-                {formatCurrency(item.price * item.quantity)}
+                {formatCurrency(item.price * item.quantity, locale === 'en' ? 'en' : 'ko')}
               </p>
             </li>
           ))}
@@ -100,19 +100,19 @@ function OrderCompleteContent({ locale }: { locale: string }) {
         <div className="border-t pt-4 space-y-2 text-sm">
           <div className="flex justify-between">
             <span className="text-muted-foreground">{t('shippingFee')}</span>
-            <span>{order.shippingFee === 0 ? t('free') : formatCurrency(order.shippingFee)}</span>
+            <span>{order.shippingFee === 0 ? t('free') : formatCurrency(order.shippingFee, locale === 'en' ? 'en' : 'ko')}</span>
           </div>
           {order.discountAmount > 0 && (
             <div className="flex justify-between">
               <span className="text-muted-foreground">{t('discount')}</span>
-              <span className="text-destructive">-{formatCurrency(order.discountAmount)}</span>
+              <span className="text-destructive">-{formatCurrency(order.discountAmount, locale === 'en' ? 'en' : 'ko')}</span>
             </div>
           )}
         </div>
 
         <div className="border-t pt-4 flex justify-between font-bold">
           <span>{t('paymentAmount')}</span>
-          <span>{formatCurrency(order.totalAmount)}</span>
+          <span>{formatCurrency(order.totalAmount, locale === 'en' ? 'en' : 'ko')}</span>
         </div>
       </section>
 

--- a/src/app/[locale]/products/[id]/page.tsx
+++ b/src/app/[locale]/products/[id]/page.tsx
@@ -14,11 +14,11 @@ export async function generateMetadata({ params }: ProductDetailProps): Promise<
   const { id, locale } = await params
   const safeLocale = routing.locales.includes(locale as Locale) ? (locale as Locale) : routing.defaultLocale;
   const product = await fetchProduct(Number(id), safeLocale)
-  if (!product) return { title: '상품을 찾을 수 없습니다' }
+  if (!product) return { title: safeLocale === 'en' ? 'Product not found' : '상품을 찾을 수 없습니다' }
 
   const imageUrl = product.images?.[0]?.url ?? '';
   const absoluteImageUrl = imageUrl.startsWith('http') ? imageUrl : `${SITE_URL}${imageUrl}`;
-  const description = product.shortDescription ?? product.description?.slice(0, 160) ?? `${product.name} 상세 페이지`;
+  const description = product.shortDescription ?? product.description?.slice(0, 160) ?? (safeLocale === 'en' ? `${product.name} detail page` : `${product.name} 상세 페이지`);
 
   const languages: Record<string, string> = {};
   for (const loc of routing.locales) {
@@ -68,14 +68,14 @@ export default async function ProductDetailPage({ params }: ProductDetailProps) 
     description: product.description,
     image: product.images?.map(img => img.url) ?? [],
     sku: product.sku,
-    brand: { '@type': 'Brand', name: '옥화당' },
+    brand: { '@type': 'Brand', name: safeLocale === 'en' ? 'Okhwadang' : '옥화당' },
     url: `${SITE_URL}/${safeLocale}/products/${id}`,
     offers: {
       '@type': 'Offer',
       priceCurrency: 'KRW',
       price: product.salePrice ?? product.price,
       availability: product.stock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
-      seller: { '@type': 'Organization', name: '옥화당' },
+      seller: { '@type': 'Organization', name: safeLocale === 'en' ? 'Okhwadang' : '옥화당' },
     },
   };
 

--- a/src/components/LogoSlider.tsx
+++ b/src/components/LogoSlider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useLocale } from 'next-intl';
 
 /**
  * 히어로 섹션 위에 fixed로 표시되는 브랜드 워드마크.
@@ -8,6 +9,7 @@ import { useEffect, useState } from 'react';
  * 헤더의 로고가 페이드인되어 자연스럽게 이어진다.
  */
 export default function LogoSlider() {
+  const locale = useLocale();
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
@@ -43,7 +45,7 @@ export default function LogoSlider() {
           textShadow: '0 1px 8px rgba(0,0,0,0.4)',
         }}
       >
-        옥화당
+        {locale === 'en' ? 'Okhwadang' : '옥화당'}
       </span>
     </div>
   );

--- a/src/components/header/MobileMenu.tsx
+++ b/src/components/header/MobileMenu.tsx
@@ -9,6 +9,7 @@ import Logo from '@/components/Logo';
 import LanguageSelector from '@/components/LanguageSelector';
 import ThemeToggle from '@/components/ThemeToggle';
 import { getHeaderNavigationLabel } from './navigationLabel';
+import { localMessage } from '@/utils/localMessages';
 import type { NavigationItem } from '@/lib/api';
 
 interface MobileMenuProps {
@@ -85,7 +86,7 @@ function MobileMenuContent({ items, history, onItemClick, onBack, onLinkClick }:
                 <button
                   type="button"
                   onClick={onBack}
-                  aria-label={`${title} 메뉴로 돌아가기`}
+                  aria-label={localMessage('header.menuBackTo', { title })}
                   tabIndex={isActive ? 0 : -1}
                   className="mb-3 flex min-h-11 w-full items-center gap-3 py-2 text-left typo-body-sm font-medium text-foreground hover:text-muted-foreground transition-colors"
                 >
@@ -105,7 +106,7 @@ function MobileMenuContent({ items, history, onItemClick, onBack, onLinkClick }:
                           type="button"
                           onClick={() => isActive && onItemClick(item)}
                           tabIndex={isActive ? 0 : -1}
-                          aria-label={`${label} 하위 메뉴 열기`}
+                          aria-label={localMessage('header.openSubmenu', { label })}
                           className="w-full min-h-11 py-3 text-left typo-body-sm text-foreground hover:text-muted-foreground transition-colors flex items-center justify-between"
                         >
                           {label}

--- a/src/components/shared/BackButton.tsx
+++ b/src/components/shared/BackButton.tsx
@@ -3,6 +3,7 @@
 import { useRouter, usePathname } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
+import { localMessage } from '@/utils/localMessages';
 
 /**
  * 헤더 아래 좌측에 fixed로 표시되는 원형 뒤로가기 버튼.
@@ -19,7 +20,7 @@ export default function BackButton() {
     <button
       type="button"
       onClick={() => router.back()}
-      aria-label="뒤로가기"
+      aria-label={localMessage('ui.back')}
       className={cn(
         'fixed left-4 top-[4.5rem] z-10',
         'flex h-9 w-9 items-center justify-center rounded-full',

--- a/src/components/shared/ErrorFallback.tsx
+++ b/src/components/shared/ErrorFallback.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { handleApiError } from '@/utils/error';
+import { localMessage } from '@/utils/localMessages';
+
 interface ErrorFallbackProps {
   error: Error & { digest?: string };
   onRetry: () => void;
@@ -10,14 +13,14 @@ export default function ErrorFallback({ error, onRetry }: ErrorFallbackProps) {
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="text-center max-w-md">
         <div className="rounded-lg border border-red-200 bg-red-50 p-6 mb-6">
-          <p className="text-sm text-red-600 mb-2">데이터를 불러오지 못했습니다</p>
-          <p className="text-xs text-red-500/70">{error.message || '알 수 없는 오류가 발생했습니다.'}</p>
+          <p className="text-sm text-red-600 mb-2">{localMessage('ui.dataLoadError')}</p>
+          <p className="text-xs text-red-500/70">{handleApiError(error, localMessage('ui.unknownError'))}</p>
         </div>
         <button
           onClick={onRetry}
           className="inline-flex items-center gap-2 text-sm font-medium bg-foreground text-background rounded px-6 py-3 hover:opacity-80 transition-opacity"
         >
-          다시 시도
+          {localMessage('ui.retry')}
         </button>
       </div>
     </div>

--- a/src/components/shared/Logo.tsx
+++ b/src/components/shared/Logo.tsx
@@ -1,13 +1,32 @@
+'use client';
+
 import Image from 'next/image';
+import { useLocale } from 'next-intl';
+import { cn } from '@/components/ui/utils';
 
 interface LogoProps {
-  /** 히어로용 큰 사이즈 vs 헤더용 작은 사이즈 */
   variant?: 'hero' | 'header';
   className?: string;
 }
 
 export default function Logo({ variant = 'header', className }: LogoProps) {
+  const locale = useLocale();
   const size = variant === 'hero' ? { width: 200, height: 56 } : { width: 140, height: 40 };
+
+  if (locale === 'en') {
+    return (
+      <span
+        className={cn(
+          'font-display text-xl font-semibold tracking-tight text-foreground',
+          variant === 'hero' && 'text-3xl text-white',
+          className,
+        )}
+        aria-label="Okhwadang"
+      >
+        Okhwadang
+      </span>
+    );
+  }
 
   return (
     <Image

--- a/src/components/shared/RecentlyViewedWidget.tsx
+++ b/src/components/shared/RecentlyViewedWidget.tsx
@@ -8,8 +8,11 @@ import { useRecentlyViewed } from '@/components/shared/hooks/useRecentlyViewed';
 import { useUrlModal } from '@/hooks/useUrlModal';
 import { formatCurrency } from '@/utils/currency';
 import { cn } from '@/components/ui/utils';
+import { getClientLocale } from '@/utils/clientLocale';
+import { localMessage } from '@/utils/localMessages';
 
 export default function RecentlyViewedWidget() {
+  const locale = getClientLocale();
   const { items } = useRecentlyViewed();
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useUrlModal('recentlyViewed');
@@ -54,7 +57,7 @@ export default function RecentlyViewedWidget() {
               <div className="max-w-32 text-xs">
                 <p className="line-clamp-1 font-medium">{item.name}</p>
                 <p className="text-muted-foreground">
-                  {formatCurrency(item.salePrice ?? item.price)}
+                  {formatCurrency(item.salePrice ?? item.price, locale)}
                 </p>
               </div>
             </Link>
@@ -64,7 +67,7 @@ export default function RecentlyViewedWidget() {
               href="/my/recently-viewed"
               className="text-center text-xs text-muted-foreground hover:underline py-1"
             >
-              전체 {items.length}개 보기
+              {localMessage('recentlyViewedWidget.more', { count: items.length })}
             </Link>
           )}
         </div>
@@ -74,7 +77,7 @@ export default function RecentlyViewedWidget() {
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-background shadow-md hover:bg-muted transition-colors"
-          aria-label="최근 본 상품"
+          aria-label={localMessage('recentlyViewedWidget.open')}
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-muted-foreground">
             <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/>
@@ -84,7 +87,7 @@ export default function RecentlyViewedWidget() {
         <button
           onClick={() => setIsHidden(true)}
           className="flex h-6 w-6 items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-muted transition-colors"
-          aria-label="위젯 닫기"
+          aria-label={localMessage('recentlyViewedWidget.close')}
         >
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-muted-foreground">
             <path d="M18 6L6 18M6 6l12 12"/>

--- a/src/components/shared/ShippingTimeline.tsx
+++ b/src/components/shared/ShippingTimeline.tsx
@@ -5,8 +5,8 @@ import { useRouter } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import { shippingApi, type ShippingResponse } from '@/lib/api';
 import {
-  CARRIER_NAMES,
   CARRIER_TRACKING_URLS,
+  getCarrierName,
 } from '@/constants/status';
 
 const SHIPPING_STEPS = ['payment_confirmed', 'preparing', 'shipped', 'in_transit', 'delivered'];
@@ -101,6 +101,7 @@ export default function ShippingTimeline({ orderId }: Props) {
   const trackingHref = trackingUrl && shipping.tracking_number
     ? `${trackingUrl}${encodeURIComponent(shipping.tracking_number)}`
     : null;
+  const carrierName = getCarrierName(shipping.carrier, locale);
 
   return (
     <section className="rounded-lg border p-6">
@@ -167,7 +168,7 @@ export default function ShippingTimeline({ orderId }: Props) {
       <div className="mb-4 rounded-md bg-muted/40 p-3 text-sm">
         <div className="flex items-center gap-2">
           <span className="text-muted-foreground">{t('carrier')}</span>
-          <span className="font-medium">{CARRIER_NAMES[shipping.carrier] ?? shipping.carrier}</span>
+          <span className="font-medium">{carrierName}</span>
         </div>
         {shipping.tracking_number ? (
           <div className="mt-1 flex items-center gap-2">
@@ -179,7 +180,7 @@ export default function ShippingTimeline({ orderId }: Props) {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs text-primary underline"
-                aria-label={t('trackingLinkLabel', { carrier: CARRIER_NAMES[shipping.carrier] ?? shipping.carrier })}
+                aria-label={t('trackingLinkLabel', { carrier: carrierName })}
               >
                 {t('trackingLink')}
               </a>

--- a/src/components/shared/WishlistButton.tsx
+++ b/src/components/shared/WishlistButton.tsx
@@ -3,6 +3,7 @@
 import { Heart } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import { useWishlistToggle } from '@/components/shared/hooks/useWishlistToggle';
+import { localMessage } from '@/utils/localMessages';
 
 interface WishlistButtonProps {
   productId: number;
@@ -26,7 +27,7 @@ export default function WishlistButton({
     <button
       type="button"
       onClick={toggle}
-      aria-label={isWishlisted ? '위시리스트에서 삭제' : '위시리스트에 추가'}
+      aria-label={isWishlisted ? localMessage('wishlist.remove') : localMessage('wishlist.add')}
       className={cn(
         'flex items-center justify-center rounded-full p-1.5 transition-colors',
         'hover:bg-muted',

--- a/src/components/shared/auth/LoginForm.tsx
+++ b/src/components/shared/auth/LoginForm.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/components/ui/utils';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
+import { localMessage } from '@/utils/localMessages';
 
 export default function LoginForm() {
   const router = useRouter();
@@ -36,10 +37,10 @@ export default function LoginForm() {
     },
     {
       onError: (err) => {
-        const message = handleApiError(err, '로그인에 실패했습니다.');
-        if (message.includes('이메일') || message.includes('email')) {
+        const message = handleApiError(err, localMessage('auth.loginError'));
+        if (message.includes('이메일') || message.toLowerCase().includes('email')) {
           setEmailError(message);
-        } else if (message.includes('비밀번호') || message.includes('password')) {
+        } else if (message.includes('비밀번호') || message.toLowerCase().includes('password')) {
           setPasswordError(message);
         } else {
           setEmailError(message);
@@ -57,12 +58,12 @@ export default function LoginForm() {
 
   return (
     <div className="mx-auto max-w-sm w-full">
-      <h1 className="text-2xl font-bold text-center mb-8">로그인</h1>
+      <h1 className="text-2xl font-bold text-center mb-8">{localMessage('auth.loginTitle')}</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="space-y-1">
           <label htmlFor="email" className="text-sm font-medium">
-            이메일
+            {localMessage('auth.email')}
           </label>
           <input
             id="email"
@@ -89,9 +90,9 @@ export default function LoginForm() {
         <div className="space-y-1">
           <div className="flex items-center justify-between">
             <label htmlFor="password" className="text-sm font-medium">
-              비밀번호
+              {localMessage('auth.password')}
             </label>
-            <span className="text-xs text-muted-foreground cursor-not-allowed">비밀번호 찾기</span>
+            <span className="text-xs text-muted-foreground cursor-not-allowed">{localMessage('auth.forgotPassword')}</span>
           </div>
           <div className="relative">
             <input
@@ -114,7 +115,7 @@ export default function LoginForm() {
             <button
               type="button"
               onClick={handleTogglePassword}
-              aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 잠깐 보기'}
+              aria-label={showPassword ? localMessage('auth.hidePassword') : localMessage('auth.showPassword')}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
             >
               {showPassword ? (
@@ -130,13 +131,13 @@ export default function LoginForm() {
         </div>
 
         <Button type="submit" className="w-full" disabled={isSubmitting}>
-          {isSubmitting ? '로그인 중...' : '로그인'}
+          {isSubmitting ? localMessage('auth.loginSubmitting') : localMessage('auth.loginSubmit')}
         </Button>
       </form>
 
       <div className="my-6 flex items-center gap-3">
         <div className="flex-1 border-t border-border" />
-        <span className="text-xs text-muted-foreground">또는</span>
+        <span className="text-xs text-muted-foreground">{localMessage('auth.dividerOr')}</span>
         <div className="flex-1 border-t border-border" />
       </div>
 
@@ -150,7 +151,7 @@ export default function LoginForm() {
           )}
         >
           <span className="font-bold">K</span>
-          카카오로 로그인
+          {localMessage('auth.kakaoLogin')}
         </button>
 
         <button
@@ -162,14 +163,14 @@ export default function LoginForm() {
           )}
         >
           <span className="font-bold text-blue-500">G</span>
-          Google로 로그인
+          {localMessage('auth.googleLogin')}
         </button>
       </div>
 
       <p className="mt-6 text-center text-sm text-muted-foreground">
-        계정이 없으신가요?{' '}
+        {localMessage('auth.noAccount')}{' '}
         <Link href="/register" className="font-medium text-primary hover:underline">
-          회원가입
+          {localMessage('auth.registerSubmit')}
         </Link>
       </p>
     </div>

--- a/src/components/shared/auth/OAuthCallbackHandler.tsx
+++ b/src/components/shared/auth/OAuthCallbackHandler.tsx
@@ -7,6 +7,7 @@ import { AuthTokenResponse } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
 import { SESSION_KEYS } from '@/constants/storage';
 import { toastMessage } from '@/utils/toastMessages';
+import { localMessage } from '@/utils/localMessages';
 
 interface OAuthCallbackHandlerProps {
   provider: 'kakao' | 'google';
@@ -50,7 +51,7 @@ export default function OAuthCallbackHandler({ provider, apiMethod }: OAuthCallb
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <p className="text-muted-foreground">{provider} 로그인 처리 중...</p>
+      <p className="text-muted-foreground">{localMessage('auth.processingOAuth', { provider })}</p>
     </div>
   );
 }

--- a/src/components/shared/auth/RegisterForm.tsx
+++ b/src/components/shared/auth/RegisterForm.tsx
@@ -7,27 +7,9 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/components/ui/utils';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
+import { localMessage } from '@/utils/localMessages';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function validateEmail(email: string): string | null {
-  if (!EMAIL_REGEX.test(email)) return '올바른 이메일 형식이 아닙니다.';
-  return null;
-}
-
-function validatePassword(password: string): string | null {
-  if (password.length < 8) return '비밀번호는 8자 이상이어야 합니다.';
-  if (!/[a-zA-Z]/.test(password) || !/[0-9]/.test(password))
-    return '비밀번호는 영문과 숫자를 모두 포함해야 합니다.';
-  if (!/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password))
-    return '비밀번호는 특수문자를 포함해야 합니다.';
-  return null;
-}
-
-function validateName(name: string): string | null {
-  if (name.length < 1 || name.length > 100) return '이름은 1~100자 사이여야 합니다.';
-  return null;
-}
 
 export default function RegisterForm() {
   const router = useRouter();
@@ -43,18 +25,17 @@ export default function RegisterForm() {
       await register(email, password, name);
       router.push('/login');
     },
-    { errorMessage: '회원가입에 실패했습니다.' },
+    { errorMessage: localMessage('auth.registerError') },
   );
 
   const validate = (): boolean => {
     const next: Record<string, string> = {};
-    const nameErr = validateName(name);
-    if (nameErr) next.name = nameErr;
-    const emailErr = validateEmail(email);
-    if (emailErr) next.email = emailErr;
-    const pwErr = validatePassword(password);
-    if (pwErr) next.password = pwErr;
-    if (password !== passwordConfirm) next.passwordConfirm = '비밀번호가 일치하지 않습니다.';
+    if (name.length < 1 || name.length > 100) next.name = localMessage('auth.validation.nameTooShort');
+    if (!EMAIL_REGEX.test(email)) next.email = localMessage('auth.validation.emailInvalid');
+    if (password.length < 8) next.password = localMessage('auth.validation.passwordTooShort');
+    else if (!/[a-zA-Z]/.test(password) || !/[0-9]/.test(password)) next.password = localMessage('auth.validation.passwordRequirements');
+    else if (!/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password)) next.password = localMessage('auth.validation.passwordNeedsSpecial');
+    if (password !== passwordConfirm) next.passwordConfirm = localMessage('auth.validation.passwordMismatch');
     setErrors(next);
     return Object.keys(next).length === 0;
   };
@@ -67,105 +48,41 @@ export default function RegisterForm() {
 
   return (
     <div className="mx-auto max-w-sm w-full">
-      <h1 className="text-2xl font-bold text-center mb-8">회원가입</h1>
+      <h1 className="text-2xl font-bold text-center mb-8">{localMessage('auth.registerTitle')}</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="space-y-1">
-          <label htmlFor="name" className="text-sm font-medium">
-            이름
-          </label>
-          <input
-            id="name"
-            type="text"
-            autoComplete="name"
-            required
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className={cn(
-              'w-full rounded-md border bg-background px-3 py-2 text-sm',
-              'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              errors.name ? 'border-destructive' : 'border-input',
-            )}
-            placeholder="홍길동"
-          />
+          <label htmlFor="name" className="text-sm font-medium">{localMessage('auth.name')}</label>
+          <input id="name" type="text" autoComplete="name" required value={name} onChange={(e) => setName(e.target.value)} className={cn('w-full rounded-md border bg-background px-3 py-2 text-sm', 'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', errors.name ? 'border-destructive' : 'border-input')} placeholder={localMessage('auth.namePlaceholder')} />
           {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
         </div>
 
         <div className="space-y-1">
-          <label htmlFor="email" className="text-sm font-medium">
-            이메일
-          </label>
-          <input
-            id="email"
-            type="email"
-            autoComplete="email"
-            required
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className={cn(
-              'w-full rounded-md border bg-background px-3 py-2 text-sm',
-              'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              errors.email ? 'border-destructive' : 'border-input',
-            )}
-            placeholder="you@example.com"
-          />
+          <label htmlFor="email" className="text-sm font-medium">{localMessage('auth.email')}</label>
+          <input id="email" type="email" autoComplete="email" required value={email} onChange={(e) => setEmail(e.target.value)} className={cn('w-full rounded-md border bg-background px-3 py-2 text-sm', 'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', errors.email ? 'border-destructive' : 'border-input')} placeholder={localMessage('auth.emailPlaceholder')} />
           {errors.email && <p className="text-xs text-destructive">{errors.email}</p>}
         </div>
 
         <div className="space-y-1">
-          <label htmlFor="password" className="text-sm font-medium">
-            비밀번호
-          </label>
-          <input
-            id="password"
-            type="password"
-            autoComplete="new-password"
-            required
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className={cn(
-              'w-full rounded-md border bg-background px-3 py-2 text-sm',
-              'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              errors.password ? 'border-destructive' : 'border-input',
-            )}
-            placeholder="영문+숫자+특수문자 8자 이상"
-          />
+          <label htmlFor="password" className="text-sm font-medium">{localMessage('auth.password')}</label>
+          <input id="password" type="password" autoComplete="new-password" required value={password} onChange={(e) => setPassword(e.target.value)} className={cn('w-full rounded-md border bg-background px-3 py-2 text-sm', 'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', errors.password ? 'border-destructive' : 'border-input')} placeholder={localMessage('auth.passwordHint')} />
           {errors.password && <p className="text-xs text-destructive">{errors.password}</p>}
         </div>
 
         <div className="space-y-1">
-          <label htmlFor="passwordConfirm" className="text-sm font-medium">
-            비밀번호 확인
-          </label>
-          <input
-            id="passwordConfirm"
-            type="password"
-            autoComplete="new-password"
-            required
-            value={passwordConfirm}
-            onChange={(e) => setPasswordConfirm(e.target.value)}
-            className={cn(
-              'w-full rounded-md border bg-background px-3 py-2 text-sm',
-              'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              errors.passwordConfirm ? 'border-destructive' : 'border-input',
-            )}
-            placeholder="비밀번호 재입력"
-          />
-          {errors.passwordConfirm && (
-            <p className="text-xs text-destructive">{errors.passwordConfirm}</p>
-          )}
+          <label htmlFor="passwordConfirm" className="text-sm font-medium">{localMessage('auth.passwordConfirm')}</label>
+          <input id="passwordConfirm" type="password" autoComplete="new-password" required value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} className={cn('w-full rounded-md border bg-background px-3 py-2 text-sm', 'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', errors.passwordConfirm ? 'border-destructive' : 'border-input')} placeholder={localMessage('auth.passwordConfirmPlaceholder')} />
+          {errors.passwordConfirm && <p className="text-xs text-destructive">{errors.passwordConfirm}</p>}
         </div>
 
         <Button type="submit" className="w-full" disabled={isSubmitting}>
-          {isSubmitting ? '가입 중...' : '회원가입'}
+          {isSubmitting ? localMessage('auth.registerSubmitting') : localMessage('auth.registerSubmit')}
         </Button>
       </form>
 
       <p className="mt-6 text-center text-sm text-muted-foreground">
-        이미 계정이 있으신가요?{' '}
-        <Link href="/login" className="font-medium text-primary hover:underline">
-          로그인
-        </Link>
+        {localMessage('auth.hasAccount')}{' '}
+        <Link href="/login" className="font-medium text-primary hover:underline">{localMessage('auth.loginSubmit')}</Link>
       </p>
     </div>
   );

--- a/src/components/shared/blocks/BlockErrorBoundary.tsx
+++ b/src/components/shared/blocks/BlockErrorBoundary.tsx
@@ -2,6 +2,7 @@
 
 import { Component } from 'react';
 import type { ReactNode, ErrorInfo } from 'react';
+import { localMessage } from '@/utils/localMessages';
 
 interface Props {
   children: ReactNode;
@@ -34,7 +35,7 @@ export default class BlockErrorBoundary extends Component<Props, State> {
           className="rounded-lg border border-red-200 bg-red-50 p-4 text-center text-sm text-red-600"
           role="alert"
         >
-          블록을 표시할 수 없습니다 ({this.props.blockType})
+          {localMessage('ui.blockError', { type: this.props.blockType })}
         </div>
       );
     }

--- a/src/components/shared/blocks/NewsletterSignupBlock.tsx
+++ b/src/components/shared/blocks/NewsletterSignupBlock.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 import type { NewsletterSignupContent } from '@/lib/api';
 import { cn } from '@/components/ui/utils';
+import { localMessage } from '@/utils/localMessages';
 
 interface Props {
   content: NewsletterSignupContent;
@@ -13,8 +14,8 @@ export default function NewsletterSignupBlock({ content }: Props) {
   const {
     title,
     description,
-    placeholder = '이메일을 입력하세요',
-    button_text = '가입하기',
+    placeholder = localMessage('newsletter.emailPlaceholder'),
+    button_text = localMessage('newsletter.button'),
     template = 'default',
     background_image,
   } = content;
@@ -47,8 +48,8 @@ export default function NewsletterSignupBlock({ content }: Props) {
           </div>
         )}
         <div className="relative z-10 max-w-xl mx-auto px-6">
-          <p className="text-lg font-medium text-foreground">감사합니다.</p>
-          <p className="mt-2 text-muted-foreground">소식を受け取る準備ができました。</p>
+          <p className="text-lg font-medium text-foreground">{localMessage('newsletter.thanks')}</p>
+          <p className="mt-2 text-muted-foreground">{localMessage('newsletter.ready')}</p>
         </div>
       </section>
     );
@@ -112,7 +113,7 @@ export default function NewsletterSignupBlock({ content }: Props) {
           </div>
         </form>
         {status === 'error' && (
-          <p className="mt-4 text-sm text-destructive">오류가 발생했습니다. 다시 시도해주세요.</p>
+          <p className="mt-4 text-sm text-destructive">{localMessage('newsletter.error')}</p>
         )}
       </div>
     </section>

--- a/src/components/shared/blocks/UnknownBlock.tsx
+++ b/src/components/shared/blocks/UnknownBlock.tsx
@@ -1,3 +1,5 @@
+import { localMessage } from '@/utils/localMessages';
+
 interface Props {
   type: string;
 }
@@ -7,9 +9,11 @@ export default function UnknownBlock({ type }: Props) {
     return <div data-block-type={type} />;
   }
 
+  const [prefix] = localMessage('ui.unknownBlock', { type }).split(type);
+
   return (
     <div className="rounded-lg border border-dashed border-yellow-400 bg-yellow-50 p-4 text-center text-sm text-yellow-700">
-      알 수 없는 블록 타입: <code>{type}</code>
+      {prefix}<code>{type}</code>
     </div>
   );
 }

--- a/src/components/shared/cart/CartItemRow.tsx
+++ b/src/components/shared/cart/CartItemRow.tsx
@@ -7,6 +7,8 @@ import { CartItem } from '@/lib/api';
 import { cn } from '@/components/ui/utils';
 import { formatCurrency } from '@/utils/currency';
 import QuantitySelector from '@/components/shared/products/QuantitySelector';
+import { getClientLocale } from '@/utils/clientLocale';
+import { localMessage } from '@/utils/localMessages';
 
 interface CartItemRowProps {
   item: CartItem;
@@ -23,6 +25,7 @@ const CartItemRowComponent = memo(function CartItemRow({
   onQuantityChange,
   onRemove,
 }: CartItemRowProps) {
+  const locale = getClientLocale();
   const thumbnail =
     item.product.images.find((img) => img.isThumbnail) ?? item.product.images[0];
 
@@ -32,7 +35,7 @@ const CartItemRowComponent = memo(function CartItemRow({
         type="checkbox"
         checked={selected}
         onChange={(e) => onSelect(item.id, e.target.checked)}
-        aria-label={`${item.product.name} 선택`}
+        aria-label={localMessage('cart.selectItemAria', { product: item.product.name })}
         className="mt-1 h-4 w-4 rounded border-input accent-foreground"
       />
 
@@ -58,7 +61,7 @@ const CartItemRowComponent = memo(function CartItemRow({
             {item.option.name}: {item.option.value}
           </p>
         )}
-        <p className="typo-price text-foreground">{formatCurrency(item.unitPrice)}</p>
+        <p className="typo-price text-foreground">{formatCurrency(item.unitPrice, locale)}</p>
 
         <div className="mt-2 flex flex-wrap items-center gap-2 md:hidden">
           <QuantitySelector
@@ -68,12 +71,12 @@ const CartItemRowComponent = memo(function CartItemRow({
             onDecrease={() => onQuantityChange(item.id, item.quantity - 1)}
           />
 
-          <p className="typo-price text-foreground">{formatCurrency(item.subtotal)}</p>
+          <p className="typo-price text-foreground">{formatCurrency(item.subtotal, locale)}</p>
 
           <button
             type="button"
             onClick={() => onRemove(item.id)}
-            aria-label={`${item.product.name} 삭제`}
+            aria-label={localMessage('cart.removeItemAria', { product: item.product.name })}
             className="ml-auto text-muted-foreground transition-colors hover:text-destructive"
           >
             <Trash2 className="h-4 w-4" />
@@ -89,12 +92,12 @@ const CartItemRowComponent = memo(function CartItemRow({
           onDecrease={() => onQuantityChange(item.id, item.quantity - 1)}
         />
 
-        <p className="typo-price mt-0.5 text-foreground">{formatCurrency(item.subtotal)}</p>
+        <p className="typo-price mt-0.5 text-foreground">{formatCurrency(item.subtotal, locale)}</p>
 
         <button
           type="button"
           onClick={() => onRemove(item.id)}
-          aria-label={`${item.product.name} 삭제`}
+          aria-label={localMessage('cart.removeItemAria', { product: item.product.name })}
           className="text-muted-foreground transition-colors hover:text-destructive"
         >
           <Trash2 className="h-4 w-4" />

--- a/src/components/shared/checkout/AddressSelectorSection.tsx
+++ b/src/components/shared/checkout/AddressSelectorSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { UserAddress } from '@/lib/api';
+import { localMessage } from '@/utils/localMessages';
 
 interface AddressSelectorSectionProps {
   addresses: UserAddress[];
@@ -18,19 +19,19 @@ export function AddressSelectorSection({
   locale,
 }: AddressSelectorSectionProps) {
   if (addressLoading) {
-    return <p className="text-sm text-muted-foreground">주소 불러오는 중...</p>;
+    return <p className="text-sm text-muted-foreground">{localMessage('checkout.loadingAddresses')}</p>;
   }
 
   if (addresses.length === 0) {
     return (
       <div className="flex items-center justify-between rounded-md border border-dashed p-4">
-        <p className="text-sm text-muted-foreground">저장된 배송지가 없습니다.</p>
+        <p className="text-sm text-muted-foreground">{localMessage('checkout.noSavedAddress')}</p>
         <button
           type="button"
           onClick={() => { window.location.href = `/${locale}/my/address`; }}
           className="text-sm font-medium underline underline-offset-2 hover:opacity-70 transition-opacity"
         >
-          배송지 추가
+          {localMessage('checkout.addAddress')}
         </button>
       </div>
     );
@@ -48,7 +49,7 @@ export function AddressSelectorSection({
             className="mt-1 accent-foreground"
           />
           <span className="text-sm">
-            <span className="font-medium">{addr.label ?? '주소'}</span>{' '}
+            <span className="font-medium">{addr.label ?? localMessage('checkout.defaultAddressLabel')}</span>{' '}
             {addr.recipientName} {addr.phone}{' '}
             <span className="text-muted-foreground">
               {addr.address} {addr.addressDetail ?? ''}
@@ -64,7 +65,7 @@ export function AddressSelectorSection({
           onChange={() => onSelect('manual')}
           className="accent-foreground"
         />
-        <span className="text-sm">직접 입력</span>
+        <span className="text-sm">{localMessage('checkout.manualEntry')}</span>
       </label>
     </div>
   );

--- a/src/components/shared/checkout/CouponSelector.tsx
+++ b/src/components/shared/checkout/CouponSelector.tsx
@@ -9,6 +9,8 @@ import { cn } from '@/components/ui/utils';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
 import { toastMessage } from '@/utils/toastMessages';
+import { getClientLocale } from '@/utils/clientLocale';
+import { localMessage } from '@/utils/localMessages';
 
 interface CouponSelectorProps {
   orderAmount: number;
@@ -16,6 +18,7 @@ interface CouponSelectorProps {
 }
 
 export default function CouponSelector({ orderAmount, onDiscountChange }: CouponSelectorProps) {
+  const locale = getClientLocale();
   const [coupons, setCoupons] = useState<CouponItem[]>([]);
   const [selectedId, setSelectedId] = useState<number | ''>('');
   const [calculating, setCalculating] = useState(false);
@@ -25,7 +28,7 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
       const res = await couponsApi.getList('available');
       setCoupons(res.coupons);
     },
-    { onError: () => setCoupons([]), errorMessage: '쿠폰 목록을 불러오지 못했습니다.' },
+    { onError: () => setCoupons([]), errorMessage: localMessage('checkout.couponLoadError') },
   );
 
   useEffect(() => {
@@ -58,13 +61,13 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
   const selected = coupons.find((c) => c.id === selectedId);
 
   if (loading) {
-    return <p className="text-sm text-muted-foreground">쿠폰 불러오는 중...</p>;
+    return <p className="text-sm text-muted-foreground">{localMessage('checkout.couponLoading')}</p>;
   }
 
   return (
     <div className="space-y-2">
       <label htmlFor="coupon-select" className="text-sm font-medium">
-        쿠폰 선택
+        {localMessage('checkout.couponSelect')}
       </label>
       <select
         id="coupon-select"
@@ -77,13 +80,13 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
           calculating && 'opacity-50 cursor-not-allowed',
         )}
       >
-        <option value="">쿠폰을 선택하세요</option>
+        <option value="">{localMessage('checkout.couponPlaceholder')}</option>
         {coupons.map((c) => (
           <option key={c.id} value={c.id}>
             {c.name} (
             {c.type === 'percentage'
-              ? `${c.value}% 할인${c.maxDiscount ? ` / 최대 ${formatCurrency(c.maxDiscount)}` : ''}`
-              : `${formatCurrency(c.value)} 할인`}
+              ? `${c.value}% ${localMessage('checkout.discount')}${c.maxDiscount ? ` / ${localMessage('checkout.maxDiscount', { amount: formatCurrency(c.maxDiscount, locale) })}` : ''}`
+              : `${formatCurrency(c.value, locale)} ${localMessage('checkout.discount')}`}
             )
           </option>
         ))}
@@ -91,13 +94,13 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
 
       {selected && (
         <p className="text-xs text-muted-foreground">
-          최소 주문금액: {formatCurrency(selected.minOrderAmount)} &middot; 만료:{' '}
-          {new Date(selected.expiresAt).toLocaleDateString('ko-KR')}
+          {localMessage('checkout.minimumOrderAmount', { amount: formatCurrency(selected.minOrderAmount, locale) })} &middot; {localMessage('checkout.expires')}:{' '}
+          {new Date(selected.expiresAt).toLocaleDateString(locale === 'en' ? 'en-US' : 'ko-KR')}
         </p>
       )}
 
       {coupons.length === 0 && (
-        <p className="text-xs text-muted-foreground">사용 가능한 쿠폰이 없습니다.</p>
+        <p className="text-xs text-muted-foreground">{localMessage('checkout.noCoupons')}</p>
       )}
     </div>
   );

--- a/src/components/shared/checkout/PaymentGateway.tsx
+++ b/src/components/shared/checkout/PaymentGateway.tsx
@@ -117,12 +117,12 @@ const TossPaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>
             method: 'CARD',
             amount: { currency: 'KRW', value: amount },
             orderId: orderNumber,
-            orderName: `주문 ${orderNumber}`,
+            orderName: locale === 'en' ? `Order ${orderNumber}` : `주문 ${orderNumber}`,
             successUrl: `${origin}/${locale}/checkout/success`,
             failUrl: `${origin}/${locale}/checkout/fail`,
           });
         } catch (err) {
-          onError(handleApiError(err, '결제 초기화 오류'));
+          onError(handleApiError(err, locale === 'en' ? 'Failed to initialize payment.' : '결제 초기화 오류'));
         }
       };
 
@@ -151,7 +151,7 @@ const TossPaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>
           readOnly
           className="accent-foreground"
         />
-        <span className="text-sm">토스페이먼츠 (카드)</span>
+        <span className="text-sm">{locale === 'en' ? 'Toss Payments (Card)' : '토스페이먼츠 (카드)'}</span>
       </label>
     );
   },
@@ -177,7 +177,7 @@ const StripePaymentGateway = forwardRef<
 
   useEffect(() => {
     if (!clientSecret || !publishableKey) {
-      setMountError('Stripe 설정이 올바르지 않습니다.');
+      setMountError(locale === 'en' ? 'Stripe is not configured correctly.' : 'Stripe 설정이 올바르지 않습니다.');
       setLoading(false);
       return;
     }
@@ -207,7 +207,7 @@ const StripePaymentGateway = forwardRef<
       });
       paymentElement.on('loaderror', () => {
         if (mounted) {
-          setMountError('결제 수단을 불러오는데 실패했습니다.');
+          setMountError(locale === 'en' ? 'Failed to load payment methods.' : '결제 수단을 불러오는데 실패했습니다.');
           setLoading(false);
         }
       });
@@ -220,7 +220,7 @@ const StripePaymentGateway = forwardRef<
           },
         });
         if (error) {
-          throw new Error(error.message ?? '결제에 실패했습니다.');
+          throw new Error(error.message ?? (locale === 'en' ? 'Payment failed.' : '결제에 실패했습니다.'));
         }
       };
     });
@@ -254,7 +254,7 @@ const StripePaymentGateway = forwardRef<
         <span className="text-sm">Stripe (International Card)</span>
       </label>
       {loading && !mountError && (
-        <p className="text-xs text-muted-foreground">결제 수단 불러오는 중...</p>
+        <p className="text-xs text-muted-foreground">{locale === 'en' ? 'Loading payment methods...' : '결제 수단 불러오는 중...'}</p>
       )}
       {mountError && <p className="text-xs text-destructive">{mountError}</p>}
       <div ref={containerRef} className={loading ? 'sr-only' : undefined} />
@@ -264,8 +264,8 @@ const StripePaymentGateway = forwardRef<
 
 // ─── Mock / fallback ──────────────────────────────────────────────────────────
 
-const MockPaymentGateway = forwardRef<PaymentGatewayHandle>(
-  function MockPaymentGateway(_props, ref) {
+const MockPaymentGateway = forwardRef<PaymentGatewayHandle, { locale: Locale }>(
+  function MockPaymentGateway({ locale }, ref) {
     useImperativeHandle(ref, () => ({
       confirm: async () => {
         // Mock gateway: no-op — caller handles mock payment directly
@@ -282,7 +282,7 @@ const MockPaymentGateway = forwardRef<PaymentGatewayHandle>(
           readOnly
           className="accent-foreground"
         />
-        <span className="text-sm">테스트 결제 (Mock)</span>
+        <span className="text-sm">{locale === 'en' ? 'Test Payment (Mock)' : '테스트 결제 (Mock)'}</span>
       </label>
     );
   },
@@ -420,7 +420,7 @@ const PaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>(
       );
     }
 
-    return <MockPaymentGateway ref={ref} />;
+    return <MockPaymentGateway ref={ref} locale={locale} />;
   },
 );
 

--- a/src/components/shared/checkout/PointInput.tsx
+++ b/src/components/shared/checkout/PointInput.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { couponsApi } from '@/lib/api';
-import { formatCurrency } from '@/utils/currency';
+import { formatCurrency, type Locale } from '@/utils/currency';
 import { cn } from '@/components/ui/utils';
 
 interface PointInputProps {
@@ -11,6 +12,8 @@ interface PointInputProps {
 }
 
 export default function PointInput({ onPointsChange }: PointInputProps) {
+  const t = useTranslations('points');
+  const locale = useLocale() as Locale;
   const [balance, setBalance] = useState(0);
   const [value, setValue] = useState('');
 
@@ -19,7 +22,7 @@ export default function PointInput({ onPointsChange }: PointInputProps) {
       const res = await couponsApi.getPoints();
       setBalance(res.balance);
     },
-    { onError: () => setBalance(0), errorMessage: '적립금을 불러오지 못했습니다.' },
+    { onError: () => setBalance(0), errorMessage: t('loadError') },
   );
 
   useEffect(() => {
@@ -39,17 +42,17 @@ export default function PointInput({ onPointsChange }: PointInputProps) {
   };
 
   if (loading) {
-    return <p className="text-sm text-muted-foreground">적립금 불러오는 중...</p>;
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
   }
 
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <label htmlFor="point-input" className="text-sm font-medium">
-          적립금 사용
+          {t('label')}
         </label>
         <span className="text-xs text-muted-foreground">
-          보유 적립금: <strong>{formatCurrency(balance)}원</strong>
+          {t('balance', { amount: formatCurrency(balance, locale) })}
         </span>
       </div>
       <div className="flex gap-2">
@@ -59,7 +62,7 @@ export default function PointInput({ onPointsChange }: PointInputProps) {
           inputMode="numeric"
           value={value}
           onChange={handleChange}
-          placeholder="사용할 적립금 입력"
+          placeholder={t('placeholder')}
           disabled={balance === 0}
           className={cn(
             'flex-1 rounded-md border px-3 py-2 text-sm',
@@ -77,11 +80,11 @@ export default function PointInput({ onPointsChange }: PointInputProps) {
             balance === 0 && 'opacity-50 cursor-not-allowed',
           )}
         >
-          전액 사용
+          {t('useAll')}
         </button>
       </div>
       {balance === 0 && (
-        <p className="text-xs text-muted-foreground">사용 가능한 적립금이 없습니다.</p>
+        <p className="text-xs text-muted-foreground">{t('empty')}</p>
       )}
     </div>
   );

--- a/src/components/shared/checkout/ShippingFormSection.tsx
+++ b/src/components/shared/checkout/ShippingFormSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ShippingForm, FormErrors } from '@/app/[locale]/checkout/page';
+import { localMessage } from '@/utils/localMessages';
 
 interface ShippingFormSectionProps {
   form: ShippingForm;
@@ -12,7 +13,7 @@ export function ShippingFormSection({ form, errors, onChange }: ShippingFormSect
   return (
     <div className="space-y-1">
       <label htmlFor="recipientName" className="typo-label">
-        받는 분 이름 <span className="text-destructive">*</span>
+        {localMessage('checkout.recipientName')} <span className="text-destructive">*</span>
       </label>
       <input
         id="recipientName"
@@ -20,7 +21,7 @@ export function ShippingFormSection({ form, errors, onChange }: ShippingFormSect
         type="text"
         value={form.recipientName}
         onChange={onChange}
-        placeholder="홍길동"
+        placeholder={localMessage('checkout.recipientName')}
         className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
       />
       {errors.recipientName && (
@@ -40,7 +41,7 @@ export function PhoneInputSection({ form, errors, onChange }: PhoneInputSectionP
   return (
     <div className="space-y-1">
       <label htmlFor="recipientPhone" className="typo-label">
-        연락처 <span className="text-destructive">*</span>
+        {localMessage('checkout.phone')} <span className="text-destructive">*</span>
       </label>
       <input
         id="recipientPhone"
@@ -68,7 +69,7 @@ export function ZipcodeInputSection({ form, errors, onChange }: ZipcodeInputSect
   return (
     <div className="space-y-1">
       <label htmlFor="zipcode" className="typo-label">
-        우편번호 <span className="text-destructive">*</span>
+        {localMessage('checkout.zipcode')} <span className="text-destructive">*</span>
       </label>
       <input
         id="zipcode"
@@ -97,7 +98,7 @@ export function AddressInputSection({ form, errors, onChange }: AddressInputSect
   return (
     <div className="space-y-1">
       <label htmlFor="address" className="typo-label">
-        주소 <span className="text-destructive">*</span>
+        {localMessage('checkout.address')} <span className="text-destructive">*</span>
       </label>
       <input
         id="address"
@@ -105,7 +106,7 @@ export function AddressInputSection({ form, errors, onChange }: AddressInputSect
         type="text"
         value={form.address}
         onChange={onChange}
-        placeholder="서울특별시 강남구 테헤란로 123"
+        placeholder={localMessage('checkout.addressPlaceholder')}
         className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
       />
       {errors.address && (
@@ -124,7 +125,7 @@ export function AddressDetailInputSection({ form, onChange }: AddressDetailInput
   return (
     <div className="space-y-1">
       <label htmlFor="addressDetail" className="typo-label">
-        상세 주소
+        {localMessage('checkout.addressDetail')}
       </label>
       <input
         id="addressDetail"
@@ -132,7 +133,7 @@ export function AddressDetailInputSection({ form, onChange }: AddressDetailInput
         type="text"
         value={form.addressDetail}
         onChange={onChange}
-        placeholder="동/호수 등"
+        placeholder={localMessage('checkout.addressDetailPlaceholder')}
         className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
       />
     </div>
@@ -148,14 +149,14 @@ export function MemoInputSection({ form, onChange }: MemoInputSectionProps) {
   return (
     <div className="space-y-1">
       <label htmlFor="memo" className="typo-label">
-        배송 메모
+        {localMessage('checkout.shippingMemo')}
       </label>
       <textarea
         id="memo"
         name="memo"
         value={form.memo}
         onChange={onChange}
-        placeholder="배송 시 요청사항을 입력해주세요."
+        placeholder={localMessage('checkout.shippingMemoPlaceholder')}
         rows={3}
         className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20 resize-none"
       />

--- a/src/components/shared/checkout/__tests__/PaymentGateway.test.tsx
+++ b/src/components/shared/checkout/__tests__/PaymentGateway.test.tsx
@@ -127,7 +127,7 @@ describe('PaymentGateway', () => {
         {...baseProps}
       />,
     );
-    expect(screen.getByText('테스트 결제 (Mock)')).toBeInTheDocument();
+    expect(screen.getByText('Test Payment (Mock)')).toBeInTheDocument();
     expect(screen.queryByText('Stripe (International Card)')).not.toBeInTheDocument();
   });
 

--- a/src/components/shared/filters/ClayTypeFilter.tsx
+++ b/src/components/shared/filters/ClayTypeFilter.tsx
@@ -14,6 +14,7 @@ interface ClayTypeFilterProps {
 
 export default function ClayTypeFilter({ collections, selected, onSelect }: ClayTypeFilterProps) {
   const tCommon = useTranslations('common');
+  const tFilters = useTranslations('filters');
 
   return (
     <SegmentedOptionGroup
@@ -26,7 +27,7 @@ export default function ClayTypeFilter({ collections, selected, onSelect }: Clay
       ]}
       value={selected ?? ''}
       onToggle={(value) => onSelect(value === selected ? undefined : value || undefined)}
-      ariaLabel="니료 필터"
+      ariaLabel={tFilters('clayAria')}
       size="xs"
       radius="full"
       tone="primary"

--- a/src/components/shared/filters/PriceRangeFilter.tsx
+++ b/src/components/shared/filters/PriceRangeFilter.tsx
@@ -3,6 +3,9 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
+import { formatCurrency } from '@/utils/currency';
+import { getClientLocale } from '@/utils/clientLocale';
+import { localMessage } from '@/utils/localMessages';
 
 interface PriceRangeFilterProps {
   min?: number;
@@ -10,11 +13,8 @@ interface PriceRangeFilterProps {
   onChange: (min?: number, max?: number) => void;
 }
 
-function formatKRW(value: number): string {
-  return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(value);
-}
-
 export default function PriceRangeFilter({ min, max, onChange }: PriceRangeFilterProps) {
+  const locale = getClientLocale();
   const t = useTranslations('product.filter');
   const tCommon = useTranslations('common');
   const [localMin, setLocalMin] = useState(min !== undefined ? String(min) : '');
@@ -64,10 +64,10 @@ export default function PriceRangeFilter({ min, max, onChange }: PriceRangeFilte
       {(min !== undefined || max !== undefined) && (
         <p className="text-xs text-muted-foreground">
           {min !== undefined && max !== undefined
-            ? `${formatKRW(min)} ~ ${formatKRW(max)}`
+            ? `${formatCurrency(min, locale)} ~ ${formatCurrency(max, locale)}`
             : min !== undefined
-              ? `${formatKRW(min)} 이상`
-              : `${formatKRW(max!)} 이하`}
+              ? localMessage('filters.priceMinOrMore', { amount: formatCurrency(min, locale) })
+              : localMessage('filters.priceMaxOrLess', { amount: formatCurrency(max!, locale) })}
         </p>
       )}
       <button

--- a/src/components/shared/home/CountdownTimer.tsx
+++ b/src/components/shared/home/CountdownTimer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { localMessage } from '@/utils/localMessages';
 
 interface Props {
   endsAt: string;
@@ -29,7 +30,7 @@ export default function CountdownTimer({ endsAt }: Props) {
     return () => clearInterval(id);
   }, [endsAt]);
 
-  if (expired) return <span className="text-red-500 text-sm font-medium">종료됨</span>;
+  if (expired) return <span className="text-red-500 text-sm font-medium">{localMessage('ui.expired')}</span>;
 
   const pad = (n: number) => String(n).padStart(2, '0');
 

--- a/src/components/shared/hooks/useCheckout.ts
+++ b/src/components/shared/hooks/useCheckout.ts
@@ -63,9 +63,9 @@ export function useCheckout(options: UseCheckoutOptions) {
     try {
       await options.paymentRef.current.confirm();
     } catch (err) {
-      handlePaymentError(handleApiError(err, '결제에 실패했습니다.'));
+      handlePaymentError(handleApiError(err, locale === 'en' ? 'Payment failed.' : '결제에 실패했습니다.'));
     }
-  }, [options, handlePaymentError]);
+  }, [options, handlePaymentError, locale]);
 
   const handleTossFlow = useCallback(async (orderId: number, orderNumber: string, result: PreparePaymentResponse): Promise<void> => {
     options.setCurrentOrderId(orderId);
@@ -95,10 +95,10 @@ export function useCheckout(options: UseCheckoutOptions) {
       try {
         await gateway.confirm();
       } catch (err) {
-        handlePaymentError(handleApiError(err, '결제에 실패했습니다.'));
+        handlePaymentError(handleApiError(err, locale === 'en' ? 'Payment failed.' : '결제에 실패했습니다.'));
       }
     }, 100);
-  }, [options, handlePaymentError]);
+  }, [options, handlePaymentError, locale]);
 
   const handleMockFlow = useCallback(async (orderId: number, orderNumber: string): Promise<void> => {
     options.setStep('confirming_payment');
@@ -139,16 +139,16 @@ export function useCheckout(options: UseCheckoutOptions) {
 
     const errors: FormErrors = {};
     if (recipientName.length < 2) {
-      errors.recipientName = '이름은 2자 이상 입력해주세요.';
+      errors.recipientName = locale === 'en' ? 'Please enter at least 2 characters for the name.' : '이름은 2자 이상 입력해주세요.';
     }
     if (!/^\d{3}-\d{3,4}-\d{4}$/.test(recipientPhone)) {
-      errors.recipientPhone = '올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)';
+      errors.recipientPhone = locale === 'en' ? 'Please enter a valid phone number. (e.g. 010-1234-5678)' : '올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)';
     }
     if (!/^\d{5}$/.test(zipcode)) {
-      errors.zipcode = '우편번호는 5자리 숫자로 입력해주세요.';
+      errors.zipcode = locale === 'en' ? 'ZIP code must be 5 digits.' : '우편번호는 5자리 숫자로 입력해주세요.';
     }
     if (address.length === 0) {
-      errors.address = '주소를 입력해주세요.';
+      errors.address = locale === 'en' ? 'Please enter your address.' : '주소를 입력해주세요.';
     }
     if (Object.keys(errors).length > 0) {
       return;

--- a/src/components/shared/journal/JournalListClient.tsx
+++ b/src/components/shared/journal/JournalListClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { TEAPOT_IMAGES } from '@/lib/teapot-images';
 import { journalsApi, type Journal, JournalCategory } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
@@ -21,6 +21,7 @@ function CategoryFilter({
 }) {
   const tCommon = useTranslations('common');
   const tCategory = useTranslations('journalCategories');
+  const tJournal = useTranslations('journalPage');
 
   return (
     <SegmentedOptionGroup
@@ -33,7 +34,7 @@ function CategoryFilter({
       ]}
       value={selected}
       onToggle={(value) => onSelect(value === ALL_CATEGORY ? null : value)}
-      ariaLabel="카테고리 필터"
+      ariaLabel={tJournal('categoryFilter')}
       className="justify-center"
       size="sm"
       radius="full"
@@ -43,7 +44,9 @@ function CategoryFilter({
 }
 
 export default function JournalListClient() {
+  const locale = useLocale();
   const tCategory = useTranslations('journalCategories');
+  const tJournal = useTranslations('journalPage');
   const [journals, setJournals] = useState<Journal[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -53,17 +56,17 @@ export default function JournalListClient() {
     async function loadJournals() {
       try {
         setLoading(true);
-        const data = await journalsApi.getAll();
+        const data = await journalsApi.getAll(undefined, locale);
         setJournals(data);
       } catch (err) {
-        setError(handleApiError(err, '저널 목록을 불러오지 못했습니다.'));
+        setError(handleApiError(err, tJournal('loadError')));
       } finally {
         setLoading(false);
       }
     }
 
     void loadJournals();
-  }, []);
+  }, [locale, tJournal]);
 
   const filtered = selectedCategory
     ? journals.filter((journal) => journal.category === selectedCategory)
@@ -89,7 +92,7 @@ export default function JournalListClient() {
 
       {filtered.length === 0 ? (
         <p className="text-center text-sm text-muted-foreground py-20">
-          해당 카테고리의 글이 아직 없습니다.
+          {tJournal('emptyCategory')}
         </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/src/components/shared/products/ImageGallery.tsx
+++ b/src/components/shared/products/ImageGallery.tsx
@@ -6,6 +6,8 @@ import { cn } from '@/components/ui/utils'
 import { ZoomIn } from 'lucide-react'
 import { useLightboxInteraction } from '@/components/shared/hooks/useLightboxInteraction'
 import { useUrlQueryState } from '@/hooks/useUrlModal'
+import { handleApiError } from '@/utils/error'
+import { localMessage } from '@/utils/localMessages'
 import LightboxOverlay from './LightboxOverlay'
 import ThumbnailStrip from './ThumbnailStrip'
 
@@ -41,8 +43,8 @@ function ImageGalleryError({ error, onRetry }: { error: Error; onRetry?: () => v
   return (
     <div className="aspect-square w-full rounded-lg bg-muted flex flex-col items-center justify-center gap-4 text-muted-foreground">
       <div className="text-center">
-        <p className="text-sm font-medium text-foreground mb-1">이미지를 불러오지 못했습니다</p>
-        <p className="text-xs text-muted-foreground">{error.message || '알 수 없는 오류가 발생했습니다.'}</p>
+        <p className="text-sm font-medium text-foreground mb-1">{localMessage('product.imageLoadError')}</p>
+        <p className="text-xs text-muted-foreground">{handleApiError(error, localMessage('product.unknownImageError'))}</p>
       </div>
       {onRetry && (
         <button
@@ -50,7 +52,7 @@ function ImageGalleryError({ error, onRetry }: { error: Error; onRetry?: () => v
           onClick={onRetry}
           className="text-sm font-medium text-primary hover:text-primary/80 transition-colors"
         >
-          다시 시도
+          {localMessage('product.retry')}
         </button>
       )}
     </div>
@@ -242,7 +244,7 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
         <svg className="w-10 h-10 text-muted-foreground/50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
-        <span className="text-sm text-muted-foreground">등록된 이미지가 없습니다</span>
+        <span className="text-sm text-muted-foreground">{localMessage('product.noImages')}</span>
       </div>
     )
   }
@@ -266,12 +268,12 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
                 onClick={() => setLightboxParam(String(index), 'push')}
                 role="button"
                 tabIndex={index === selectedIndex ? 0 : -1}
-                aria-label={`이미지 ${index + 1} 확대해서 보기`}
+                aria-label={localMessage('product.zoomImage', { index: index + 1 })}
                 onKeyDown={(e) => e.key === 'Enter' && setLightboxParam(String(index), 'push')}
               >
                 <Image
                   src={image.url}
-                  alt={image.alt ?? `상품 이미지 ${index + 1}`}
+                  alt={image.alt ?? localMessage('product.productImage', { index: index + 1 })}
                   fill
                   sizes="(max-width: 768px) 100vw, 50vw"
                   className={cn(
@@ -301,7 +303,7 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
             <div className="absolute inset-0 flex items-end justify-end p-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
               <span className="flex items-center gap-1 rounded-full bg-black/50 px-2 py-1 text-xs text-white backdrop-blur-sm">
                 <ZoomIn className="size-3" />
-                확대
+                {localMessage('product.zoom')}
               </span>
             </div>
           )}
@@ -313,7 +315,7 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
                 onClick={(e) => { e.stopPropagation(); goPrev() }}
                 className="absolute left-0 top-0 h-full w-16 flex items-center justify-center z-10 opacity-0 hover:opacity-100 transition-opacity"
                 style={{ background: 'transparent' }}
-                aria-label="이전 이미지"
+                aria-label={localMessage('product.prevProduct')}
               >
                 <span className="flex items-center justify-center w-10 h-20 rounded-md bg-black/40 text-white text-2xl font-bold shadow hover:bg-black/60 transition-colors">
                   ‹
@@ -324,7 +326,7 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
                 onClick={(e) => { e.stopPropagation(); goNext() }}
                 className="absolute right-0 top-0 h-full w-16 flex items-center justify-center z-10 opacity-0 hover:opacity-100 transition-opacity"
                 style={{ background: 'transparent' }}
-                aria-label="다음 이미지"
+                aria-label={localMessage('product.nextProduct')}
               >
                 <span className="flex items-center justify-center w-10 h-20 rounded-md bg-black/40 text-white text-2xl font-bold shadow hover:bg-black/60 transition-colors">
                   ›

--- a/src/components/shared/products/LightboxOverlay.tsx
+++ b/src/components/shared/products/LightboxOverlay.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image'
 import { ZoomIn, ZoomOut, X, ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@/components/ui/utils'
+import { localMessage } from '@/utils/localMessages'
 
 interface LightboxOverlayProps {
   images: Array<{
@@ -67,7 +68,7 @@ export default function LightboxOverlay({
         type="button"
         onClick={onClose}
         className="absolute right-4 top-4 rounded-full bg-white/10 hover:bg-white/20 p-3 text-white transition-colors z-50"
-        aria-label="닫기"
+        aria-label={localMessage('product.close')}
       >
         <X className="size-6" />
       </button>
@@ -86,7 +87,7 @@ export default function LightboxOverlay({
           'absolute right-16 top-4 rounded-full p-3 text-white transition-colors z-50',
           lightboxZoomed ? 'bg-white/30 hover:bg-white/40' : 'bg-white/10 hover:bg-white/20',
         )}
-        aria-label={lightboxZoomed ? '축소' : '확대'}
+        aria-label={lightboxZoomed ? localMessage('product.zoomOut') : localMessage('product.zoomIn')}
       >
         {lightboxZoomed ? <ZoomOut className="size-6" /> : <ZoomIn className="size-6" />}
       </button>
@@ -114,7 +115,7 @@ export default function LightboxOverlay({
         >
           <Image
             src={selectedImage.url}
-            alt={selectedImage.alt ?? '상품 이미지'}
+            alt={selectedImage.alt ?? localMessage('product.defaultImage')}
             width={900}
             height={900}
             className="object-contain w-full h-full"
@@ -133,7 +134,7 @@ export default function LightboxOverlay({
               onPrev()
             }}
             className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 hover:bg-white/20 p-4 text-white transition-colors z-50 opacity-60 hover:opacity-100"
-            aria-label="이전 이미지"
+            aria-label={localMessage('product.prevImage')}
           >
             <ChevronLeft className="size-8" />
           </button>
@@ -144,7 +145,7 @@ export default function LightboxOverlay({
               onNext()
             }}
             className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 hover:bg-white/20 p-4 text-white transition-colors z-50 opacity-60 hover:opacity-100"
-            aria-label="다음 이미지"
+            aria-label={localMessage('product.nextImage')}
           >
             <ChevronRight className="size-8" />
           </button>
@@ -169,7 +170,7 @@ export default function LightboxOverlay({
                 'size-2 rounded-full transition-all',
                 i === selectedIndex ? 'bg-white scale-125' : 'bg-white/40',
               )}
-              aria-label={`이미지 ${i + 1}`}
+              aria-label={localMessage('product.imageDot', { index: i + 1 })}
             />
           ))}
         </div>

--- a/src/components/shared/products/OptionSelector.tsx
+++ b/src/components/shared/products/OptionSelector.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl'
 import { cn } from '@/components/ui/utils'
 import type { ProductOption } from '@/lib/api'
 import { formatCurrency } from '@/utils/currency'
+import { getClientLocale } from '@/utils/clientLocale'
 
 interface OptionSelectorProps {
   options: ProductOption[]
@@ -13,6 +14,7 @@ interface OptionSelectorProps {
 
 export default function OptionSelector({ options, selectedOptionId, onSelect }: OptionSelectorProps) {
   const t = useTranslations('product.stockStatus')
+  const locale = getClientLocale()
   const groups = options.reduce<Record<string, ProductOption[]>>((acc, option) => {
     if (!acc[option.name]) {
       acc[option.name] = []
@@ -52,7 +54,7 @@ export default function OptionSelector({ options, selectedOptionId, onSelect }: 
                   {option.priceAdjustment !== 0 && (
                     <span className="text-xs">
                       ({option.priceAdjustment > 0 ? '+' : ''}
-                      {formatCurrency(option.priceAdjustment)})
+                      {formatCurrency(option.priceAdjustment, locale)})
                     </span>
                   )}
                   <span className={cn('text-xs', isSelected ? 'text-background/80' : 'text-muted-foreground', isSoldout && 'text-destructive')}>

--- a/src/components/shared/products/ProductErrorState.tsx
+++ b/src/components/shared/products/ProductErrorState.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import EmptyState from '@/components/shared/EmptyState';
 
 export default function ProductErrorState() {
   const router = useRouter();
+  const t = useTranslations('product');
   return (
     <EmptyState
-      title="상품을 불러올 수 없습니다"
-      description="잠시 후 다시 시도해주세요."
-      action={{ label: '다시 시도', onClick: () => router.refresh() }}
+      title={t('loadErrorTitle')}
+      description={t('loadErrorDescription')}
+      action={{ label: t('retry'), onClick: () => router.refresh() }}
     />
   );
 }

--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -12,6 +12,7 @@ import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction'
 import { useAuth } from '@/contexts/AuthContext'
 import { cn } from '@/components/ui/utils'
 import ReviewsTab from '@/components/shared/reviews/ReviewsTab'
+import { localMessage } from '@/utils/localMessages'
 
 interface ProductTabsProps {
   description: string | null
@@ -24,26 +25,6 @@ interface ProductTabsProps {
 const TABS = ['details', 'reviews', 'inquiry'] as const
 type Tab = (typeof TABS)[number]
 const INQUIRY_TYPE_PRODUCT = '상품'
-
-const NOTICE_INFO_LABELS: Record<keyof Omit<ProductNoticeInfo, 'type'>, string> = {
-  productName: '품명 및 모델명',
-  material: '재질',
-  components: '구성품',
-  sizeCapacity: '크기/용량',
-  manufacturer: '제조자/수입자',
-  countryOfOrigin: '제조국',
-  handlingPrecautions: '취급 시 주의사항',
-  warrantyPolicy: '품질보증기준',
-  asContact: 'A/S 책임자와 전화번호',
-  foodType: '식품 유형',
-  producer: '생산자/수입자',
-  origin: '원산지',
-  manufactureDate: '제조연월일',
-  expirationDate: '소비기한',
-  storageMethod: '보관방법',
-  ingredients: '원재료명',
-  customerServicePhone: '소비자상담 전화번호',
-}
 
 const TEA_NOTICE_FIELDS: Array<keyof Omit<ProductNoticeInfo, 'type'>> = [
   'foodType',
@@ -73,7 +54,7 @@ function ProductNoticeInfoGuide({ noticeInfo }: { noticeInfo?: ProductNoticeInfo
 
   const keys = noticeInfo.type === 'tea' ? TEA_NOTICE_FIELDS : TEAWARE_NOTICE_FIELDS
   const rows = keys
-    .map((key) => ({ key, label: NOTICE_INFO_LABELS[key], value: noticeInfo[key] }))
+    .map((key) => ({ key, label: localMessage(`product.tabs.noticeInfo.labels.${key}`), value: noticeInfo[key] }))
     .filter((row): row is { key: keyof Omit<ProductNoticeInfo, 'type'>; label: string; value: string } => typeof row.value === 'string' && row.value.trim().length > 0)
 
   if (rows.length === 0) return null
@@ -81,8 +62,8 @@ function ProductNoticeInfoGuide({ noticeInfo }: { noticeInfo?: ProductNoticeInfo
   return (
     <section className="rounded-lg border border-border bg-muted/20 p-5" aria-labelledby="product-notice-info-title">
       <div className="mb-4">
-        <p className="typo-label text-muted-foreground">Product information</p>
-        <h2 id="product-notice-info-title" className="typo-h2 text-foreground">상품고시정보</h2>
+        <p className="typo-label text-muted-foreground">{localMessage('product.tabs.noticeInfo.eyebrow')}</p>
+        <h2 id="product-notice-info-title" className="typo-h2 text-foreground">{localMessage('product.tabs.noticeInfo.title')}</h2>
       </div>
       <dl className="grid gap-3 md:grid-cols-2">
         {rows.map((row) => (

--- a/src/components/shared/products/QuantitySelector.tsx
+++ b/src/components/shared/products/QuantitySelector.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Minus, Plus } from 'lucide-react'
+import { localMessage } from '@/utils/localMessages'
 import { cn } from '@/components/ui/utils'
 
 interface QuantitySelectorProps {
@@ -22,7 +23,7 @@ export default function QuantitySelector({
         type="button"
         onClick={onDecrease}
         disabled={quantity <= 1}
-        aria-label="수량 감소"
+        aria-label={localMessage('product.quantityDecrease')}
         className={cn(
           'flex items-center justify-center h-9 w-9 shrink-0 border-r border-border transition-colors text-muted-foreground hover:bg-muted',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
@@ -40,7 +41,7 @@ export default function QuantitySelector({
         type="button"
         onClick={onIncrease}
         disabled={quantity >= maxQuantity}
-        aria-label="수량 증가"
+        aria-label={localMessage('product.quantityIncrease')}
         className={cn(
           'flex items-center justify-center h-9 w-9 shrink-0 border-l border-border transition-colors text-muted-foreground hover:bg-muted',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',

--- a/src/components/shared/products/ThumbnailStrip.tsx
+++ b/src/components/shared/products/ThumbnailStrip.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { cn } from '@/components/ui/utils'
+import { localMessage } from '@/utils/localMessages'
 
 interface ThumbnailStripProps {
   images: Array<{
@@ -36,11 +37,11 @@ export default function ThumbnailStrip({
                 ? 'ring-2 ring-primary border-transparent'
                 : 'border-transparent hover:border-border',
             )}
-            aria-label={`이미지 ${index + 1} 선택`}
+            aria-label={localMessage('product.selectImage', { index: index + 1 })}
           >
             <Image
               src={image.url}
-              alt={image.alt ?? `상품 이미지 ${index + 1}`}
+              alt={image.alt ?? localMessage('product.productImage', { index: index + 1 })}
               fill
               sizes="64px"
               className="object-cover"

--- a/src/components/shared/reviews/ReviewCard.tsx
+++ b/src/components/shared/reviews/ReviewCard.tsx
@@ -4,15 +4,18 @@ import { useState, memo } from 'react'
 import Image from 'next/image'
 import type { ReviewItem } from '@/lib/api'
 import StarRating from './StarRating'
+import { getClientLocale } from '@/utils/clientLocale'
+import { localMessage } from '@/utils/localMessages'
 
 interface ReviewCardProps {
   review: ReviewItem
 }
 
 const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps) {
+  const locale = getClientLocale()
   const [expandedImage, setExpandedImage] = useState<string | null>(null)
 
-  const formattedDate = new Date(review.createdAt).toLocaleDateString('ko-KR', {
+  const formattedDate = new Date(review.createdAt).toLocaleDateString(locale === 'en' ? 'en-US' : 'ko-KR', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -28,7 +31,7 @@ const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps
           <span className="text-sm font-medium text-foreground">{review.userName}</span>
           {isSmartStoreReview && (
             <span className="rounded-full bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700">
-              네이버 스마트스토어
+              {localMessage('review.smartstore')}
             </span>
           )}
         </div>
@@ -47,11 +50,11 @@ const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps
               type="button"
               className="shrink-0 overflow-hidden rounded-md border border-border"
               onClick={() => setExpandedImage(url)}
-              aria-label={`리뷰 이미지 ${idx + 1}`}
+              aria-label={localMessage('review.imageAria', { index: idx + 1 })}
             >
               <Image
                 src={url}
-                alt={`리뷰 이미지 ${idx + 1}`}
+                alt={localMessage('review.imageAria', { index: idx + 1 })}
                 width={80}
                 height={80}
                 className="object-cover"
@@ -66,11 +69,11 @@ const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
           onClick={() => setExpandedImage(null)}
           role="dialog"
-          aria-label="이미지 확대"
+          aria-label={localMessage('review.expandImage')}
         >
           <Image
             src={expandedImage}
-            alt="확대 이미지"
+            alt={localMessage('review.expandedImageAlt')}
             width={1200}
             height={900}
             className="max-h-[80svh] max-w-[90svw] rounded-lg object-contain"

--- a/src/components/shared/reviews/ReviewForm.tsx
+++ b/src/components/shared/reviews/ReviewForm.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { reviewsApi } from '@/lib/api'
 import StarRating from './StarRating'
 import { toastMessage } from '@/utils/toastMessages';
+import { localMessage } from '@/utils/localMessages';
 
 interface ReviewFormProps {
   productId: number
@@ -87,11 +88,11 @@ export default function ReviewForm({
 
   return (
     <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4 rounded-lg border border-border p-4">
-      <h3 className="text-sm font-medium text-foreground">리뷰 작성</h3>
+      <h3 className="text-sm font-medium text-foreground">{localMessage('review.title')}</h3>
 
       {/* Star rating */}
       <div className="flex items-center gap-2">
-        <span className="text-sm text-muted-foreground">별점</span>
+        <span className="text-sm text-muted-foreground">{localMessage('review.rating')}</span>
         <StarRating rating={rating} size="lg" interactive onChange={setRating} />
       </div>
 
@@ -99,7 +100,7 @@ export default function ReviewForm({
       <textarea
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        placeholder="상품에 대한 리뷰를 작성해 주세요."
+        placeholder={localMessage('review.contentPlaceholder')}
         className="w-full min-h-24 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
       />
 
@@ -113,7 +114,7 @@ export default function ReviewForm({
             disabled={isUploading || imageUrls.length >= 5}
             onClick={() => fileInputRef.current?.click()}
           >
-            {isUploading ? '업로드 중...' : '사진 첨부'}
+            {isUploading ? localMessage('review.uploading') : localMessage('review.attachPhoto')}
           </Button>
           <span className="text-xs text-muted-foreground">{imageUrls.length}/5</span>
         </div>
@@ -129,12 +130,12 @@ export default function ReviewForm({
           <div className="mt-2 flex gap-2 flex-wrap">
             {imageUrls.map((url, idx) => (
               <div key={url} className="relative">
-                <Image src={url} alt={`첨부 이미지 ${idx + 1}`} width={64} height={64} className="rounded object-cover" />
+                <Image src={url} alt={localMessage('review.attachedImage', { index: idx + 1 })} width={64} height={64} className="rounded object-cover" />
                 <button
                   type="button"
                   onClick={() => removeImage(idx)}
                   className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-xs text-destructive-foreground"
-                  aria-label="이미지 삭제"
+                  aria-label={localMessage('review.deleteImage')}
                 >
                   x
                 </button>
@@ -147,10 +148,10 @@ export default function ReviewForm({
       {/* Actions */}
       <div className="flex gap-2">
         <Button type="submit" disabled={isSubmitting || rating === 0} size="sm">
-          {isSubmitting ? '등록 중...' : '리뷰 등록'}
+          {isSubmitting ? localMessage('review.submitting') : localMessage('review.submit')}
         </Button>
         <Button type="button" variant="outline" size="sm" onClick={onCancel}>
-          취소
+          {localMessage('review.cancel')}
         </Button>
       </div>
     </form>

--- a/src/components/shared/reviews/ReviewList.tsx
+++ b/src/components/shared/reviews/ReviewList.tsx
@@ -7,15 +7,16 @@ import { cn } from '@/components/ui/utils'
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction'
 import ReviewCard from './ReviewCard'
 import ReviewStatsComponent from './ReviewStats'
+import { localMessage } from '@/utils/localMessages'
 
 interface ReviewListProps {
   productId: number
 }
 
-const SORT_OPTIONS: { value: ReviewSort; label: string }[] = [
-  { value: 'recent', label: '최신순' },
-  { value: 'rating_high', label: '별점 높은순' },
-  { value: 'rating_low', label: '별점 낮은순' },
+const SORT_OPTIONS: { value: ReviewSort; key: 'sortRecent' | 'sortRatingHigh' | 'sortRatingLow' }[] = [
+  { value: 'recent', key: 'sortRecent' },
+  { value: 'rating_high', key: 'sortRatingHigh' },
+  { value: 'rating_low', key: 'sortRatingLow' },
 ]
 
 export default function ReviewList({ productId }: ReviewListProps) {
@@ -37,7 +38,7 @@ export default function ReviewList({ productId }: ReviewListProps) {
       setStats(res.stats)
       setTotal(res.pagination.total)
     },
-    { errorMessage: '리뷰를 불러올 수 없습니다.' },
+    { errorMessage: localMessage('review.submitError') },
   )
 
   useEffect(() => {
@@ -64,7 +65,7 @@ export default function ReviewList({ productId }: ReviewListProps) {
                 : 'bg-muted text-muted-foreground hover:bg-muted/80',
             )}
           >
-            {opt.label}
+            {localMessage(`review.${opt.key}`)}
           </button>
         ))}
       </div>
@@ -78,7 +79,7 @@ export default function ReviewList({ productId }: ReviewListProps) {
         </div>
       ) : reviews.length === 0 ? (
         <p className="py-8 text-center text-sm text-muted-foreground">
-          아직 리뷰가 없습니다.
+          {localMessage('review.noReviews')}
         </p>
       ) : (
         <div>

--- a/src/components/shared/reviews/ReviewStats.tsx
+++ b/src/components/shared/reviews/ReviewStats.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react'
 import { useTranslations } from 'next-intl'
 import type { ReviewStats as ReviewStatsType } from '@/lib/api'
 import StarRating from './StarRating'
+import { localMessage } from '@/utils/localMessages'
 
 interface ReviewStatsProps {
   stats: ReviewStatsType
@@ -27,7 +28,7 @@ const ReviewStatsComponent = memo(function ReviewStats({ stats }: ReviewStatsPro
         </span>
         {externalCount > 0 && (
           <span className="text-[11px] text-muted-foreground">
-            네이버 스마트스토어 {externalCount}개 포함
+            {localMessage('review.smartstoreIncluded', { count: externalCount })}
           </span>
         )}
       </div>

--- a/src/components/shared/search/SearchInput.tsx
+++ b/src/components/shared/search/SearchInput.tsx
@@ -8,6 +8,7 @@ import { useAutocomplete } from '@/components/shared/hooks/useAutocomplete';
 import { useRecentSearches } from '@/components/shared/hooks/useRecentSearches';
 import { useUrlModal } from '@/hooks/useUrlModal';
 import { searchApi } from '@/lib/api';
+import { localMessage } from '@/utils/localMessages';
 
 interface SearchInputProps {
   className?: string;
@@ -91,7 +92,7 @@ export default function SearchInput({ className, placeholder = '' }: SearchInput
           onChange={(e) => setValue(e.target.value)}
           onFocus={() => setIsOpen(true, isOpen ? 'replace' : 'push')}
           placeholder={placeholder}
-          aria-label="상품 검색"
+          aria-label={localMessage('search.productSearch')}
           className={cn(
             'w-full rounded-md border border-input bg-background py-1.5 pl-9 pr-3 text-sm',
             'placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring',
@@ -104,9 +105,9 @@ export default function SearchInput({ className, placeholder = '' }: SearchInput
           {showAutocomplete && (
             <div>
               {isLoading ? (
-                <div className="px-4 py-3 text-sm text-muted-foreground">검색 중...</div>
+                <div className="px-4 py-3 text-sm text-muted-foreground">{localMessage('search.searching')}</div>
               ) : (
-                <ul role="listbox" aria-label="자동완성 결과">
+                <ul role="listbox" aria-label={localMessage('search.autocompleteResults')}>
                   {suggestions.map((item) => (
                     <li key={item.id}>
                       <button
@@ -127,16 +128,16 @@ export default function SearchInput({ className, placeholder = '' }: SearchInput
           {showRecent && (
             <div>
               <div className="flex items-center justify-between px-4 py-2">
-                <span className="text-xs font-medium text-muted-foreground">최근 검색어</span>
+                <span className="text-xs font-medium text-muted-foreground">{localMessage('search.recentSearches')}</span>
                 <button
                   type="button"
                   onClick={clearSearches}
                   className="text-xs text-muted-foreground hover:text-foreground"
                 >
-                  전체 삭제
+                  {localMessage('search.clearAll')}
                 </button>
               </div>
-              <ul role="listbox" aria-label="최근 검색어">
+              <ul role="listbox" aria-label={localMessage('search.recentSearches')}>
                 {recentSearches.map((term) => (
                   <li key={term} className="flex items-center">
                     <button
@@ -150,7 +151,7 @@ export default function SearchInput({ className, placeholder = '' }: SearchInput
                     <button
                       type="button"
                       onClick={() => removeSearch(term)}
-                      aria-label={`${term} 삭제`}
+                      aria-label={localMessage('search.deleteTerm', { term })}
                       className="px-3 py-2 text-muted-foreground hover:text-foreground"
                     >
                       <X className="h-3 w-3" />
@@ -164,9 +165,9 @@ export default function SearchInput({ className, placeholder = '' }: SearchInput
           {showPopular && (
             <div>
               <div className="px-4 py-2">
-                <span className="text-xs font-medium text-muted-foreground">인기 검색어</span>
+                <span className="text-xs font-medium text-muted-foreground">{localMessage('search.popularSearches')}</span>
               </div>
-              <ul role="listbox" aria-label="인기 검색어">
+              <ul role="listbox" aria-label={localMessage('search.popularSearches')}>
                 {popularKeywords.map((keyword, index) => (
                   <li key={keyword}>
                     <button

--- a/src/components/shared/search/SearchPage.tsx
+++ b/src/components/shared/search/SearchPage.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
+import { localMessage } from '@/utils/localMessages';
 import { cn } from '@/components/ui/utils';
 import { Button } from '@/components/ui/button';
 import EmptyState from '@/components/shared/EmptyState';
@@ -11,12 +12,7 @@ import { productsApi, type Product, type ProductSort } from '@/lib/api';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
 
-const SORT_OPTIONS: { value: ProductSort; label: string }[] = [
-  { value: 'latest', label: '최신순' },
-  { value: 'popular', label: '인기순' },
-  { value: 'price_asc', label: '가격낮은순' },
-  { value: 'price_desc', label: '가격높은순' },
-];
+const SORT_OPTIONS: ProductSort[] = ['latest', 'popular', 'price_asc', 'price_desc'];
 
 const LIMIT = 20;
 
@@ -31,6 +27,7 @@ export default function SearchPage() {
     updateQuery,
   } = useCatalogQueryParams();
   const tProduct = useTranslations('product');
+  const tCommon = useTranslations('common');
 
   const activeSort = (sort as ProductSort) ?? 'latest';
 
@@ -54,7 +51,7 @@ export default function SearchPage() {
       setProducts(data.items);
       setTotal(data.total);
     },
-    { errorMessage: '검색 중 오류가 발생했습니다.' },
+    { errorMessage: localMessage('search.loadError') },
   );
 
   useEffect(() => {
@@ -92,34 +89,34 @@ export default function SearchPage() {
       <div className="mb-6 flex flex-wrap items-end gap-4">
         <div className="flex items-center gap-2">
           <label htmlFor="sort-select" className="text-sm text-muted-foreground">
-            정렬
+            {localMessage('search.sort')}
           </label>
           <select
             id="sort-select"
             value={activeSort}
             onChange={handleSortChange}
-            aria-label="정렬 기준"
+            aria-label={localMessage('search.sortAria')}
             className={cn(
               'rounded-md border border-input bg-background px-3 py-1.5 text-sm',
               'focus:outline-none focus:ring-2 focus:ring-ring',
             )}
           >
-            {SORT_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
+            {SORT_OPTIONS.map((value) => (
+              <option key={value} value={value}>
+                {localMessage(`search.sortOptions.${value}`)}
               </option>
             ))}
           </select>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
-          <label className="text-sm text-muted-foreground">가격</label>
+          <label className="text-sm text-muted-foreground">{localMessage('search.price')}</label>
           <input
             type="number"
             value={priceMinInput}
             onChange={(e) => setPriceMinInput(e.target.value)}
-            placeholder="최소"
-            aria-label="최소 가격"
+            placeholder={localMessage('search.min')}
+            aria-label={localMessage('search.minPrice')}
             className={cn(
               'w-24 rounded-md border border-input bg-background px-3 py-1.5 text-sm',
               'placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring',
@@ -130,15 +127,15 @@ export default function SearchPage() {
             type="number"
             value={priceMaxInput}
             onChange={(e) => setPriceMaxInput(e.target.value)}
-            placeholder="최대"
-            aria-label="최대 가격"
+            placeholder={localMessage('search.max')}
+            aria-label={localMessage('search.maxPrice')}
             className={cn(
               'w-24 rounded-md border border-input bg-background px-3 py-1.5 text-sm',
               'placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring',
             )}
           />
           <Button type="button" size="sm" variant="outline" onClick={handlePriceApply}>
-            적용
+            {tCommon('apply')}
           </Button>
         </div>
       </div>
@@ -151,8 +148,8 @@ export default function SearchPage() {
         </div>
       ) : products.length === 0 ? (
         <EmptyState
-          title="검색 결과가 없습니다"
-          description="다른 키워드를 시도해보세요"
+          title={localMessage('search.noResults')}
+          description={localMessage('search.noResultsDescription')}
         />
       ) : (
         <>
@@ -178,7 +175,7 @@ export default function SearchPage() {
           {hasMore && (
             <div className="mt-8 flex justify-center">
               <Button variant="outline" onClick={handleLoadMore}>
-                더 보기
+                {localMessage('search.loadMore')}
               </Button>
             </div>
           )}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { X } from 'lucide-react';
+import { localMessage } from '@/utils/localMessages';
 import { cn } from '@/components/ui/utils';
 
 interface ModalProps {
@@ -67,7 +68,7 @@ export default function Modal({
         <button
           type="button"
           onClick={onClose}
-          aria-label="닫기"
+          aria-label={localMessage('ui.close')}
           className="absolute right-4 top-4 text-muted-foreground hover:text-foreground transition-colors"
         >
           <X className="h-5 w-5" />

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -1,4 +1,5 @@
 import type { CarrierCode } from '@/lib/api';
+import type { Locale } from '@/utils/currency';
 
 export const ORDER_STATUS_LABELS: Record<string, string> = {
   pending: '결제 대기',
@@ -26,6 +27,17 @@ export const CARRIER_NAMES: Record<CarrierCode, string> = {
   hanjin: '한진택배',
   lotte: '롯데택배',
 };
+
+const CARRIER_NAMES_EN: Record<CarrierCode, string> = {
+  mock: 'Test carrier',
+  cj: 'CJ Logistics',
+  hanjin: 'Hanjin Express',
+  lotte: 'Lotte Logistics',
+};
+
+export function getCarrierName(carrier: CarrierCode, locale: Locale | string): string {
+  return locale === 'en' ? CARRIER_NAMES_EN[carrier] : CARRIER_NAMES[carrier];
+}
 
 export const CARRIER_TRACKING_URLS: Partial<Record<CarrierCode, string>> = {
   cj: 'https://trace.cjlogistics.com/next/tracking.html?wblNo=',

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -85,7 +85,9 @@
     "themeToggleToLight": "Switch to light mode",
     "themeToggleToDark": "Switch to dark mode",
     "languageSelector": "Select Language",
-    "languageList": "Language list"
+    "languageList": "Language list",
+    "menuBackTo": "Back to {title} menu",
+    "openSubmenu": "Open {label} submenu"
   },
   "footer": {
     "customerService": "Customer Service",
@@ -112,7 +114,7 @@
       "addressLabel": "Address: {value}",
       "bizNo": "Business Reg. No.: 131-72-05631",
       "bizNoLabel": "Business Reg. No.: {value}",
-      "mailOrderNo": "Mail-Order Reg. No.: 2026-서울강남-01632",
+      "mailOrderNo": "Mail-order business registration: 2026-Seoul Gangnam-01632",
       "mailOrderNoLabel": "Mail-Order Reg. No.: {value}",
       "phone": "Phone: 010-2908-0393",
       "phoneLabel": "Phone: {value}",
@@ -160,7 +162,10 @@
       "passwordNeedsSpecial": "Password must contain at least one special character.",
       "nameTooShort": "Name must be between 1 and 100 characters.",
       "passwordMismatch": "Passwords do not match."
-    }
+    },
+    "showPassword": "Temporarily show password",
+    "hidePassword": "Hide password",
+    "processingOAuth": "Processing {provider} login..."
   },
   "product": {
     "addToCart": "Add to Cart",
@@ -272,6 +277,29 @@
           "label": "Tea and food restrictions",
           "value": "For tea and food products, change-of-mind exchanges or returns may be restricted if opened, used, packaging is damaged, or product value is reduced."
         }
+      },
+      "noticeInfo": {
+        "eyebrow": "Product information",
+        "title": "Required Product Information",
+        "labels": {
+          "productName": "Product / model name",
+          "material": "Material",
+          "components": "Components",
+          "sizeCapacity": "Size / capacity",
+          "manufacturer": "Manufacturer / importer",
+          "countryOfOrigin": "Country of origin",
+          "handlingPrecautions": "Handling precautions",
+          "warrantyPolicy": "Warranty policy",
+          "asContact": "A/S contact",
+          "foodType": "Food type",
+          "producer": "Producer / importer",
+          "origin": "Origin",
+          "manufactureDate": "Manufacture date",
+          "expirationDate": "Best-before / expiration date",
+          "storageMethod": "Storage method",
+          "ingredients": "Ingredients",
+          "customerServicePhone": "Customer service phone"
+        }
       }
     },
     "sort": {
@@ -315,7 +343,26 @@
       "lowStock": "Only {count} left",
       "available": "Available",
       "restockNotice": "Restock notification support is being prepared."
-    }
+    },
+    "quantityDecrease": "Decrease quantity",
+    "quantityIncrease": "Increase quantity",
+    "loadErrorTitle": "Unable to load products",
+    "loadErrorDescription": "Please try again in a moment.",
+    "retry": "Try again",
+    "imageLoadError": "Failed to load image",
+    "unknownImageError": "An unknown error occurred.",
+    "noImages": "No images available",
+    "zoom": "Zoom",
+    "close": "Close",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "productImage": "Product image {index}",
+    "zoomImage": "Open image {index} enlarged",
+    "selectImage": "Select image {index}",
+    "prevImage": "Previous image",
+    "nextImage": "Next image",
+    "imageDot": "Image {index}",
+    "defaultImage": "Product image"
   },
   "cart": {
     "title": "Cart",
@@ -337,7 +384,9 @@
     "continueShopping": "Continue shopping",
     "freeShipping": "Free",
     "freeShippingUnlocked": "Free shipping is now applied.",
-    "freeShippingRemaining": "Add {amount} more for free shipping"
+    "freeShippingRemaining": "Add {amount} more for free shipping",
+    "selectItemAria": "Select {product}",
+    "removeItemAria": "Remove {product}"
   },
   "checkout": {
     "title": "Order / Payment",
@@ -402,7 +451,21 @@
       "requiredDescription": "I have reviewed the product name, price, shipping information, and exchange/refund policy, and agree to proceed with this purchase.\nI agree to personal information collection/use and processing delegation or third-party provision to payment gateways and shipping providers for payment and delivery.",
       "marketingLabel": "[Optional] I agree to receive marketing communications.",
       "marketingDescription": "Receive new product, promotion, and event updates by email or SMS."
-    }
+    },
+    "couponLoadError": "Failed to load coupons.",
+    "couponLoading": "Loading coupons...",
+    "couponSelect": "Select Coupon",
+    "couponPlaceholder": "Choose a coupon",
+    "discount": "off",
+    "maxDiscount": "max {amount}",
+    "minimumOrderAmount": "Minimum order: {amount}",
+    "expires": "Expires",
+    "noCoupons": "No available coupons.",
+    "defaultAddressLabel": "Address",
+    "addressPlaceholder": "123 Main St, Seoul",
+    "stripeSetupError": "Stripe is not configured correctly.",
+    "paymentMethodLoadError": "Failed to load payment methods.",
+    "loadingPaymentMethods": "Loading payment methods..."
   },
   "order": {
     "orderHistory": "Order History",
@@ -534,7 +597,14 @@
     "submitSuccess": "Review submitted successfully.",
     "submitError": "Failed to submit review.",
     "nStar": "{n}-star",
-    "totalCount": "{count} reviews"
+    "totalCount": "{count} reviews",
+    "smartstore": "Naver Smart Store",
+    "smartstoreIncluded": "Includes {count} Naver Smart Store review(s)",
+    "imageAria": "Review image {index}",
+    "expandImage": "Enlarge image",
+    "expandedImageAlt": "Enlarged image",
+    "previous": "Previous",
+    "next": "Next"
   },
   "shipping": {
     "title": "Register Tracking Number",
@@ -671,7 +741,7 @@
       "import": {
         "title": "Import SmartStore Product Excel",
         "description": "Validate a SmartStore Excel file, then create new products and update existing SKU matches.",
-        "supportedFormats": "Supported formats: product-list export XLSX and bulk-edit XLSX (일괄수정 sheet).",
+        "supportedFormats": "Supported formats: product-list export XLSX and bulk-edit XLSX (bulk-edit sheet).",
         "supportedScope": "Initial scope: basic product fields only. Options, detail images, and additional-image expansion remain follow-up work.",
         "fileLabel": "SmartStore product Excel file",
         "previewButton": "Preview upload",
@@ -816,8 +886,28 @@
     "recentSearches": "Recent Searches",
     "clearAll": "Clear All",
     "noResults": "No results found",
-    "noResultsDescription": "No results found for \"{query}\".",
-    "results": "Results for \"{query}\""
+    "noResultsDescription": "Try a different keyword.",
+    "results": "Results for \"{query}\"",
+    "productSearch": "Search products",
+    "searching": "Searching...",
+    "autocompleteResults": "Autocomplete results",
+    "deleteTerm": "Delete {term}",
+    "popularSearches": "Popular Searches",
+    "sort": "Sort",
+    "sortAria": "Sort by",
+    "price": "Price",
+    "min": "Min",
+    "max": "Max",
+    "minPrice": "Minimum price",
+    "maxPrice": "Maximum price",
+    "loadMore": "Load more",
+    "loadError": "An error occurred while searching.",
+    "sortOptions": {
+      "latest": "Newest",
+      "popular": "Most Popular",
+      "price_asc": "Lowest Price",
+      "price_desc": "Highest Price"
+    }
   },
   "wishlist": {
     "add": "Add to Wishlist",
@@ -941,7 +1031,12 @@
   "journalPage": {
     "heroEyebrow": "Journal",
     "heroTitle": "Stories of Tea, Clay, and People",
-    "heroDesc": "The depth of tea culture, how to care for your teapot, artful tea settings, and news from Ockhwadang — for those who love tea."
+    "heroDesc": "The depth of tea culture, how to care for your teapot, artful tea settings, and news from Ockhwadang — for those who love tea.",
+    "readSuffix": "read",
+    "backToList": "← Back to journal list",
+    "emptyCategory": "No posts in this category yet.",
+    "categoryFilter": "Category filter",
+    "loadError": "Failed to load journal entries."
   },
   "nav": {
     "products": "Products",
@@ -1191,5 +1286,65 @@
         "body": "Refund approval: Refund eligibility is confirmed after the returned item is collected and inspected.\nProcessing period: After approval, refunds are processed to the original payment method within 3–7 business days.\nTiming by payment method: Card and easy-payment cancellations may reflect at different times depending on card issuer and PG policies; international payments follow the payment provider schedule."
       }
     }
+  },
+  "points": {
+    "loadError": "Failed to load points.",
+    "loading": "Loading points...",
+    "label": "Use points",
+    "balance": "Available points: {amount}",
+    "placeholder": "Enter points to use",
+    "useAll": "Use all",
+    "empty": "No points are available."
+  },
+  "recentlyViewedWidget": {
+    "more": "View all {count} items",
+    "open": "Recently viewed products",
+    "close": "Close widget"
+  },
+  "artistPage": {
+    "metaTitle": "Artisans | Ockhwadang",
+    "metaDescription": "Meet the Yixing artisans who craft Ockhwadang teapots.",
+    "title": "Artisans",
+    "description": "Yixing masters who craft Ockhwadang teapots",
+    "clayFilter": "Clay filter",
+    "noArtists": "No artisans found for this clay.",
+    "all": "All",
+    "worksCount": "{count} pieces",
+    "backToList": "← Artisan list",
+    "workshop": "{workshop} workshop",
+    "representativeClay": "Signature clay",
+    "specialty": "Specialty",
+    "works": "Works",
+    "workshopLocation": "Workshop location",
+    "storyTitle": "Artisan Story",
+    "galleryTitle": "Signature Works",
+    "workLabel": "Work {index}",
+    "collectionTitle": "Works by {name}",
+    "collectionDescription": "Discover {clay} Yixing teapots crafted by {name}.",
+    "viewWorks": "View this artisan’s works",
+    "notFound": "Artisan not found",
+    "metaTitleDetail": "{name} | Ockhwadang Artisan"
+  },
+  "ui": {
+    "close": "Close",
+    "back": "Go back",
+    "expired": "Ended",
+    "dataLoadError": "Failed to load data",
+    "unknownError": "An unknown error occurred.",
+    "retry": "Try again",
+    "blockError": "Unable to display this block ({type})",
+    "unknownBlock": "Unknown block type: {type}"
+  },
+  "newsletter": {
+    "emailPlaceholder": "Enter your email",
+    "button": "Subscribe",
+    "thanks": "Thank you.",
+    "ready": "You are ready to receive updates.",
+    "error": "An error occurred. Please try again."
+  },
+  "filters": {
+    "clayAria": "Clay filter",
+    "priceMinOrMore": "{amount} or more",
+    "priceMaxOrLess": "{amount} or less"
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -85,7 +85,9 @@
     "themeToggleToLight": "라이트 모드로 전환",
     "themeToggleToDark": "다크 모드로 전환",
     "languageSelector": "언어 선택",
-    "languageList": "언어 목록"
+    "languageList": "언어 목록",
+    "menuBackTo": "{title} 메뉴로 돌아가기",
+    "openSubmenu": "{label} 하위 메뉴 열기"
   },
   "footer": {
     "customerService": "고객센터",
@@ -160,7 +162,10 @@
       "passwordNeedsSpecial": "비밀번호는 특수문자를 포함해야 합니다.",
       "nameTooShort": "이름은 1~100자 사이여야 합니다.",
       "passwordMismatch": "비밀번호가 일치하지 않습니다."
-    }
+    },
+    "showPassword": "비밀번호 잠깐 보기",
+    "hidePassword": "비밀번호 숨기기",
+    "processingOAuth": "{provider} 로그인 처리 중..."
   },
   "product": {
     "addToCart": "장바구니 담기",
@@ -272,6 +277,29 @@
           "label": "차류·식품 제한",
           "value": "차류/식품 상품은 개봉, 사용, 포장 훼손 또는 가치 감소가 발생한 경우 단순 변심 교환/반품이 제한됩니다."
         }
+      },
+      "noticeInfo": {
+        "eyebrow": "상품 정보",
+        "title": "상품고시정보",
+        "labels": {
+          "productName": "품명 및 모델명",
+          "material": "재질",
+          "components": "구성품",
+          "sizeCapacity": "크기/용량",
+          "manufacturer": "제조자/수입자",
+          "countryOfOrigin": "제조국",
+          "handlingPrecautions": "취급 시 주의사항",
+          "warrantyPolicy": "품질보증기준",
+          "asContact": "A/S 책임자와 전화번호",
+          "foodType": "식품 유형",
+          "producer": "생산자/수입자",
+          "origin": "원산지",
+          "manufactureDate": "제조연월일",
+          "expirationDate": "소비기한",
+          "storageMethod": "보관방법",
+          "ingredients": "원재료명",
+          "customerServicePhone": "소비자상담 전화번호"
+        }
       }
     },
     "sort": {
@@ -315,7 +343,26 @@
       "lowStock": "남은 수량 {count}개",
       "available": "구매 가능",
       "restockNotice": "재입고 알림 기능과 연결될 수 있도록 준비 중입니다."
-    }
+    },
+    "quantityDecrease": "수량 감소",
+    "quantityIncrease": "수량 증가",
+    "loadErrorTitle": "상품을 불러올 수 없습니다",
+    "loadErrorDescription": "잠시 후 다시 시도해주세요.",
+    "retry": "다시 시도",
+    "imageLoadError": "이미지를 불러오지 못했습니다",
+    "unknownImageError": "알 수 없는 오류가 발생했습니다.",
+    "noImages": "등록된 이미지가 없습니다",
+    "zoom": "확대",
+    "close": "닫기",
+    "zoomIn": "확대",
+    "zoomOut": "축소",
+    "productImage": "상품 이미지 {index}",
+    "zoomImage": "이미지 {index} 확대해서 보기",
+    "selectImage": "이미지 {index} 선택",
+    "prevImage": "이전 이미지",
+    "nextImage": "다음 이미지",
+    "imageDot": "이미지 {index}",
+    "defaultImage": "상품 이미지"
   },
   "cart": {
     "title": "장바구니",
@@ -337,7 +384,9 @@
     "continueShopping": "쇼핑 계속하기",
     "freeShipping": "무료",
     "freeShippingUnlocked": "무료배송이 적용되었습니다.",
-    "freeShippingRemaining": "{amount} 더 담으면 무료배송"
+    "freeShippingRemaining": "{amount} 더 담으면 무료배송",
+    "selectItemAria": "{product} 선택",
+    "removeItemAria": "{product} 삭제"
   },
   "checkout": {
     "title": "주문 / 결제",
@@ -402,7 +451,21 @@
       "requiredDescription": "주문할 상품의 상품명, 가격, 배송정보, 교환·환불 규정을 확인했으며 구매에 동의합니다.\n결제 및 배송 처리를 위해 개인정보 수집·이용과 PG사/배송사 처리위탁 또는 제3자 제공 안내에 동의합니다.",
       "marketingLabel": "[선택] 마케팅 정보 수신에 동의합니다.",
       "marketingDescription": "신상품, 프로모션, 이벤트 안내를 이메일 또는 문자로 받을 수 있습니다."
-    }
+    },
+    "couponLoadError": "쿠폰 목록을 불러오지 못했습니다.",
+    "couponLoading": "쿠폰 불러오는 중...",
+    "couponSelect": "쿠폰 선택",
+    "couponPlaceholder": "쿠폰을 선택하세요",
+    "discount": "할인",
+    "maxDiscount": "최대 {amount}",
+    "minimumOrderAmount": "최소 주문금액: {amount}",
+    "expires": "만료",
+    "noCoupons": "사용 가능한 쿠폰이 없습니다.",
+    "defaultAddressLabel": "주소",
+    "addressPlaceholder": "서울특별시 강남구 테헤란로 123",
+    "stripeSetupError": "Stripe 설정이 올바르지 않습니다.",
+    "paymentMethodLoadError": "결제 수단을 불러오는데 실패했습니다.",
+    "loadingPaymentMethods": "결제 수단 불러오는 중..."
   },
   "order": {
     "orderHistory": "주문 내역",
@@ -534,7 +597,14 @@
     "submitSuccess": "리뷰가 등록되었습니다.",
     "submitError": "리뷰 작성에 실패했습니다.",
     "nStar": "{n}점",
-    "totalCount": "{count}개 리뷰"
+    "totalCount": "{count}개 리뷰",
+    "smartstore": "네이버 스마트스토어",
+    "smartstoreIncluded": "네이버 스마트스토어 {count}개 포함",
+    "imageAria": "리뷰 이미지 {index}",
+    "expandImage": "이미지 확대",
+    "expandedImageAlt": "확대 이미지",
+    "previous": "이전",
+    "next": "다음"
   },
   "shipping": {
     "title": "운송장 등록",
@@ -816,8 +886,28 @@
     "recentSearches": "최근 검색어",
     "clearAll": "전체 삭제",
     "noResults": "검색 결과가 없습니다",
-    "noResultsDescription": "\"{query}\"에 대한 검색 결과를 찾을 수 없습니다.",
-    "results": "\"{query}\" 검색 결과"
+    "noResultsDescription": "다른 키워드를 시도해보세요",
+    "results": "\"{query}\" 검색 결과",
+    "productSearch": "상품 검색",
+    "searching": "검색 중...",
+    "autocompleteResults": "자동완성 결과",
+    "deleteTerm": "{term} 삭제",
+    "popularSearches": "인기 검색어",
+    "sort": "정렬",
+    "sortAria": "정렬 기준",
+    "price": "가격",
+    "min": "최소",
+    "max": "최대",
+    "minPrice": "최소 가격",
+    "maxPrice": "최대 가격",
+    "loadMore": "더 보기",
+    "loadError": "검색 중 오류가 발생했습니다.",
+    "sortOptions": {
+      "latest": "최신순",
+      "popular": "인기순",
+      "price_asc": "가격낮은순",
+      "price_desc": "가격높은순"
+    }
   },
   "wishlist": {
     "add": "위시리스트에 추가",
@@ -941,7 +1031,12 @@
   "journalPage": {
     "heroEyebrow": "Journal",
     "heroTitle": "차와 흙, 그리고 사람의 이야기",
-    "heroDesc": "다문화의 깊이, 자사호 사용법, 아름다운 찻자리 세팅, 옥화당 소식까지. 차를 사랑하는 이들을 위한 읽을거리를 모았습니다."
+    "heroDesc": "다문화의 깊이, 자사호 사용법, 아름다운 찻자리 세팅, 옥화당 소식까지. 차를 사랑하는 이들을 위한 읽을거리를 모았습니다.",
+    "readSuffix": "읽기",
+    "backToList": "← 저널 목록으로 돌아가기",
+    "emptyCategory": "해당 카테고리의 글이 아직 없습니다.",
+    "categoryFilter": "카테고리 필터",
+    "loadError": "저널 목록을 불러오지 못했습니다."
   },
   "nav": {
     "products": "상품목록",
@@ -1191,5 +1286,65 @@
         "body": "환불 승인 조건: 반품 상품 회수 및 검수 완료 후 환불 가능 여부를 확정합니다.\n처리 기간: 환불 승인 후 영업일 기준 3~7일 이내 결제수단별로 환불 처리를 진행합니다.\n결제수단별 소요기간: 카드/간편결제 취소는 카드사·PG사 정책에 따라 반영 시점이 달라질 수 있으며, 해외 결제는 결제사 승인 일정에 따릅니다."
       }
     }
+  },
+  "points": {
+    "loadError": "적립금을 불러오지 못했습니다.",
+    "loading": "적립금 불러오는 중...",
+    "label": "적립금 사용",
+    "balance": "보유 적립금: {amount}",
+    "placeholder": "사용할 적립금 입력",
+    "useAll": "전액 사용",
+    "empty": "사용 가능한 적립금이 없습니다."
+  },
+  "recentlyViewedWidget": {
+    "more": "전체 {count}개 보기",
+    "open": "최근 본 상품",
+    "close": "위젯 닫기"
+  },
+  "artistPage": {
+    "metaTitle": "장인 | 옥화당",
+    "metaDescription": "옥화당 자사호를 빚는 장인들을 만나보세요.",
+    "title": "장인",
+    "description": "옥화당의 자사호를 빚는 의흥 장인들",
+    "clayFilter": "니료 필터",
+    "noArtists": "해당 니료의 장인이 없습니다.",
+    "all": "전체",
+    "worksCount": "작품 {count}점",
+    "backToList": "← 장인 목록",
+    "workshop": "{workshop} 공방",
+    "representativeClay": "대표 니료",
+    "specialty": "전문 분야",
+    "works": "작품 수",
+    "workshopLocation": "공방 소재지",
+    "storyTitle": "장인 이야기",
+    "galleryTitle": "대표 작품",
+    "workLabel": "작품 {index}",
+    "collectionTitle": "{name}의 작품 컬렉션",
+    "collectionDescription": "{name} 장인이 빚은 {clay} 자사호를 만나보세요.",
+    "viewWorks": "이 장인의 작품 보기",
+    "notFound": "장인을 찾을 수 없습니다",
+    "metaTitleDetail": "{name} | 옥화당 장인"
+  },
+  "ui": {
+    "close": "닫기",
+    "back": "뒤로가기",
+    "expired": "종료됨",
+    "dataLoadError": "데이터를 불러오지 못했습니다",
+    "unknownError": "알 수 없는 오류가 발생했습니다.",
+    "retry": "다시 시도",
+    "blockError": "블록을 표시할 수 없습니다 ({type})",
+    "unknownBlock": "알 수 없는 블록 타입: {type}"
+  },
+  "newsletter": {
+    "emailPlaceholder": "이메일을 입력하세요",
+    "button": "가입하기",
+    "thanks": "감사합니다.",
+    "ready": "소식을 받을 준비가 되었습니다.",
+    "error": "오류가 발생했습니다. 다시 시도해주세요."
+  },
+  "filters": {
+    "clayAria": "니료 필터",
+    "priceMinOrMore": "{amount} 이상",
+    "priceMaxOrLess": "{amount} 이하"
   }
 }

--- a/src/lib/artists.ts
+++ b/src/lib/artists.ts
@@ -2,12 +2,18 @@ export interface Artist {
   slug: string;
   name: string;
   nameKo: string;
+  nameEn: string;
   clay: string;
+  clayEn: string;
   workshop: string;
+  workshopEn: string;
   productCount: number;
   bio: string;
   story: string[];
   specialty: string;
+  bioEn: string;
+  storyEn: string[];
+  specialtyEn: string;
 }
 
 export const ARTISTS: Artist[] = [
@@ -15,8 +21,11 @@ export const ARTISTS: Artist[] = [
     slug: 'master-chen',
     name: '陳師傅',
     nameKo: '진사부',
+    nameEn: 'Master Chen',
     clay: '주니',
+    clayEn: 'Zhuni',
     workshop: '의흥',
+    workshopEn: 'Yixing',
     productCount: 12,
     bio: '40년 경력의 의흥 주니 전문 장인',
     story: [
@@ -25,13 +34,23 @@ export const ARTISTS: Artist[] = [
       '현재 의흥 공방에서 전통 방식만을 고집하며, 한 점 한 점 손으로 빚어냅니다.',
     ],
     specialty: '주니 자사호',
+    bioEn: 'A Yixing Zhuni artisan with 40 years of experience',
+    storyEn: [
+      'Master Chen was born into a Yixing pottery family and began learning clay work beside his father at the age of fifteen.',
+      'He is known for bringing out the warm red character of Zhuni clay, with a style that follows the natural rhythm of the material.',
+      'He continues to make each piece by hand in his Yixing workshop using traditional methods.',
+    ],
+    specialtyEn: 'Zhuni zisha teapots',
   },
   {
     slug: 'master-li',
     name: '李師傅',
     nameKo: '이사부',
+    nameEn: 'Master Li',
     clay: '단니',
+    clayEn: 'Duanni',
     workshop: '의흥',
+    workshopEn: 'Yixing',
     productCount: 8,
     bio: '단니 재료 연구 30년, 의흥 단니의 권위자',
     story: [
@@ -40,13 +59,23 @@ export const ARTISTS: Artist[] = [
       '그의 다관은 뚜껑과 본체의 유격이 머리카락 한 올 수준으로 알려져 있습니다.',
     ],
     specialty: '단니 다관',
+    bioEn: 'A Duanni specialist with 30 years of clay-material research',
+    storyEn: [
+      'Master Li has spent three decades studying the golden tone and mineral character of Duanni clay.',
+      'He oversees everything from clay selection to blending and firing temperature to achieve stable, deep color.',
+      'His teapots are known for precise fit between lid and body.',
+    ],
+    specialtyEn: 'Duanni teapots',
   },
   {
     slug: 'master-wang',
     name: '王師傅',
     nameKo: '왕사부',
+    nameEn: 'Master Wang',
     clay: '자니',
+    clayEn: 'Zini',
     workshop: '의흥',
+    workshopEn: 'Yixing',
     productCount: 15,
     bio: '자니 명장, 전통 형태 복원 프로젝트 주도',
     story: [
@@ -55,13 +84,23 @@ export const ARTISTS: Artist[] = [
       '의흥 박물관과 협력하여 전통 형태 자료집 편찬에도 참여한 학자적 장인입니다.',
     ],
     specialty: '자니 고전형 자사호',
+    bioEn: 'A Zini master leading traditional-form restoration projects',
+    storyEn: [
+      'Master Wang has focused on restoring classical forms from the Ming dynasty for contemporary use.',
+      'He developed a double-firing approach to bring out the deep purple tone of Zini clay.',
+      'He also works with Yixing museum materials, combining scholarship with craftsmanship.',
+    ],
+    specialtyEn: 'Classical Zini zisha teapots',
   },
   {
     slug: 'master-zhao',
     name: '趙師傅',
     nameKo: '조사부',
+    nameEn: 'Master Zhao',
     clay: '흑니',
+    clayEn: 'Heini',
     workshop: '의흥',
+    workshopEn: 'Yixing',
     productCount: 6,
     bio: '흑니 전문 신예 장인, 현대적 감각의 전통 계승',
     story: [
@@ -70,11 +109,31 @@ export const ARTISTS: Artist[] = [
       '스승 왕사부에게 소성 기술을 전수받아 독자적인 광택 처리 기법을 발전시켰습니다.',
     ],
     specialty: '흑니 현대형 자사호',
+    bioEn: 'An emerging Heini artisan with a contemporary sense of tradition',
+    storyEn: [
+      'Master Zhao graduated at the top of his class from a Yixing ceramic school and has dedicated his practice to Heini clay.',
+      'He is gaining attention among younger tea drinkers by blending modern lines with traditional forms.',
+      'After learning firing techniques from Master Wang, he developed his own surface-finishing method.',
+    ],
+    specialtyEn: 'Contemporary Heini zisha teapots',
   },
 ];
 
 export function getArtistBySlug(slug: string): Artist | undefined {
   return ARTISTS.find((a) => a.slug === slug);
+}
+
+export function localizeArtist(artist: Artist, locale: string) {
+  const isEn = locale === 'en';
+  return {
+    ...artist,
+    displayName: isEn ? artist.nameEn : artist.nameKo,
+    displayClay: isEn ? artist.clayEn : artist.clay,
+    displayWorkshop: isEn ? artist.workshopEn : artist.workshop,
+    displayBio: isEn ? artist.bioEn : artist.bio,
+    displayStory: isEn ? artist.storyEn : artist.story,
+    displaySpecialty: isEn ? artist.specialtyEn : artist.specialty,
+  };
 }
 
 export const CLAY_FILTERS = ['전체', '주니', '단니', '자니', '흑니'] as const;

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -11,6 +11,8 @@ export interface JournalEntry {
   content: string[];
 }
 
+export type JournalLocale = 'ko' | 'en';
+
 export const JOURNAL_CATEGORIES: JournalCategory[] = [
   '다문화',
   '사용법',
@@ -118,8 +120,103 @@ export const JOURNAL_ENTRIES: JournalEntry[] = [
   },
 ];
 
+const ENGLISH_JOURNAL_ENTRIES: Record<string, Omit<JournalEntry, 'slug' | 'date'>> = {
+  'yixing-clay-origin': {
+    title: 'The Origins of Yixing Zisha Teapots',
+    subtitle: 'Tracing 600 years of clay history',
+    category: 'Tea Culture' as JournalCategory,
+    readTime: '8 min',
+    summary:
+      'A history of Yixing zisha teapots from the Ming dynasty to today, following the discovery of Huanglong Mountain clay and the craft inherited by modern artisans.',
+    content: [
+      'Yixing is a small city on the western shore of Lake Tai in southern Jiangsu. The zisha clay mined around Huanglong Mountain has a mineral composition found nowhere else.',
+      'Records say that during the Zhengde era of the Ming dynasty, a monk from Jinsha Temple began making teapots from zisha clay. Gong Chun later refined the method and became known as an early master of the craft.',
+      'By the Qing dynasty, masters such as Chen Mingyuan and Hui Mengchen had elevated the teapot from a simple tea tool into an art object. Hui Mengchen’s small teapots became closely tied to Chaozhou gongfu tea culture.',
+      'Today, thousands of ceramic artisans work in Yixing, ranging from nationally recognized masters to emerging makers. Ockhwadang works directly with these artisans and introduces only carefully verified pieces.',
+    ],
+  },
+  'how-to-season-teapot': {
+    title: 'How to Season a New Zisha Teapot',
+    subtitle: 'What to do before the first brew',
+    category: 'How to Use' as JournalCategory,
+    readTime: '5 min',
+    summary:
+      'A step-by-step guide to preparing a new zisha teapot before first use, including key precautions for safe seasoning.',
+    content: [
+      'Seasoning opens the pores of a new zisha teapot and removes the raw clay smell. It helps the teapot develop its natural ability to absorb and enrich tea aroma.',
+      'Step 1: Rinse the inside and outside gently with lukewarm water. Do not use detergent, as chemicals can seep into the clay pores.',
+      'Step 2: Place the teapot in a clean pot, cover it with filtered water, and simmer over low heat for 30 minutes. Start from cool water and warm slowly to avoid thermal shock.',
+      'Step 3: Add the tea leaves you plan to brew in this teapot and simmer for another 20 minutes. The aroma begins to settle into the pores and forms a foundation for future brews.',
+      'Step 4: Turn off the heat and let everything cool naturally at room temperature. After it is fully cool, dry it with a clean cloth and leave it in a well-ventilated place.',
+    ],
+  },
+  'spring-tea-table': {
+    title: 'A Spring Tea Table',
+    subtitle: 'Seasonal tea setting ideas',
+    category: 'Tea Table' as JournalCategory,
+    readTime: '6 min',
+    summary:
+      'Tea table ideas for spring, from green and white tea pairings to teaware, cloth, and floral details.',
+    content: [
+      'The key to a spring tea table is lightness. It is a season for fresh green tea or clear white tea after the weight of winter pu-erh.',
+      'For teaware, duanni or qingshuini zisha teapots bring a bright mood to the table. A porcelain gaiwan is also ideal for appreciating the color of the liquor.',
+      'A linen tea cloth in pale beige or soft green pairs well with the season. A single seasonal flower can complete the visual mood without overwhelming the table.',
+      'For sweets, mung bean jelly or a small honey rice cake works beautifully with spring green tea. One or two restrained pairings are enough.',
+    ],
+  },
+  'puer-storage-guide': {
+    title: 'The Art of Storing Pu-erh',
+    subtitle: 'Temperature, humidity, and airflow',
+    category: 'How to Use' as JournalCategory,
+    readTime: '7 min',
+    summary:
+      'Pu-erh is a living tea. The right storage environment shapes its flavor. Here are practical home storage guidelines.',
+    content: [
+      'Pu-erh continues to change through microbial and enzymatic activity. Temperature, humidity, and ventilation all directly influence that process.',
+      'Keep the temperature around 20–30°C. Avoid direct sunlight, heaters, and hot pipes, and try to maintain a stable year-round environment.',
+      'Relative humidity of 60–75% is generally suitable. If it is too dry, aging slows; if it is too humid, mold can appear. During humid seasons, use dehumidifiers carefully without direct contact with tea.',
+      'Loose ventilation is better than airtight sealing. Traditional storage often uses paper wrapping or a ceramic jar with slight airflow. Keep tea away from strong odors such as perfume, detergent, and coffee.',
+    ],
+  },
+  'okhwadang-first-anniversary': {
+    title: 'Ockhwadang, One Year In',
+    subtitle: 'A note of gratitude',
+    category: 'News' as JournalCategory,
+    readTime: '4 min',
+    summary:
+      'Looking back on Ockhwadang’s first year: relationships with Yixing artisans, support from customers, and where we go next.',
+    content: [
+      'Ockhwadang began as a small online shop in spring 2024. Since then, we have worked directly with four Yixing artisans and introduced each handmade piece with care.',
+      'Many customers have asked where we find these teapots. Our answer is always the same: we go in person, examine in person, and recommend only what we have used and trusted.',
+      'This year we plan to expand our pu-erh selection and begin an artisan interview series. We also hope to host offline tea gatherings where customers can experience the texture of zisha clay and the aroma of tea directly.',
+      'Thank you to everyone who has supported us. Ockhwadang will continue to stand by the principle of good clay, good tea, and good people.',
+    ],
+  },
+  'gongfu-tea-ceremony': {
+    title: 'An Introduction to Gongfu Tea',
+    subtitle: 'A concentrated cup from a small pot',
+    category: 'Tea Culture' as JournalCategory,
+    readTime: '9 min',
+    summary:
+      'A beginner-friendly guide to gongfu tea, the southern Chinese brewing method using a small zisha teapot and multiple short infusions.',
+    content: [
+      'In gongfu tea, “gongfu” means time, skill, and devoted effort. The method developed in Guangdong, Fujian, and Chaozhou using a small zisha teapot or gaiwan with generous leaves and short infusions.',
+      'Basic tools include a zisha teapot or gaiwan, fairness pitcher, tasting cups, tea tray, tea scoop, and boiled water. These six are enough to begin.',
+      'The basic order is warming the pot, adding leaves, rinsing, brewing, pouring into the fairness pitcher, and serving into cups. Start the first infusion at about five seconds and lengthen gradually.',
+      'The beauty of gongfu tea is watching the same leaves change over many infusions: freshness in the first cup, deeper sweetness in the middle, and a lingering finish at the end.',
+    ],
+  },
+};
+
 export function getJournalBySlug(slug: string): JournalEntry | undefined {
   return JOURNAL_ENTRIES.find((e) => e.slug === slug);
+}
+
+export function getLocalizedJournalBySlug(slug: string, locale: JournalLocale): JournalEntry | undefined {
+  const entry = getJournalBySlug(slug);
+  if (!entry || locale !== 'en') return entry;
+  const translated = ENGLISH_JOURNAL_ENTRIES[slug];
+  return translated ? { ...entry, ...translated } : entry;
 }
 
 export function getJournalsByCategory(category: JournalCategory): JournalEntry[] {

--- a/src/utils/clientLocale.ts
+++ b/src/utils/clientLocale.ts
@@ -1,0 +1,7 @@
+import type { Locale } from '@/utils/currency';
+
+export function getClientLocale(): Locale {
+  if (typeof document !== 'undefined' && document.documentElement.lang === 'en') return 'en';
+  if (typeof window !== 'undefined' && (window.location.pathname ?? '').startsWith('/en')) return 'en';
+  return 'ko';
+}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,3 +1,34 @@
+const HANGUL_PATTERN = /[가-힣]/;
+
+const ENGLISH_GENERIC_ERROR = 'An error occurred.';
+
+const COMMON_KOREAN_ERROR_TRANSLATIONS: Record<string, string> = {
+  '오류가 발생했습니다.': ENGLISH_GENERIC_ERROR,
+  '접근 권한이 없습니다.': 'You do not have permission to access this.',
+  '토큰 갱신 함수가 등록되지 않았습니다.': 'The session refresh handler is not available.',
+  '로그인에 실패했습니다.': 'Login failed.',
+  '결제에 실패했습니다.': 'Payment failed.',
+  '결제 초기화 오류': 'Failed to initialize payment.',
+  '적립금을 불러오지 못했습니다.': 'Failed to load points.',
+  '저널 목록을 불러오지 못했습니다.': 'Failed to load journal entries.',
+};
+
+function isEnglishDocument(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.documentElement.lang === 'en' || (window.location.pathname ?? '').startsWith('/en');
+}
+
+function localizeErrorMessage(message: string, fallback: string): string {
+  if (!isEnglishDocument()) return message;
+  if (!HANGUL_PATTERN.test(message)) return message;
+
+  const translated = COMMON_KOREAN_ERROR_TRANSLATIONS[message];
+  if (translated) return translated;
+  if (!HANGUL_PATTERN.test(fallback)) return fallback;
+  return ENGLISH_GENERIC_ERROR;
+}
+
 export function handleApiError(err: unknown, fallback = '오류가 발생했습니다.'): string {
-  return err instanceof Error ? err.message : fallback;
+  const message = err instanceof Error ? err.message : fallback;
+  return localizeErrorMessage(message, fallback);
 }

--- a/src/utils/localMessages.ts
+++ b/src/utils/localMessages.ts
@@ -1,0 +1,23 @@
+import koMessages from '@/i18n/messages/ko.json';
+import enMessages from '@/i18n/messages/en.json';
+import { getClientLocale } from '@/utils/clientLocale';
+
+const MESSAGES = { ko: koMessages, en: enMessages } as const;
+
+type MessageTree = Record<string, unknown>;
+
+export function localMessage(path: string, values?: Record<string, string | number>): string {
+  const locale = getClientLocale();
+  const segments = path.split('.');
+  let current: unknown = MESSAGES[locale] as MessageTree;
+  for (const segment of segments) {
+    if (!current || typeof current !== 'object' || !(segment in current)) return path.split('.').at(-1) ?? path;
+    current = (current as MessageTree)[segment];
+  }
+  if (typeof current !== 'string') return path.split('.').at(-1) ?? path;
+  if (!values) return current;
+  return Object.entries(values).reduce(
+    (message, [key, value]) => message.replaceAll(`{${key}}`, String(value)),
+    current,
+  );
+}


### PR DESCRIPTION
## Summary
- Closes #879.
- Removes remaining Korean UI exposure from English customer-facing flows: checkout, search, product gallery/lightbox, journal, artist pages, shared error states, widgets, alerts/toasts, and fallback UI.
- Adds local locale-aware message helpers and regression coverage so English locale messages reject Hangul.
- Adds English static content/fallbacks for journal and artisan pages so prerendered `/en` pages contain English-only copy.

## Verification
- `npm run test:run` ✅ 129 files / 757 tests
- `npm run build` ✅ (existing warning only: `src/components/AppShell.tsx` unused `locale`)
- `cd backend && npm run build && npm run test` ✅ 108 suites / 1076 tests
- `rg -n "[가-힣]" .next/server/app/en --glob '*.html' --glob '!admin/**'` ✅ no matches
- `src/__tests__/english-locale-no-korean.test.ts` ✅ verifies `en.json` has no Hangul and Korean backend errors are suppressed on English pages
- `bash scripts/start-local.sh` ✅ local stack started during initial verification

## Review Notes
- Reviewed for locale fallback regressions: English UI now uses translated strings or English generic fallbacks instead of surfacing backend Korean.
- Admin Korean strings were not targeted by this issue; customer `/en` prerendered HTML is verified Hangul-free.
