### PR TITLE
Load non-public products in admin edit

### DIFF
--- a/backend/src/modules/products/__tests__/admin-products.controller.spec.ts
+++ b/backend/src/modules/products/__tests__/admin-products.controller.spec.ts
@@ -1,4 +1,5 @@
 import { AdminProductsController } from '../admin-products.controller';
+import { ProductStatus } from '../entities/product.entity';
 import { ProductsService } from '../products.service';
 
 describe('AdminProductsController', () => {
@@ -14,5 +15,31 @@ describe('AdminProductsController', () => {
       { status: 'draft', page: 2, limit: 20 },
       true,
     );
+  });
+
+  it.each([ProductStatus.DRAFT, ProductStatus.HIDDEN])(
+    '관리자 상세 조회는 %s 상품을 관리자 권한으로 조회한다',
+    async (status) => {
+      const product = { id: 10, name: '비공개 상품', status };
+      const productsService = {
+        findOne: jest.fn().mockResolvedValue(product),
+      };
+      const controller = new AdminProductsController(productsService as unknown as ProductsService);
+
+      await expect(controller.findOne(10, undefined)).resolves.toBe(product);
+
+      expect(productsService.findOne).toHaveBeenCalledWith(10, true, undefined);
+    },
+  );
+
+  it('관리자 상세 조회는 locale 파라미터를 전달한다', async () => {
+    const productsService = {
+      findOne: jest.fn().mockResolvedValue({ id: 11, name: 'Localized' }),
+    };
+    const controller = new AdminProductsController(productsService as unknown as ProductsService);
+
+    await controller.findOne(11, 'en');
+
+    expect(productsService.findOne).toHaveBeenCalledWith(11, true, 'en');
   });
 });

--- a/backend/src/modules/products/admin-products.controller.ts
+++ b/backend/src/modules/products/admin-products.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import {
   ApiCookieAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { Roles } from '../../common/decorators/roles.decorator';
+import { OptionalLocalePipe } from '../../common/pipes/optional-locale.pipe';
 import { ProductsService } from './products.service';
 import { QueryProductsDto } from './dto/query-products.dto';
 
@@ -27,5 +29,21 @@ export class AdminProductsController {
   @ApiQuery({ name: 'status', required: false, type: String, description: '상품 상태 필터' })
   findAll(@Query() query: QueryProductsDto) {
     return this.productsService.findAll(query, true);
+  }
+
+  @Get(':id')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '관리자 상품 상세 조회', description: '초안/숨김 상품을 포함한 상품 상세 정보를 조회합니다.' })
+  @ApiResponse({ status: 200, description: '관리자 상품 상세 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 404, description: '상품을 찾을 수 없음' })
+  @ApiParam({ name: 'id', type: Number, description: '상품 ID' })
+  @ApiQuery({ name: 'locale', required: false, type: String, description: 'locale (ko/en)' })
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('locale', OptionalLocalePipe) locale: string | undefined,
+  ) {
+    return this.productsService.findOne(id, true, locale);
   }
 }

