### PR TITLE
fix: 유료 취소 신청을 결제 취소 경로로 처리

### DIFF
--- a/backend/src/modules/orders/__tests__/order-service-requests.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/order-service-requests.service.spec.ts
@@ -1,0 +1,174 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ModuleRef } from '@nestjs/core';
+import { DataSource, EntityManager } from 'typeorm';
+import { OrderServiceRequestsService } from '../order-service-requests.service';
+import { Order, OrderStatus } from '../entities/order.entity';
+import {
+  OrderServiceRequest,
+  OrderServiceRequestStatus,
+  OrderServiceRequestType,
+} from '../entities/order-service-request.entity';
+import { NotificationService } from '../../notification/notification.service';
+import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
+import type { PaymentsService } from '../../payments/payments.service';
+import { PaymentStatus } from '../../payments/entities/payment.entity';
+
+const makeOrder = (overrides: Partial<Order> = {}): Order => ({
+  id: 7,
+  userId: 10,
+  orderNumber: 'ORD-20260101-ABCDE',
+  status: OrderStatus.PAID,
+  totalAmount: 30000,
+  discountAmount: 0,
+  shippingFee: 0,
+  recipientName: '홍길동',
+  recipientPhone: '010-0000-0000',
+  zipcode: '12345',
+  address: '서울시',
+  addressDetail: null,
+  memo: null,
+  pointsUsed: 1000,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  items: [],
+  ...overrides,
+} as Order);
+
+const makeRequest = (
+  order: Order,
+  overrides: Partial<OrderServiceRequest> = {},
+): OrderServiceRequest => ({
+  id: 55,
+  orderId: Number(order.id),
+  userId: order.userId,
+  type: OrderServiceRequestType.CANCEL,
+  status: OrderServiceRequestStatus.REQUESTED,
+  reason: '고객 변심',
+  detail: null,
+  imageUrls: null,
+  useShippingAddress: true,
+  pickupName: null,
+  pickupPhone: null,
+  pickupZipcode: null,
+  pickupAddress: null,
+  pickupAddressDetail: null,
+  adminNote: null,
+  processedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  order,
+  user: { id: order.userId, email: 'user@example.com', name: '홍길동' },
+  ...overrides,
+} as unknown as OrderServiceRequest);
+
+const makeRepository = () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  createQueryBuilder: jest.fn(),
+});
+
+const makeManager = () => ({
+  update: jest.fn().mockResolvedValue({}),
+  findOne: jest.fn(),
+  find: jest.fn().mockResolvedValue([]),
+  increment: jest.fn().mockResolvedValue({}),
+  save: jest.fn().mockResolvedValue({}),
+});
+
+describe('OrderServiceRequestsService', () => {
+  let service: OrderServiceRequestsService;
+  let requestRepository: ReturnType<typeof makeRepository>;
+  let orderRepository: ReturnType<typeof makeRepository>;
+  let manager: ReturnType<typeof makeManager>;
+  let paymentsService: jest.Mocked<Pick<PaymentsService, 'cancelPaidOrder'>>;
+
+  beforeEach(async () => {
+    requestRepository = makeRepository();
+    orderRepository = makeRepository();
+    manager = makeManager();
+    paymentsService = {
+      cancelPaidOrder: jest.fn().mockResolvedValue({
+        paymentId: 100,
+        status: PaymentStatus.CANCELLED,
+        cancelledAt: new Date(),
+        cancelReason: '관리자 승인',
+      }),
+    };
+
+    const dataSource = {
+      transaction: jest.fn((cb: (txManager: EntityManager) => Promise<unknown>) => cb(manager as unknown as EntityManager)),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrderServiceRequestsService,
+        { provide: getRepositoryToken(OrderServiceRequest), useValue: requestRepository },
+        { provide: getRepositoryToken(Order), useValue: orderRepository },
+        { provide: DataSource, useValue: dataSource },
+        { provide: NotificationService, useValue: { sendEmail: jest.fn() } },
+        { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
+        { provide: ModuleRef, useValue: { get: jest.fn().mockReturnValue(paymentsService) } },
+      ],
+    }).compile();
+
+    service = module.get<OrderServiceRequestsService>(OrderServiceRequestsService);
+  });
+
+  it('paid cancel request completion routes through shared payment cancellation in the same transaction', async () => {
+    const order = makeOrder({ status: OrderStatus.PAID });
+    const request = makeRequest(order);
+    const updated = makeRequest(order, {
+      status: OrderServiceRequestStatus.COMPLETED,
+      adminNote: '관리자 승인',
+    });
+    requestRepository.findOne
+      .mockResolvedValueOnce(request)
+      .mockResolvedValueOnce(updated);
+    manager.findOne.mockResolvedValue(order);
+
+    await service.updateForAdmin(request.id, {
+      status: OrderServiceRequestStatus.COMPLETED,
+      adminNote: '관리자 승인',
+    });
+
+    expect(paymentsService.cancelPaidOrder).toHaveBeenCalledWith(
+      order.id,
+      '관리자 승인',
+    );
+    expect(manager.update).toHaveBeenCalledWith(
+      OrderServiceRequest,
+      request.id,
+      expect.objectContaining({
+        status: OrderServiceRequestStatus.COMPLETED,
+        adminNote: '관리자 승인',
+        processedAt: expect.any(Date),
+      }),
+    );
+    expect(manager.update).not.toHaveBeenCalledWith(
+      Order,
+      order.id,
+      { status: OrderStatus.CANCELLED },
+    );
+  });
+
+  it('pending cancel request completion keeps the local unpaid cancellation path', async () => {
+    const order = makeOrder({ status: OrderStatus.PENDING, pointsUsed: 0 });
+    const request = makeRequest(order);
+    const updated = makeRequest(order, { status: OrderServiceRequestStatus.COMPLETED });
+    requestRepository.findOne
+      .mockResolvedValueOnce(request)
+      .mockResolvedValueOnce(updated);
+    manager.findOne.mockResolvedValue(order);
+
+    await service.updateForAdmin(request.id, {
+      status: OrderServiceRequestStatus.COMPLETED,
+    });
+
+    expect(paymentsService.cancelPaidOrder).not.toHaveBeenCalled();
+    expect(manager.update).toHaveBeenCalledWith(Order, order.id, { status: OrderStatus.CANCELLED });
+  });
+});

