### PR TITLE
Limit upload memory buffering before validation

### DIFF
--- a/backend/src/common/multer/single-file-upload.options.ts
+++ b/backend/src/common/multer/single-file-upload.options.ts
@@ -1,0 +1,63 @@
+import { BadRequestException } from '@nestjs/common';
+import type { Request } from 'express';
+import { memoryStorage } from 'multer';
+
+interface SingleFileMemoryUploadOptionsInput {
+  fileSize: number;
+  allowedMimeTypes?: readonly string[];
+  invalidMimeMessage?: string;
+}
+
+interface MulterFileLimits {
+  fileSize: number;
+  files: 1;
+  fields: 0;
+}
+
+type FileFilterCallback = (error: Error | null, acceptFile: boolean) => void;
+
+type FileFilter = (
+  req: Request,
+  file: Express.Multer.File,
+  callback: FileFilterCallback,
+) => void;
+
+export interface SingleFileMemoryUploadOptions {
+  storage: ReturnType<typeof memoryStorage>;
+  limits: MulterFileLimits;
+  fileFilter?: FileFilter;
+}
+
+export function createSingleFileMemoryUploadOptions(
+  input: SingleFileMemoryUploadOptionsInput,
+): SingleFileMemoryUploadOptions {
+  return {
+    storage: memoryStorage(),
+    limits: {
+      fileSize: input.fileSize,
+      files: 1,
+      fields: 0,
+    },
+    ...(input.allowedMimeTypes
+      ? {
+          fileFilter: (
+            _req: Request,
+            file: Express.Multer.File,
+            callback: FileFilterCallback,
+          ): void => {
+            if (!input.allowedMimeTypes!.some((mimeType) => mimeType === file.mimetype)) {
+              callback(
+                new BadRequestException(
+                  input.invalidMimeMessage ?? '허용되지 않는 파일 형식입니다.',
+                ),
+                false,
+              );
+              return;
+            }
+
+            callback(null, true);
+          },
+        }
+      : {}),
+  };
+}

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -39,7 +39,7 @@ import { CreateRestockAlertDto } from '../restock-alerts/dto/create-restock-aler
 import { RecentlyViewedService } from './recently-viewed.service';
 import { SmartStoreProductImportService } from './smartstore-product-import.service';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { memoryStorage } from 'multer';
+import { createSingleFileMemoryUploadOptions } from '../../common/multer/single-file-upload.options';
 
 @ApiTags('상품')
 @Controller('products')
@@ -119,10 +119,10 @@ export class ProductsController {
   @ApiResponse({ status: 403, description: '권한 없음' })
   @ApiConsumes('multipart/form-data')
   @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: ['file'] } })
-  @UseInterceptors(FileInterceptor('file', {
-    storage: memoryStorage(),
-    limits: { fileSize: 10 * 1024 * 1024 },
-  }))
+  @UseInterceptors(FileInterceptor(
+    'file',
+    createSingleFileMemoryUploadOptions({ fileSize: 10 * 1024 * 1024 }),
+  ))
   previewSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
     return this.smartStoreProductImportService.preview(file);
   }
@@ -137,10 +137,10 @@ export class ProductsController {
   @ApiResponse({ status: 403, description: '권한 없음' })
   @ApiConsumes('multipart/form-data')
   @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: ['file'] } })
-  @UseInterceptors(FileInterceptor('file', {
-    storage: memoryStorage(),
-    limits: { fileSize: 10 * 1024 * 1024 },
-  }))
+  @UseInterceptors(FileInterceptor(
+    'file',
+    createSingleFileMemoryUploadOptions({ fileSize: 10 * 1024 * 1024 }),
+  ))
   commitSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
     return this.smartStoreProductImportService.commit(file);
   }

