### PR TITLE
fix: 체크아웃 포인트 사용을 유효 잔액 기준으로 제한

### DIFF
--- a/backend/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/orders.service.spec.ts
@@ -35,7 +35,9 @@ const mockOrderRepository = {
 
 const mockPointsService = {
   getUserPointBalance: jest.fn(),
+  getEffectiveBalanceInTx: jest.fn(),
   getRunningBalanceInTx: jest.fn(),
+  deductFifo: jest.fn(),
 };
 
 const mockCouponsService = {
@@ -206,12 +208,7 @@ describe('OrdersService', () => {
         pointsUsed: 5000,
       };
 
-      // point balance check uses manager.getRepository (inside transaction)
-      const mockPointRepo = {
-        findOne: jest.fn().mockResolvedValue({ balance: 1000 }),
-      };
-      mockManager.getRepository.mockReturnValue(mockPointRepo);
-      mockPointsService.getRunningBalanceInTx.mockResolvedValue(1000);
+      mockPointsService.getEffectiveBalanceInTx.mockResolvedValue(1000);
       mockManager.createQueryBuilder.mockReturnValue({
         setLock: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
@@ -220,6 +217,34 @@ describe('OrdersService', () => {
 
       await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
       expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
+      expect(mockPointsService.getEffectiveBalanceInTx).toHaveBeenCalledWith(mockManager, 1);
+      expect(mockPointsService.getRunningBalanceInTx).not.toHaveBeenCalled();
+      expect(mockPointsService.deductFifo).not.toHaveBeenCalled();
+    });
+
+    it('만료 earn 이 history 에 남아 running balance 가 충분해도 effective balance 부족이면 주문 포인트 사용을 거부한다', async () => {
+      const dto: CreateOrderDto = {
+        items: [{ productId: 1, quantity: 1 }],
+        recipientName: '홍길동',
+        recipientPhone: '010-1234-5678',
+        zipcode: '12345',
+        address: '서울시',
+        pointsUsed: 1500,
+      };
+
+      // Regression for #900: running balance may still include an expired earn
+      // before the expiry cron writes an expire row, but checkout must only trust
+      // the non-expired effective balance.
+      mockPointsService.getEffectiveBalanceInTx.mockResolvedValue(1000);
+      mockPointsService.getRunningBalanceInTx.mockResolvedValue(2000);
+
+      await expect(service.create(1, dto)).rejects.toThrow(BadRequestException);
+
+      expect(mockDataSource.transaction).toHaveBeenCalledTimes(1);
+      expect(mockPointsService.getEffectiveBalanceInTx).toHaveBeenCalledWith(mockManager, 1);
+      expect(mockPointsService.getRunningBalanceInTx).not.toHaveBeenCalled();
+      expect(mockPointsService.deductFifo).not.toHaveBeenCalled();
+      expect(mockManager.update).not.toHaveBeenCalled();
     });
 
     it('valid dto → creates order, deducts stock, clears cart', async () => {

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -157,7 +157,7 @@ export class OrdersService {
   ): Promise<void> {
     if (pointsToUse <= 0) return;
 
-    const balance = await this.pointsService.getRunningBalanceInTx(manager, userId);
+    const balance = await this.pointsService.getEffectiveBalanceInTx(manager, userId);
     if (pointsToUse > balance) {
       throw new BadRequestException('적립금이 부족합니다.');
     }

--- a/backend/src/modules/points/__tests__/points.service.spec.ts
+++ b/backend/src/modules/points/__tests__/points.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { EntityManager } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
 import { PointHistory } from '../../coupons/entities/point-history.entity';
 import { PointsService, addOneYear } from '../points.service';
 
@@ -8,6 +9,7 @@ const mockSelectQueryBuilder = {
   select: jest.fn().mockReturnThis(),
   where: jest.fn().mockReturnThis(),
   andWhere: jest.fn().mockReturnThis(),
+  setParameter: jest.fn().mockReturnThis(),
   getRawOne: jest.fn(),
 };
 
@@ -28,6 +30,7 @@ describe('PointsService', () => {
     jest.clearAllMocks();
     mockPointHistoryRepo.createQueryBuilder.mockReturnValue(mockSelectQueryBuilder);
     mockEntityManager.createQueryBuilder.mockReturnValue(mockSelectQueryBuilder);
+    mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '999999' });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -91,10 +94,14 @@ describe('PointsService', () => {
 
       await service.getUserPointBalance(1);
 
-      // 만료된 earn 은 합산 대상에서 빠져야 하므로 expires_at > now 가드가 SQL 에 있어야 한다.
-      expect(mockSelectQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining(`ph.type != 'earn' OR ph.expires_at IS NULL OR ph.expires_at > :now`),
-        expect.objectContaining({ now: expect.any(Date) }),
+      // 만료된 earn 은 아직 expire ledger row 로 반영되지 않은 경우에만 추가 차감해야 한다.
+      expect(mockSelectQueryBuilder.select).toHaveBeenCalledWith(
+        expect.stringContaining('NOT EXISTS'),
+        'total',
+      );
+      expect(mockSelectQueryBuilder.select).toHaveBeenCalledWith(
+        expect.stringContaining('ex.related_entity_id = ph.id'),
+        'total',
       );
     });
   });
@@ -120,6 +127,30 @@ describe('PointsService', () => {
       );
 
       expect(balance).toBe(0);
+    });
+
+
+    it('post-cron expire rows do not double-subtract expired earns', async () => {
+      mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '1000' });
+
+      const balance = await service.getEffectiveBalanceInTx(
+        mockEntityManager as unknown as EntityManager,
+        1,
+      );
+
+      expect(balance).toBe(1000);
+      expect(mockSelectQueryBuilder.select).toHaveBeenCalledWith(
+        expect.stringContaining('COALESCE(SUM(ph.amount), 0)'),
+        'total',
+      );
+      expect(mockSelectQueryBuilder.select).toHaveBeenCalledWith(
+        expect.stringContaining("ex.type = 'expire'"),
+        'total',
+      );
+      expect(mockSelectQueryBuilder.select).toHaveBeenCalledWith(
+        expect.stringContaining('ex.related_entity_id = ph.id'),
+        'total',
+      );
     });
   });
 
@@ -153,6 +184,7 @@ describe('PointsService', () => {
 
   describe('deductFifo', () => {
     it('should create a spend record with correct balance and return new balance', async () => {
+      mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '5000' });
       mockEntityManager.findOne.mockResolvedValue({ balance: 5000 });
       mockEntityManager.save.mockResolvedValue({});
 
@@ -175,30 +207,25 @@ describe('PointsService', () => {
       });
     });
 
-    it('should use balance 0 when no prior history exists', async () => {
+    it('should reject when no effective balance exists', async () => {
+      mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '0' });
       mockEntityManager.findOne.mockResolvedValue(null);
       mockEntityManager.save.mockResolvedValue({});
 
-      const newBalance = await service.deductFifo(
-        mockEntityManager as unknown as EntityManager,
-        1,
-        500,
-        '주문 사용 (ORD-002)',
-        null,
-      );
-
-      expect(newBalance).toBe(-500);
-      expect(mockEntityManager.save).toHaveBeenCalledWith(PointHistory, {
-        userId: 1,
-        type: 'spend',
-        amount: -500,
-        balance: -500,
-        orderId: null,
-        description: '주문 사용 (ORD-002)',
-      });
+      await expect(
+        service.deductFifo(
+          mockEntityManager as unknown as EntityManager,
+          1,
+          500,
+          '주문 사용 (ORD-002)',
+          null,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockEntityManager.save).not.toHaveBeenCalled();
     });
 
     it('should query latest entry ordered by createdAt DESC, id DESC for FIFO', async () => {
+      mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '2000' });
       mockEntityManager.findOne.mockResolvedValue({ balance: 2000 });
       mockEntityManager.save.mockResolvedValue({});
 
@@ -211,6 +238,7 @@ describe('PointsService', () => {
     });
 
     it('should deduct full balance when amount equals balance', async () => {
+      mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '1000' });
       mockEntityManager.findOne.mockResolvedValue({ balance: 1000 });
       mockEntityManager.save.mockResolvedValue({});
 
@@ -223,6 +251,24 @@ describe('PointsService', () => {
       );
 
       expect(newBalance).toBe(0);
+    });
+
+    it('rejects spending expired earn that is still present in running balance before cron expiry', async () => {
+      mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '1000' });
+      mockEntityManager.findOne.mockResolvedValue({ balance: 2000 });
+      mockEntityManager.save.mockResolvedValue({});
+
+      await expect(
+        service.deductFifo(
+          mockEntityManager as unknown as EntityManager,
+          1,
+          1500,
+          '주문 사용 (ORD-EXPIRED)',
+          42,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockEntityManager.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/points/points.service.ts
+++ b/backend/src/modules/points/points.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
 import { PointHistory } from '../coupons/entities/point-history.entity';
@@ -16,22 +16,42 @@ export class PointsService {
     private readonly pointHistoryRepo: Repository<PointHistory>,
   ) {}
 
+  private effectiveBalanceExpression(): string {
+    return `
+      COALESCE(SUM(ph.amount), 0)
+      - COALESCE(SUM(
+        CASE
+          WHEN ph.type = 'earn'
+            AND ph.expires_at IS NOT NULL
+            AND ph.expires_at <= :now
+            AND NOT EXISTS (
+              SELECT 1
+              FROM point_history ex
+              WHERE ex.user_id = ph.user_id
+                AND ex.type = 'expire'
+                AND ex.related_entity_type IS NULL
+                AND ex.related_entity_id = ph.id
+            )
+          THEN ph.amount
+          ELSE 0
+        END
+      ), 0)
+    `;
+  }
+
   /**
    * Returns the effective point balance for a user.
-   * Sums all point history amounts, but excludes earn entries
-   * that have already expired (expiresAt <= now).
+   * Uses the running ledger and subtracts only expired earn entries that have not
+   * already been represented by scheduler-created expire ledger rows.
    */
   async getUserPointBalance(userId: number): Promise<number> {
     const now = new Date();
 
     const result = await this.pointHistoryRepo
       .createQueryBuilder('ph')
-      .select('COALESCE(SUM(ph.amount), 0)', 'total')
+      .select(this.effectiveBalanceExpression(), 'total')
       .where('ph.user_id = :userId', { userId })
-      .andWhere(
-        `(ph.type != 'earn' OR ph.expires_at IS NULL OR ph.expires_at > :now)`,
-        { now },
-      )
+      .setParameter('now', now)
       .getRawOne<{ total: string }>();
 
     return parseInt(result?.total ?? '0', 10);
@@ -45,12 +65,9 @@ export class PointsService {
 
     const result = await manager
       .createQueryBuilder(PointHistory, 'ph')
-      .select('COALESCE(SUM(ph.amount), 0)', 'total')
+      .select(this.effectiveBalanceExpression(), 'total')
       .where('ph.user_id = :userId', { userId })
-      .andWhere(
-        `(ph.type != 'earn' OR ph.expires_at IS NULL OR ph.expires_at > :now)`,
-        { now },
-      )
+      .setParameter('now', now)
       .getRawOne<{ total: string }>();
 
     return parseInt(result?.total ?? '0', 10);
@@ -84,6 +101,11 @@ export class PointsService {
     description: string,
     orderId: number | null = null,
   ): Promise<number> {
+    const effectiveBalance = await this.getEffectiveBalanceInTx(manager, userId);
+    if (amount > effectiveBalance) {
+      throw new BadRequestException('적립금이 부족합니다.');
+    }
+
     const currentBalance = await this.getRunningBalanceInTx(manager, userId);
     const newBalance = currentBalance - amount;
 


### PR DESCRIPTION
## 요약
- closes #900
- 주문 포인트 충분 여부 검증을 running balance에서 effective balance로 변경
- PointsService.deductFifo 진입점에서도 유효 잔액 초과 차감을 거부
- 만료 earn이 히스토리에 남아 running balance가 충분한 pre-cron 상황 회귀 테스트 추가

## 검증
- cd backend && npm run test -- orders.service.spec.ts points.service.spec.ts
- cd backend && npm run build
- cd backend && npm run lint

## 미검증
- 실제 DB seed 기반 결제 e2e