### PR TITLE
Block sessions before email verification

### DIFF
--- a/backend/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.service.spec.ts
@@ -177,19 +177,27 @@ describe('AuthService', () => {
       );
     });
 
-    it('가입 성공 시 accessToken, refreshToken, user 반환', async () => {
+    it('가입 성공 시 토큰 없이 user만 반환하고 refreshToken을 저장하지 않음', async () => {
       mockUserRepository.findOne.mockResolvedValue(null);
       const newUser = makeUser({ id: 2, email: 'new@example.com', name: '신규' });
       mockUserRepository.create.mockReturnValue(newUser);
       mockUserRepository.save.mockResolvedValue(newUser);
-      mockUserRepository.update.mockResolvedValue(undefined);
+      mockVerificationTokenRepository.create.mockImplementation((value) => value);
+      mockVerificationTokenRepository.save.mockResolvedValue(undefined);
+      mockNotificationService.sendEmailVerification.mockResolvedValue(undefined);
 
       const result = await service.register({ email: 'new@example.com', password: 'Test1234!', name: '신규' });
 
-      expect(result).toHaveProperty('accessToken');
-      expect(result).toHaveProperty('refreshToken');
-      expect(result).toHaveProperty('user');
-      expect(result.user.email).toBe('new@example.com');
+      expect(result).toEqual({
+        user: expect.objectContaining({ email: 'new@example.com' }),
+      });
+      expect(result).not.toHaveProperty('accessToken');
+      expect(result).not.toHaveProperty('refreshToken');
+      expect(mockTokenIssuerService.issueAndPersistRefresh).not.toHaveBeenCalled();
+      expect(mockUserRepository.update).not.toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({ refreshToken: expect.any(String) }),
+      );
     });
   });
 

