### PR TITLE
chore: dev runtime bootstrap guard 개선

### DIFF
--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -27,13 +27,21 @@ gh issue view <number> --json title,body,labels,state,comments
 3. Use `ralplan` first if requirements, tests, or architectural impact need clarification.
 4. Implement with TDD where practical.
 5. Verify:
+   - `make bootstrap` before implementation in a new worktree; use `make up` for local runtime verification.
+   - `bash scripts/codex-project-guard.sh` before final reporting to catch merge markers, invalid locale JSON, shell syntax errors in local runtime scripts, and missing JWT key files.
    - `npm run build && npm run test:run`
    - `cd backend && npm run build && npm run test`
    - `cd backend && npm run test:e2e` for schema or migration changes
+   - For runtime/UI/CMS/i18n changes, do not trust script success alone: verify `curl http://localhost:3000/api/health`, `curl -I http://localhost:5173/ko`, listening ports `3000`/`5173`, and affected locale URLs such as `/en/p/<slug>`.
 6. Create a Korean commit message following repo rules.
 7. Push branch, open PR, and run a code-review pass before merge.
 8. After merge, verify GitHub Actions and remote health checks if the changed area affects deployment/runtime.
-9. Restart local services with `bash scripts/start-local.sh` unless the user said not to.
+9. Pull/update `main` locally and return to the main checkout.
+10. If an isolated git worktree was created for the issue, always remove that local worktree folder after the PR has merged into `main`:
+   - Use `git worktree remove --force <worktree-path>` when the path is still registered.
+   - Then verify the worktree folder no longer exists; if it remains, remove that exact folder path directly.
+   - Do not leave the worktree in Finder Trash. Prefer direct deletion over moving to Trash; if an exact matching worktree folder was moved to `~/.Trash`, remove that exact trashed folder too. Never empty the whole Trash.
+11. Restart local services with `bash scripts/start-local.sh` unless the user said not to.
 
 ## Guardrails
 

--- a/scripts/codex-project-guard.sh
+++ b/scripts/codex-project-guard.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Fast project invariant checks for Codex hooks.
+# Keep this lightweight: no builds, no server starts, no network.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+failures=()
+warnings=()
+
+find_node() {
+  local node_bin="${NODE_BIN:-}"
+  if [ -z "$node_bin" ]; then
+    node_bin="$(command -v node || true)"
+  fi
+  if [ -z "$node_bin" ]; then
+    local candidate
+    for candidate in "$HOME"/.nvm/versions/node/*/bin/node /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+      if [ -x "$candidate" ]; then
+        node_bin="$candidate"
+        break
+      fi
+    done
+  fi
+  printf '%s' "$node_bin"
+}
+
+add_failure() {
+  failures+=("$1")
+}
+
+add_warning() {
+  warnings+=("$1")
+}
+
+if command -v rg >/dev/null 2>&1; then
+  if rg -n '^(<<<<<<< |=======$|>>>>>>> )' \
+    --glob '!node_modules/**' \
+    --glob '!.next/**' \
+    --glob '!dist/**' \
+    --glob '!backend/dist/**' \
+    --glob '!backend/dist.nosync/**' \
+    --glob '!coverage/**' \
+    . >/tmp/okhwadang-conflict-markers.txt 2>/dev/null; then
+    add_failure "merge conflict markers remain:\n$(cat /tmp/okhwadang-conflict-markers.txt)"
+  fi
+fi
+
+node_bin="$(find_node)"
+if [ -z "$node_bin" ]; then
+  add_failure "node executable not found for locale JSON validation"
+else
+  for file in src/i18n/messages/ko.json src/i18n/messages/en.json; do
+    if [ -f "$file" ]; then
+      if ! "$node_bin" -e "JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'))" "$file" >/dev/null 2>&1; then
+        add_failure "invalid JSON: $file"
+      fi
+    fi
+  done
+fi
+
+for script in scripts/start-local.sh scripts/stop-local.sh scripts/worktree-bootstrap.sh; do
+  if [ -f "$script" ]; then
+    if ! bash -n "$script" >/dev/null 2>&1; then
+      add_failure "shell syntax check failed: $script"
+    fi
+  fi
+done
+
+if [ -f backend/.env ]; then
+  while IFS='=' read -r key value; do
+    case "$key" in
+      JWT_PRIVATE_KEY_PATH|JWT_PUBLIC_KEY_PATH)
+        value="${value%%#*}"
+        value="${value//\"/}"
+        value="${value//\'/}"
+        value="${value## }"
+        value="${value%% }"
+        if [ -n "$value" ] && [ ! -s "backend/$value" ]; then
+          add_warning "backend/.env references missing $key file: backend/$value (run: make bootstrap)"
+        fi
+        ;;
+    esac
+  done < backend/.env
+fi
+
+if [ ${#warnings[@]} -gt 0 ]; then
+  printf "${YELLOW}Okhwadang project guard warnings:${NC}\n" >&2
+  for item in "${warnings[@]}"; do
+    printf -- "- %b\n" "$item" >&2
+  done
+fi
+
+if [ ${#failures[@]} -gt 0 ]; then
+  printf "${RED}Okhwadang project guard failed:${NC}\n" >&2
+  for item in "${failures[@]}"; do
+    printf -- "- %b\n" "$item" >&2
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/prune-omx-state.mjs
+++ b/scripts/prune-omx-state.mjs
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 const write = process.argv.includes('--write');
+const json = process.argv.includes('--json');
 const root = process.cwd();
 const stateRoot = path.join(root, '.omx', 'state');
 const now = new Date().toISOString();
@@ -141,4 +142,6 @@ for (const filePath of await collectSkillStateFiles()) {
   }
 }
 
-console.log(JSON.stringify({ checked, pruned, write }));
+if (json) {
+  process.stdout.write(`${JSON.stringify({ checked, pruned, write })}\n`);
+}

--- a/scripts/run-node-script.sh
+++ b/scripts/run-node-script.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_path="${1:?usage: run-node-script.sh <project-relative-script> [args...]}"
+shift || true
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "$script_path" == /* || "$script_path" == *".."* ]]; then
+  echo "Refusing unsafe script path: $script_path" >&2
+  exit 64
+fi
+
+target="$PROJECT_ROOT/$script_path"
+if [[ ! -f "$target" ]]; then
+  echo "Unable to find project script: $script_path" >&2
+  exit 66
+fi
+
+node_bin="${NODE_BIN:-}"
+if [[ -z "$node_bin" ]]; then
+  node_bin="$(command -v node || true)"
+fi
+if [[ -z "$node_bin" ]]; then
+  for candidate in "$HOME"/.nvm/versions/node/*/bin/node /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+    if [[ -x "$candidate" ]]; then
+      node_bin="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$node_bin" ]]; then
+  echo "Unable to find node. Set NODE_BIN to the Node executable." >&2
+  exit 127
+fi
+
+exec "$node_bin" "$target" "$@"

