### PR TITLE
Use server pagination for admin inquiries

### DIFF
--- a/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
+++ b/backend/src/modules/inquiries/__tests__/inquiries.service.spec.ts
@@ -13,6 +13,7 @@ const mockRepo = () => ({
   save: jest.fn(),
   create: jest.fn(),
   find: jest.fn(),
+  count: jest.fn(),
 });
 
 describe('InquiriesService', () => {
@@ -212,6 +213,37 @@ describe('InquiriesService', () => {
       await service.findAllForAdmin({});
 
       expect(mockQb.andWhere).not.toHaveBeenCalled();
+    });
+
+    it('status 필터와 pagination metadata/counts를 함께 반환한다', async () => {
+      const mockQb = buildMockQb();
+      const items = [{ id: 51, status: InquiryStatus.PENDING }] as Inquiry[];
+      mockQb.getManyAndCount.mockResolvedValue([items, 52]);
+      repo.count
+        .mockResolvedValueOnce(52)
+        .mockResolvedValueOnce(8);
+
+      const result = await service.findAllForAdmin({
+        status: InquiryStatus.PENDING,
+        page: 2,
+        limit: 10,
+      });
+
+      expect(mockQb.andWhere).toHaveBeenCalledWith('inquiry.status = :status', { status: InquiryStatus.PENDING });
+      expect(mockQb.skip).toHaveBeenCalledWith(10);
+      expect(mockQb.take).toHaveBeenCalledWith(10);
+      expect(result).toEqual({
+        items,
+        total: 52,
+        page: 2,
+        limit: 10,
+        counts: {
+          pending: 52,
+          answered: 8,
+        },
+      });
+      expect(repo.count).toHaveBeenNthCalledWith(1, { where: { status: InquiryStatus.PENDING } });
+      expect(repo.count).toHaveBeenNthCalledWith(2, { where: { status: InquiryStatus.ANSWERED } });
     });
   });
 });