--- a/backend/src/modules/auth/__tests__/oauth.service.spec.ts
+++ b/backend/src/modules/auth/__tests__/oauth.service.spec.ts
@@ -164,6 +164,12 @@ describe('OAuthService', () => {
       expect(result.isNewUser).toBe(true);
       expect(result.accessToken).toBe('mock-access-token');
       expect(result.user.email).toBe('new@kakao.com');
+      expect(mockUserRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isEmailVerified: true,
+          emailVerifiedAt: expect.any(Date),
+        }),
+      );
     });
 
     it('카카오 기존 사용자 시 isNewUser: false', async () => {
@@ -271,7 +277,13 @@ describe('OAuthService', () => {
       // No existing google auth record
       mockUserAuthRepository.findOne.mockResolvedValue(null);
       // But user exists with same email (e.g. registered via kakao before)
-      const existingUser = makeUser({ id: 5, email: 'same@email.com', name: '동일유저' });
+      const existingUser = makeUser({
+        id: 5,
+        email: 'same@email.com',
+        name: '동일유저',
+        isEmailVerified: false,
+        emailVerifiedAt: null,
+      });
       mockUserRepository.findOne.mockResolvedValue(existingUser);
       mockUserAuthRepository.create.mockReturnValue(makeUserAuth({
         user: existingUser,
@@ -286,6 +298,13 @@ describe('OAuthService', () => {
       // Not a new user — linked to existing account
       expect(result.isNewUser).toBe(false);
       expect(result.user.email).toBe('same@email.com');
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        5,
+        expect.objectContaining({
+          isEmailVerified: true,
+          emailVerifiedAt: expect.any(Date),
+        }),
+      );
       expect(mockUserRepository.create).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -76,13 +76,11 @@ export class AuthController {
 
   @Post('register')
   @Public()
-  @ApiOperation({ summary: '회원가입', description: '이메일/비밀번호로 새로운 계정을 생성합니다. 성공 시 accessToken과 refreshToken이 쿠키에 저장됩니다.' })
+  @ApiOperation({ summary: '회원가입', description: '이메일/비밀번호로 새로운 계정을 생성하고 인증 이메일을 발송합니다. 이메일 인증 전에는 토큰 또는 인증 쿠키를 발급하지 않습니다.' })
   @ApiResponse({ status: 201, description: '회원가입 성공' })
   @ApiResponse({ status: 400, description: '입력값 오류 또는 이미 존재하는 이메일' })
-  async register(@Body() dto: RegisterDto, @Res({ passthrough: true }) res: Response) {
-    const { accessToken, refreshToken, user } = await this.authService.register(dto);
-    setAuthCookies(res, accessToken, refreshToken, this.authConfig.cookie.secure);
-    return { user, accessToken, refreshToken };
+  async register(@Body() dto: RegisterDto) {
+    return this.authService.register(dto);
   }
 
   @Post('login')

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -58,7 +58,7 @@ export interface TokenPair {
   refreshToken: string;
 }
 
-export interface AuthResponse extends TokenPair {
+export interface AuthUserResponse {
   user: {
     id: number;
     email: string;
@@ -66,6 +66,8 @@ export interface AuthResponse extends TokenPair {
     role: string;
   };
 }
+
+export interface AuthResponse extends TokenPair, AuthUserResponse {}
 
 @Injectable()
 export class AuthService implements OnModuleInit {
@@ -100,7 +102,7 @@ export class AuthService implements OnModuleInit {
     }
   }
 
-  async register(dto: RegisterDto): Promise<AuthResponse> {
+  async register(dto: RegisterDto): Promise<AuthUserResponse> {
     if (!PASSWORD_REGEX.test(dto.password)) {
       throw new BadRequestException('비밀번호는 문자, 숫자, 특수문자를 포함해야 합니다.');
     }
@@ -125,11 +127,8 @@ export class AuthService implements OnModuleInit {
 
     await this.createVerificationTokenAndSendEmail(user);
 
-    const tokens = await this.tokenIssuerService.issueAndPersistRefresh(user);
-
     this.logger.log(`User registered: ${dto.email}`);
     return {
-      ...tokens,
       user: { id: user.id, email: user.email, name: user.name, role: user.role },
     };
   }

--- a/backend/src/modules/auth/oauth.service.ts
+++ b/backend/src/modules/auth/oauth.service.ts
@@ -169,6 +169,7 @@ export class OAuthService {
     });
 
     if (existingAuth) {
+      await this.markEmailVerifiedForOAuth(existingAuth.user);
       return { user: existingAuth.user, isNewUser: false };
     }
 
@@ -189,10 +190,14 @@ export class OAuthService {
         name,
         role: UserRole.USER,
         isActive: true,
+        isEmailVerified: true,
+        emailVerifiedAt: new Date(),
       });
       user = await this.userRepository.save(user);
       isNewUser = true;
     }
+
+    await this.markEmailVerifiedForOAuth(user);
 
     // 4. Create auth record (do not persist provider access token)
     const auth = this.userAuthRepository.create({
@@ -205,6 +210,20 @@ export class OAuthService {
     await this.userAuthRepository.save(auth);
 
     return { user, isNewUser };
+  }
+
+  private async markEmailVerifiedForOAuth(user: User): Promise<void> {
+    if (user.isEmailVerified) {
+      return;
+    }
+
+    const emailVerifiedAt = new Date();
+    await this.userRepository.update(user.id, {
+      isEmailVerified: true,
+      emailVerifiedAt,
+    });
+    user.isEmailVerified = true;
+    user.emailVerifiedAt = emailVerifiedAt;
   }
 
   private async exchangeKakaoToken(code: string): Promise<string> {

--- a/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -22,6 +22,7 @@ describe('JwtStrategy', () => {
     email: 'test@test.com',
     role: UserRole.USER,
     isActive: true,
+    isEmailVerified: true,
   } as User;
 
   beforeEach(() => {
@@ -85,6 +86,20 @@ describe('JwtStrategy', () => {
       mockUserRepository.findOne.mockResolvedValue({ id: 1, isActive: false } as User);
       const payload = { sub: 1, email: 'test@test.com', role: 'user' };
       await expect(strategy.validate(payload)).rejects.toThrow('비활성화된 계정입니다.');
+    });
+
+    it('should throw UnauthorizedException when user email is not verified', async () => {
+      mockUserRepository.findOne.mockResolvedValue({
+        id: 1,
+        email: 'test@test.com',
+        role: UserRole.USER,
+        isActive: true,
+        isEmailVerified: false,
+      } as User);
+      const payload = { sub: 1, email: 'test@test.com', role: 'user' };
+
+      await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
+      await expect(strategy.validate(payload)).rejects.toThrow('이메일 인증이 필요합니다.');
     });
 
     it('should throw UnauthorizedException when token is blacklisted', async () => {

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -65,6 +65,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('비활성화된 계정입니다.');
     }
 
+    if (!user.isEmailVerified) {
+      throw new UnauthorizedException('이메일 인증이 필요합니다.');
+    }
+
     return { id: payload.sub, email: user.email, role: user.role, jti: payload.jti };
   }
 }

--- a/backend/test/helpers/auth-cookie.helper.ts
+++ b/backend/test/helpers/auth-cookie.helper.ts
@@ -67,8 +67,13 @@ export async function registerAndGetCookies(
     [body.user.id],
   );
 
+  const cookies = await loginAndGetCookies(app, {
+    email: payload.email,
+    password: payload.password,
+  });
+
   return {
-    cookies: extractAuthCookies(res),
+    cookies,
     body,
   };
 }

--- a/backend/test/suites/auth.e2e-spec.ts
+++ b/backend/test/suites/auth.e2e-spec.ts
@@ -30,6 +30,7 @@ interface RefreshBody {
 
 const ACCESS_COOKIE_REGEX = /^accessToken=/;
 const REFRESH_COOKIE_REGEX = /^refreshToken=/;
+const AUTH_COOKIE_REGEX = /^(accessToken|refreshToken)=/;
 const CLEARED_ACCESS_COOKIE_REGEX = /^accessToken=;/;
 const CLEARED_REFRESH_COOKIE_REGEX = /^refreshToken=;/;
 
@@ -73,18 +74,18 @@ export function registerAuthSuite(getApp: () => INestApplication): void {
     });
 
     describe('POST /api/auth/register', () => {
-      it('유효한 정보로 가입 → 201, 인증 쿠키 설정', async () => {
+      it('유효한 정보로 가입 → 201, 인증 쿠키/토큰 미발급 및 /me 접근 거부', async () => {
         const res = await request(app.getHttpServer())
           .post('/api/auth/register')
           .send({ email, password, name })
           .expect(201);
 
-        expect(res.headers['set-cookie']).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(ACCESS_COOKIE_REGEX),
-            expect.stringMatching(REFRESH_COOKIE_REGEX),
-          ]),
-        );
+        const setCookie = (res.headers['set-cookie'] ?? []) as unknown as string[];
+        expect(setCookie.some((cookie) => AUTH_COOKIE_REGEX.test(cookie))).toBe(false);
+        expect(res.body).not.toHaveProperty('accessToken');
+        expect(res.body).not.toHaveProperty('refreshToken');
+
+        await request(app.getHttpServer()).get('/api/auth/me').expect(401);
 
         const body = res.body as AuthBody;
         expect(body.user.id).toBeDefined();
@@ -93,7 +94,6 @@ export function registerAuthSuite(getApp: () => INestApplication): void {
           'UPDATE users SET is_email_verified = 1, email_verified_at = NOW() WHERE id = ?',
           [userId],
         );
-        cookies = extractAuthCookies(res);
       });
 
       it('중복 이메일 → 409', () => {


### PR DESCRIPTION
Closes #901

## Summary
- Stop issuing access/refresh tokens and auth cookies from register before email verification
- Reject email-unverified users in JWT strategy to cover existing tokens
- Preserve OAuth sessions by marking OAuth users email-verified
- Add/update auth, JWT strategy, OAuth, and auth e2e regression coverage

## Verification
- cd backend && npm run test -- auth.service.spec.ts jwt.strategy.spec.ts oauth.service.spec.ts --runInBand
- cd backend && npm run build && npm run test -- --runInBand
- npm run build && npm run test:run
- bash scripts/codex-project-guard.sh
- git diff --check

## Notes
- Full e2e script was attempted by the worker but hit a pre-existing migration duplicate-column blocker before Jest suites ran.
- Added `/api/auth/me` denial smoke coverage in auth e2e, but that suite could not be executed because of the migration blocker.