--- a/backend/src/modules/orders/order-service-requests.service.ts
+++ b/backend/src/modules/orders/order-service-requests.service.ts
@@ -17,9 +17,14 @@ import { NotificationService } from '../notification/notification.service';
 import { NotificationDispatchHelper } from '../notification/notification-dispatch.helper';
 import { restoreOrderStock } from './order-stock.util';
 import { PointHistory } from '../coupons/entities/point-history.entity';
+import { ModuleRef } from '@nestjs/core';
 
 const CANCELLABLE_STATUSES = new Set<OrderStatus>([OrderStatus.PENDING, OrderStatus.PAID]);
 const AFTER_DELIVERY_REQUEST_STATUSES = new Set<OrderStatus>([OrderStatus.DELIVERED, OrderStatus.COMPLETED]);
+
+interface PaymentCancellationService {
+  cancelPaidOrder(orderId: number, reason: string): Promise<unknown>;
+}
 const ACTIVE_REQUEST_STATUSES = [OrderServiceRequestStatus.REQUESTED, OrderServiceRequestStatus.APPROVED];
 
 @Injectable()
@@ -34,6 +39,7 @@ export class OrderServiceRequestsService {
     private readonly dataSource: DataSource,
     private readonly notificationService: NotificationService,
     private readonly notificationDispatchHelper: NotificationDispatchHelper,
+    private readonly moduleRef: ModuleRef,
   ) {}
 
   async create(orderId: number, userId: number, dto: CreateOrderServiceRequestDto): Promise<OrderServiceRequest> {
@@ -111,10 +117,22 @@ export class OrderServiceRequestsService {
       ['order', 'user'],
     );
 
+    const adminNote = dto.adminNote?.trim() || null;
+
+    // 유료 주문의 취소 신청 완료는 외부 PG 취소를 포함하므로, 신청 상태 업데이트
+    // 트랜잭션을 연 채로 네트워크 호출을 수행하지 않는다. 결제 취소 서비스가 PG
+    // 성공 후 Payment/Order/stock/points 동기화를 자체 트랜잭션으로 처리한다.
+    if (this.isPaidCancelCompletion(request, dto.status)) {
+      await this.getPaymentsService().cancelPaidOrder(
+        Number(request.orderId),
+        adminNote || `고객 취소 신청 처리: ${request.reason}`,
+      );
+    }
+
     await this.dataSource.transaction(async (manager) => {
       await manager.update(OrderServiceRequest, id, {
         status: dto.status,
-        adminNote: dto.adminNote?.trim() || null,
+        adminNote,
         processedAt: dto.status === OrderServiceRequestStatus.REQUESTED ? null : new Date(),
       });
 
@@ -131,6 +149,19 @@ export class OrderServiceRequestsService {
     );
     void this.notifyRequestStatusChanged(updated);
     return updated;
+  }
+
+  private getPaymentsService(): PaymentCancellationService {
+    return this.moduleRef.get<PaymentCancellationService>('PaymentsService', { strict: false });
+  }
+
+  private isPaidCancelCompletion(
+    request: OrderServiceRequest,
+    nextStatus: OrderServiceRequestStatus,
+  ): boolean {
+    return nextStatus === OrderServiceRequestStatus.COMPLETED
+      && request.type === OrderServiceRequestType.CANCEL
+      && request.order?.status === OrderStatus.PAID;
   }
 
   private assertRequestAllowed(orderStatus: OrderStatus, type: OrderServiceRequestType): void {
@@ -158,6 +189,13 @@ export class OrderServiceRequestsService {
 
     if (request.type === OrderServiceRequestType.CANCEL) {
       if (![OrderStatus.PENDING, OrderStatus.PAID].includes(order.status)) return;
+
+      if (order.status === OrderStatus.PAID) {
+        // Paid cancellations are handled before this transaction by PaymentsService
+        // so the external gateway call is not made while this request transaction is open.
+        return;
+      }
+
       await manager.update(Order, order.id, { status: OrderStatus.CANCELLED });
       await restoreOrderStock(manager, Number(order.id));
       await this.restorePoints(manager, order);

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { DataSource } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 import { NotFoundException, BadRequestException, ConflictException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
 import { PaymentsService } from '../payments.service';
 import { Payment, PaymentStatus, PaymentMethod, PaymentGatewayType } from '../entities/payment.entity';
@@ -780,6 +780,92 @@ describe('PaymentsService', () => {
       expect(txManager.increment).toHaveBeenCalledWith(expect.anything(), { id: 12 }, 'stock', 5);
       // 옵션 있는 상품의 product.stock 은 건드리지 않음.
       expect(txManager.increment).toHaveBeenCalledTimes(2);
+    });
+
+
+
+    it('cancelPaidOrder() persists reconciliation marker when DB sync fails after gateway cancellation (#898)', async () => {
+      const order = makeOrder({ status: OrderStatus.PAID, pointsUsed: 0 });
+      const payment = makePayment({
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: 'pay_abc',
+        order,
+      });
+      const cancelledAt = new Date();
+      const syncError = new Error('db sync failed');
+      mockPaymentRepo.findOne.mockResolvedValue(payment);
+      mockDefaultGateway.cancel.mockResolvedValue({ cancelledAt, rawResponse: { mock: true } });
+      mockDataSource.transaction.mockRejectedValueOnce(syncError);
+
+      await expect(service.cancelPaidOrder(1, '관리자 승인')).rejects.toThrow(syncError);
+
+      expect(mockDefaultGateway.cancel).toHaveBeenCalledWith('pay_abc', '관리자 승인');
+      expect(mockPaymentRepo.update).toHaveBeenCalledWith(payment.id, {
+        status: PaymentStatus.CANCELLED,
+        cancelledAt,
+        cancelReason: '관리자 승인',
+        rawResponse: expect.objectContaining({
+          gatewayCancellationSucceeded: true,
+          reconciliationRequired: true,
+          orderId: 1,
+          rawResponse: { mock: true },
+          error: 'db sync failed',
+        }),
+      });
+    });
+
+    it('cancelPaidOrder()는 전달받은 트랜잭션에서 PG 취소 후 Payment/Order/stock/points를 함께 갱신한다 (#898)', async () => {
+      const order = makeOrder({
+        status: OrderStatus.PAID,
+        pointsUsed: 1000,
+      });
+      const payment = makePayment({
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: 'pay_abc',
+        order,
+      });
+      const items = [
+        { orderId: 1, productId: 11, productOptionId: 22, quantity: 3 },
+        { orderId: 1, productId: 12, productOptionId: null, quantity: 5 },
+      ];
+      const cancelledAt = new Date();
+      const txManager = makeTransactionManager({
+        findOne: jest.fn().mockImplementation((entity: unknown) => {
+          if (entity === Payment) return Promise.resolve(payment);
+          return Promise.resolve({ balance: 2000 });
+        }),
+        find: jest.fn().mockResolvedValue(items),
+        increment: jest.fn().mockResolvedValue({}),
+      });
+      mockDefaultGateway.cancel.mockResolvedValue({ cancelledAt, rawResponse: { mock: true } });
+
+      const result = await service.cancelPaidOrder(
+        1,
+        '관리자 승인',
+        txManager as unknown as EntityManager,
+      );
+
+      expect(result.status).toBe(PaymentStatus.CANCELLED);
+      expect(mockDefaultGateway.cancel).toHaveBeenCalledWith('pay_abc', '관리자 승인');
+      expect(mockDataSource.transaction).not.toHaveBeenCalled();
+      expect(txManager.update).toHaveBeenCalledWith(Payment, payment.id, {
+        status: PaymentStatus.CANCELLED,
+        cancelledAt,
+        cancelReason: '관리자 승인',
+        rawResponse: { mock: true },
+      });
+      expect(txManager.update).toHaveBeenCalledWith(Order, 1, { status: OrderStatus.CANCELLED });
+      expect(txManager.increment).toHaveBeenCalledTimes(2);
+      expect(txManager.save).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          userId: order.userId,
+          type: 'admin_adjust',
+          amount: 1000,
+          balance: 3000,
+          orderId: order.id,
+        }),
+      );
     });
   });
 });

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -5,6 +5,7 @@ import { PaymentWebhookEvent } from './entities/payment-webhook-event.entity';
 import { Refund } from './entities/refund.entity';
 import { Shipping } from './entities/shipping.entity';
 import { Order } from '../orders/entities/order.entity';
