### PR TITLE
fix: 리뷰 삭제 적립금 회수를 음수 차감으로 고정

### DIFF
--- a/backend/src/database/migrations/1785100000000-FixPositiveReviewPointRevocations.ts
+++ b/backend/src/database/migrations/1785100000000-FixPositiveReviewPointRevocations.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixPositiveReviewPointRevocations1785100000000 implements MigrationInterface {
+  name = 'FixPositiveReviewPointRevocations1785100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`point_history\`
+       SET \`amount\` = -ABS(\`amount\`)
+       WHERE \`type\` = 'spend'
+         AND \`amount\` > 0
+         AND \`related_entity_type\` = 'review'
+         AND \`description\` LIKE '리뷰 포인트 환수%'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`point_history\`
+       SET \`amount\` = ABS(\`amount\`)
+       WHERE \`type\` = 'spend'
+         AND \`amount\` < 0
+         AND \`related_entity_type\` = 'review'
+         AND \`description\` LIKE '리뷰 포인트 환수%'`,
+    );
+  }
+}

--- a/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
@@ -426,8 +426,9 @@ describe('ReviewsService', () => {
   });
 
   describe('remove', () => {
-    it('should delete own review and revoke points', async () => {
+    it('should delete own review and revoke points with negative spend amount', async () => {
       mockRepo.findOne.mockResolvedValue({ ...mockReview });
+      mockPointsService.getRunningBalanceInTx.mockResolvedValue(250);
 
       const earnEntry = {
         id: 99,
@@ -452,7 +453,13 @@ describe('ReviewsService', () => {
         return data?.type === 'spend';
       });
       expect(revokeSave).toBeDefined();
-      expect((revokeSave![1] as { amount: number }).amount).toBe(100);
+      expect(revokeSave![1]).toEqual(
+        expect.objectContaining({
+          type: 'spend',
+          amount: -100,
+          balance: 150,
+        }),
+      );
     });
 
     it('should revoke based on relatedEntity columns even when description format changes', async () => {

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -407,7 +407,7 @@ export class ReviewsService {
           const revokeEntry = manager.create(PointHistory, {
             userId: Number(review.userId),
             type: 'spend' as const,
-            amount: earnEntry.amount,
+            amount: -earnEntry.amount,
             balance: newBalance,
             description: `리뷰 포인트 환수 (review_id:${id})`,
             orderId: null,

--- a/backend/test/suites/reviews.e2e-spec.ts
+++ b/backend/test/suites/reviews.e2e-spec.ts
@@ -239,7 +239,7 @@ export function registerReviewsSuite(getApp: () => INestApplication) {
           [userId],
         ) as Array<{ amount: number; description: string }>;
         expect(revokeRow).toBeDefined();
-        expect(revokeRow.amount).toBe(100);
+        expect(revokeRow.amount).toBe(-100);
         expect(revokeRow.description).toContain(`review_id:${reviewId}`);
       });
 


### PR DESCRIPTION
## 요약
- closes #896
- 리뷰 삭제 시 적립금 회수 spend 기록을 음수 amount로 저장
- 회귀 테스트에서 음수 차감과 잔액 원상복구를 검증

## 검증
- cd backend && npm run test -- reviews.service.spec.ts --runInBand (pre-fix failure 확인)
- cd backend && npm run test -- reviews.service.spec.ts points.service.spec.ts --runInBand
- cd backend && npm run build