### PR TITLE
fix: 포인트 만료 중복 방지를 원본 적립금 기준으로 고정

### DIFF
--- a/backend/src/modules/scheduler/__tests__/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/__tests__/scheduler.service.spec.ts
@@ -98,7 +98,23 @@ describe('SchedulerService', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+
+    mockDataSource.query.mockReset();
+    mockDataSource.createQueryRunner.mockReset();
     mockDataSource.createQueryRunner.mockReturnValue(mockQueryRunner);
+    mockQueryRunner.connect.mockReset();
+    mockQueryRunner.startTransaction.mockReset();
+    mockQueryRunner.commitTransaction.mockReset();
+    mockQueryRunner.rollbackTransaction.mockReset();
+    mockQueryRunner.release.mockReset();
+    mockQueryRunner.manager.createQueryBuilder.mockReset();
+    mockQueryRunner.manager.create.mockReset();
+    mockQueryRunner.manager.save.mockReset();
+    mockQueryRunner.manager.update.mockReset();
+    mockQueryRunner.manager.findOne.mockReset();
+    mockQueryRunner.manager.increment.mockReset();
+    mockQueryRunner.manager.getRepository.mockReset();
+    mockSchedulerLockService.runWithLock.mockReset();
     mockSchedulerLockService.runWithLock.mockImplementation(
       async (
         _policy: { lockName: string; ttlMinutes: number },
@@ -267,7 +283,6 @@ describe('SchedulerService', () => {
           { id: 1, user_id: 1, amount: 1000, expires_at: new Date(Date.now() - 24 * 60 * 60 * 1000) },
         ]);
 
-      mockQueryRunner.manager.findOne.mockResolvedValue({ balance: 5000 });
       mockQueryRunner.manager.save.mockResolvedValue({});
       mockQueryRunner.manager.findOne
         .mockResolvedValueOnce({ balance: 5000 })   // latest balance
@@ -276,6 +291,59 @@ describe('SchedulerService', () => {
       await service.handlePointExpiry();
 
       expect(mockDataSource.query).toHaveBeenCalled();
+      expect(mockQueryRunner.manager.save).toHaveBeenCalledWith(PointHistory, expect.objectContaining({
+        userId: 1,
+        type: 'expire',
+        amount: -1000,
+        balance: 4000,
+        relatedEntityType: null,
+        relatedEntityId: 1,
+      }));
+    });
+
+    it('should not expire the same earn row again on a later day', async () => {
+      const earnRow = {
+        id: 99,
+        user_id: 1,
+        amount: 1000,
+        expires_at: new Date('2026-01-01T00:00:00.000Z'),
+      };
+      const expireMarkers: Array<{ type?: string; relatedEntityType?: string | null; relatedEntityId?: number | null }> = [];
+
+      mockDataSource.query.mockImplementation(async (query: string) => {
+        expect(query).toContain('ex.related_entity_id = ph.id');
+        expect(query).not.toContain('DATE(ex.created_at)');
+
+        return expireMarkers.some((marker) => (
+          marker.type === 'expire'
+          && marker.relatedEntityType === null
+          && marker.relatedEntityId === earnRow.id
+        ))
+          ? []
+          : [earnRow];
+      });
+      mockQueryRunner.manager.findOne
+        .mockResolvedValueOnce({ balance: 1000 })
+        .mockResolvedValueOnce(null);
+      mockQueryRunner.manager.save.mockImplementation(async (_entity, entry) => {
+        expireMarkers.push(entry);
+        return entry;
+      });
+
+      jest.setSystemTime(new Date('2026-01-02T02:00:00.000Z'));
+      await service.handlePointExpiry();
+
+      jest.setSystemTime(new Date('2026-01-03T02:00:00.000Z'));
+      await service.handlePointExpiry();
+
+      expect(mockDataSource.query).toHaveBeenCalledTimes(2);
+      expect(mockQueryRunner.manager.save).toHaveBeenCalledTimes(1);
+      expect(mockQueryRunner.manager.save).toHaveBeenCalledWith(PointHistory, expect.objectContaining({
+        type: 'expire',
+        amount: -1000,
+        relatedEntityType: null,
+        relatedEntityId: earnRow.id,
+      }));
     });
 
     it('should do nothing when no expired points found', async () => {

--- a/backend/src/modules/scheduler/jobs/point-scheduler.job.ts
+++ b/backend/src/modules/scheduler/jobs/point-scheduler.job.ts
@@ -18,7 +18,10 @@ export class PointSchedulerJob {
   async handlePointExpiry(): Promise<void> {
     const now = new Date();
 
-    // Only process earn entries that have expired and have NOT yet had an expire record created.
+    // Only process earn entries that have expired and have NOT yet had an expire record
+    // created for that source earn row. `related_entity_id` stores the source earn id
+    // for scheduler-created expiration markers; `related_entity_type` stays null because
+    // the existing enum is for business entities, not point_history self-references.
     const expiredPoints = await this.deps.dataSource.query<
       Array<{ id: number; user_id: number; amount: number; expires_at: string }>
     >(
@@ -31,10 +34,10 @@ export class PointSchedulerJob {
            SELECT 1 FROM point_history ex
            WHERE ex.user_id = ph.user_id
              AND ex.type = 'expire'
-             AND ex.description = '포인트 만료'
-             AND DATE(ex.created_at) = DATE(?)
+             AND ex.related_entity_type IS NULL
+             AND ex.related_entity_id = ph.id
          )`,
-      [now, now],
+      [now],
     );
 
     if (expiredPoints.length === 0) {
@@ -44,14 +47,15 @@ export class PointSchedulerJob {
 
     this.deps.logger.log(`[cron:point-expiry] Processing ${expiredPoints.length} expired point records`);
 
-    const userExpiredMap = new Map<number, number>();
+    const userExpiredMap = new Map<number, Array<{ id: number; amount: number }>>();
     for (const ph of expiredPoints) {
-      const uid = Number(ph.user_id);
-      const current = userExpiredMap.get(uid) || 0;
-      userExpiredMap.set(uid, current + Number(ph.amount));
+      const userId = Number(ph.user_id);
+      const entries = userExpiredMap.get(userId) ?? [];
+      entries.push({ id: Number(ph.id), amount: Number(ph.amount) });
+      userExpiredMap.set(userId, entries);
     }
 
-    for (const [userId, totalExpired] of userExpiredMap) {
+    for (const [userId, entries] of userExpiredMap) {
       const queryRunner = this.deps.dataSource.createQueryRunner();
       await queryRunner.connect();
       await queryRunner.startTransaction();
@@ -62,27 +66,35 @@ export class PointSchedulerJob {
           order: { createdAt: 'DESC', id: 'DESC' },
         });
 
-        const currentBalance = latestBalance?.balance ?? 0;
-        const expireAmount = Math.min(totalExpired, currentBalance);
+        let currentBalance = latestBalance?.balance ?? 0;
+        let totalExpired = 0;
 
-        if (expireAmount > 0 && currentBalance > 0) {
+        for (const entry of entries) {
+          const expireAmount = Math.max(0, Math.min(entry.amount, currentBalance));
+          currentBalance -= expireAmount;
+          totalExpired += expireAmount;
+
           await queryRunner.manager.save(PointHistory, {
             userId,
             type: 'expire',
             amount: -expireAmount,
-            balance: currentBalance - expireAmount,
+            balance: currentBalance,
             description: '포인트 만료',
             expiresAt: null,
+            relatedEntityType: null,
+            relatedEntityId: entry.id,
           });
+        }
 
+        if (totalExpired > 0) {
           const user = await queryRunner.manager.findOne(User, { where: { id: userId } });
           if (user?.email) {
             void Promise.resolve(
               this.deps.notificationService.sendEmail({
                 to: user.email,
                 subject: '[옥화당] 포인트 만료 안내',
-                text: `안녕하세요. 고객님의 포인트 ${expireAmount.toLocaleString()}원이 만료되었습니다.`,
-                html: `<p>안녕하세요.</p><p>고객님의 포인트 <strong>${expireAmount.toLocaleString()}원</strong>이 만료되었습니다.</p>`,
+                text: `안녕하세요. 고객님의 포인트 ${totalExpired.toLocaleString()}원이 만료되었습니다.`,
+                html: `<p>안녕하세요.</p><p>고객님의 포인트 <strong>${totalExpired.toLocaleString()}원</strong>이 만료되었습니다.</p>`,
               }),
             )
               .catch((err) => this.deps.logger.warn(`Failed to send point expiry email: ${String(err)}`));
@@ -90,7 +102,7 @@ export class PointSchedulerJob {
         }
 
         await queryRunner.commitTransaction();
-        this.deps.logger.log(`[cron:point-expiry] Expired ${expireAmount} points for user ${userId}`);
+        this.deps.logger.log(`[cron:point-expiry] Expired ${totalExpired} points for user ${userId}`);
       } catch (err) {
         await queryRunner.rollbackTransaction();
         this.deps.logger.error(`[cron:point-expiry] Failed to expire points for user ${userId}: ${String(err)}`);


### PR DESCRIPTION
## 요약
- closes #899
- 포인트 만료 중복 제외 조건을 사용자+일자에서 원본 earn row 기준으로 변경
- 만료 기록에 기존 related_entity_id로 source earn id 저장
- 이틀 연속 크론 실행 시 같은 적립금이 한 번만 만료되는 회귀 테스트 추가

## 마이그레이션
- 추가 없음: 기존 nullable related_entity_id / related_entity_type 컬럼 활용

## 검증
- cd backend && npm run test -- scheduler.service.spec.ts points.service.spec.ts
- cd backend && npm run build
- cd backend && npm run lint
- git diff --check

## 미검증
- 과거 양수 중복 expire 데이터가 있는 production DB 보정