+import { PointHistory } from '../coupons/entities/point-history.entity';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
 import { AdminOrderRefundsController } from './admin-order-refunds.controller';
@@ -96,9 +97,9 @@ const gatewayProviders = [
 ];
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment, PaymentWebhookEvent, Refund, Shipping, Order])],
+  imports: [TypeOrmModule.forFeature([Payment, PaymentWebhookEvent, Refund, Shipping, Order, PointHistory])],
   controllers: [PaymentsController, AdminOrderRefundsController, AdminPaymentWebhooksController],
-  providers: [...gatewayProviders, PaymentsService],
-  exports: [PaymentsService],
+  providers: [...gatewayProviders, PaymentsService, { provide: 'PaymentsService', useExisting: PaymentsService }],
+  exports: [PaymentsService, 'PaymentsService'],
 })
 export class PaymentsModule {}

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -1,15 +1,16 @@
 import {
-  Injectable, BadRequestException, ConflictException,
+  Injectable, BadRequestException, ConflictException, NotFoundException,
   Logger, Inject, Optional,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { Payment, PaymentStatus, PaymentGatewayType, PaymentMethod } from './entities/payment.entity';
 import { PaymentWebhookEvent } from './entities/payment-webhook-event.entity';
 import { Refund } from './entities/refund.entity';
 import { Shipping } from './entities/shipping.entity';
 import { Order, OrderStatus } from '../orders/entities/order.entity';
 import { restoreOrderStock } from '../orders/order-stock.util';
+import { PointHistory } from '../coupons/entities/point-history.entity';
 import { PaymentGateway } from './interfaces/payment-gateway.interface';
 import { PreparePaymentDto } from './dto/prepare-payment.dto';
 import { ConfirmPaymentDto } from './dto/confirm-payment.dto';
@@ -229,28 +230,28 @@ export class PaymentsService {
     }
 
     const reason = dto.reason ?? '고객 요청';
-    const cancelGateway = this.resolveGatewayByType(payment.gateway);
-    const result = await cancelGateway.cancel(payment.paymentKey!, reason);
+    return this.cancelConfirmedOrderPayment(payment, dto.orderId, reason);
+  }
 
