### PR TITLE
Run frontend typecheck and build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   frontend:
-    name: Frontend (lint + test)
+    name: Frontend (lint + typecheck + build + test)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -19,6 +19,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run build
       - run: npm run test:run
 
   backend:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev --turbopack -p 5173",
     "build": "next build",
+    "typecheck": "tsc --noEmit --project tsconfig.json",
     "build:analyze": "ANALYZE=true npm run build",
     "start": "next start",
     "audit:bundle-imports": "bash scripts/audit-bundle-imports.sh",

--- a/src/components/__tests__/FaqPage.test.tsx
+++ b/src/components/__tests__/FaqPage.test.tsx
@@ -38,7 +38,7 @@ vi.mock('@/lib/api', () => ({
 describe('FaqPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(faqsApi.getList).mockResolvedValue([]);
+    vi.mocked(faqsApi.getList).mockResolvedValue({ data: [], total: 0 });
   });
 
   it('비회원 주문조회 대신 회원 주문 전용 정책 안내를 노출한다', async () => {

--- a/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
@@ -87,6 +87,7 @@ describe('ProductFormPage', () => {
         sku: null,
         options: [],
         detailImages: [],
+        noticeInfo: null,
       });
 
       render(<ProductFormPage mode="create" />);
@@ -136,6 +137,7 @@ describe('ProductFormPage', () => {
         sku: null,
         options: [],
         detailImages: [],
+        noticeInfo: null,
       });
 
       render(<ProductFormPage mode="create" />);
@@ -231,6 +233,7 @@ describe('ProductFormPage', () => {
         sku: null,
         options: [],
         detailImages: [],
+        noticeInfo: null,
       });
 
       render(<ProductFormPage mode="create" />);

--- a/src/lib/api/pages.ts
+++ b/src/lib/api/pages.ts
@@ -78,7 +78,7 @@ export interface ProductCarouselContent {
 
 export interface CategoryNavContent {
   title?: string;
-  category_ids: number[];
+  category_ids?: number[];
   template: 'icon' | 'image' | 'text';
   prefetched_categories?: Category[];
 }

--- a/src/utils/__tests__/upload.test.ts
+++ b/src/utils/__tests__/upload.test.ts
@@ -25,8 +25,8 @@ describe('upload utils', () => {
     uploadImageMock.mockResolvedValue({ url: '/uploads/product.jpg' });
     const file = new File(['image'], 'product.jpg', { type: 'image/jpeg' });
 
-    await expect(uploadImage(file, 'products')).resolves.toEqual({ url: '/uploads/product.jpg' });
-    expect(uploadImageMock).toHaveBeenCalledWith(file, 'products');
+    await expect(uploadImage(file)).resolves.toEqual({ url: '/uploads/product.jpg' });
+    expect(uploadImageMock).toHaveBeenCalledWith(file);
   });
 
   it('delegates review image uploads to reviewsApi', async () => {


### PR DESCRIPTION
Closes #921

## Summary
- Add frontend typecheck script and run it in CI
- Run frontend build in CI before tests
- Fix current TypeScript fixture/API type drift so typecheck passes

## Verification
- make bootstrap
- npx tsc --noEmit --pretty false --project tsconfig.json (reproduced initial failure before fixes)
- npm run lint
- npm run typecheck
- npm run build
- npm run test:run
- bash scripts/codex-project-guard.sh
- git diff --check

## Notes
- Next lint/build still reports the pre-existing AppShell unused locale warning.
- Local services were not restarted because this is CI/test/type fixture work.