### PR TITLE
Preserve locale in product navigation

### DIFF
--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -22,6 +22,19 @@ vi.mock('next/link', () => ({
 const mockRouterPush = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockRouterPush }),
+  usePathname: () => '/en/products',
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    children,
+    href,
+    locale = 'ko',
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; locale?: string }) => (
+    <a href={`/${locale}${href}`} onClick={(e) => e.preventDefault()} {...props}>{children}</a>
+  ),
+  useRouter: () => ({ push: mockRouterPush }),
 }));
 
 const mockAddItem = vi.fn();
@@ -54,6 +67,7 @@ const translations: Record<string, string> = {
 };
 
 vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
   useTranslations: () => (key: string, values?: Record<string, string | number>) => {
     const template = translations[key] ?? key;
     if (!values) return template;
@@ -85,6 +99,7 @@ describe('ProductCard', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.history.pushState({}, '', '/en/products');
     mockRouterPush.mockReset();
     mockUseAuth.mockReturnValue({
       isAuthenticated: false,
@@ -120,7 +135,13 @@ describe('ProductCard', () => {
   it('links to the product detail page', () => {
     render(<ProductCard {...baseProps} />);
     const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', '/products/1');
+    expect(link).toHaveAttribute('href', '/ko/products/1');
+  });
+
+  it('links to the English product detail page when rendered with locale en', () => {
+    render(<ProductCard {...baseProps} locale="en" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/en/products/1');
   });
 
   it('shows wishlist button', () => {
@@ -142,12 +163,13 @@ describe('ProductCard', () => {
     render(<ProductCard {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: '찜하기' }));
     await waitFor(() => {
-      expect(mockRouterPush).toHaveBeenCalledWith('/login');
+      expect(mockRouterPush).toHaveBeenCalledWith('/login?redirect=%2Fen%2Fproducts', { locale: 'en' });
     });
     expect(toast.error).not.toHaveBeenCalled();
   });
 
   it('calls wishlistApi.add and shows toast on wishlist click when authenticated', async () => {
+    window.history.pushState({}, '', '/ko/products');
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,

--- a/src/components/__tests__/ProductDetailClient.test.tsx
+++ b/src/components/__tests__/ProductDetailClient.test.tsx
@@ -26,7 +26,6 @@ const getMessage = (path: string): string => {
 }
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: pushMock }),
   usePathname: () => '/en/products/1',
 }))
 
@@ -34,6 +33,18 @@ vi.mock('next/link', () => ({
   default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
     <a href={href} {...props}>{children}</a>
   ),
+}))
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    children,
+    href,
+    locale = 'en',
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; locale?: string }) => (
+    <a href={`/${locale}${href}`} {...props}>{children}</a>
+  ),
+  useRouter: () => ({ push: pushMock }),
 }))
 
 vi.mock('next-intl', () => ({
@@ -128,8 +139,14 @@ const product: ProductDetail = {
   description: '<p>Detail</p>',
   stock: 12,
   sku: 'TP-001',
+  noticeInfo: null,
   options: [{ id: 11, name: 'Size', value: 'Large', priceAdjustment: 0, stock: 12, sortOrder: 0 }],
   detailImages: [],
+}
+
+const productWithoutOptions: ProductDetail = {
+  ...product,
+  options: [],
 }
 
 describe('ProductDetailClient', () => {
@@ -157,5 +174,13 @@ describe('ProductDetailClient', () => {
     expect(container.innerHTML).not.toContain('text-[#')
     expect(container.innerHTML).not.toContain('border-[#')
     expect(container.innerHTML).not.toContain('max-w-8xl')
+  })
+
+  it('keeps English buy-now checkout navigation locale-aware', async () => {
+    render(<ProductDetailClient product={productWithoutOptions} locale="en" />)
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Buy Now' })[0])
+
+    expect(pushMock).toHaveBeenCalledWith('/checkout', { locale: 'en' })
   })
 })

--- a/src/components/__tests__/ProductsPage.test.tsx
+++ b/src/components/__tests__/ProductsPage.test.tsx
@@ -3,11 +3,16 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockPush = vi.fn();
+const mockLocaleAwarePush = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => '/products',
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  useRouter: () => ({ push: mockLocaleAwarePush }),
 }));
 
 const translations: Record<string, string> = {
@@ -100,6 +105,7 @@ describe('SortDropdown', () => {
 describe('Pagination', () => {
   beforeEach(() => {
     mockPush.mockClear();
+    mockLocaleAwarePush.mockClear();
   });
 
   it('renders page buttons and navigates on click', async () => {
@@ -109,7 +115,17 @@ describe('Pagination', () => {
     const nextButton = screen.getByText('다음');
     await userEvent.click(nextButton);
 
-    expect(mockPush).toHaveBeenCalledWith('/products?page=2');
+    expect(mockLocaleAwarePush).toHaveBeenCalledWith('/products?page=2');
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('uses locale-aware router for English pagination links', async () => {
+    const { default: Pagination } = await import('@/components/shared/products/Pagination');
+    render(<Pagination total={100} page={1} limit={20} />);
+
+    await userEvent.click(screen.getByText('다음'));
+
+    expect(mockLocaleAwarePush).toHaveBeenCalledWith('/products?page=2');
   });
 
   it('disables prev button on first page', async () => {

--- a/src/components/__tests__/WishlistButton.test.tsx
+++ b/src/components/__tests__/WishlistButton.test.tsx
@@ -7,6 +7,10 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
+vi.mock('@/i18n/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 const mockUseAuth = vi.fn();
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => mockUseAuth(),
@@ -34,13 +38,14 @@ import WishlistButton from '@/components/shared/WishlistButton';
 describe('WishlistButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.history.pushState({}, '', '/en/products/1');
     mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false, user: null, logout: vi.fn() });
   });
 
-  it('비로그인 클릭 → router.push("/login")', () => {
+  it('비로그인 클릭 → locale-aware router.push("/login")', () => {
     render(<WishlistButton productId={1} />);
     fireEvent.click(screen.getByRole('button'));
-    expect(mockPush).toHaveBeenCalledWith('/login');
+    expect(mockPush).toHaveBeenCalledWith('/login?redirect=%2Fen%2Fproducts%2F1', { locale: 'en' });
   });
 
   it('로그인 상태 추가 → API 호출 후 wishlistId 업데이트', async () => {

--- a/src/components/shared/blocks/ProductGridBlock.test.tsx
+++ b/src/components/shared/blocks/ProductGridBlock.test.tsx
@@ -24,7 +24,20 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    children,
+    href,
+    locale = 'ko',
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; locale?: string }) => (
+    <a href={`/${locale}${href}`} {...props}>{children}</a>
+  ),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
 vi.mock('next-intl', () => ({
+  useLocale: () => 'ko',
   useTranslations: () => (key: string) => {
     const map: Record<string, string> = { viewAll: '전체 보기' };
     return map[key] ?? key;

--- a/src/components/shared/hooks/__tests__/useWishlistToggle.test.ts
+++ b/src/components/shared/hooks/__tests__/useWishlistToggle.test.ts
@@ -13,7 +13,15 @@ vi.mock('@/lib/api', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
+  usePathname: () => '/en/products/1',
+}));
+
+vi.mock('@/i18n/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
 }));
 
 const mockIsAuthenticated = vi.fn(() => true);
@@ -32,6 +40,7 @@ vi.mock('sonner', () => ({
 describe('useWishlistToggle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.history.pushState({}, '', '/en/products/1');
     mockIsAuthenticated.mockReturnValue(true);
   });
 
@@ -51,7 +60,7 @@ describe('useWishlistToggle', () => {
     expect(result.current.isWishlisted).toBe(true);
   });
 
-  it('미인증 상태에서 toggle 호출 시 로그인 페이지로 이동한다', async () => {
+  it('미인증 상태에서 toggle 호출 시 locale-aware 로그인 페이지로 이동한다', async () => {
     mockIsAuthenticated.mockReturnValue(false);
 
     const { result } = renderHook(() => useWishlistToggle(1));
@@ -62,7 +71,7 @@ describe('useWishlistToggle', () => {
       await result.current.toggle(fakeEvent);
     });
 
-    expect(mockPush).toHaveBeenCalledWith('/login');
+    expect(mockPush).toHaveBeenCalledWith('/login?redirect=%2Fen%2Fproducts%2F1', { locale: 'en' });
     expect(mockAdd).not.toHaveBeenCalled();
   });
 

--- a/src/components/shared/hooks/useWishlistToggle.ts
+++ b/src/components/shared/hooks/useWishlistToggle.ts
@@ -1,11 +1,17 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { toast } from 'sonner';
 import { wishlistApi } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { toastMessage } from '@/utils/toastMessages';
+import type { Locale } from '@/i18n/routing';
+
+function getLocaleFromPathname(pathname: string | null): Locale {
+  const firstSegment = pathname?.split('/').filter(Boolean)[0];
+  return firstSegment === 'en' ? 'en' : 'ko';
+}
 
 interface UseWishlistToggleOptions {
   initialIsWishlisted?: boolean;
@@ -25,6 +31,8 @@ export function useWishlistToggle(
   const { initialIsWishlisted = false, initialWishlistId = null } = options;
 
   const router = useRouter();
+  const pathname = typeof window === 'undefined' ? null : window.location.pathname;
+  const locale = getLocaleFromPathname(pathname);
   const { isAuthenticated } = useAuth();
   const [isWishlisted, setIsWishlisted] = useState(initialIsWishlisted);
   const [wishlistId, setWishlistId] = useState<number | null>(initialWishlistId);
@@ -36,7 +44,8 @@ export function useWishlistToggle(
     e.stopPropagation();
 
     if (!isAuthenticated) {
-      router.push('/login');
+      const loginHref = pathname ? `/login?redirect=${encodeURIComponent(pathname)}` : '/login';
+      router.push(loginHref, { locale });
       return;
     }
 

--- a/src/components/shared/products/Pagination.tsx
+++ b/src/components/shared/products/Pagination.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
 

--- a/src/components/shared/products/ProductCard.tsx
+++ b/src/components/shared/products/ProductCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { memo, useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import Image from 'next/image';
 import { Heart, ShoppingCart } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -93,6 +93,7 @@ function ProductCard({
   return (
     <Link
       href={`/products/${id}`}
+      locale={locale}
       className={cn(
         'group flex flex-col h-full',
         isSoldout && 'opacity-60',

--- a/src/components/shared/products/ProductDetailClient.tsx
+++ b/src/components/shared/products/ProductDetailClient.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { usePathname, useRouter } from 'next/navigation'
-import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Link, useRouter } from '@/i18n/navigation'
 import { toast } from 'sonner'
 import { Heart } from 'lucide-react'
 import { useTranslations } from 'next-intl'
@@ -147,7 +147,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
   const { execute: buyNow } = useAsyncAction(
     async () => {
       await addItem({ productId: Number(product.id), productOptionId: selectedOptionId, quantity })
-      router.push('/checkout')
+      router.push('/checkout', { locale })
     },
     { errorMessage: t('buyNowError') },
   )
@@ -202,7 +202,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
           {/* Breadcrumb */}
           {product.category && (
             <nav className="typo-label text-muted-foreground tracking-widest uppercase">
-              <Link href={`/products?categoryId=${product.category.id}`} className="hover:text-foreground transition-colors">
+              <Link href={`/products?categoryId=${product.category.id}`} locale={locale} className="hover:text-foreground transition-colors">
                 {product.category.name}
               </Link>
               <span className="mx-2 text-danni">·</span>
@@ -219,6 +219,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
                     <Link
                       key={attr.id}
                       href={`/products?attrs=clay_type:${encodeURIComponent(attr.value)}`}
+                      locale={locale}
                       className={cn(
                         'inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors',
                         'tag-clay border-transparent',
@@ -234,6 +235,7 @@ export default function ProductDetailClient({ product, locale = 'ko', clayCollec
                     <Link
                       key={attr.id}
                       href={`/products?attrs=teapot_shape:${encodeURIComponent(attr.value)}`}
+                      locale={locale}
                       className="inline-flex items-center rounded-full border border-border bg-background px-3 py-1 text-xs font-medium text-foreground transition-colors hover:border-foreground/30"
                     >
                       {t('shape')}: {findCollectionLabel(shapeCollections, 'teapot_shape', attr.value)}

--- a/src/components/shared/products/__tests__/ProductCard.test.tsx
+++ b/src/components/shared/products/__tests__/ProductCard.test.tsx
@@ -14,6 +14,17 @@ vi.mock('next-intl', () => ({
     }[key] ?? key),
 }));
 
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    children,
+    href,
+    locale = 'ko',
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; locale?: string }) => (
+    <a href={`/${locale}${href}`} {...props}>{children}</a>
+  ),
+}));
+
 vi.mock('@/components/shared/hooks/useWishlistToggle', () => ({
   useWishlistToggle: () => ({ isWishlisted: false, loading: false, toggle: vi.fn() }),
 }));
@@ -87,5 +98,13 @@ describe('ProductCard summary display', () => {
 
     expect(screen.getByText('Fujian Zhuni · Xishi · 120ml · Gongfu Tea')).toBeInTheDocument();
     expect(screen.queryByText(/Xishi Shape/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ProductCard locale-aware navigation', () => {
+  it('renders English product detail links under /en', () => {
+    renderCard({ locale: 'en' });
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/en/products/1');
   });
 });

--- a/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
+++ b/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
@@ -13,6 +13,7 @@ const {
   wishlistRemoveMock,
   wishlistCheckMock,
   mockUseAuth,
+  mockPathname,
 } = vi.hoisted(() => ({
   pushMock: vi.fn(),
   toastSuccessMock: vi.fn(),
@@ -22,11 +23,23 @@ const {
   wishlistRemoveMock: vi.fn(),
   wishlistCheckMock: vi.fn(),
   mockUseAuth: vi.fn(() => ({ isAuthenticated: true, isLoading: false, user: { id: 1, email: 'test@example.com', name: '테스터', role: 'user' } })),
+  mockPathname: vi.fn(() => '/ko/products/1'),
 }));
 
 vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    children,
+    href,
+    locale = 'ko',
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; locale?: string }) => (
+    <a href={`/${locale}${href}`} {...props}>{children}</a>
+  ),
   useRouter: () => ({ push: pushMock }),
-  usePathname: () => '/ko/products/1',
 }));
 
 vi.mock('next/link', () => ({
@@ -203,6 +216,8 @@ describe('ProductDetailClient', () => {
     wishlistAddMock.mockResolvedValue({ id: 999 });
     wishlistRemoveMock.mockReset();
     pushMock.mockReset();
+    mockPathname.mockReset();
+    mockPathname.mockReturnValue('/ko/products/1');
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     mockUseAuth.mockReturnValue({
@@ -245,12 +260,20 @@ describe('ProductDetailClient', () => {
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
 
-  it('바로 구매 → addItem + router.push("/checkout")', async () => {
+  it('바로 구매 → addItem + locale-aware router.push("/checkout")', async () => {
     render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
     await userEvent.click(screen.getAllByRole('button', { name: '바로 구매' })[0]);
     await waitFor(() => {
       expect(addCartItemMock).toHaveBeenCalled();
-      expect(pushMock).toHaveBeenCalledWith('/checkout');
+      expect(pushMock).toHaveBeenCalledWith('/checkout', { locale: 'ko' });
+    });
+  });
+
+  it('English 바로 구매 keeps checkout navigation under /en', async () => {
+    render(<ProductDetailClient product={productWithoutOptions} locale="en" />);
+    await userEvent.click(screen.getAllByRole('button', { name: '바로 구매' })[0]);
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/checkout', { locale: 'en' });
     });
   });
 
@@ -289,7 +312,7 @@ describe('ProductDetailClient', () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
-      user: null,
+      user: { id: 1, email: 'test@example.com', name: '테스터', role: 'user' },
     });
 
     render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
@@ -299,6 +322,23 @@ describe('ProductDetailClient', () => {
     await userEvent.click(screen.getAllByLabelText('찜하기')[0]);
 
     expect(pushMock).toHaveBeenCalledWith('/login?redirect=%2Fko%2Fproducts%2F1');
+    expect(wishlistAddMock).not.toHaveBeenCalled();
+    expect(wishlistRemoveMock).not.toHaveBeenCalled();
+  });
+
+  it('English 비로그인 찜 클릭 → locale-aware login redirect로 이동', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      user: { id: 1, email: 'test@example.com', name: '테스터', role: 'user' },
+    });
+    mockPathname.mockReturnValue('/en/products/1');
+
+    render(<ProductDetailClient product={productWithoutOptions} locale="en" />);
+
+    await userEvent.click(screen.getAllByLabelText('찜하기')[0]);
+
+    expect(pushMock).toHaveBeenCalledWith('/login?redirect=%2Fen%2Fproducts%2F1');
     expect(wishlistAddMock).not.toHaveBeenCalled();
     expect(wishlistRemoveMock).not.toHaveBeenCalled();
   });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,6 +8,33 @@ vi.mock('next/image', () => ({
   default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
 }));
 
+vi.mock('@/i18n/navigation', () => {
+  const localizeHref = (href: unknown, locale?: string) => {
+    const value = typeof href === 'string' ? href : String(href);
+    return locale && value.startsWith('/') ? `/${locale}${value}` : value;
+  };
+
+  return {
+    Link: ({
+      children,
+      href,
+      locale,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: unknown; locale?: string }) =>
+      React.createElement('a', { href: localizeHref(href, locale), ...props }, children),
+    redirect: vi.fn(),
+    usePathname: () => '/',
+    useRouter: () => ({
+      back: vi.fn(),
+      forward: vi.fn(),
+      prefetch: vi.fn(),
+      push: vi.fn(),
+      refresh: vi.fn(),
+      replace: vi.fn(),
+    }),
+  };
+});
+
 // jsdom does not implement window.matchMedia — provide a stub so tests can spy on it
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
Closes #909

## Summary
- Use locale-aware navigation for product cards, product detail links/actions, pagination, and wishlist auth redirects
- Add test navigation mock coverage for locale-aware links/router
- Add regressions for /en product card/detail/pagination/wishlist flows

## Verification
- npm run test:run -- ProductCard ProductDetailClient ProductsPage WishlistButton useWishlistToggle ProductGridBlock
- npm run build
- npm run test:run
- npm run lint
- bash scripts/codex-project-guard.sh
- git diff --check

## Notes
- Next lint reports the pre-existing AppShell unused locale warning.
- Manual browser /en smoke was not performed.