### PR TITLE
Fix admin reorder payload contracts

### DIFF
--- a/src/lib/__tests__/collections-archives-api.test.ts
+++ b/src/lib/__tests__/collections-archives-api.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { apiClient } from '@/lib/api/core';
+import { adminArchivesApi } from '@/lib/api/admin/archives';
+import { adminCollectionsApi } from '@/lib/api/admin/collections';
+
+describe('admin reorder API payloads', () => {
+  const orders = [
+    { id: 2, sortOrder: 1 },
+    { id: 1, sortOrder: 2 },
+  ];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('wraps collection reorder items in an orders object', async () => {
+    const patchSpy = vi.spyOn(apiClient, 'patch').mockResolvedValue(undefined);
+
+    await adminCollectionsApi.reorder(orders);
+
+    expect(patchSpy).toHaveBeenCalledWith('/admin/collections/reorder', { orders });
+  });
+
+  it('wraps nilo type reorder items in an orders object', async () => {
+    const patchSpy = vi.spyOn(apiClient, 'patch').mockResolvedValue(undefined);
+
+    await adminArchivesApi.reorderNiloTypes(orders);
+
+    expect(patchSpy).toHaveBeenCalledWith('/admin/archives/nilo-types/reorder', { orders });
+  });
+
+  it('wraps artist reorder items in an orders object', async () => {
+    const patchSpy = vi.spyOn(apiClient, 'patch').mockResolvedValue(undefined);
+
+    await adminArchivesApi.reorderArtists(orders);
+
+    expect(patchSpy).toHaveBeenCalledWith('/admin/archives/artists/reorder', { orders });
+  });
+});

--- a/src/lib/api/admin/archives.ts
+++ b/src/lib/api/admin/archives.ts
@@ -74,7 +74,7 @@ export const adminArchivesApi = {
   deleteNiloType: (id: number) =>
     apiClient.delete<void>(`/admin/archives/nilo-types/${id}`),
   reorderNiloTypes: (orders: Array<{ id: number; sortOrder: number }>) =>
-    apiClient.patch<void>('/admin/archives/nilo-types/reorder', orders),
+    apiClient.patch<void>('/admin/archives/nilo-types/reorder', { orders }),
 
   getProcessSteps: () => apiClient.get<ProcessStep[]>('/admin/archives/process-steps'),
   createProcessStep: (data: CreateProcessStepData) =>
@@ -92,5 +92,5 @@ export const adminArchivesApi = {
   deleteArtist: (id: number) =>
     apiClient.delete<void>(`/admin/archives/artists/${id}`),
   reorderArtists: (orders: Array<{ id: number; sortOrder: number }>) =>
-    apiClient.patch<void>('/admin/archives/artists/reorder', orders),
+    apiClient.patch<void>('/admin/archives/artists/reorder', { orders }),
 };

--- a/src/lib/api/admin/collections.ts
+++ b/src/lib/api/admin/collections.ts
@@ -41,5 +41,5 @@ export const adminCollectionsApi = {
   remove: (id: number) =>
     apiClient.delete<void>(`/admin/collections/${id}`),
   reorder: (orders: Array<{ id: number; sortOrder: number }>) =>
-    apiClient.patch<void>('/admin/collections/reorder', orders),
+    apiClient.patch<void>('/admin/collections/reorder', { orders }),
 };


### PR DESCRIPTION
Closes #911

## Summary
- Send collection reorder payloads as `{ orders }` to match backend DTOs
- Send archive Nilo type and artist reorder payloads as `{ orders }`
- Add API contract tests for reorder request body shape

## Verification
- npm run test:run -- src/lib/__tests__/collections-archives-api.test.ts
- npm run test:run -- collections archives
- bash scripts/codex-project-guard.sh
- npm run build

## Notes
- Backend code unchanged; backend service tests were not rerun.
- Next build still reports the pre-existing AppShell unused locale warning.