### PR TITLE
Fetch journal details from CMS API

### DIFF
--- a/src/app/[locale]/journal/[slug]/__tests__/page.test.tsx
+++ b/src/app/[locale]/journal/[slug]/__tests__/page.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import JournalDetailPage, { generateMetadata } from '../page';
+import { JournalCategory, type Journal } from '@/lib/api';
+import { fetchJournal } from '@/lib/api-server';
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('notFound');
+  }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn(async ({ namespace }: { namespace: string }) => {
+    const messages: Record<string, Record<string, string>> = {
+      journalPage: {
+        readSuffix: 'read',
+        backToList: 'Back to journal list',
+      },
+      journalCategories: {
+        culture: 'Tea Culture',
+        usage: 'How to Use',
+        tableSetting: 'Tea Table',
+        news: 'News',
+      },
+    };
+
+    return (key: string) => messages[namespace]?.[key] ?? key;
+  }),
+}));
+
+vi.mock('@/lib/api-server', () => ({
+  fetchJournal: vi.fn(),
+}));
+
+const mockFetchJournal = vi.mocked(fetchJournal);
+
+const apiCreatedJournal: Journal = {
+  id: 914,
+  slug: 'cms-created-journal',
+  title: 'CMS Created Journal',
+  subtitle: 'Created from admin CMS',
+  category: JournalCategory.NEWS,
+  date: '2026-06-20',
+  readTime: '4 min',
+  summary: 'A journal entry created through the API.',
+  content: JSON.stringify(['First API paragraph.', 'Second API paragraph.']),
+  coverImageUrl: null,
+  isPublished: true,
+  createdAt: '2026-06-20T00:00:00.000Z',
+  updatedAt: '2026-06-20T00:00:00.000Z',
+};
+
+describe('/[locale]/journal/[slug] detail page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches an API-created journal by slug and route locale before rendering', async () => {
+    mockFetchJournal.mockResolvedValue(apiCreatedJournal);
+
+    const jsx = await JournalDetailPage({
+      params: Promise.resolve({ locale: 'en', slug: 'cms-created-journal' }),
+    });
+    render(jsx);
+
+    expect(mockFetchJournal).toHaveBeenCalledWith('cms-created-journal', 'en');
+    expect(screen.getByRole('heading', { name: 'CMS Created Journal' })).toBeInTheDocument();
+    expect(screen.getByText('News')).toBeInTheDocument();
+    expect(screen.getByText('First API paragraph.')).toBeInTheDocument();
+    expect(screen.getByText('Second API paragraph.')).toBeInTheDocument();
+  });
+
+  it('uses the API journal for metadata', async () => {
+    mockFetchJournal.mockResolvedValue(apiCreatedJournal);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: 'en', slug: 'cms-created-journal' }),
+    });
+
+    expect(mockFetchJournal).toHaveBeenCalledWith('cms-created-journal', 'en');
+    expect(metadata.title).toBe('CMS Created Journal — Journal');
+    expect(metadata.description).toBe('A journal entry created through the API.');
+  });
+});

--- a/src/app/[locale]/journal/[slug]/page.tsx
+++ b/src/app/[locale]/journal/[slug]/page.tsx
@@ -2,27 +2,99 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
-import { JOURNAL_ENTRIES, getLocalizedJournalBySlug } from '@/lib/journal';
+import { getJournalCategoryMessageKey } from '@/components/shared/journal/journalCategory';
+import type { Journal } from '@/lib/api';
+import { fetchJournal } from '@/lib/api-server';
+import {
+  JOURNAL_ENTRIES,
+  type JournalEntry as LocalJournalEntry,
+  getLocalizedJournalBySlug,
+} from '@/lib/journal';
 
 interface PageProps {
   params: Promise<{ locale: 'ko' | 'en'; slug: string }>;
+}
+
+interface RenderableJournal {
+  title: string;
+  subtitle: string | null;
+  category: string;
+  date: string;
+  readTime: string | null;
+  summary: string | null;
+  content: string[];
 }
 
 export async function generateStaticParams() {
   return JOURNAL_ENTRIES.map((entry) => ({ slug: entry.slug }));
 }
 