--- a/scripts/run-omx-script.sh
+++ b/scripts/run-omx-script.sh
@@ -15,6 +15,15 @@ if [[ -z "$node_bin" ]]; then
 fi
 
 if [[ -z "$node_bin" ]]; then
+  for candidate in "$HOME"/.nvm/versions/node/*/bin/node /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+    if [[ -x "$candidate" ]]; then
+      node_bin="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$node_bin" ]]; then
   echo "Unable to find node. Set NODE_BIN to the Node executable used by oh-my-codex." >&2
   exit 127
 fi

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -112,13 +112,31 @@ fi
 echo -e "${BLUE}🔧 백엔드 + 🎨 프론트엔드 시작...${NC}"
 export NODE_ENV=development
 
-cd "$BACKEND_DIR"
-npm run start:dev > /tmp/commerce-backend.log 2>&1 &
-BACKEND_PID=$!
+if command -v tmux > /dev/null 2>&1; then
+    tmux kill-session -t okhwadang-backend 2>/dev/null || true
+    tmux kill-session -t okhwadang-frontend 2>/dev/null || true
 
-cd "$PROJECT_ROOT"
-npm run dev > /tmp/commerce-frontend.log 2>&1 &
-FRONTEND_PID=$!
+    tmux new-session -d -s okhwadang-backend \
+        "cd '$BACKEND_DIR' && set -a && source .env && set +a && export NODE_ENV=development && npm run start:dev > /tmp/commerce-backend.log 2>&1"
+    BACKEND_PID=$(tmux display-message -p -t okhwadang-backend '#{pane_pid}')
+
+    tmux new-session -d -s okhwadang-frontend \
+        "cd '$PROJECT_ROOT' && npm run dev > /tmp/commerce-frontend.log 2>&1"
+    FRONTEND_PID=$(tmux display-message -p -t okhwadang-frontend '#{pane_pid}')
+else
+    cd "$BACKEND_DIR"
+    nohup npm run start:dev > /tmp/commerce-backend.log 2>&1 < /dev/null &
+    BACKEND_PID=$!
+    disown "$BACKEND_PID" 2>/dev/null || true
+
+    cd "$PROJECT_ROOT"
+    nohup npm run dev > /tmp/commerce-frontend.log 2>&1 < /dev/null &
+    FRONTEND_PID=$!
+    disown "$FRONTEND_PID" 2>/dev/null || true
+fi
+
+echo "$BACKEND_PID" > /tmp/commerce-backend.pid
+echo "$FRONTEND_PID" > /tmp/commerce-frontend.pid
 
 # 백엔드 health check
 echo -e "${YELLOW}⏳ 백엔드 준비 대기...${NC}"

--- a/scripts/stop-local.sh
+++ b/scripts/stop-local.sh
@@ -51,6 +51,10 @@ stop_ssh_tunnel() {
 }
 
 echo -e "${YELLOW}백엔드 + 프론트엔드 + Vitest + SSH 터널 종료 중...${NC}"
+if command -v tmux > /dev/null 2>&1; then
+    tmux kill-session -t okhwadang-backend 2>/dev/null || true
+    tmux kill-session -t okhwadang-frontend 2>/dev/null || true
+fi
 stop_backend &
 stop_frontend &
 stop_vitest_workers &

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -11,6 +11,10 @@ NC='\033[0m'
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BACKEND_DIR="$PROJECT_ROOT/backend"
 CACHE_DIR="$PROJECT_ROOT/.omx/bootstrap-cache"
+SHARED_CONFIG_DIR="${OKHWADANG_DEV_CONFIG_DIR:-$HOME/.config/okhwadang/dev}"
+SHARED_ROOT_DIR="$SHARED_CONFIG_DIR/root"
+SHARED_BACKEND_DIR="$SHARED_CONFIG_DIR/backend"
+SHARED_BACKEND_KEYS_DIR="$SHARED_BACKEND_DIR/keys"
 VENV_DIR="$PROJECT_ROOT/scripts/venv"
 SENTINEL_FILE="$PROJECT_ROOT/.omx/.worktree_bootstrap_done"
 
@@ -30,7 +34,8 @@ while (($#)); do
   shift
 done
 
-mkdir -p "$CACHE_DIR"
+mkdir -p "$CACHE_DIR" "$SHARED_ROOT_DIR" "$SHARED_BACKEND_KEYS_DIR"
+chmod 700 "$SHARED_CONFIG_DIR" "$SHARED_ROOT_DIR" "$SHARED_BACKEND_DIR" "$SHARED_BACKEND_KEYS_DIR" 2>/dev/null || true
 
 hash_file() {
   local path="$1"
@@ -46,8 +51,22 @@ find_origin_worktree() {
 ensure_env_file() {
   local target="$1"
   local fallback="$2"
+  local shared_source="$3"
 
   if [ -f "$target" ]; then
+    if [ ! -f "$shared_source" ]; then
+      mkdir -p "$(dirname "$shared_source")"
+      cp "$target" "$shared_source"
+      chmod 600 "$shared_source" 2>/dev/null || true
+      echo -e "${GREEN}✅ ${target#$PROJECT_ROOT/} → 공통 dev 설정에 저장했습니다.${NC}"
+    fi
+    return 0
+  fi
+
+  if [ -f "$shared_source" ]; then
+    cp "$shared_source" "$target"
+    chmod 600 "$target" 2>/dev/null || true
+    echo -e "${GREEN}✅ ${target#$PROJECT_ROOT/} → 공통 dev 설정에서 복사했습니다.${NC}"
     return 0
   fi
 
@@ -59,6 +78,8 @@ ensure_env_file() {
 
   if [ -n "$origin_worktree" ] && [ "$origin_worktree" != "$PROJECT_ROOT" ] && [ -f "$origin_source" ]; then
     cp "$origin_source" "$target"
+    cp "$target" "$shared_source"
+    chmod 600 "$target" "$shared_source" 2>/dev/null || true
     echo -e "${GREEN}✅ ${relative_path} → origin worktree에서 복사했습니다.${NC}"
     return 0
   fi
@@ -70,6 +91,69 @@ ensure_env_file() {
     echo -e "${RED}❌ ${relative_path} 파일이 없고 기본 예시 파일도 찾지 못했습니다.${NC}"
     exit 1
   fi
+}
+
+ensure_jwt_key_file() {
+  local filename="$1"
+  local target="$BACKEND_DIR/keys/$filename"
+  local shared_source="$SHARED_BACKEND_KEYS_DIR/$filename"
+
+  mkdir -p "$BACKEND_DIR/keys"
+  chmod 700 "$BACKEND_DIR/keys" 2>/dev/null || true
+
+  if [ -s "$target" ]; then
+    if [ ! -s "$shared_source" ]; then
+      cp "$target" "$shared_source"
+      chmod 600 "$shared_source" 2>/dev/null || true
+      echo -e "${GREEN}✅ backend/keys/$filename → 공통 dev 설정에 저장했습니다.${NC}"
+    fi
+    return 0
+  fi
+
+  if [ -s "$shared_source" ]; then
+    cp "$shared_source" "$target"
+    echo -e "${GREEN}✅ backend/keys/$filename → 공통 dev 설정에서 복사했습니다.${NC}"
+    return 0
+  fi
+
+  local origin_worktree
+  origin_worktree="$(find_origin_worktree)"
+  local origin_source="$origin_worktree/backend/keys/$filename"
+  if [ -n "$origin_worktree" ] && [ "$origin_worktree" != "$PROJECT_ROOT" ] && [ -s "$origin_source" ]; then
+    cp "$origin_source" "$target"
+    cp "$target" "$shared_source"
+    chmod 600 "$shared_source" 2>/dev/null || true
+    echo -e "${GREEN}✅ backend/keys/$filename → origin worktree에서 복사했습니다.${NC}"
+    return 0
+  fi
+
+  return 1
+}
+
+ensure_dev_jwt_keys() {
+  if ensure_jwt_key_file "jwt-private.pem" && ensure_jwt_key_file "jwt-public.pem"; then
+    chmod 600 "$BACKEND_DIR/keys/jwt-private.pem" 2>/dev/null || true
+    chmod 644 "$BACKEND_DIR/keys/jwt-public.pem" 2>/dev/null || true
+    return 0
+  fi
+
+  if ! command -v openssl >/dev/null 2>&1; then
+    echo -e "${RED}❌ JWT dev key가 없고 openssl도 없어 자동 생성할 수 없습니다.${NC}"
+    echo -e "${YELLOW}   해결: origin worktree의 backend/keys/*.pem 을 복사하거나 openssl 설치 후 재실행하세요.${NC}"
+    exit 1
+  fi
+
+  echo -e "${YELLOW}⚠️  공통 dev JWT 키가 없어 새로 생성합니다: ${SHARED_BACKEND_KEYS_DIR}${NC}"
+  openssl genrsa -out "$SHARED_BACKEND_KEYS_DIR/jwt-private.pem" 2048 >/dev/null 2>&1
+  openssl rsa -in "$SHARED_BACKEND_KEYS_DIR/jwt-private.pem" -pubout -out "$SHARED_BACKEND_KEYS_DIR/jwt-public.pem" >/dev/null 2>&1
+  chmod 600 "$SHARED_BACKEND_KEYS_DIR/jwt-private.pem"
+  chmod 644 "$SHARED_BACKEND_KEYS_DIR/jwt-public.pem"
+
+  cp "$SHARED_BACKEND_KEYS_DIR/jwt-private.pem" "$BACKEND_DIR/keys/jwt-private.pem"
+  cp "$SHARED_BACKEND_KEYS_DIR/jwt-public.pem" "$BACKEND_DIR/keys/jwt-public.pem"
+  chmod 600 "$BACKEND_DIR/keys/jwt-private.pem"
+  chmod 644 "$BACKEND_DIR/keys/jwt-public.pem"
+  echo -e "${GREEN}✅ backend/keys JWT dev 키 준비 완료${NC}"
 }
 
 ensure_node_modules() {
@@ -142,8 +226,9 @@ ensure_node_runtime() {
 echo -e "${BLUE}🔧 worktree bootstrap 시작${NC}"
 ensure_node_runtime
 
-ensure_env_file "$PROJECT_ROOT/.env.local" "$PROJECT_ROOT/.env.example"
-ensure_env_file "$BACKEND_DIR/.env" "$BACKEND_DIR/.env.example"
+ensure_env_file "$PROJECT_ROOT/.env.local" "$PROJECT_ROOT/.env.example" "$SHARED_ROOT_DIR/.env.local"
+ensure_env_file "$BACKEND_DIR/.env" "$BACKEND_DIR/.env.example" "$SHARED_BACKEND_DIR/.env"
+ensure_dev_jwt_keys
 
 ensure_node_modules "$PROJECT_ROOT" "frontend"
 ensure_node_modules "$BACKEND_DIR" "backend"


### PR DESCRIPTION
## Summary
- Make worktree bootstrap reuse shared dev env/JWT key files and generate dev JWT keys when needed
- Keep local backend/frontend sessions alive via tmux/nohup and stop tmux sessions cleanly
- Add lightweight Codex project guard and node runner scripts for hook/runtime stability

## Test plan
- [x] bash -n scripts/worktree-bootstrap.sh scripts/start-local.sh scripts/stop-local.sh scripts/run-omx-script.sh scripts/run-node-script.sh scripts/codex-project-guard.sh
- [x] bash scripts/codex-project-guard.sh
- [x] npx vitest run scripts/prune-omx-state.test.mjs