### PR TITLE
Use RS256 public key for user-aware throttling

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,6 +38,7 @@ import { AnnouncementBarsModule } from './modules/announcement-bars/announcement
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.guard';
+import { AuthConfigModule } from './config/auth-config.module';
 
 @Module({
   imports: [
@@ -52,6 +53,7 @@ import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.gu
       autoLoadEntities: true,
       migrations: ['dist/database/migrations/*.js'],
     }),
+    AuthConfigModule,
     ThrottlerModule.forRoot([
       {
         name: 'global',

--- a/backend/src/common/guards/user-aware-throttler.guard.spec.ts
+++ b/backend/src/common/guards/user-aware-throttler.guard.spec.ts
@@ -1,19 +1,58 @@
+import { generateKeyPairSync } from 'crypto';
 import * as jwt from 'jsonwebtoken';
+import type { AuthConfig } from '../../config/auth.config';
 import { UserAwareThrottlerGuard } from './user-aware-throttler.guard';
 
 describe('UserAwareThrottlerGuard', () => {
   let guard: UserAwareThrottlerGuard;
-  const originalJwtSecret = process.env.JWT_SECRET;
+  let privateKey: string;
+  let publicKey: string;
+  let wrongPrivateKey: string;
   const call = (req: unknown) =>
     (guard as unknown as { getTracker: (r: unknown) => Promise<string> }).getTracker(req);
 
-  beforeEach(() => {
-    guard = Object.create(UserAwareThrottlerGuard.prototype) as UserAwareThrottlerGuard;
-    process.env.JWT_SECRET = 'test-secret';
+  const buildAuthConfig = (jwtPublicKey: string): AuthConfig => ({
+    nodeEnv: 'test',
+    cookie: { secure: false },
+    frontend: { baseUrl: 'http://localhost:5173', allowedOrigins: [] },
+    jwt: {
+      secret: 'legacy-secret-not-used-for-access-token-verification',
+      refreshSecret: null,
+      expiresIn: '1h',
+      refreshExpiresIn: '7d',
+      privateKey,
+      publicKey: jwtPublicKey,
+    },
+    oauth: {
+      kakao: { clientId: '', clientSecret: '', redirectUri: '' },
+      google: { clientId: '', clientSecret: '', redirectUri: '' },
+    },
   });
 
-  afterEach(() => {
-    process.env.JWT_SECRET = originalJwtSecret;
+  const setAuthConfig = (authConfig: AuthConfig) => {
+    (guard as unknown as { authConfig: AuthConfig }).authConfig = authConfig;
+  };
+
+  beforeAll(() => {
+    const keyPair = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    });
+    privateKey = keyPair.privateKey;
+    publicKey = keyPair.publicKey;
+
+    const wrongKeyPair = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    });
+    wrongPrivateKey = wrongKeyPair.privateKey;
+  });
+
+  beforeEach(() => {
+    guard = Object.create(UserAwareThrottlerGuard.prototype) as UserAwareThrottlerGuard;
+    setAuthConfig(buildAuthConfig(publicKey));
   });
 
   describe('getTracker — post-JwtAuthGuard request.user', () => {
@@ -27,11 +66,20 @@ describe('UserAwareThrottlerGuard', () => {
   });
 
   describe('getTracker — cookie accessToken fallback (runs before JwtAuthGuard)', () => {
-    it('uses sub from a verified accessToken cookie when request.user is missing', async () => {
-      const token = jwt.sign({ sub: 99, role: 'user' }, 'test-secret');
+    it('uses sub from an actual RS256 accessToken cookie when request.user is missing', async () => {
+      const token = jwt.sign({ sub: 99, role: 'user' }, privateKey, { algorithm: 'RS256' });
+
       await expect(
         call({ user: undefined, ip: '10.0.0.1', cookies: { accessToken: token } }),
       ).resolves.toBe('user:99');
+    });
+
+    it('falls back to ip when a legacy HS256 JWT_SECRET token is supplied', async () => {
+      const token = jwt.sign({ sub: 99, role: 'user' }, 'legacy-secret-not-used-for-access-token-verification');
+
+      await expect(
+        call({ user: undefined, ip: '203.0.113.4', cookies: { accessToken: token } }),
+      ).resolves.toBe('ip:203.0.113.4');
     });
 
     it('falls back to ip when cookie token is malformed', async () => {
@@ -47,29 +95,29 @@ describe('UserAwareThrottlerGuard', () => {
     });
 
     it('falls back to ip when cookie token lacks sub', async () => {
-      const token = jwt.sign({ foo: 'bar' }, 'test-secret');
+      const token = jwt.sign({ foo: 'bar' }, privateKey, { algorithm: 'RS256' });
       await expect(
         call({ user: undefined, ip: '203.0.113.7', cookies: { accessToken: token } }),
       ).resolves.toBe('ip:203.0.113.7');
     });
 
     it('ignores refresh token (tokenType=refresh) to avoid mixing buckets', async () => {
-      const token = jwt.sign({ sub: 5, tokenType: 'refresh' }, 'test-secret');
+      const token = jwt.sign({ sub: 5, tokenType: 'refresh' }, privateKey, { algorithm: 'RS256' });
       await expect(
         call({ user: undefined, ip: '203.0.113.8', cookies: { accessToken: token } }),
       ).resolves.toBe('ip:203.0.113.8');
     });
 
     it('falls back to ip when cookie token signature is invalid', async () => {
-      const token = jwt.sign({ sub: 'spoofed-user' }, 'wrong-secret');
+      const token = jwt.sign({ sub: 'spoofed-user' }, wrongPrivateKey, { algorithm: 'RS256' });
       await expect(
         call({ user: undefined, ip: '203.0.113.9', cookies: { accessToken: token } }),
       ).resolves.toBe('ip:203.0.113.9');
     });
 
-    it('falls back to ip when JWT_SECRET is missing', async () => {
-      delete process.env.JWT_SECRET;
-      const token = jwt.sign({ sub: 77 }, 'test-secret');
+    it('falls back to ip when AuthConfig public key is missing', async () => {
+      setAuthConfig(buildAuthConfig(''));
+      const token = jwt.sign({ sub: 77 }, privateKey, { algorithm: 'RS256' });
 
       await expect(
         call({ user: undefined, ip: '203.0.113.10', cookies: { accessToken: token } }),

--- a/backend/src/common/guards/user-aware-throttler.guard.ts
+++ b/backend/src/common/guards/user-aware-throttler.guard.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import * as jwt from 'jsonwebtoken';
+import { AUTH_CONFIG, AuthConfig } from '../../config/auth.config';
 
 /**
  * NAT/사옥/공유 프록시 환경에서 한 사용자의 burst 가 다른 사용자에게
@@ -13,6 +14,9 @@ import * as jwt from 'jsonwebtoken';
  */
 @Injectable()
 export class UserAwareThrottlerGuard extends ThrottlerGuard {
+  @Inject(AUTH_CONFIG)
+  private readonly authConfig!: AuthConfig;
+
   protected async getTracker(req: Record<string, unknown>): Promise<string> {
     const userFromReq = req?.user as { id?: number | string } | undefined;
     if (this.hasId(userFromReq?.id)) {
@@ -46,10 +50,10 @@ export class UserAwareThrottlerGuard extends ThrottlerGuard {
 
   private decodeSub(token: string): number | string | undefined {
     try {
-      const secret = process.env.JWT_SECRET?.trim();
-      if (!secret) return undefined;
+      const publicKey = this.authConfig.jwt.publicKey.trim();
+      if (!publicKey) return undefined;
 
-      const payload = jwt.verify(token, secret);
+      const payload = jwt.verify(token, publicKey, { algorithms: ['RS256'] });
       if (!payload || typeof payload !== 'object') return undefined;
       // refresh 토큰은 tracker 버킷을 access 와 섞지 않도록 거부
       if ((payload as { tokenType?: string }).tokenType === 'refresh') return undefined;


### PR DESCRIPTION
Closes #907

## Summary
- Verify access-token cookies in UserAwareThrottlerGuard with the AuthConfig RS256 public key
- Import AuthConfigModule for the global throttler guard dependency
- Add generated RS256 token coverage proving user bucket selection and fallback behavior

## Verification
- cd backend && npm run test -- user-aware-throttler.guard.spec.ts
- cd backend && npm run build
- cd backend && npm run lint
- bash scripts/codex-project-guard.sh
- git diff --check

## Notes
- Full backend/e2e suite not rerun locally for this guard-only fix.