+function parseJournalContent(content: string | null): string[] {
+  if (!content) return [];
+
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (paragraph): paragraph is string => typeof paragraph === 'string' && paragraph.length > 0,
+      );
+    }
+  } catch {
+    return [content];
+  }
+
+  return [content];
+}
+
+async function resolveJournal(
+  slug: string,
+  locale: 'ko' | 'en',
+): Promise<RenderableJournal | null> {
+  const apiJournal = await fetchJournal(slug, locale);
+  if (apiJournal) {
+    const tCategory = await getTranslations({ locale, namespace: 'journalCategories' });
+    return normalizeApiJournal(apiJournal, tCategory);
+  }
+
+  const fallbackEntry = getLocalizedJournalBySlug(slug, locale);
+  return fallbackEntry ? normalizeLocalJournal(fallbackEntry) : null;
+}
+
+function normalizeApiJournal(journal: Journal, tCategory: (key: string) => string): RenderableJournal {
+  return {
+    title: journal.title,
+    subtitle: journal.subtitle,
+    category: tCategory(getJournalCategoryMessageKey(journal.category)),
+    date: journal.date,
+    readTime: journal.readTime,
+    summary: journal.summary,
+    content: parseJournalContent(journal.content),
+  };
+}
+
+function normalizeLocalJournal(entry: LocalJournalEntry): RenderableJournal {
+  return {
+    title: entry.title,
+    subtitle: entry.subtitle,
+    category: entry.category,
+    date: entry.date,
+    readTime: entry.readTime,
+    summary: entry.summary,
+    content: entry.content,
+  };
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { locale, slug } = await params;
-  const entry = getLocalizedJournalBySlug(slug, locale);
+  const entry = await resolveJournal(slug, locale);
   if (!entry) return { title: locale === 'en' ? 'Journal — Ockhwadang' : 'Journal — 옥화당' };
 
   return {
     title: `${entry.title} — Journal`,
-    description: entry.summary,
+    description: entry.summary ?? undefined,
     openGraph: {
       title: entry.title,
-      description: entry.summary,
+      description: entry.summary ?? undefined,
       type: 'article',
       publishedTime: entry.date,
     },
@@ -32,7 +104,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function JournalDetailPage({ params }: PageProps) {
   const { locale, slug } = await params;
   const t = await getTranslations({ locale, namespace: 'journalPage' });
-  const entry = getLocalizedJournalBySlug(slug, locale);
+  const entry = await resolveJournal(slug, locale);
 
   if (!entry) {
     notFound();
@@ -66,23 +138,31 @@ export default async function JournalDetailPage({ params }: PageProps) {
             </span>
             <span className="text-xs text-background/40">·</span>
             <time className="text-xs text-background/60">{entry.date}</time>
-            <span className="text-xs text-background/40">·</span>
-            <span className="text-xs text-background/60">{entry.readTime} {t('readSuffix')}</span>
+            {entry.readTime ? (
+              <>
+                <span className="text-xs text-background/40">·</span>
+                <span className="text-xs text-background/60">{entry.readTime} {t('readSuffix')}</span>
+              </>
+            ) : null}
           </div>
           <h1 className="font-display typo-h1 tracking-tight mb-3">
             {entry.title}
           </h1>
-          <p className="typo-h3 text-background/70 font-display">
-            {entry.subtitle}
-          </p>
+          {entry.subtitle ? (
+            <p className="typo-h3 text-background/70 font-display">
+              {entry.subtitle}
+            </p>
+          ) : null}
         </div>
       </section>
 
       {/* 본문 */}
       <article className="py-16 px-4 max-w-3xl mx-auto">
-        <p className="text-base text-muted-foreground leading-relaxed mb-8 border-l-2 border-foreground pl-4 italic">
-          {entry.summary}
-        </p>
+        {entry.summary ? (
+          <p className="text-base text-muted-foreground leading-relaxed mb-8 border-l-2 border-foreground pl-4 italic">
+            {entry.summary}
+          </p>
+        ) : null}
         <div className="space-y-6">
           {entry.content.map((paragraph, i) => (
             <p key={i} className="text-base text-foreground leading-relaxed">

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,5 +1,5 @@
 import { cache } from 'react';
-import type { ProductListResponse, ProductSort, Category, ProductDetail, Page, SiteSetting } from '@/lib/api';
+import type { ProductListResponse, ProductSort, Category, ProductDetail, Page, SiteSetting, Journal } from '@/lib/api';
 
 const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
 
@@ -85,6 +85,15 @@ export const fetchProduct = cache(async (id: number, locale?: string): Promise<P
 export async function fetchPage(slug: string, locale?: string): Promise<Page | null> {
   try {
     return await fetchFromBackend<Page>(`/pages/${slug}`, locale ? { locale } : undefined);
+  } catch {
+    return null;
+  }
+}
+
+
+export async function fetchJournal(slug: string, locale?: string): Promise<Journal | null> {
+  try {
+    return await fetchFromBackend<Journal>(`/journals/${slug}`, locale ? { locale } : undefined);
   } catch {
     return null;
   }


### PR DESCRIPTION
Closes #914

## Summary
- Fetch journal detail pages from the API/CMS by slug and locale before falling back to local fixtures
- Normalize API/local journal data for rendering and metadata
- Add tests for API-created journal detail and metadata rendering

## Verification
- make bootstrap
- npm run test:run -- Journal
- npm run lint
- npm run build
- bash scripts/codex-project-guard.sh
- npx eslint changed files
- git diff --check

## Notes
- Manual CMS create/browser smoke was not run.
- Worker observed npx tsc --noEmit failing on unrelated pre-existing fixture errors in its branch; #921 addresses frontend typecheck drift separately.