### PR TITLE
fix: #887 영어 로고 표기 수정

### DIFF
--- a/src/app/[locale]/p/[slug]/page.tsx
+++ b/src/app/[locale]/p/[slug]/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const page = await fetchPage(slug);
   if (!page) return { title: locale === 'en' ? 'Page not found' : '페이지를 찾을 수 없습니다' };
   return {
-    title: `${page.title} | ${locale === 'en' ? 'Okhwadang' : '옥화당'}`,
+    title: `${page.title} | ${locale === 'en' ? 'Ockhwadang' : '옥화당'}`,
   };
 }
 

--- a/src/app/[locale]/products/[id]/page.tsx
+++ b/src/app/[locale]/products/[id]/page.tsx
@@ -68,14 +68,14 @@ export default async function ProductDetailPage({ params }: ProductDetailProps) 
     description: product.description,
     image: product.images?.map(img => img.url) ?? [],
     sku: product.sku,
-    brand: { '@type': 'Brand', name: safeLocale === 'en' ? 'Okhwadang' : '옥화당' },
+    brand: { '@type': 'Brand', name: safeLocale === 'en' ? 'Ockhwadang' : '옥화당' },
     url: `${SITE_URL}/${safeLocale}/products/${id}`,
     offers: {
       '@type': 'Offer',
       priceCurrency: 'KRW',
       price: product.salePrice ?? product.price,
       availability: product.stock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
-      seller: { '@type': 'Organization', name: safeLocale === 'en' ? 'Okhwadang' : '옥화당' },
+      seller: { '@type': 'Organization', name: safeLocale === 'en' ? 'Ockhwadang' : '옥화당' },
     },
   };
 

--- a/src/components/LogoSlider.tsx
+++ b/src/components/LogoSlider.tsx
@@ -45,7 +45,7 @@ export default function LogoSlider() {
           textShadow: '0 1px 8px rgba(0,0,0,0.4)',
         }}
       >
-        {locale === 'en' ? 'Okhwadang' : '옥화당'}
+        {locale === 'en' ? 'Ockhwadang' : '옥화당'}
       </span>
     </div>
   );

--- a/src/components/__tests__/EnglishLogoSpelling.test.tsx
+++ b/src/components/__tests__/EnglishLogoSpelling.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import LogoSlider from '@/components/LogoSlider';
+import Logo from '@/components/shared/Logo';
+
+let mockLocale = 'ko';
+
+vi.mock('next-intl', () => ({
+  useLocale: () => mockLocale,
+}));
+
+afterEach(() => {
+  mockLocale = 'ko';
+});
+
+describe('English logo spelling', () => {
+  it('renders the English header wordmark as Ockhwadang', () => {
+    mockLocale = 'en';
+
+    render(<Logo />);
+
+    expect(screen.getByText('Ockhwadang')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ockhwadang')).toBeInTheDocument();
+    expect(screen.queryByText('Okhwadang')).not.toBeInTheDocument();
+  });
+
+  it('renders the English hero overlay wordmark as Ockhwadang', () => {
+    mockLocale = 'en';
+
+    render(<LogoSlider />);
+
+    expect(screen.getByText('Ockhwadang')).toBeInTheDocument();
+    expect(screen.queryByText('Okhwadang')).not.toBeInTheDocument();
+  });
+
+  it('keeps the Korean image logo unchanged', () => {
+    render(<Logo />);
+
+    expect(screen.getByRole('img', { name: '옥화당' })).toHaveAttribute('src', '/logo-okhwadang.png');
+  });
+});

--- a/src/components/shared/Logo.tsx
+++ b/src/components/shared/Logo.tsx
@@ -21,9 +21,9 @@ export default function Logo({ variant = 'header', className }: LogoProps) {
           variant === 'hero' && 'text-3xl text-white',
           className,
         )}
-        aria-label="Okhwadang"
+        aria-label="Ockhwadang"
       >
-        Okhwadang
+        Ockhwadang
       </span>
     );
   }


### PR DESCRIPTION
## Summary
- Correct English brand wordmark text from `Okhwadang` to `Ockhwadang` in header/hero logo components
- Align English brand metadata/structured data strings with `Ockhwadang`
- Add focused regression coverage for English logo spelling and unchanged Korean logo behavior

Closes #887

## Verification
- `npx vitest run src/components/__tests__/EnglishLogoSpelling.test.tsx`
- `npm run build`
- `npm run test:run`
- `cd backend && npm run build && npm run test`

## Notes
- `bash scripts/codex-project-guard.sh` could not run before commit because the script is not present in this origin/main worktree.
