### PR TITLE
fix: shared frontend hook 안정성 보강

### DIFF
--- a/src/components/shared/hooks/__tests__/useAutocomplete.test.tsx
+++ b/src/components/shared/hooks/__tests__/useAutocomplete.test.tsx
@@ -58,4 +58,29 @@ describe('useAutocomplete', () => {
     expect(result.current.suggestions).toEqual([]);
     expect(result.current.isLoading).toBe(false);
   });
+
+  it('ignores stale results when the query changes before a request settles', async () => {
+    let resolveFirst!: (value: Array<{ id: number; name: string; slug: string }>) => void;
+    autocompleteMock
+      .mockReturnValueOnce(new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce([{ id: 2, name: '새 검색어', slug: 'new' }]);
+
+    const { result, rerender } = renderHook(({ query }) => useAutocomplete(query), {
+      initialProps: { query: '이전' },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    rerender({ query: '새 검색어' });
+
+    await act(async () => {
+      resolveFirst([{ id: 1, name: '이전', slug: 'old' }]);
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(result.current.suggestions).toEqual([{ id: 2, name: '새 검색어', slug: 'new' }]);
+    expect(result.current.isLoading).toBe(false);
+  });
 });

--- a/src/components/shared/hooks/__tests__/useBlockData.test.tsx
+++ b/src/components/shared/hooks/__tests__/useBlockData.test.tsx
@@ -24,10 +24,21 @@ describe('useBlockData', () => {
     expect(result.current.data).toEqual([{ id: 2, title: 'loaded' }]);
   });
 
+  it('uses empty prefetched data without fetching', () => {
+    const fetch = vi.fn();
+    const prefetched: Array<{ id: number }> = [];
+
+    const { result } = renderHook(() => useBlockData({ prefetched, fetch, deps: [] }));
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('does not update state after unmount', async () => {
     let resolve!: (value: Array<{ id: number }>) => void;
     const fetch = vi.fn().mockReturnValue(new Promise((res) => { resolve = res; }));
-    const { unmount } = renderHook(() => useBlockData({ prefetched: [], fetch, deps: [] }));
+    const { unmount } = renderHook(() => useBlockData({ prefetched: null, fetch, deps: [] }));
 
     unmount();
 

--- a/src/components/shared/hooks/useAutocomplete.ts
+++ b/src/components/shared/hooks/useAutocomplete.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useEffect } from 'react';
 import { productsApi, type AutocompleteItem } from '@/lib/api';
 
@@ -8,22 +10,34 @@ export function useAutocomplete(query: string) {
   useEffect(() => {
     if (query.length < 2) {
       setSuggestions([]);
+      setIsLoading(false);
       return;
     }
+
+    let cancelled = false;
 
     const timer = setTimeout(async () => {
       setIsLoading(true);
       try {
         const results = await productsApi.autocomplete(query);
-        setSuggestions(results);
+        if (!cancelled) {
+          setSuggestions(results);
+        }
       } catch {
-        setSuggestions([]);
+        if (!cancelled) {
+          setSuggestions([]);
+        }
       } finally {
-        setIsLoading(false);
+        if (!cancelled) {
+          setIsLoading(false);
+        }
       }
     }, 300);
 
-    return () => clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [query]);
 
   return { suggestions, isLoading };

--- a/src/components/shared/hooks/useBlockData.ts
+++ b/src/components/shared/hooks/useBlockData.ts
@@ -22,15 +22,21 @@ export function useBlockData<T>({
   const [loading, setLoading] = useState(!prefetched);
 
   useEffect(() => {
-    if (prefetched && prefetched.length > 0) return;
+    if (prefetched) {
+      setData(prefetched);
+      setLoading(false);
+      return;
+    }
 
     let cancelled = false;
+    setLoading(true);
 
     async function load() {
       try {
         const result = await fetch();
         if (!cancelled) setData(result);
       } catch {
+        if (!cancelled) setData([]);
         // network errors are non-fatal for CMS blocks
       } finally {
         if (!cancelled) setLoading(false);

--- a/src/components/shared/hooks/useMediaQuery.ts
+++ b/src/components/shared/hooks/useMediaQuery.ts
@@ -6,11 +6,15 @@ export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState(false);
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
     const mq = window.matchMedia(query);
     setMatches(mq.matches);
     const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
+    mq.addEventListener?.('change', handler);
+    return () => mq.removeEventListener?.('change', handler);
   }, [query]);
 
   return matches;

--- a/src/components/shared/hooks/useRecentSearches.ts
+++ b/src/components/shared/hooks/useRecentSearches.ts
@@ -1,4 +1,6 @@
-import { useState, useCallback } from 'react';
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
 
 const STORAGE_KEY = 'recent_searches';
 const MAX_ITEMS = 10;
@@ -15,7 +17,11 @@ function readFromStorage(): string[] {
 
 function writeToStorage(items: string[]): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    if (items.length === 0) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    }
   } catch {
     // ignore storage errors
   }
@@ -23,6 +29,10 @@ function writeToStorage(items: string[]): void {
 
 export function useRecentSearches() {
   const [recentSearches, setRecentSearches] = useState<string[]>(() => readFromStorage());
+
+  useEffect(() => {
+    setRecentSearches(readFromStorage());
+  }, []);
 
   const addSearch = useCallback((query: string) => {
     const trimmed = query.trim();

--- a/src/components/shared/hooks/useUnsavedChanges.ts
+++ b/src/components/shared/hooks/useUnsavedChanges.ts
@@ -8,6 +8,7 @@ export function useUnsavedChanges(hasChanges: boolean) {
 
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       e.preventDefault();
+      e.returnValue = '';
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);

--- a/src/components/shared/hooks/useWishlistToggle.ts
+++ b/src/components/shared/hooks/useWishlistToggle.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { wishlistApi } from '@/lib/api';
@@ -29,6 +29,7 @@ export function useWishlistToggle(
   const [isWishlisted, setIsWishlisted] = useState(initialIsWishlisted);
   const [wishlistId, setWishlistId] = useState<number | null>(initialWishlistId);
   const [loading, setLoading] = useState(false);
+  const loadingRef = useRef(false);
 
   const toggle = async (e: React.MouseEvent): Promise<void> => {
     e.preventDefault();
@@ -39,7 +40,8 @@ export function useWishlistToggle(
       return;
     }
 
-    if (loading) return;
+    if (loadingRef.current) return;
+    loadingRef.current = true;
     setLoading(true);
 
     // Optimistic update
@@ -63,6 +65,7 @@ export function useWishlistToggle(
       setWishlistId(prevWishlistId);
       toast.error(toastMessage('wishlistError'));
     } finally {
+      loadingRef.current = false;
       setLoading(false);
     }
   };


### PR DESCRIPTION
## Summary
- Ignore stale autocomplete requests after query changes
- Treat empty prefetched block data as valid and avoid post-unmount updates
- Harden media query, recent searches, unsaved-change, and wishlist toggle hooks

## Test plan
- [x] npm run test:run -- src/components/shared/hooks/__tests__/useAutocomplete.test.tsx src/components/shared/hooks/__tests__/useBlockData.test.tsx
- [x] npm run build

## Notes
- Frontend build passes with existing warning: `src/components/AppShell.tsx` unused `locale` parameter.