-    // PG 취소 성공 후 결제 상태/주문 상태/재고 복구를 한 트랜잭션으로 묶는다.
-    // 재고 복구 정책 및 멱등성: `orders/order-stock.util.ts` 참고.
-    await this.dataSource.transaction(async (manager) => {
-      await manager.update(Payment, payment.id, {
-        status: PaymentStatus.CANCELLED,
-        cancelledAt: result.cancelledAt,
-        cancelReason: reason,
-        rawResponse: result.rawResponse as object,
-      });
-      await manager.update(Order, dto.orderId, { status: OrderStatus.CANCELLED });
-      await restoreOrderStock(manager, dto.orderId);
-    });
+  async cancelPaidOrder(
+    orderId: number,
+    reason: string,
+    manager?: EntityManager,
+  ): Promise<{
+    paymentId: number;
+    status: PaymentStatus;
+    cancelledAt: Date;
+    cancelReason: string;
+  }> {
+    const payment = manager
+      ? await manager.findOne(Payment, { where: { orderId }, relations: ['order'] })
+      : await this.paymentRepository.findOne({ where: { orderId }, relations: ['order'] });
 
-    return {
-      paymentId: Number(payment.id),
-      status: PaymentStatus.CANCELLED,
-      cancelledAt: result.cancelledAt,
-      cancelReason: reason,
-    };
+    if (!payment) {
+      throw new NotFoundException('결제 정보를 찾을 수 없습니다.');
+    }
+
+    return this.cancelConfirmedOrderPayment(payment, orderId, reason, manager);
   }
 
   async cancelAdmin(orderId: number, reason: string): Promise<{
@@ -293,5 +294,103 @@ export class PaymentsService {
 
   async handleWebhook(payload: unknown, signature: string): Promise<void> {
     return this.paymentWebhookService.handleWebhook(payload, signature);
+  }
+
+  private async cancelConfirmedOrderPayment(
+    payment: Payment,
+    orderId: number,
+    reason: string,
+    manager?: EntityManager,
+  ): Promise<{
+    paymentId: number;
+    status: PaymentStatus;
+    cancelledAt: Date;
+    cancelReason: string;
+  }> {
+    if (payment.status !== PaymentStatus.CONFIRMED) {
+      throw new BadRequestException('취소 가능한 상태가 아닙니다.');
+    }
+
+    const cancelGateway = this.resolveGatewayByType(payment.gateway);
+    const result = await cancelGateway.cancel(payment.paymentKey!, reason);
+
+    const applyCancellation = async (txManager: EntityManager): Promise<void> => {
+      await txManager.update(Payment, payment.id, {
+        status: PaymentStatus.CANCELLED,
+        cancelledAt: result.cancelledAt,
+        cancelReason: reason,
+        rawResponse: result.rawResponse as object,
+      });
+      await txManager.update(Order, orderId, { status: OrderStatus.CANCELLED });
+      await restoreOrderStock(txManager, orderId);
+      await this.restorePoints(txManager, payment.order);
+    };
+
+    try {
+      if (manager) {
+        await applyCancellation(manager);
+      } else {
+        // PG 취소 성공 후 결제 상태/주문 상태/재고/포인트 복구를 한 트랜잭션으로 묶는다.
+        // 재고 복구 정책 및 멱등성: `orders/order-stock.util.ts` 참고.
+        await this.dataSource.transaction(applyCancellation);
+      }
+    } catch (err) {
+      await this.persistCancellationReconciliation(payment, orderId, reason, result, err);
+      throw err;
+    }
+
+    return {
+      paymentId: Number(payment.id),
+      status: PaymentStatus.CANCELLED,
+      cancelledAt: result.cancelledAt,
+      cancelReason: reason,
+    };
+  }
+
+  private async persistCancellationReconciliation(
+    payment: Payment,
+    orderId: number,
+    reason: string,
+    result: { cancelledAt: Date; rawResponse?: unknown },
+    err: unknown,
+  ): Promise<void> {
+    const reconciliationPayload = {
+      gatewayCancellationSucceeded: true,
+      reconciliationRequired: true,
+      orderId,
+      rawResponse: result.rawResponse,
+      error: err instanceof Error ? err.message : String(err),
+    };
+
+    try {
+      await this.paymentRepository.update(payment.id, {
+        status: PaymentStatus.CANCELLED,
+        cancelledAt: result.cancelledAt,
+        cancelReason: reason,
+        rawResponse: reconciliationPayload,
+      });
+    } catch (persistErr) {
+      this.logger.error(
+        `Failed to persist cancellation reconciliation for payment ${payment.id}: ${String(persistErr)}`,
+      );
+    }
+  }
+
+  private async restorePoints(manager: EntityManager, order: Order): Promise<void> {
+    if (!order.pointsUsed || order.pointsUsed <= 0) return;
+
+    const last = await manager.findOne(PointHistory, {
+      where: { userId: order.userId },
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+    const balance = Number(last?.balance ?? 0) + Number(order.pointsUsed);
+    await manager.save(PointHistory, {
+      userId: order.userId,
+      type: 'admin_adjust',
+      amount: order.pointsUsed,
+      balance,
+      orderId: Number(order.id),
+      description: `주문 ${order.orderNumber} 취소로 인한 적립금 복구`,
+    });
   }
 }


### PR DESCRIPTION
## 요약
- closes #898
- paid 주문 취소 신청 완료를 PaymentsService 공용 결제 취소 경로로 라우팅
- 결제 취소가 Payment/Order/stock/points를 함께 갱신하도록 공유 로직 추가
- pending unpaid 주문은 기존 로컬 취소 경로 유지

## 검증
- cd backend && npm run test -- order-service-requests.service.spec.ts payments.service.spec.ts
- cd backend && npm run test -- admin-orders.service.spec.ts order-service-requests.service.spec.ts payments.service.spec.ts
- cd backend && npm run build
- git diff --check

## 미검증
- 실제 결제 게이트웨이 sandbox 취소