### PR TITLE
feat: CMS 영문 페이지 locale/backfill 적용

### DIFF
--- a/backend/src/common/utils/__tests__/locale.util.spec.ts
+++ b/backend/src/common/utils/__tests__/locale.util.spec.ts
@@ -122,4 +122,17 @@ describe('applyLocaleToContent', () => {
     const result = applyLocaleToContent(content, 'en') as Record<string, unknown>;
     expect(result.config).toBe('English config');
   });
+
+  it('JSON content의 camelCase En 필드도 base 필드로 매핑한다', () => {
+    const content = {
+      items: [
+        { name: '주니', nameEn: 'Zhuni', hrefLabel: '주니 작품 보기', hrefLabel_en: 'View Zhuni pieces' },
+      ],
+    };
+
+    const result = applyLocaleToContent(content, 'en') as typeof content;
+
+    expect(result.items[0].name).toBe('Zhuni');
+    expect(result.items[0].hrefLabel).toBe('View Zhuni pieces');
+  });
 });

--- a/backend/src/common/utils/locale.util.ts
+++ b/backend/src/common/utils/locale.util.ts
@@ -10,6 +10,10 @@ const LOCALE_SNAKE_SUFFIX_MAP: Record<string, string> = {
 
 const MAX_CONTENT_DEPTH = 16;
 
+const CAMEL_LOCALE_SUFFIX_MAP: Record<string, string> = {
+  en: 'En',
+};
+
 /**
  * 엔티티의 다국어 필드를 locale에 맞게 매핑한다.
  * locale이 'ko'이거나 없으면 원본 그대로 반환.
@@ -56,12 +60,19 @@ export function applyLocaleToContent<T>(
   const snakeSuffix = LOCALE_SNAKE_SUFFIX_MAP[locale];
   if (!snakeSuffix) return content;
 
-  return applyLocaleRecursive(content, snakeSuffix, new WeakSet(), 0) as T;
+  return applyLocaleRecursive(
+    content,
+    snakeSuffix,
+    CAMEL_LOCALE_SUFFIX_MAP[locale] ?? '',
+    new WeakSet(),
+    0,
+  ) as T;
 }
 
 function applyLocaleRecursive(
   value: unknown,
   snakeSuffix: string,
+  camelSuffix: string,
   seen: WeakSet<object>,
   depth: number,
 ): unknown {
@@ -74,7 +85,7 @@ function applyLocaleRecursive(
   seen.add(value as object);
 
   if (Array.isArray(value)) {
-    return value.map((item) => applyLocaleRecursive(item, snakeSuffix, seen, depth + 1));
+    return value.map((item) => applyLocaleRecursive(item, snakeSuffix, camelSuffix, seen, depth + 1));
   }
 
   const source = value as Record<string, unknown>;
@@ -89,6 +100,14 @@ function applyLocaleRecursive(
         overrides[baseKey] = v;
       }
     }
+
+    if (camelSuffix && key.endsWith(camelSuffix)) {
+      const baseKey = key.slice(0, -camelSuffix.length);
+      const normalizedBaseKey = baseKey.charAt(0).toLowerCase() + baseKey.slice(1);
+      if (v !== null && v !== undefined && v !== '') {
+        overrides[normalizedBaseKey] = v;
+      }
+    }
   }
 
   // Pass 2: 기본 필드는 재귀 처리, 오버라이드가 있으면 해당 값으로 대체
@@ -97,7 +116,7 @@ function applyLocaleRecursive(
     if (key in overrides) {
       result[key] = overrides[key];
     } else if (Array.isArray(v) || (v && typeof v === 'object')) {
-      result[key] = applyLocaleRecursive(v, snakeSuffix, seen, depth + 1);
+      result[key] = applyLocaleRecursive(v, snakeSuffix, camelSuffix, seen, depth + 1);
     } else {
       result[key] = v;
     }

--- a/backend/src/database/migrations/1785000000000-BackfillCmsPageEnglishContent.ts
+++ b/backend/src/database/migrations/1785000000000-BackfillCmsPageEnglishContent.ts
@@ -1,0 +1,182 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+type JsonRecord = Record<string, unknown>;
+
+interface BlockRow {
+  id: number;
+  slug: string;
+  type: string;
+  content: JsonRecord | string | null;
+}
+
+function parseContent(content: BlockRow['content']): JsonRecord {
+  if (!content) return {};
+  if (typeof content === 'string') {
+    try {
+      return JSON.parse(content) as JsonRecord;
+    } catch {
+      return {};
+    }
+  }
+  return content;
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function viewLabel(name: unknown): string | undefined {
+  return nonEmpty(name) ? `View ${name} pieces` : undefined;
+}
+
+export class BackfillCmsPageEnglishContent1785000000000 implements MigrationInterface {
+  name = 'BackfillCmsPageEnglishContent1785000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.backfillKnownPageBlocks(queryRunner);
+    await this.backfillGenericCollectionBlocks(queryRunner);
+  }
+
+  public async down(): Promise<void> {
+    // Data-only English backfill. Keep translations on rollback to avoid removing admin-authored content.
+  }
+
+  private async backfillKnownPageBlocks(queryRunner: QueryRunner): Promise<void> {
+    const textBlocks: Array<{ slug: string; type: string; sortOrder?: number; content: JsonRecord }> = [
+      {
+        slug: 'best',
+        type: 'text_content',
+        sortOrder: 0,
+        content: {
+          html_en: '<h1>Best Sellers</h1><p>Discover the most-loved pieces from Ockhwadang.</p>',
+        },
+      },
+      {
+        slug: 'best',
+        type: 'product_grid',
+        sortOrder: 1,
+        content: { title_en: 'Best Sellers' },
+      },
+      {
+        slug: 'support',
+        type: 'split_content',
+        content: {
+          title_en: 'How Can We Help You?',
+          subtitle_en: 'CUSTOMER CENTER',
+          description_en: 'Find quick answers through FAQs, notices, and one-on-one inquiries.',
+          cta_text_en: 'Contact Us',
+        },
+      },
+      {
+        slug: 'shipping',
+        type: 'text_content',
+        content: {
+          html_en: '<h2>Shipping Information</h2><p>Ockhwadang ships orders within 2–3 business days after order confirmation, excluding weekends and holidays.</p><h3>Shipping Costs</h3><ul><li><strong>Standard Shipping:</strong> 3,000 KRW; remote-area surcharges may apply.</li><li><strong>Free Shipping:</strong> Orders over 50,000 KRW.</li><li><strong>Carrier:</strong> CJ Korea Express.</li></ul><p>Tracking is available from your order details page.</p>',
+        },
+      },
+    ];
+
+    for (const item of textBlocks) {
+      const rows = await this.findBlocks(queryRunner, item.slug, item.type, item.sortOrder);
+      for (const row of rows) {
+        const content = { ...parseContent(row.content), ...item.content };
+        await this.updateBlock(queryRunner, row.id, content);
+      }
+    }
+  }
+
+  private async backfillGenericCollectionBlocks(queryRunner: QueryRunner): Promise<void> {
+    const niloTypes = await queryRunner.query(
+      `SELECT id, name, nameKo, name_en, characteristics_en FROM nilo_types WHERE is_active = 1`,
+    ) as Array<Record<string, unknown>>;
+    const clayCollections = await queryRunner.query(
+      `SELECT id, name, nameKo, name_en FROM collections WHERE is_active = 1 AND type = 'clay'`,
+    ) as Array<Record<string, unknown>>;
+    const shapeCollections = await queryRunner.query(
+      `SELECT id, name, name_en FROM collections WHERE is_active = 1 AND type = 'shape'`,
+    ) as Array<Record<string, unknown>>;
+
+    const byId = (rows: Array<Record<string, unknown>>) =>
+      new Map(rows.map((row) => [String(row.id), row]));
+
+    const dictionaries: Record<string, Map<string, Record<string, unknown>>> = {
+      nilo: byId(niloTypes),
+      'collection-clay': byId(clayCollections),
+      'collection-shape': byId(shapeCollections),
+    };
+
+    const blocks = await queryRunner.query(
+      `SELECT b.id, p.slug, b.type, b.content
+         FROM page_blocks b
+         INNER JOIN pages p ON p.id = b.page_id
+        WHERE p.slug IN ('archive', 'collection')
+          AND b.type IN ('color_card_list', 'image_card_grid')`,
+    ) as BlockRow[];
+
+    for (const block of blocks) {
+      const content = parseContent(block.content);
+      if (!Array.isArray(content.items)) continue;
+
+      const items = content.items.map((rawItem) => {
+        if (!rawItem || typeof rawItem !== 'object') return rawItem;
+        const item = { ...(rawItem as JsonRecord) };
+        const id = String(item.id ?? '');
+        const sourceKey = id.startsWith('nilo-')
+          ? 'nilo'
+          : id.startsWith('collection-clay-')
+            ? 'collection-clay'
+            : id.startsWith('collection-shape-')
+              ? 'collection-shape'
+              : '';
+        const sourceId = id.replace(`${sourceKey}-`, '');
+        const source = dictionaries[sourceKey]?.get(sourceId);
+        const englishName = source?.name_en ?? source?.name ?? item.nameEn ?? item.name_en;
+
+        if (nonEmpty(englishName)) {
+          item.name_en = englishName;
+          item.nameEn = englishName;
+        }
+        const label = viewLabel(englishName);
+        if (label) item.hrefLabel_en = label;
+
+        if (Array.isArray(source?.characteristics_en)) {
+          item.characteristics_en = source.characteristics_en;
+        } else if (nonEmpty(source?.characteristics_en)) {
+          try {
+            item.characteristics_en = JSON.parse(source.characteristics_en) as unknown;
+          } catch {
+            item.characteristics_en = source.characteristics_en;
+          }
+        }
+
+        return item;
+      });
+
+      await this.updateBlock(queryRunner, block.id, { ...content, items });
+    }
+  }
+
+  private findBlocks(
+    queryRunner: QueryRunner,
+    slug: string,
+    type: string,
+    sortOrder?: number,
+  ): Promise<BlockRow[]> {
+    const sortClause = sortOrder === undefined ? '' : 'AND b.sort_order = ?';
+    const args = sortOrder === undefined ? [slug, type] : [slug, type, sortOrder];
+    return queryRunner.query(
+      `SELECT b.id, p.slug, b.type, b.content
+         FROM page_blocks b
+         INNER JOIN pages p ON p.id = b.page_id
+        WHERE p.slug = ? AND b.type = ? ${sortClause}`,
+      args,
+    ) as Promise<BlockRow[]>;
+  }
+
+  private updateBlock(queryRunner: QueryRunner, id: number, content: JsonRecord): Promise<unknown> {
+    return queryRunner.query(
+      `UPDATE page_blocks SET content = ? WHERE id = ?`,
+      [JSON.stringify(content), id],
+    ) as Promise<unknown>;
+  }
+}

--- a/src/app/[locale]/p/[slug]/__tests__/page.test.tsx
+++ b/src/app/[locale]/p/[slug]/__tests__/page.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import SlugPage, { generateMetadata } from '../page';
+import { fetchPage } from '@/lib/api-server';
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('notFound');
+  }),
+}));
+
+vi.mock('@/components/shared/blocks/BlockRenderer', () => ({
+  default: ({ blocks }: { blocks: Array<{ content: { html?: string } }> }) => (
+    <div data-testid="blocks">{blocks.map((block) => block.content.html).join('')}</div>
+  ),
+}));
+
+vi.mock('@/lib/api-server', () => ({
+  fetchPage: vi.fn(),
+}));
+
+const mockFetchPage = vi.mocked(fetchPage);
+
+describe('/[locale]/p/[slug] CMS page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requests the CMS page with the route locale for metadata', async () => {
+    mockFetchPage.mockResolvedValue({
+      id: 12,
+      slug: 'best',
+      title: 'Best Sellers',
+      is_published: true,
+      blocks: [],
+    });
+
+    const metadata = await generateMetadata({ params: Promise.resolve({ locale: 'en', slug: 'best' }) });
+
+    expect(mockFetchPage).toHaveBeenCalledWith('best', 'en');
+    expect(metadata.title).toBe('Best Sellers | Okhwadang');
+  });
+
+  it('requests the CMS page with the route locale before rendering blocks', async () => {
+    mockFetchPage.mockResolvedValue({
+      id: 8,
+      slug: 'about',
+      title: 'About Okhwadang',
+      is_published: true,
+      blocks: [
+        {
+          id: 1,
+          type: 'text_content',
+          sort_order: 0,
+          is_visible: true,
+          content: { html: '<h1>About Okhwadang</h1>' },
+        },
+      ],
+    });
+
+    const jsx = await SlugPage({ params: Promise.resolve({ locale: 'en', slug: 'about' }) });
+    render(jsx);
+
+    expect(mockFetchPage).toHaveBeenCalledWith('about', 'en');
+    expect(screen.getByTestId('blocks')).toHaveTextContent('About Okhwadang');
+  });
+});

--- a/src/app/[locale]/p/[slug]/page.tsx
+++ b/src/app/[locale]/p/[slug]/page.tsx
@@ -11,7 +11,7 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { locale, slug } = await params;
-  const page = await fetchPage(slug);
+  const page = await fetchPage(slug, locale);
   if (!page) return { title: locale === 'en' ? 'Page not found' : '페이지를 찾을 수 없습니다' };
   return {
     title: `${page.title} | ${locale === 'en' ? 'Okhwadang' : '옥화당'}`,
@@ -19,8 +19,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function SlugPage({ params }: PageProps) {
-  const { slug } = await params;
-  const page = await fetchPage(slug);
+  const { locale, slug } = await params;
+  const page = await fetchPage(slug, locale);
 
   if (!page || !page.is_published) {
     notFound();

--- a/src/components/shared/blocks/ColorCardListBlock.tsx
+++ b/src/components/shared/blocks/ColorCardListBlock.tsx
@@ -8,6 +8,8 @@ import type { ColorCardItem, ColorCardListContent } from '@/lib/api';
 import { getHeadingId, InlineHtmlText } from './genericBlockUtils';
 
 function AlternatingCard({ item, reversed }: { item: ColorCardItem; reversed: boolean }) {
+  const displayName = item.name ?? item.nameKo;
+
   return (
     <article
       className={cn(
@@ -19,14 +21,14 @@ function AlternatingCard({ item, reversed }: { item: ColorCardItem; reversed: bo
         className="w-full md:w-2/5 aspect-square rounded-lg shrink-0"
         style={{ backgroundColor: item.color }}
         role="img"
-        aria-label={item.nameKo}
+        aria-label={displayName}
       />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-3 mb-4">
           <span className="inline-block w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: item.color }} aria-hidden="true" />
           {item.nameEn && <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">{item.nameEn}</span>}
         </div>
-        <h3 className="text-2xl font-bold text-foreground mb-1">{item.nameKo}</h3>
+        <h3 className="text-2xl font-bold text-foreground mb-1">{displayName}</h3>
         {item.region && <p className="text-xs text-muted-foreground mb-4">{item.region}</p>}
         <InlineHtmlText html={item.description} className="text-sm text-foreground leading-relaxed mb-6 [&_b]:font-semibold [&_strong]:font-semibold" />
         {item.characteristics && item.characteristics.length > 0 && (
@@ -40,7 +42,7 @@ function AlternatingCard({ item, reversed }: { item: ColorCardItem; reversed: bo
         )}
         {item.href && (
           <Link href={item.href} className="inline-flex items-center gap-1 text-sm font-medium text-foreground border border-foreground rounded px-4 py-2 hover:bg-foreground hover:text-background transition-colors">
-            {item.hrefLabel || item.nameKo}
+            {item.hrefLabel || displayName}
           </Link>
         )}
       </div>
@@ -49,17 +51,19 @@ function AlternatingCard({ item, reversed }: { item: ColorCardItem; reversed: bo
 }
 
 function GridCard({ item }: { item: ColorCardItem }) {
+  const displayName = item.name ?? item.nameKo;
+
   const body = (
     <>
-      <div className="h-40 transition-transform duration-300 group-hover:scale-105" style={{ backgroundColor: item.color }} role="img" aria-label={item.nameKo} />
+      <div className="h-40 transition-transform duration-300 group-hover:scale-105" style={{ backgroundColor: item.color }} role="img" aria-label={displayName} />
       <div className="p-5">
         <div className="flex items-center gap-2 mb-2">
           <span className="inline-block w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: item.color }} aria-hidden="true" />
           {item.nameEn && <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">{item.nameEn}</span>}
         </div>
-        <h3 className="text-lg font-bold text-foreground mb-1">{item.nameKo}</h3>
+        <h3 className="text-lg font-bold text-foreground mb-1">{displayName}</h3>
         <InlineHtmlText html={item.description} className="text-sm text-muted-foreground leading-relaxed [&_b]:font-semibold [&_strong]:font-semibold [&_b]:text-foreground [&_strong]:text-foreground" />
-        {item.href && <span className="inline-block mt-4 text-xs font-medium text-foreground border-b border-foreground pb-0.5 group-hover:border-foreground/60 transition-colors">{item.hrefLabel || item.nameKo}</span>}
+        {item.href && <span className="inline-block mt-4 text-xs font-medium text-foreground border-b border-foreground pb-0.5 group-hover:border-foreground/60 transition-colors">{item.hrefLabel || displayName}</span>}
       </div>
     </>
   );

--- a/src/lib/api/pages.ts
+++ b/src/lib/api/pages.ts
@@ -107,6 +107,7 @@ export interface SectionHeadingBlockContent {
 export interface ColorCardItem {
   id: string;
   color: string;
+  name?: string;
   nameEn?: string;
   nameKo: string;
   region?: string;


### PR DESCRIPTION
## Summary
- Pass route locale into CMS page fetching for metadata/rendering
- Normalize CMS JSON block `nameEn`/`*_en` fields for English content
- Add an English CMS content backfill migration and regression tests

## Test plan
- [x] cd backend && npm test -- --runTestsByPath src/common/utils/__tests__/locale.util.spec.ts
- [x] cd backend && npm run build
- [x] npm run test:run -- src/app/[locale]/p/[slug]/__tests__/page.test.tsx
- [x] npm run build

## Notes
- Frontend build passes with existing warning: `src/components/AppShell.tsx` unused `locale` parameter.