### PR TITLE
Escape order service request notification HTML

### DIFF
--- a/backend/src/modules/orders/__tests__/order-service-requests.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/order-service-requests.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ModuleRef } from '@nestjs/core';
+import { validate } from 'class-validator';
 import { DataSource, EntityManager } from 'typeorm';
 import { OrderServiceRequestsService } from '../order-service-requests.service';
 import { Order, OrderStatus } from '../entities/order.entity';
@@ -13,6 +14,7 @@ import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import type { PaymentsService } from '../../payments/payments.service';
 import { PaymentStatus } from '../../payments/entities/payment.entity';
+import { UpdateOrderServiceRequestDto } from '../dto/update-order-service-request.dto';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order => ({
   id: 7,
@@ -79,12 +81,33 @@ const makeManager = () => ({
   save: jest.fn().mockResolvedValue({}),
 });
 
+describe('UpdateOrderServiceRequestDto', () => {
+  it('rejects admin notes longer than the email-safe limit', async () => {
+    const dto = new UpdateOrderServiceRequestDto();
+    dto.status = OrderServiceRequestStatus.APPROVED;
+    dto.adminNote = 'a'.repeat(501);
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        property: 'adminNote',
+        constraints: expect.objectContaining({
+          maxLength: '관리자 메모는 최대 500자까지 입력 가능합니다.',
+        }),
+      }),
+    ]));
+  });
+});
+
 describe('OrderServiceRequestsService', () => {
   let service: OrderServiceRequestsService;
   let requestRepository: ReturnType<typeof makeRepository>;
   let orderRepository: ReturnType<typeof makeRepository>;
   let manager: ReturnType<typeof makeManager>;
   let paymentsService: jest.Mocked<Pick<PaymentsService, 'cancelPaidOrder'>>;
+  let notificationService: jest.Mocked<Pick<NotificationService, 'sendEmail'>>;
+  let notificationDispatchHelper: jest.Mocked<Pick<NotificationDispatchHelper, 'dispatch'>>;
 
   beforeEach(async () => {
     requestRepository = makeRepository();
@@ -98,6 +121,8 @@ describe('OrderServiceRequestsService', () => {
         cancelReason: '관리자 승인',
       }),
     };
+    notificationService = { sendEmail: jest.fn().mockResolvedValue(undefined) };
+    notificationDispatchHelper = { dispatch: jest.fn().mockResolvedValue(undefined) };
 
     const dataSource = {
       transaction: jest.fn((cb: (txManager: EntityManager) => Promise<unknown>) => cb(manager as unknown as EntityManager)),
@@ -109,8 +134,8 @@ describe('OrderServiceRequestsService', () => {
         { provide: getRepositoryToken(OrderServiceRequest), useValue: requestRepository },
         { provide: getRepositoryToken(Order), useValue: orderRepository },
         { provide: DataSource, useValue: dataSource },
-        { provide: NotificationService, useValue: { sendEmail: jest.fn() } },
-        { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
+        { provide: NotificationService, useValue: notificationService },
+        { provide: NotificationDispatchHelper, useValue: notificationDispatchHelper },
         { provide: ModuleRef, useValue: { get: jest.fn().mockReturnValue(paymentsService) } },
       ],
     }).compile();
@@ -170,5 +195,60 @@ describe('OrderServiceRequestsService', () => {
 
     expect(paymentsService.cancelPaidOrder).not.toHaveBeenCalled();
     expect(manager.update).toHaveBeenCalledWith(Order, order.id, { status: OrderStatus.CANCELLED });
+  });
+
+  it('escapes HTML-like recipient names in received request notification email HTML', async () => {
+    const order = makeOrder();
+    const request = makeRequest(order);
+    notificationDispatchHelper.dispatch.mockImplementation(async (params) => {
+      await params.send({
+        id: request.userId,
+        email: 'user@example.com',
+        name: '<img src=x onerror=alert(1)>',
+      });
+    });
+
+    await (service as unknown as {
+      notifyRequestReceived: (request: OrderServiceRequest, order: Order) => Promise<void>;
+    }).notifyRequestReceived(request, order);
+
+    expect(notificationService.sendEmail).toHaveBeenCalledWith(expect.objectContaining({
+      html: expect.not.stringContaining('<img'),
+    }));
+    expect(notificationService.sendEmail).toHaveBeenCalledWith(expect.objectContaining({
+      html: expect.stringContaining('&lt;img src=x onerror=alert(1)&gt;'),
+    }));
+  });
+
+  it('escapes HTML-like recipient names and admin notes in status notification email HTML', async () => {
+    const order = makeOrder();
+    const request = makeRequest(order, {
+      status: OrderServiceRequestStatus.APPROVED,
+      adminNote: '<a href="https://evil.test">확인</a> & "추적"',
+    });
+    notificationDispatchHelper.dispatch.mockImplementation(async (params) => {
+      await params.send({
+        id: request.userId,
+        email: 'user@example.com',
+        name: '홍<script>alert(1)</script>',
+      });
+    });
+
+    await (service as unknown as {
+      notifyRequestStatusChanged: (request: OrderServiceRequest) => Promise<void>;
+    }).notifyRequestStatusChanged(request);
+
+    expect(notificationService.sendEmail).toHaveBeenCalledWith(expect.objectContaining({
+      html: expect.not.stringContaining('<script>'),
+    }));
+    expect(notificationService.sendEmail).toHaveBeenCalledWith(expect.objectContaining({
+      html: expect.not.stringContaining('<a href='),
+    }));
+    expect(notificationService.sendEmail).toHaveBeenCalledWith(expect.objectContaining({
+      html: expect.stringContaining('홍&lt;script&gt;alert(1)&lt;/script&gt;'),
+    }));
+    expect(notificationService.sendEmail).toHaveBeenCalledWith(expect.objectContaining({
+      html: expect.stringContaining('&lt;a href=&quot;https://evil.test&quot;&gt;확인&lt;/a&gt; &amp; &quot;추적&quot;'),
+    }));
   });
 });

--- a/backend/src/modules/orders/dto/update-order-service-request.dto.ts
+++ b/backend/src/modules/orders/dto/update-order-service-request.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
 import { OrderServiceRequestStatus } from '../entities/order-service-request.entity';
 
 export class UpdateOrderServiceRequestDto {
@@ -7,8 +7,9 @@ export class UpdateOrderServiceRequestDto {
   @IsEnum(OrderServiceRequestStatus, { message: '처리 상태가 올바르지 않습니다.' })
   status!: OrderServiceRequestStatus;
 
-  @ApiPropertyOptional({ example: '고객 안내 완료' })
+  @ApiPropertyOptional({ example: '고객 안내 완료', maxLength: 500 })
   @IsOptional()
   @IsString()
+  @MaxLength(500, { message: '관리자 메모는 최대 500자까지 입력 가능합니다.' })
   adminNote?: string;
 }

--- a/backend/src/modules/orders/order-service-requests.service.ts
+++ b/backend/src/modules/orders/order-service-requests.service.ts
@@ -15,6 +15,7 @@ import { assertOwnership } from '../../common/utils/ownership.util';
 import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
 import { NotificationService } from '../notification/notification.service';
 import { NotificationDispatchHelper } from '../notification/notification-dispatch.helper';
+import { escapeHtml } from '../notification/templates/sanitize';
 import { restoreOrderStock } from './order-stock.util';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { ModuleRef } from '@nestjs/core';
@@ -234,12 +235,15 @@ export class OrderServiceRequestsService {
       resourceId: request.id,
       mode: 'fire-and-forget',
       logger: this.logger,
-      send: (recipient) => this.notificationService.sendEmail({
-        to: recipient.email,
-        subject: `[옥화당] ${order.orderNumber} 신청이 접수되었습니다`,
-        text: `${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청이 접수되었습니다. 처리 상태는 마이페이지 주문 상세에서 확인하실 수 있습니다.`,
-        html: `<p>${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청이 접수되었습니다.</p><p>처리 상태는 마이페이지 주문 상세에서 확인하실 수 있습니다.</p>`,
-      }),
+      send: (recipient) => {
+        const recipientNameHtml = escapeHtml(recipient.name);
+        return this.notificationService.sendEmail({
+          to: recipient.email,
+          subject: `[옥화당] ${order.orderNumber} 신청이 접수되었습니다`,
+          text: `${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청이 접수되었습니다. 처리 상태는 마이페이지 주문 상세에서 확인하실 수 있습니다.`,
+          html: `<p>${recipientNameHtml}님, ${this.getRequestTypeLabel(request.type)} 신청이 접수되었습니다.</p><p>처리 상태는 마이페이지 주문 상세에서 확인하실 수 있습니다.</p>`,
+        });
+      },
     });
   }
 
@@ -250,12 +254,16 @@ export class OrderServiceRequestsService {
       resourceId: request.id,
       mode: 'fire-and-forget',
       logger: this.logger,
-      send: (recipient) => this.notificationService.sendEmail({
-        to: recipient.email,
-        subject: `[옥화당] ${request.order.orderNumber} 신청 처리 상태 안내`,
-        text: `${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청 상태가 ${this.getRequestStatusLabel(request.status)}(으)로 변경되었습니다.${request.adminNote ? `\n안내: ${request.adminNote}` : ''}`,
-        html: `<p>${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청 상태가 <strong>${this.getRequestStatusLabel(request.status)}</strong>(으)로 변경되었습니다.</p>${request.adminNote ? `<p>안내: ${request.adminNote}</p>` : ''}`,
-      }),
+      send: (recipient) => {
+        const recipientNameHtml = escapeHtml(recipient.name);
+        const adminNoteHtml = request.adminNote ? escapeHtml(request.adminNote) : '';
+        return this.notificationService.sendEmail({
+          to: recipient.email,
+          subject: `[옥화당] ${request.order.orderNumber} 신청 처리 상태 안내`,
+          text: `${recipient.name}님, ${this.getRequestTypeLabel(request.type)} 신청 상태가 ${this.getRequestStatusLabel(request.status)}(으)로 변경되었습니다.${request.adminNote ? `\n안내: ${request.adminNote}` : ''}`,
+          html: `<p>${recipientNameHtml}님, ${this.getRequestTypeLabel(request.type)} 신청 상태가 <strong>${this.getRequestStatusLabel(request.status)}</strong>(으)로 변경되었습니다.</p>${adminNoteHtml ? `<p>안내: ${adminNoteHtml}</p>` : ''}`,
+        });
+      },
     });
   }
 


### PR DESCRIPTION
Closes #905

## Summary
- Escape recipient names and admin notes before rendering service request email HTML
- Add a max length constraint for admin notes
- Add regression tests for HTML-like user/admin input in notification emails

## Verification
- cd backend && npm run test -- notification.service.spec.ts order-service-requests.service.spec.ts
- cd backend && npm run build
- cd backend && npm run lint
- cd backend && npx tsc --noEmit --pretty false
- bash scripts/codex-project-guard.sh

## Notes
- Local service restart deferred during parallel work to avoid interrupting other worktrees.