--- a/src/app/[locale]/admin/products/[id]/edit/__tests__/AdminProductEditPage.test.tsx
+++ b/src/app/[locale]/admin/products/[id]/edit/__tests__/AdminProductEditPage.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AdminProductEditPage from '../page';
+import { adminProductsApi } from '@/lib/api';
+import type { ProductDetail } from '@/lib/api';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: '42' }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/api', () => ({
+  adminProductsApi: {
+    getById: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/shared/admin/ProductFormPage', () => ({
+  default: ({ product }: { product: ProductDetail }) => (
+    <div data-testid="product-form" data-status={product.status}>
+      {product.name}
+    </div>
+  ),
+}));
+
+function makeProduct(status: ProductDetail['status']): ProductDetail {
+  return {
+    id: 42,
+    name: `${status} product`,
+    slug: `${status}-product`,
+    price: 10000,
+    salePrice: null,
+    shortDescription: null,
+    description: null,
+    rating: 0,
+    reviewCount: 0,
+    status,
+    isFeatured: false,
+    viewCount: 0,
+    category: null,
+    images: [],
+    stock: 0,
+    sku: null,
+    noticeInfo: null,
+    options: [],
+    detailImages: [],
+  };
+}
+
+describe('AdminProductEditPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(['draft', 'hidden'] as const)(
+    'loads a %s product through the protected admin product API',
+    async (status) => {
+      vi.mocked(adminProductsApi.getById).mockResolvedValue(makeProduct(status));
+
+      render(<AdminProductEditPage />);
+
+      await waitFor(() => {
+        expect(adminProductsApi.getById).toHaveBeenCalledWith(42);
+      });
+      expect(await screen.findByTestId('product-form')).toHaveAttribute('data-status', status);
+      expect(screen.getByText(`${status} product`)).toBeInTheDocument();
+    },
+  );
+});

--- a/src/app/[locale]/admin/products/[id]/edit/page.tsx
+++ b/src/app/[locale]/admin/products/[id]/edit/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
-import { productsApi } from '@/lib/api';
+import { adminProductsApi } from '@/lib/api';
 import type { ProductDetail } from '@/lib/api';
 import ProductFormPage from '@/components/shared/admin/ProductFormPage';
 
@@ -19,7 +19,7 @@ export default function AdminProductEditPage() {
         setNotFound(true);
         return;
       }
-      const p = await productsApi.getById(id);
+      const p = await adminProductsApi.getById(id);
       setProduct(p);
     },
     { onError: () => setNotFound(true), errorMessage: '상품을 불러오지 못했습니다.' },

--- a/src/lib/__tests__/products-api.test.ts
+++ b/src/lib/__tests__/products-api.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { adminProductsApi } from '@/lib/api/admin/products';
 import { apiClient } from '@/lib/api/core';
 import { productsApi } from '@/lib/api/products';
 
@@ -10,6 +11,19 @@ describe('productsApi', () => {
 
     expect(getSpy).toHaveBeenCalledWith('/products', {
       params: { attrs: 'clay_type:junni', price_min: 10000 },
+    });
+    getSpy.mockRestore();
+  });
+});
+
+describe('adminProductsApi', () => {
+  it('loads product detail from the protected admin route', async () => {
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue({ id: 42, status: 'hidden' });
+
+    await adminProductsApi.getById(42);
+
+    expect(getSpy).toHaveBeenCalledWith('/admin/products/42', {
+      params: undefined,
     });
     getSpy.mockRestore();
   });

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -67,6 +67,10 @@ export const adminProductsApi = {
     apiClient.get<ProductListResponse>('/admin/products', {
       params: params as Record<string, string | number | undefined>,
     }),
+  getById: (id: number, locale?: string) =>
+    apiClient.get<ProductDetail>(`/admin/products/${id}`, {
+      params: locale ? { locale } : undefined,
+    }),
   create: (data: CreateProductData) =>
     apiClient.post<ProductDetail>('/products', data),
   update: (id: number, data: UpdateProductData) =>


### PR DESCRIPTION
Closes #910

## Summary
- Add protected admin product detail endpoint
- Use admin product API in the admin edit page instead of the public product API
- Add backend, frontend, and API wrapper regression tests for draft/hidden product loading

## Verification
- cd backend && npm run test -- admin-products.controller.spec.ts
- npx vitest run src/app/[locale]/admin/products/[id]/edit/__tests__/AdminProductEditPage.test.tsx src/lib/__tests__/products-api.test.ts
- cd backend && npm run build && npm run test
- cd backend && npm run lint
- npm run build && npm run lint && npm run test:run
- bash scripts/codex-project-guard.sh
- bash scripts/start-local.sh
- curl http://localhost:3000/api/health
- curl -I http://localhost:5173/ko
- git diff --check

## Notes
- Next lint reports the pre-existing AppShell unused locale warning.