### PR TITLE
fix: 상품 속성 변경 권한을 관리자에게 제한

### DIFF
--- a/backend/src/modules/products/__tests__/attributes.controller.spec.ts
+++ b/backend/src/modules/products/__tests__/attributes.controller.spec.ts
@@ -1,0 +1,116 @@
+import { CanActivate, ExecutionContext, INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import request from 'supertest';
+import { RolesGuard } from '../../../common/guards/roles.guard';
+import { AttributesController } from '../attributes.controller';
+import { AttributesService } from '../attributes.service';
+
+interface TestRequest {
+  headers: Record<string, string | string[] | undefined>;
+  user?: { id: number; role: string };
+}
+
+class HeaderRoleAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const testRequest = context.switchToHttp().getRequest<TestRequest>();
+    const roleHeader = testRequest.headers['x-test-role'];
+    const role = Array.isArray(roleHeader) ? roleHeader[0] : roleHeader;
+    testRequest.user = { id: 1, role: role ?? 'user' };
+    return true;
+  }
+}
+
+describe('AttributesController RBAC', () => {
+  let app: INestApplication;
+
+  const attributesService = {
+    findAllAttributeTypes: jest.fn().mockResolvedValue([]),
+    getFilterableAttributes: jest.fn().mockResolvedValue([]),
+    findAttributeTypeById: jest.fn().mockResolvedValue({ id: 1, code: 'clay' }),
+    findAttributeTypeByCode: jest.fn().mockResolvedValue({ id: 1, code: 'clay' }),
+    getAttributeValuesByTypeCode: jest.fn().mockResolvedValue([]),
+    createAttributeType: jest.fn().mockResolvedValue({ id: 1, code: 'clay' }),
+    updateAttributeType: jest.fn().mockResolvedValue({ id: 1, code: 'clay', name: 'updated' }),
+    deleteAttributeType: jest.fn().mockResolvedValue(undefined),
+    findAttributesByProductId: jest.fn().mockResolvedValue([]),
+    createProductAttribute: jest.fn().mockResolvedValue({ id: 1, productId: 1, attributeTypeId: 1, value: 'zhuni' }),
+    updateProductAttribute: jest.fn().mockResolvedValue({ id: 1, value: 'duanni' }),
+    deleteProductAttribute: jest.fn().mockResolvedValue(undefined),
+    setProductAttributes: jest.fn().mockResolvedValue([{ id: 1, productId: 1, attributeTypeId: 1, value: 'zhuni' }]),
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AttributesController],
+      providers: [
+        Reflector,
+        RolesGuard,
+        { provide: AttributesService, useValue: attributesService },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalGuards(new HeaderRoleAuthGuard(), module.get(RolesGuard));
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const mutationRequests = [
+    {
+      label: 'POST /api/attributes/types',
+      send: () => request(app.getHttpServer()).post('/api/attributes/types').send({ code: 'clay', name: '니료' }),
+      successStatus: 201,
+    },
+    {
+      label: 'PATCH /api/attributes/types/:id',
+      send: () => request(app.getHttpServer()).patch('/api/attributes/types/1').send({ name: '수정' }),
+      successStatus: 200,
+    },
+    {
+      label: 'DELETE /api/attributes/types/:id',
+      send: () => request(app.getHttpServer()).delete('/api/attributes/types/1'),
+      successStatus: 204,
+    },
+    {
+      label: 'POST /api/attributes/products',
+      send: () => request(app.getHttpServer()).post('/api/attributes/products').send({ productId: 1, attributeTypeId: 1, value: 'zhuni' }),
+      successStatus: 201,
+    },
+    {
+      label: 'PATCH /api/attributes/products/:id',
+      send: () => request(app.getHttpServer()).patch('/api/attributes/products/1').send({ value: 'duanni' }),
+      successStatus: 200,
+    },
+    {
+      label: 'DELETE /api/attributes/products/:id',
+      send: () => request(app.getHttpServer()).delete('/api/attributes/products/1'),
+      successStatus: 204,
+    },
+    {
+      label: 'POST /api/attributes/products/:productId/set',
+      send: () => request(app.getHttpServer()).post('/api/attributes/products/1/set').send({ attributes: [{ attributeTypeId: 1, value: 'zhuni' }] }),
+      successStatus: 200,
+    },
+  ];
+
+  describe('ordinary authenticated user', () => {
+    it.each(mutationRequests)('$label -> 403', async ({ send }) => {
+      await send().set('x-test-role', 'user').expect(403);
+    });
+  });
+
+  describe.each(['admin', 'super_admin'])('%s user', (role) => {
+    it.each(mutationRequests)('$label -> success', async ({ send, successStatus }) => {
+      await send().set('x-test-role', role).expect(successStatus);
+    });
+  });
+});

--- a/backend/src/modules/products/attributes.controller.ts
+++ b/backend/src/modules/products/attributes.controller.ts
@@ -15,10 +15,11 @@ import { OptionalLocalePipe } from '../../common/pipes/optional-locale.pipe';
 import {
   ApiTags,
   ApiOperation,
-  ApiBearerAuth,
+  ApiCookieAuth,
   ApiQuery,
 } from '@nestjs/swagger';
 import { Public } from '../../common/decorators';
+import { Roles } from '../../common/decorators/roles.decorator';
 import { AttributesService } from './attributes.service';
 import { CreateAttributeTypeDto, UpdateAttributeTypeDto } from './dto/attribute-type.dto';
 import { CreateProductAttributeDto, UpdateProductAttributeDto, SetProductAttributesDto } from './dto/product-attribute.dto';
@@ -78,14 +79,16 @@ export class AttributesController {
   }
 
   @Post('types')
-  @ApiBearerAuth()
+  @Roles('admin', 'super_admin')
+  @ApiCookieAuth()
   @ApiOperation({ summary: '속성 유형 생성 (관리자)' })
   async createType(@Body() dto: CreateAttributeTypeDto): Promise<AttributeType> {
     return this.attributesService.createAttributeType(dto);
   }
 
   @Patch('types/:id')
-  @ApiBearerAuth()
+  @Roles('admin', 'super_admin')
+  @ApiCookieAuth()
   @ApiOperation({ summary: '속성 유형 수정 (관리자)' })
   async updateType(
     @Param('id', ParseIntPipe) id: number,
@@ -95,7 +98,8 @@ export class AttributesController {
   }
 
   @Delete('types/:id')
-  @ApiBearerAuth()
+  @Roles('admin', 'super_admin')
+  @ApiCookieAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: '속성 유형 삭제 (관리자)' })
   async deleteType(@Param('id', ParseIntPipe) id: number): Promise<void> {
@@ -112,14 +116,16 @@ export class AttributesController {
   }
 
   @Post('products')
-  @ApiBearerAuth()
+  @Roles('admin', 'super_admin')
+  @ApiCookieAuth()
   @ApiOperation({ summary: '상품 속성 생성 (관리자)' })
   async create(@Body() dto: CreateProductAttributeDto): Promise<ProductAttribute> {
     return this.attributesService.createProductAttribute(dto);
   }
 
   @Patch('products/:id')
-  @ApiBearerAuth()
+  @Roles('admin', 'super_admin')
+  @ApiCookieAuth()
   @ApiOperation({ summary: '상품 속성 수정 (관리자)' })
   async update(
     @Param('id', ParseIntPipe) id: number,
@@ -129,7 +135,8 @@ export class AttributesController {
   }
 
   @Delete('products/:id')
-  @ApiBearerAuth()
+  @Roles('admin', 'super_admin')
+  @ApiCookieAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: '상품 속성 삭제 (관리자)' })
   async delete(@Param('id', ParseIntPipe) id: number): Promise<void> {
@@ -137,7 +144,8 @@ export class AttributesController {
   }
 
   @Post('products/:productId/set')
-  @ApiBearerAuth()
+  @Roles('admin', 'super_admin')
+  @ApiCookieAuth()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '상품 속성 일괄 설정 (관리자)' })
   async setProductAttributes(


### PR DESCRIPTION
## 요약
- closes #895
- 상품 속성 타입/상품 속성 변경 엔드포인트에 admin/super_admin 역할 제한 추가
- 일반 사용자 403 및 관리자 성공 컨트롤러 회귀 테스트 추가
- Swagger 인증 표기를 쿠키 인증으로 정리

## 검증
- cd backend && npm test -- --runTestsByPath src/modules/products/__tests__/attributes.controller.spec.ts src/modules/products/__tests__/attributes.service.spec.ts --runInBand
- cd backend && npx eslint src/modules/products/attributes.controller.ts src/modules/products/__tests__/attributes.controller.spec.ts --max-warnings 0
- cd backend && npm run build
- bash scripts/codex-project-guard.sh
- bash scripts/start-local.sh
- curl -sS http://localhost:3000/api/health