--- a/backend/src/modules/reviews/__tests__/reviews.controller.spec.ts
+++ b/backend/src/modules/reviews/__tests__/reviews.controller.spec.ts
@@ -1,0 +1,64 @@
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { ReviewsController } from '../reviews.controller';
+import { ReviewsService } from '../reviews.service';
+import { UploadService } from '../../upload/upload.service';
+
+const REVIEW_MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+function expectMulterRejected(status: number): void {
+  expect([HttpStatus.BAD_REQUEST, HttpStatus.PAYLOAD_TOO_LARGE]).toContain(status);
+}
+
+describe('ReviewsController multipart limits', () => {
+  let app: INestApplication;
+  let uploadService: jest.Mocked<Pick<UploadService, 'uploadImage'>>;
+
+  beforeAll(async () => {
+    uploadService = {
+      uploadImage: jest.fn(),
+    };
+
+    const reviewsService = {
+      findAll: jest.fn(),
+      importSmartStoreReviews: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReviewsController],
+      providers: [
+        { provide: ReviewsService, useValue: reviewsService },
+        { provide: UploadService, useValue: uploadService },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('blocks oversized review image upload before UploadService.uploadImage', async () => {
+    const oversized = Buffer.alloc(REVIEW_MAX_FILE_SIZE + 1);
+
+    const res = await request(app.getHttpServer())
+      .post('/reviews/upload-image')
+      .attach('file', oversized, {
+        filename: 'oversized.png',
+        contentType: 'image/png',
+      });
+
+    expectMulterRejected(res.status);
+    expect(uploadService.uploadImage).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/reviews/reviews.controller.ts
+++ b/backend/src/modules/reviews/reviews.controller.ts
@@ -25,6 +25,7 @@ import {
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { createSingleFileMemoryUploadOptions } from '../../common/multer/single-file-upload.options';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
@@ -35,8 +36,17 @@ import { Roles } from '../../common/decorators/roles.decorator';
 import { AuthenticatedRequestWithAuthUser } from '../../common/interfaces/auth-user.interface';
 import { UploadService } from '../upload/upload.service';
 
-const REVIEW_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const REVIEW_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
 const REVIEW_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+const REVIEW_IMAGE_UPLOAD_INTERCEPTOR = FileInterceptor(
+  'file',
+  createSingleFileMemoryUploadOptions({
+    fileSize: REVIEW_MAX_FILE_SIZE,
+    allowedMimeTypes: REVIEW_ALLOWED_MIME_TYPES,
+    invalidMimeMessage: '허용되지 않는 파일 형식입니다. (jpg, png, webp만 허용)',
+  }),
+);
 
 @ApiTags('후기')
 @Controller('reviews')
@@ -100,7 +110,7 @@ export class ReviewsController {
       },
     },
   })
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(REVIEW_IMAGE_UPLOAD_INTERCEPTOR)
   async uploadImage(
     @UploadedFile() file: Express.Multer.File,
   ) {
@@ -108,7 +118,7 @@ export class ReviewsController {
       throw new BadRequestException('파일이 필요합니다.');
     }
 
-    if (!REVIEW_ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+    if (!REVIEW_ALLOWED_MIME_TYPES.some((mimeType) => mimeType === file.mimetype)) {
       throw new BadRequestException('허용되지 않는 파일 형식입니다. (jpg, png, webp만 허용)');
     }
 

--- a/backend/src/modules/upload/__tests__/upload.controller.spec.ts
+++ b/backend/src/modules/upload/__tests__/upload.controller.spec.ts
@@ -1,0 +1,84 @@
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { UploadController } from '../upload.controller';
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../upload.constants';
+import { UploadService } from '../upload.service';
+
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X4r0AAAAASUVORK5CYII=',
+  'base64',
+);
+
+function expectMulterRejected(status: number): void {
+  expect([HttpStatus.BAD_REQUEST, HttpStatus.PAYLOAD_TOO_LARGE]).toContain(status);
+}
+
+describe('UploadController multipart limits', () => {
+  let app: INestApplication;
+  let uploadService: jest.Mocked<Pick<UploadService, 'uploadImage' | 'uploadCategoryImage'>>;
+
+  beforeAll(async () => {
+    uploadService = {
+      uploadImage: jest.fn(),
+      uploadCategoryImage: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UploadController],
+      providers: [{ provide: UploadService, useValue: uploadService }],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('blocks oversized admin image upload before UploadService.uploadImage', async () => {
+    const oversized = Buffer.alloc(MAX_UPLOAD_FILE_SIZE_BYTES + 1);
+
+    const res = await request(app.getHttpServer())
+      .post('/upload/image')
+      .attach('file', oversized, {
+        filename: 'oversized.png',
+        contentType: 'image/png',
+      });
+
+    expectMulterRejected(res.status);
+    expect(uploadService.uploadImage).not.toHaveBeenCalled();
+  });
+
+  it('blocks oversized category image upload before UploadService.uploadCategoryImage', async () => {
+    const oversized = Buffer.alloc(MAX_UPLOAD_FILE_SIZE_BYTES + 1);
+
+    const res = await request(app.getHttpServer())
+      .post('/upload/category-image')
+      .attach('file', oversized, {
+        filename: 'oversized.png',
+        contentType: 'image/png',
+      });
+
+    expectMulterRejected(res.status);
+    expect(uploadService.uploadCategoryImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects extra multipart fields before the service layer', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/upload/image')
+      .field('caption', 'not allowed')
+      .attach('file', PNG_1X1, {
+        filename: 'ok.png',
+        contentType: 'image/png',
+      });
+
+    expectMulterRejected(res.status);
+    expect(uploadService.uploadImage).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/upload/upload.controller.ts
+++ b/backend/src/modules/upload/upload.controller.ts
@@ -13,7 +13,11 @@ import {
   ApiCookieAuth,
 } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { memoryStorage } from 'multer';
+import { createSingleFileMemoryUploadOptions } from '../../common/multer/single-file-upload.options';
+import {
+  ALLOWED_IMAGE_MIME_TYPES,
+  MAX_UPLOAD_FILE_SIZE_BYTES,
+} from './upload.constants';
 import { UploadService } from './upload.service';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { UploadedFile as UploadedFileType } from './interfaces/storage.interface';
@@ -27,9 +31,14 @@ const IMAGE_UPLOAD_BODY_SCHEMA = {
   },
 } as const;
 
-const FILE_UPLOAD_INTERCEPTOR = FileInterceptor('file', {
-  storage: memoryStorage(),
-});
+const FILE_UPLOAD_INTERCEPTOR = FileInterceptor(
+  'file',
+  createSingleFileMemoryUploadOptions({
+    fileSize: MAX_UPLOAD_FILE_SIZE_BYTES,
+    allowedMimeTypes: ALLOWED_IMAGE_MIME_TYPES,
+    invalidMimeMessage: '허용되지 않는 이미지 형식입니다. (jpeg, png, webp만 허용)',
+  }),
+);
 
 @ApiTags('업로드')
 @Controller('upload')


### PR DESCRIPTION
Closes #902

## Summary
- Add shared Multer image upload limits before service-layer validation
- Apply upload limits to admin/product and review image upload interceptors
- Add controller regression coverage for over-limit multipart rejection before service handlers run

## Verification
- See commit and worker report for targeted backend tests/build.

## Notes
- Backend upload paths retain service-level magic-byte/type validation.