--- a/backend/src/modules/inquiries/dto/admin-inquiry-query.dto.ts
+++ b/backend/src/modules/inquiries/dto/admin-inquiry-query.dto.ts
@@ -1,8 +1,14 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import { IsBoolean, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { IsBoolean, IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { InquiryStatus } from '../entities/inquiry.entity';
 
 export class AdminInquiryQueryDto {
+  @ApiPropertyOptional({ description: '문의 상태', enum: InquiryStatus, example: InquiryStatus.PENDING })
+  @IsOptional()
+  @IsEnum(InquiryStatus, { message: 'status는 pending 또는 answered여야 합니다.' })
+  status?: InquiryStatus;
+
   @ApiPropertyOptional({ description: '페이지 번호', example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)

--- a/backend/src/modules/inquiries/inquiries.service.ts
+++ b/backend/src/modules/inquiries/inquiries.service.ts
@@ -14,6 +14,15 @@ import { NotificationService } from '../notification/notification.service';
 import { NotificationDispatchHelper } from '../notification/notification-dispatch.helper';
 import { PaginatedResult, paginate } from '../../common/utils/pagination.util';
 
+export interface AdminInquiryCounts {
+  pending: number;
+  answered: number;
+}
+
+export interface AdminInquiryListResult extends PaginatedResult<Inquiry> {
+  counts: AdminInquiryCounts;
+}
+
 @Injectable()
 export class InquiriesService {
   private readonly logger = new Logger(InquiriesService.name);
@@ -58,21 +67,34 @@ export class InquiriesService {
     return saved;
   }
 
-  async findAllForAdmin(query: AdminInquiryQueryDto = {}): Promise<PaginatedResult<Inquiry>> {
+  async findAllForAdmin(query: AdminInquiryQueryDto = {}): Promise<AdminInquiryListResult> {
     const qb = this.inquiryRepo
       .createQueryBuilder('inquiry')
       .leftJoinAndSelect('inquiry.user', 'user')
       .orderBy('inquiry.createdAt', 'DESC');
+
+    if (query.status) {
+      qb.andWhere('inquiry.status = :status', { status: query.status });
+    }
 
     if (query.unread) {
       qb.andWhere('inquiry.answeredAt IS NOT NULL')
         .andWhere('inquiry.customerReadAt IS NULL');
     }
 
-    return paginate(qb, {
-      page: query.page ?? 1,
-      limit: query.limit ?? 20,
-    });
+    const [result, pending, answered] = await Promise.all([
+      paginate(qb, {
+        page: query.page ?? 1,
+        limit: query.limit ?? 20,
+      }),
+      this.inquiryRepo.count({ where: { status: InquiryStatus.PENDING } }),
+      this.inquiryRepo.count({ where: { status: InquiryStatus.ANSWERED } }),
+    ]);
+
+    return {
+      ...result,
+      counts: { pending, answered },
+    };
   }
 
   async answerInquiry(id: number, dto: AnswerInquiryDto): Promise<Inquiry> {

--- a/src/app/[locale]/admin/inquiries/__tests__/AdminInquiriesPage.test.tsx
+++ b/src/app/[locale]/admin/inquiries/__tests__/AdminInquiriesPage.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AdminInquiriesPage from '../page';
+import type { Inquiry } from '@/lib/api';
+
+const mockUseAdminGuard = vi.fn();
+const mockGetAll = vi.fn();
+const mockAnswer = vi.fn();
+
+vi.mock('@/components/shared/hooks/useAdminGuard', () => ({
+  useAdminGuard: () => mockUseAdminGuard(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  adminInquiriesApi: {
+    getAll: (...args: unknown[]) => mockGetAll(...args),
+    answer: (...args: unknown[]) => mockAnswer(...args),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const makeInquiry = (overrides: Partial<Inquiry>): Inquiry => ({
+  id: 1,
+  type: '배송',
+  title: '문의',
+  content: '문의 내용',
+  isSecret: false,
+  status: 'pending',
+  answer: null,
+  answeredAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  user: {
+    id: 1,
+    email: 'customer@example.com',
+    name: '고객',
+  },
+  ...overrides,
+});
+
+describe('AdminInquiriesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAdminGuard.mockReturnValue({
+      user: { id: 1, email: 'admin@test.com', name: 'Admin', role: 'admin' },
+      isLoading: false,
+      isAdmin: true,
+    });
+  });
+
+  it('uses server metadata for pending count instead of the current page subset', async () => {
+    mockGetAll.mockResolvedValue({
+      items: [
+        makeInquiry({
+          id: 10,
+          status: 'answered',
+          title: '답변된 문의',
+          answer: '답변',
+          answeredAt: '2026-01-02T00:00:00.000Z',
+        }),
+      ],
+      total: 80,
+      page: 1,
+      limit: 20,
+      counts: {
+        pending: 72,
+        answered: 8,
+      },
+    });
+
+    render(<AdminInquiriesPage />);
+
+    expect(await screen.findByText('답변된 문의')).toBeInTheDocument();
+    expect(screen.getByText('미답변 72건')).toBeInTheDocument();
+    expect(mockGetAll).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: undefined,
+    });
+  });
+
+  it('requests server-side status-filtered pages instead of filtering the first page locally', async () => {
+    mockGetAll
+      .mockResolvedValueOnce({
+        items: [
+          makeInquiry({
+            id: 10,
+            status: 'answered',
+            title: '첫 페이지 답변 문의',
+            answer: '답변',
+            answeredAt: '2026-01-02T00:00:00.000Z',
+          }),
+        ],
+        total: 80,
+        page: 1,
+        limit: 20,
+        counts: {
+          pending: 72,
+          answered: 8,
+        },
+      })
+      .mockResolvedValueOnce({
+        items: [
+          makeInquiry({
+            id: 51,
+            status: 'pending',
+            title: '서버에서 가져온 미답변 문의',
+          }),
+        ],
+        total: 72,
+        page: 1,
+        limit: 20,
+        counts: {
+          pending: 72,
+          answered: 8,
+        },
+      });
+
+    render(<AdminInquiriesPage />);
+
+    expect(await screen.findByText('첫 페이지 답변 문의')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '미답변' }));
+
+    await waitFor(() => {
+      expect(mockGetAll).toHaveBeenLastCalledWith({
+        page: 1,
+        limit: 20,
+        status: 'pending',
+      });
+    });
+    expect(await screen.findByText('서버에서 가져온 미답변 문의')).toBeInTheDocument();
+    expect(screen.queryByText('첫 페이지 답변 문의')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/admin/inquiries/page.tsx
+++ b/src/app/[locale]/admin/inquiries/page.tsx
@@ -13,6 +13,7 @@ import { AdminTable } from '@/components/shared/admin/AdminTable';
 import { InquiryStatusBadge } from '@/components/shared/admin/StatusBadge';
 import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
 import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
+import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
 import { toastMessage } from '@/utils/toastMessages';
 
 type InquiryStatusFilter = 'all' | 'pending' | 'answered';
@@ -23,14 +24,18 @@ const STATUS_FILTERS = [
   { label: '답변완료', value: 'answered' },
 ] as const;
 
+const PAGE_SIZE = 20;
+
 export default function AdminInquiriesPage() {
   const { isAdmin } = useAdminGuard();
 
   const [inquiries, setInquiries] = useState<Inquiry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [pendingCount, setPendingCount] = useState(0);
   const [openId, setOpenId] = useState<number | null>(null);
   const [answerText, setAnswerText] = useState('');
   const [answering, setAnswering] = useState(false);
-  const { filters, setFilter } = useAdminListPage({
+  const { page, setPage, filters, setFilter } = useAdminListPage({
     initialFilters: {
       status: 'all' as InquiryStatusFilter,
     },
@@ -38,19 +43,21 @@ export default function AdminInquiriesPage() {
 
   const { execute: loadInquiries, isLoading } = useAsyncAction(
     async () => {
-      const data = await adminInquiriesApi.getAll();
-      setInquiries(data);
+      const response = await adminInquiriesApi.getAll({
+        page,
+        limit: PAGE_SIZE,
+        status: filters.status === 'all' ? undefined : filters.status,
+      });
+      setInquiries(response.items);
+      setTotal(response.total);
+      setPendingCount(response.counts.pending);
     },
     { errorMessage: '문의 목록을 불러오지 못했습니다.' },
   );
 
   useEffect(() => {
     if (isAdmin) void loadInquiries();
-  }, [isAdmin, loadInquiries]);
-
-  const filtered = filters.status === 'all'
-    ? inquiries
-    : inquiries.filter((inquiry) => inquiry.status === filters.status);
+  }, [isAdmin, loadInquiries, page, filters.status]);
 
   const handleAnswer = async (id: number) => {
     if (!answerText.trim()) {
@@ -60,8 +67,8 @@ export default function AdminInquiriesPage() {
 
     setAnswering(true);
     try {
-      const updated = await adminInquiriesApi.answer(id, answerText.trim());
-      setInquiries((prev) => prev.map((inquiry) => (inquiry.id === id ? updated : inquiry)));
+      await adminInquiriesApi.answer(id, answerText.trim());
+      await loadInquiries();
       setAnswerText('');
       setOpenId(null);
       toast.success(toastMessage('answerCreated'));
@@ -72,18 +79,7 @@ export default function AdminInquiriesPage() {
     }
   };
 
-  if (isLoading) {
-    return (
-      <div className="space-y-4">
-        <h1 className="typo-h1">문의 관리</h1>
-        {Array.from({ length: 5 }).map((_, index) => (
-          <SkeletonBox key={index} className="h-14 rounded-lg" />
-        ))}
-      </div>
-    );
-  }
-
-  const pendingCount = inquiries.filter((inquiry) => inquiry.status === 'pending').length;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
 
   return (
     <div className="space-y-4">
@@ -105,9 +101,22 @@ export default function AdminInquiriesPage() {
         size="sm"
       />
 
-      {filtered.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">문의가 없습니다.</p>
+      {isLoading && inquiries.length === 0 ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <SkeletonBox key={index} className="h-14 rounded-lg" />
+          ))}
+        </div>
       ) : (
+        <PaginatedAdminTableShell
+          loading={isLoading}
+          loadingMessage="문의 목록을 불러오는 중..."
+          isEmpty={inquiries.length === 0}
+          emptyMessage="문의가 없습니다."
+          currentPage={page}
+          totalPages={totalPages}
+          onPageChange={setPage}
+        >
         <AdminTable
           columns={[
             { label: '상태', width: 'w-20' },
@@ -116,10 +125,10 @@ export default function AdminInquiriesPage() {
             { label: '제목' },
             { label: '접수일', width: 'w-28' },
           ]}
-          isEmpty={filtered.length === 0}
+          isEmpty={inquiries.length === 0}
           emptyMessage="문의가 없습니다."
         >
-          {filtered.map((inquiry) => (
+          {inquiries.map((inquiry) => (
             <React.Fragment key={inquiry.id}>
               <tr
                 className="border-b hover:bg-muted/50 cursor-pointer transition-colors"
@@ -174,6 +183,7 @@ export default function AdminInquiriesPage() {
             </React.Fragment>
           ))}
         </AdminTable>
+        </PaginatedAdminTableShell>
       )}
     </div>
   );

--- a/src/lib/__tests__/admin-inquiries-api.test.ts
+++ b/src/lib/__tests__/admin-inquiries-api.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { adminInquiriesApi } from '@/lib/api/admin/inquiries';
+import { apiClient } from '@/lib/api/core';
+
+describe('admin inquiries API', () => {
+  it('preserves pagination metadata and status counts from the admin inquiries response', async () => {
+    const response = {
+      items: [],
+      total: 52,
+      page: 2,
+      limit: 20,
+      counts: {
+        pending: 52,
+        answered: 8,
+      },
+    };
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue(response);
+
+    const result = await adminInquiriesApi.getAll({
+      page: 2,
+      limit: 20,
+      status: 'pending',
+    });
+
+    expect(getSpy).toHaveBeenCalledWith('/admin/inquiries', {
+      params: {
+        page: 2,
+        limit: 20,
+        status: 'pending',
+        unread: undefined,
+      },
+    });
+    expect(result).toEqual(response);
+    expect(result.total).toBe(52);
+    expect(result.counts.pending).toBe(52);
+    getSpy.mockRestore();
+  });
+});

--- a/src/lib/api/admin/inquiries.ts
+++ b/src/lib/api/admin/inquiries.ts
@@ -1,12 +1,34 @@
 import { apiClient, type PaginatedResponse } from '../core';
 import type { Inquiry } from '../inquiries';
 
+export type AdminInquiryStatusFilter = 'pending' | 'answered';
+
+export interface AdminInquiryQueryParams {
+  page?: number;
+  limit?: number;
+  status?: AdminInquiryStatusFilter;
+  unread?: boolean;
+}
+
+export interface AdminInquiryCounts {
+  pending: number;
+  answered: number;
+}
+
+export type AdminInquiryListResponse = PaginatedResponse<Inquiry> & {
+  counts: AdminInquiryCounts;
+};
+
 export const adminInquiriesApi = {
-  getAll: async (page = 1, limit = 50) => {
-    const response = await apiClient.get<PaginatedResponse<Inquiry>>('/admin/inquiries', {
-      params: { page, limit },
+  getAll: (params: AdminInquiryQueryParams = {}) => {
+    const { unread, ...rest } = params;
+
+    return apiClient.get<AdminInquiryListResponse>('/admin/inquiries', {
+      params: {
+        ...rest,
+        unread: unread === undefined ? undefined : String(unread),
+      },
     });
-    return response.items;
   },
   answer: (id: number, answer: string) =>
     apiClient.post<Inquiry>(`/admin/inquiries/${id}/answer`, { answer }),


### PR DESCRIPTION
Closes #913

## Summary
- Preserve admin inquiry pagination metadata and server counts in the API wrapper
- Add backend status filtering and pending/answered counts for admin inquiry lists
- Switch admin inquiries UI to server pagination/status filtering and server pending count
- Add backend/frontend/API regression tests

## Verification
- npm run test:run -- admin inquiries
- cd backend && npm test -- inquiries
- npm run build
- npm run lint
- cd backend && npm run build
- cd backend && npm run lint
- cd backend && npm run test
- bash scripts/codex-project-guard.sh

## Notes
- Manual 51+ inquiry seed/browser verification was not run.
- Next lint reports the pre-existing AppShell unused locale warning.