### PR TITLE
Fix admin order status contract drift

### DIFF
--- a/backend/src/modules/admin/__tests__/admin-dashboard.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-dashboard.service.spec.ts
@@ -127,6 +127,8 @@ describe('AdminDashboardService', () => {
             { status: 'pending', count: '5' },
             { status: 'paid', count: '12' },
             { status: 'delivered', count: '150' },
+            { status: 'completed', count: '9' },
+            { status: 'refund_requested', count: '4' },
           ]),
         }),
       );
@@ -136,6 +138,8 @@ describe('AdminDashboardService', () => {
       expect(result.order_status_summary.pending).toBe(5);
       expect(result.order_status_summary.paid).toBe(12);
       expect(result.order_status_summary.delivered).toBe(150);
+      expect(result.order_status_summary.completed).toBe(9);
+      expect(result.order_status_summary.refund_requested).toBe(4);
       expect(result.order_status_summary.shipped).toBe(0);
     });
 

--- a/backend/src/modules/admin/admin-dashboard.service.ts
+++ b/backend/src/modules/admin/admin-dashboard.service.ts
@@ -30,7 +30,9 @@ interface OrderStatusSummary {
   preparing: number;
   shipped: number;
   delivered: number;
+  completed: number;
   cancelled: number;
+  refund_requested: number;
   refunded: number;
 }
 
@@ -260,7 +262,9 @@ export class AdminDashboardService {
       preparing: 0,
       shipped: 0,
       delivered: 0,
+      completed: 0,
       cancelled: 0,
+      refund_requested: 0,
       refunded: 0,
     };
 

--- a/backend/src/modules/admin/dto/admin-order-query.dto.ts
+++ b/backend/src/modules/admin/dto/admin-order-query.dto.ts
@@ -3,10 +3,10 @@ import { IsOptional, IsString, IsInt, Max, Min, IsIn } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class AdminOrderQueryDto {
-  @ApiProperty({ example: 'paid', enum: ['pending', 'paid', 'preparing', 'shipped', 'delivered', 'cancelled', 'refunded'], description: '주문 상태', required: false })
+  @ApiProperty({ example: 'paid', enum: ['pending', 'paid', 'preparing', 'shipped', 'delivered', 'completed', 'cancelled', 'refund_requested', 'refunded'], description: '주문 상태', required: false })
   @IsOptional()
   @IsString()
-  @IsIn(['pending', 'paid', 'preparing', 'shipped', 'delivered', 'cancelled', 'refunded'])
+  @IsIn(['pending', 'paid', 'preparing', 'shipped', 'delivered', 'completed', 'cancelled', 'refund_requested', 'refunded'])
   status?: string;
 
   @ApiProperty({ example: '홍길동', description: '검색어 (수령인명 또는 주문번호)', required: false })

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -20,7 +20,9 @@ const STATUS_FILTERS = [
   { label: '상품준비중', value: 'preparing' },
   { label: '배송중', value: 'shipped' },
   { label: '배송완료', value: 'delivered' },
+  { label: '구매확정', value: 'completed' },
   { label: '주문취소', value: 'cancelled' },
+  { label: '환불요청', value: 'refund_requested' },
   { label: '환불완료', value: 'refunded' },
 ] as const;
 

--- a/src/components/shared/admin/OrderStatusSelect.tsx
+++ b/src/components/shared/admin/OrderStatusSelect.tsx
@@ -12,8 +12,10 @@ const ALLOWED_TRANSITIONS: Record<string, string[]> = {
   paid: ['preparing', 'cancelled', 'refunded'],
   preparing: ['shipped', 'cancelled', 'refunded'],
   shipped: ['delivered', 'refunded'],
-  delivered: [],
+  delivered: ['completed', 'refund_requested'],
+  completed: [],
   cancelled: [],
+  refund_requested: ['refunded'],
   refunded: [],
 };
 

--- a/src/components/shared/admin/__tests__/OrderStatusSelect.test.tsx
+++ b/src/components/shared/admin/__tests__/OrderStatusSelect.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OrderStatusSelect } from '../OrderStatusSelect';
+import { ORDER_STATUS_LABELS } from '@/constants/status';
+
+vi.mock('@/lib/api', () => ({
+  adminOrdersApi: { updateStatus: vi.fn() },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe('OrderStatusSelect status contract', () => {
+  it('exposes completed and refund_requested transitions from delivered orders', () => {
+    render(<OrderStatusSelect orderId={1} currentStatus="delivered" onStatusChange={vi.fn()} />);
+
+    expect(screen.getByRole('option', { name: `→ ${ORDER_STATUS_LABELS.completed}` })).toHaveValue('completed');
+    expect(screen.getByRole('option', { name: `→ ${ORDER_STATUS_LABELS.refund_requested}` })).toHaveValue('refund_requested');
+  });
+
+  it('allows refund_requested orders to move to refunded', () => {
+    render(<OrderStatusSelect orderId={1} currentStatus="refund_requested" onStatusChange={vi.fn()} />);
+
+    expect(screen.getByRole('option', { name: `→ ${ORDER_STATUS_LABELS.refunded}` })).toHaveValue('refunded');
+  });
+
+  it('has labels and colors for every backend order status', () => {
+    expect(Object.keys(ORDER_STATUS_LABELS).sort()).toEqual([
+      'cancelled',
+      'completed',
+      'delivered',
+      'paid',
+      'pending',
+      'preparing',
+      'refund_requested',
+      'refunded',
+      'shipped',
+    ]);
+  });
+});

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -7,7 +7,9 @@ export const ORDER_STATUS_LABELS: Record<string, string> = {
   preparing: '상품 준비 중',
   shipped: '배송 중',
   delivered: '배송 완료',
+  completed: '구매 확정',
   cancelled: '취소됨',
+  refund_requested: '환불 요청',
   refunded: '환불됨',
 };
 
@@ -17,7 +19,9 @@ export const ORDER_STATUS_COLORS: Record<string, string> = {
   preparing: 'bg-purple-100 text-purple-800',
   shipped: 'bg-indigo-100 text-indigo-800',
   delivered: 'bg-green-100 text-green-800',
+  completed: 'bg-emerald-100 text-emerald-800',
   cancelled: 'bg-gray-100 text-gray-800',
+  refund_requested: 'bg-orange-100 text-orange-800',
   refunded: 'bg-red-100 text-red-800',
 };
 

--- a/src/lib/api/admin/dashboard.ts
+++ b/src/lib/api/admin/dashboard.ts
@@ -22,7 +22,9 @@ export interface OrderStatusSummary {
   preparing: number;
   shipped: number;
   delivered: number;
+  completed: number;
   cancelled: number;
+  refund_requested: number;
   refunded: number;
 }
 


### PR DESCRIPTION
Closes #912

## Summary
- Add completed/refund_requested to backend admin order query validation and dashboard summaries
- Expose completed/refund_requested labels, colors, filters, dashboard API types, and admin transition UI
- Add regression coverage for dashboard aggregation and admin status transition controls

## Verification
- cd backend && npm run test -- admin-dashboard.service.spec.ts admin-orders.service.spec.ts --runInBand
- cd backend && npm run build
- cd backend && npm run lint
- npm run test:run -- OrderStatusSelect
- npm run build
- git diff --check

## Notes
- Frontend build still reports the pre-existing AppShell unused locale warning during Next lint/type phase.