### PR TITLE
feat: #966 스마트스토어 엑셀 가져오기 옵션·추가이미지·상세이미지 S3 업로드 지원

### DIFF
--- a/backend/src/modules/products/__tests__/product-command.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-command.service.spec.ts
@@ -4,6 +4,7 @@ import { ConflictException, NotFoundException } from '@nestjs/common';
 import { ObjectLiteral, Repository } from 'typeorm';
 import { ProductCommandService } from '../product-command.service';
 import { Product } from '../entities/product.entity';
+import { ProductOption } from '../entities/product-option.entity';
 import { CacheService } from '../../cache/cache.service';
 import { RestockAlertsService } from '../../restock-alerts/restock-alerts.service';
 
@@ -25,6 +26,7 @@ interface ManagerMock {
   create: jest.Mock;
   save: jest.Mock;
   delete: jest.Mock;
+  find: jest.Mock;
 }
 
 describe('ProductCommandService', () => {
@@ -48,6 +50,7 @@ describe('ProductCommandService', () => {
       create: jest.fn(),
       save: jest.fn(),
       delete: jest.fn().mockResolvedValue(undefined),
+      find: jest.fn().mockResolvedValue([]),
     };
     dataSource = {
       transaction: jest.fn().mockImplementation(async (cb: (m: ManagerMock) => Promise<unknown>) => cb(manager)),
@@ -130,6 +133,31 @@ describe('ProductCommandService', () => {
       expect(manager.save).toHaveBeenCalledTimes(2); // product + images batch
     });
 
+    it('옵션 함께 생성 시 ProductOption 저장', async () => {
+      const created = { id: 5 } as Product;
+      manager.create.mockImplementation((_entity: unknown, data: Record<string, unknown>) => data);
+      manager.save.mockResolvedValue(created);
+
+      await service.create({
+        name: 'p',
+        slug: 'p-opt',
+        price: 100,
+        options: [
+          { name: '용량', value: '100cc', priceAdjustment: 5000, stock: 3 },
+          { name: '용량', value: '200cc' },
+        ],
+      });
+
+      expect(manager.create).toHaveBeenCalledWith(
+        ProductOption,
+        expect.objectContaining({ name: '용량', value: '100cc', priceAdjustment: 5000, stock: 3, sortOrder: 0 }),
+      );
+      expect(manager.create).toHaveBeenCalledWith(
+        ProductOption,
+        expect.objectContaining({ name: '용량', value: '200cc', priceAdjustment: 0, stock: 0, sortOrder: 1 }),
+      );
+    });
+
     it('ER_DUP_ENTRY 에러는 ConflictException 으로 변환', async () => {
       const dupErr = Object.assign(new Error('Duplicate entry'), { code: 'ER_DUP_ENTRY' });
       manager.create.mockReturnValue({ id: 1 } as Product);
@@ -186,6 +214,43 @@ describe('ProductCommandService', () => {
       await service.update(1, { name: 'newName' });
 
       expect(restockAlerts.processProductRestock).not.toHaveBeenCalled();
+    });
+
+    it('옵션 수정 시 기존 (name,value) 매칭은 갱신하고 미매칭은 삭제', async () => {
+      const existing = { id: 1, stock: 0 } as Product;
+      productRepo.findOne.mockResolvedValue(existing);
+      manager.save.mockResolvedValue(existing);
+      manager.create.mockImplementation((_entity: unknown, data: Record<string, unknown>) => data);
+      manager.find.mockResolvedValue([
+        { id: 11, productId: 1, name: '용량', value: '100cc', priceAdjustment: 0, stock: 1, sortOrder: 0 },
+        { id: 12, productId: 1, name: '용량', value: '300cc', priceAdjustment: 0, stock: 1, sortOrder: 1 },
+      ]);
+
+      await service.update(1, {
+        options: [
+          { name: '용량', value: '100cc', priceAdjustment: 2000, stock: 5 },
+          { name: '용량', value: '500cc', stock: 2 },
+        ],
+      });
+
+      // 매칭(100cc) 갱신 + 신규(500cc) 저장
+      expect(manager.save).toHaveBeenCalledWith(ProductOption, expect.arrayContaining([
+        expect.objectContaining({ id: 11, priceAdjustment: 2000, stock: 5 }),
+        expect.objectContaining({ name: '용량', value: '500cc', stock: 2 }),
+      ]));
+      // 미매칭(300cc) 삭제
+      expect(manager.delete).toHaveBeenCalledWith(ProductOption, { id: expect.anything() });
+    });
+
+    it('options 미지정 시 옵션을 건드리지 않음', async () => {
+      const existing = { id: 1, stock: 0 } as Product;
+      productRepo.findOne.mockResolvedValue(existing);
+      manager.save.mockResolvedValue(existing);
+
+      await service.update(1, { name: 'newName' });
+
+      expect(manager.find).not.toHaveBeenCalled();
+      expect(manager.delete).not.toHaveBeenCalled();
     });
 
     it('이미지 교체 시 manager.delete 가 먼저 호출됨', async () => {

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -286,6 +286,44 @@ describe('SmartStoreProductImportService', () => {
       }));
     });
 
+    it('keeps option price and stock alignment when optional cells contain blanks', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값', '옵션가', '옵션 재고수량', '옵션 사용여부'],
+        ['SKU-1', '빈 옵션 보조값 상품', 10000, '단독형', '용량', '100cc,200cc,300cc', ',3000,', '5,,9', 'Y,,N'],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        options: [
+          expect.objectContaining({ value: '100cc', priceAdjustment: 0, stock: 5 }),
+          expect.objectContaining({ value: '200cc', priceAdjustment: 3000, stock: 0 }),
+        ],
+      }));
+    });
+
+    it('keeps 조합형 option line alignment when price or stock lines are blank', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값', '옵션가', '옵션 재고수량'],
+        ['SKU-1', '조합형 빈 보조값 상품', 10000, '조합형', '색상,용량', '홍니,100cc\n자니,200cc', '\n5000', '3\n'],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        options: [
+          expect.objectContaining({ value: '홍니/100cc', priceAdjustment: 0, stock: 3 }),
+          expect.objectContaining({ value: '자니/200cc', priceAdjustment: 5000, stock: 0 }),
+        ],
+      }));
+    });
+
     it('skips options marked 사용안함 and keeps 설정안함 rows optionless', async () => {
       const repository = createRepositoryMock([]);
       const commandService = createCommandServiceMock();

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -3,6 +3,7 @@ import { BadRequestException } from '@nestjs/common';
 import { ProductStatus, Product } from '../entities/product.entity';
 import { SmartStoreProductImportService } from '../smartstore-product-import.service';
 import { ProductCommandService } from '../product-command.service';
+import { RemoteImageIngestService } from '../../upload/remote-image-ingest.service';
 
 function createRepositoryMock(existingProducts: Product[] = []) {
   return {
@@ -16,6 +17,31 @@ function createCommandServiceMock() {
     create: jest.fn().mockImplementation(async (dto) => ({ id: 100, ...dto })),
     update: jest.fn().mockImplementation(async (id, dto) => ({ id, ...dto })),
   };
+}
+
+function createIngestServiceMock() {
+  return {
+    ingest: jest.fn().mockImplementation(async (url: string) => ({
+      url: `https://cdn.okhwadang.com/uploads/${encodeURIComponent(url)}`,
+      filename: 'uploaded.jpg',
+    })),
+  };
+}
+
+function ingestedUrl(url: string): string {
+  return `https://cdn.okhwadang.com/uploads/${encodeURIComponent(url)}`;
+}
+
+function createService(
+  repository: ReturnType<typeof createRepositoryMock>,
+  commandService: ReturnType<typeof createCommandServiceMock>,
+  ingestService: ReturnType<typeof createIngestServiceMock> = createIngestServiceMock(),
+) {
+  return new SmartStoreProductImportService(
+    repository as never,
+    commandService as unknown as ProductCommandService,
+    ingestService as unknown as RemoteImageIngestService,
+  );
 }
 
 async function createWorkbookBuffer(rows: Array<Array<string | number>>, sheetName = 'products') {
@@ -46,10 +72,8 @@ describe('SmartStoreProductImportService', () => {
     const existing = { id: 7, sku: 'SKU-2', slug: 'old-product' } as Product;
     const repository = createRepositoryMock([existing]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const ingestService = createIngestServiceMock();
+    const service = createService(repository, commandService, ingestService);
     const buffer = await createWorkbookBuffer([
       ['상품번호', '판매자상품코드', '상품명', '판매가', '재고수량', '판매상태', '대표이미지 URL'],
       ['111', 'SKU-1', '신규 상품', 12000, 3, '판매중', 'https://cdn.example.com/1.jpg'],
@@ -63,15 +87,13 @@ describe('SmartStoreProductImportService', () => {
     expect(result.rows[1].productId).toBe(7);
     expect(commandService.create).not.toHaveBeenCalled();
     expect(commandService.update).not.toHaveBeenCalled();
+    expect(ingestService.ingest).not.toHaveBeenCalled();
   });
 
   it('commits valid rows and maps SmartStore fields to product DTOs', async () => {
     const repository = createRepositoryMock([]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const service = createService(repository, commandService);
     const buffer = await createWorkbookBuffer([
       ['상품번호', '판매자상품코드', '상품명', '판매가', '재고수량', '판매상태', '대표이미지 URL', '상세설명'],
       ['111', 'SKU-1', '신규 상품', '12,000원', 3, '판매중', 'https://cdn.example.com/1.jpg', '<p>상세</p>'],
@@ -87,7 +109,7 @@ describe('SmartStoreProductImportService', () => {
       stock: 3,
       status: ProductStatus.ACTIVE,
       description: '<p>상세</p>',
-      images: [expect.objectContaining({ url: 'https://cdn.example.com/1.jpg', isThumbnail: true })],
+      images: [expect.objectContaining({ url: ingestedUrl('https://cdn.example.com/1.jpg'), isThumbnail: true })],
     }));
   });
 
@@ -95,10 +117,7 @@ describe('SmartStoreProductImportService', () => {
     const existing = { id: 7, sku: 'SKU-2', slug: 'old-product' } as Product;
     const repository = createRepositoryMock([existing]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const service = createService(repository, commandService);
     const buffer = await createWorkbookBuffer([
       ['판매자상품코드', '상품명', '판매가', '재고수량'],
       ['SKU-2', '기존 상품', 9000, 2],
@@ -110,6 +129,9 @@ describe('SmartStoreProductImportService', () => {
       slug: expect.any(String),
       description: undefined,
       salePrice: undefined,
+      images: expect.anything(),
+      detailImages: expect.anything(),
+      options: expect.anything(),
     }));
     expect(commandService.update).toHaveBeenCalledWith(7, expect.objectContaining({
       name: '기존 상품',
@@ -121,10 +143,7 @@ describe('SmartStoreProductImportService', () => {
   it('uses naver product number as fallback identifier and marks zero-stock active rows as soldout', async () => {
     const repository = createRepositoryMock([]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const service = createService(repository, commandService);
     const buffer = await createWorkbookBuffer([
       ['상품번호', '상품명', '판매가', '재고수량', '판매상태'],
       ['98765', '번호만 있는 상품', 5000, 0, '판매중'],
@@ -142,10 +161,7 @@ describe('SmartStoreProductImportService', () => {
     const existing = { id: 7, sku: 'naver-98765', slug: 'old-product' } as Product;
     const repository = createRepositoryMock([existing]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const service = createService(repository, commandService);
     const buffer = await createWorkbookBuffer([
       ['상품번호(스마트스토어)', '상품명', '판매가', '재고수량', '판매상태', '전시상태'],
       ['98765', '목록 다운로드 상품', 5000, 2, '판매중', '전시중'],
@@ -160,10 +176,7 @@ describe('SmartStoreProductImportService', () => {
   it('skips SmartStore bulk-edit guide rows and ignores 상품상태 when mapping sales status', async () => {
     const repository = createRepositoryMock([]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const service = createService(repository, commandService);
     const buffer = await createWorkbookBuffer([
       ['기본정보', '기본정보', '가격정보', '상태정보', '상태정보', '상태정보'],
       ['상품번호(스마트스토어)', '상품명', '판매가', '재고수량', '판매상태', '상품상태'],
@@ -191,10 +204,7 @@ describe('SmartStoreProductImportService', () => {
   it('uses 전시상태 and 판매상태 semantics without treating 상품상태 as a visibility alias', async () => {
     const repository = createRepositoryMock([]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const service = createService(repository, commandService);
     const buffer = await createWorkbookBuffer([
       ['상품번호', '상품명', '판매가', '재고수량', '상품상태', '전시상태'],
       ['111', '숨김 상품', 12000, 3, '신상품', '전시중지'],
@@ -211,10 +221,7 @@ describe('SmartStoreProductImportService', () => {
   it('rejects invalid file types before parsing', async () => {
     const repository = createRepositoryMock([]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const service = createService(repository, commandService);
 
     await expect(service.preview(createFile(Buffer.from('x'), {
       originalname: 'products.csv',
@@ -225,10 +232,7 @@ describe('SmartStoreProductImportService', () => {
   it('skips rows with missing required values or duplicate identifiers', async () => {
     const repository = createRepositoryMock([]);
     const commandService = createCommandServiceMock();
-    const service = new SmartStoreProductImportService(
-      repository as never,
-      commandService as unknown as ProductCommandService,
-    );
+    const service = createService(repository, commandService);
     const buffer = await createWorkbookBuffer([
       ['판매자상품코드', '상품명', '판매가'],
       ['SKU-1', '', 1000],
@@ -241,5 +245,261 @@ describe('SmartStoreProductImportService', () => {
     expect(result.summary).toMatchObject({ totalRows: 3, skipCount: 3, failureCount: 3 });
     expect(result.rows[0].errors).toContain('상품명이 필요합니다.');
     expect(result.rows[1].errors[0]).toContain('중복된 상품 식별자');
+  });
+
+  describe('옵션 가져오기', () => {
+    it('parses 조합형 options into ProductOption inputs', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값', '옵션가', '옵션 재고수량', '옵션 사용여부'],
+        ['SKU-1', '조합형 상품', 10000, '조합형', '색상,용량', '홍니,100cc\n자니,200cc', '0\n5000', '3\n7', 'Y\nY'],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        options: [
+          expect.objectContaining({ name: '색상/용량', value: '홍니/100cc', priceAdjustment: 0, stock: 3, sortOrder: 0 }),
+          expect.objectContaining({ name: '색상/용량', value: '자니/200cc', priceAdjustment: 5000, stock: 7, sortOrder: 1 }),
+        ],
+      }));
+    });
+
+    it('parses 단독형 options with a single option name', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값', '옵션가', '옵션 재고수량'],
+        ['SKU-1', '단독형 상품', 10000, '단독형', '용량', '100cc,200cc', '0,3000', '5,2'],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        options: [
+          expect.objectContaining({ name: '용량', value: '100cc', priceAdjustment: 0, stock: 5 }),
+          expect.objectContaining({ name: '용량', value: '200cc', priceAdjustment: 3000, stock: 2 }),
+        ],
+      }));
+    });
+
+    it('skips options marked 사용안함 and keeps 설정안함 rows optionless', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값', '옵션 사용여부'],
+        ['SKU-1', '옵션 상품', 10000, '단독형', '용량', '100cc,200cc', 'Y,N'],
+        ['SKU-2', '단일 상품', 5000, '설정안함', '', '', ''],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(commandService.create).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        options: [expect.objectContaining({ value: '100cc' })],
+      }));
+      expect(commandService.create).toHaveBeenNthCalledWith(2, expect.not.objectContaining({
+        options: expect.anything(),
+      }));
+    });
+
+    it('reports option value count mismatch as a row error', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값'],
+        ['SKU-1', '불일치 상품', 10000, '조합형', '색상,용량', '홍니\n자니,200cc'],
+      ]);
+
+      const result = await service.preview(createFile(buffer));
+
+      expect(result.rows[0].action).toBe('skip');
+      expect(result.rows[0].errors.join(' ')).toContain('옵션값');
+      expect(commandService.create).not.toHaveBeenCalled();
+    });
+
+    it('includes option counts in preview rows', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값'],
+        ['SKU-1', '옵션 상품', 10000, '단독형', '용량', '100cc,200cc,300cc'],
+      ]);
+
+      const result = await service.preview(createFile(buffer));
+
+      expect(result.rows[0].optionCount).toBe(3);
+    });
+  });
+
+  describe('이미지 가져오기', () => {
+    it('ingests multiple 추가이미지 URLs in order and marks the representative image as thumbnail', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const ingestService = createIngestServiceMock();
+      const service = createService(repository, commandService, ingestService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '대표이미지', '추가이미지'],
+        ['SKU-1', '이미지 상품', 10000, 'https://img.example.com/rep.jpg', 'https://img.example.com/a.jpg\nhttps://img.example.com/b.jpg'],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(ingestService.ingest).toHaveBeenCalledTimes(3);
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        images: [
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/rep.jpg'), sortOrder: 0, isThumbnail: true }),
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/a.jpg'), sortOrder: 1, isThumbnail: false }),
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/b.jpg'), sortOrder: 2, isThumbnail: false }),
+        ],
+      }));
+    });
+
+    it('deduplicates repeated image URLs and reuses ingest results', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const ingestService = createIngestServiceMock();
+      const service = createService(repository, commandService, ingestService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '대표이미지', '추가이미지'],
+        ['SKU-1', '중복 이미지 상품', 10000, 'https://img.example.com/rep.jpg', 'https://img.example.com/rep.jpg\nhttps://img.example.com/a.jpg'],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(ingestService.ingest).toHaveBeenCalledTimes(2);
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        images: [
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/rep.jpg'), isThumbnail: true }),
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/a.jpg'), isThumbnail: false }),
+        ],
+      }));
+    });
+
+    it('extracts detail images from 상세설명 HTML img tags', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const html = '<div><img src="https://img.example.com/d1.jpg"><p>설명</p><img alt="x" src=\'https://img.example.com/d2.jpg\' /></div>';
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '상세설명'],
+        ['SKU-1', '상세 상품', 10000, html],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        detailImages: [
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/d1.jpg'), sortOrder: 0 }),
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/d2.jpg'), sortOrder: 1 }),
+        ],
+      }));
+    });
+
+    it('parses multi-delimiter URLs from a custom 상세이미지 column', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '상세이미지 URL'],
+        ['SKU-1', '상세 컬럼 상품', 10000, 'https://img.example.com/d1.jpg\nhttps://img.example.com/d2.jpg;https://img.example.com/d3.jpg|https://img.example.com/d4.jpg'],
+      ]);
+
+      const result = await service.commit(createFile(buffer));
+
+      expect(result.rows[0].detailImageCount).toBe(4);
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        detailImages: [
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/d1.jpg'), sortOrder: 0 }),
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/d2.jpg'), sortOrder: 1 }),
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/d3.jpg'), sortOrder: 2 }),
+          expect.objectContaining({ url: ingestedUrl('https://img.example.com/d4.jpg'), sortOrder: 3 }),
+        ],
+      }));
+    });
+
+    it('reports invalid image URLs during preview without downloading', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const ingestService = createIngestServiceMock();
+      const service = createService(repository, commandService, ingestService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '대표이미지'],
+        ['SKU-1', '잘못된 이미지 상품', 10000, 'ftp://img.example.com/rep.jpg'],
+      ]);
+
+      const result = await service.preview(createFile(buffer));
+
+      expect(result.rows[0].action).toBe('skip');
+      expect(result.rows[0].errors.join(' ')).toContain('ftp://img.example.com/rep.jpg');
+      expect(ingestService.ingest).not.toHaveBeenCalled();
+    });
+
+    it('marks the row failed with the failing URL when ingest fails and keeps processing other rows', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const ingestService = createIngestServiceMock();
+      ingestService.ingest.mockImplementation(async (url: string) => {
+        if (url.includes('broken')) {
+          throw new BadRequestException(`이미지 다운로드에 실패했습니다. (HTTP 404): ${url}`);
+        }
+        return { url: ingestedUrl(url), filename: 'uploaded.jpg' };
+      });
+      const service = createService(repository, commandService, ingestService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '대표이미지'],
+        ['SKU-1', '실패 상품', 10000, 'https://img.example.com/broken.jpg'],
+        ['SKU-2', '정상 상품', 10000, 'https://img.example.com/ok.jpg'],
+      ]);
+
+      const result = await service.commit(createFile(buffer));
+
+      expect(result.summary).toMatchObject({ successCount: 1, failureCount: 1 });
+      expect(result.rows[0].status).toBe('failed');
+      expect(result.rows[0].errors.join(' ')).toContain('broken.jpg');
+      expect(commandService.create).toHaveBeenCalledTimes(1);
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({ sku: 'SKU-2' }));
+    });
+
+    it('includes gallery and detail image counts in preview rows', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '대표이미지', '추가이미지', '상세이미지 URL'],
+        ['SKU-1', '카운트 상품', 10000, 'https://img.example.com/rep.jpg', 'https://img.example.com/a.jpg,https://img.example.com/b.jpg', 'https://img.example.com/d1.jpg'],
+      ]);
+
+      const result = await service.preview(createFile(buffer));
+
+      expect(result.rows[0]).toMatchObject({
+        galleryImageCount: 3,
+        detailImageCount: 1,
+        optionCount: 0,
+      });
+    });
+
+    it('syncs options and images when updating an existing SKU', async () => {
+      const existing = { id: 7, sku: 'SKU-2', slug: 'old-product' } as Product;
+      const repository = createRepositoryMock([existing]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값', '대표이미지'],
+        ['SKU-2', '기존 상품 갱신', 9000, '단독형', '용량', '100cc', 'https://img.example.com/rep.jpg'],
+      ]);
+
+      await service.commit(createFile(buffer));
+
+      expect(commandService.update).toHaveBeenCalledWith(7, expect.objectContaining({
+        options: [expect.objectContaining({ name: '용량', value: '100cc' })],
+        images: [expect.objectContaining({ url: ingestedUrl('https://img.example.com/rep.jpg'), isThumbnail: true })],
+      }));
+    });
   });
 });

--- a/backend/src/modules/products/dto/create-product.dto.ts
+++ b/backend/src/modules/products/dto/create-product.dto.ts
@@ -139,6 +139,34 @@ export class ProductDetailImageInputDto {
   sortOrder?: number;
 }
 
+export class ProductOptionInputDto {
+  @ApiProperty({ example: '용량', description: '옵션명' })
+  @IsString({ message: '옵션명을 입력해 주세요.' })
+  @MaxLength(100, { message: '옵션명은 최대 100자까지 입력 가능합니다.' })
+  name!: string;
+
+  @ApiProperty({ example: '100cc', description: '옵션값' })
+  @IsString({ message: '옵션값을 입력해 주세요.' })
+  @MaxLength(100, { message: '옵션값은 최대 100자까지 입력 가능합니다.' })
+  value!: string;
+
+  @ApiPropertyOptional({ example: 5000, description: '옵션 가격 조정 (원)' })
+  @IsOptional()
+  @IsNumber({}, { message: '옵션 가격 조정은 숫자여야 합니다.' })
+  priceAdjustment?: number;
+
+  @ApiPropertyOptional({ example: 10, description: '옵션 재고 수량' })
+  @IsOptional()
+  @IsNumber({}, { message: '옵션 재고는 숫자여야 합니다.' })
+  @Min(0, { message: '옵션 재고는 0 이상이어야 합니다.' })
+  stock?: number;
+
+  @ApiPropertyOptional({ example: 0, description: '정렬 순서' })
+  @IsOptional()
+  @IsNumber()
+  sortOrder?: number;
+}
+
 export class CreateProductDto {
   @ApiProperty({ example: 1, description: '카테고리 ID', required: false })
   @IsOptional()
@@ -252,4 +280,11 @@ export class CreateProductDto {
   @ValidateNested({ each: true })
   @Type(() => ProductDetailImageInputDto)
   detailImages?: ProductDetailImageInputDto[];
+
+  @ApiPropertyOptional({ type: [ProductOptionInputDto], description: '상품 옵션 목록' })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ProductOptionInputDto)
+  options?: ProductOptionInputDto[];
 }

--- a/backend/src/modules/products/dto/update-product.dto.ts
+++ b/backend/src/modules/products/dto/update-product.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsNumber, IsOptional, IsBoolean, IsEnum, MaxLength, Min, IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ProductStatus } from '../entities/product.entity';
-import { ProductImageInputDto, ProductDetailImageInputDto, ProductNoticeInfoDto } from './create-product.dto';
+import { ProductImageInputDto, ProductDetailImageInputDto, ProductNoticeInfoDto, ProductOptionInputDto } from './create-product.dto';
 
 export class UpdateProductDto {
   @ApiProperty({ example: 1, description: '카테고리 ID', required: false })
@@ -120,4 +120,11 @@ export class UpdateProductDto {
   @ValidateNested({ each: true })
   @Type(() => ProductDetailImageInputDto)
   detailImages?: ProductDetailImageInputDto[];
+
+  @ApiPropertyOptional({ type: [ProductOptionInputDto], description: '상품 옵션 목록' })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ProductOptionInputDto)
+  options?: ProductOptionInputDto[];
 }

--- a/backend/src/modules/products/product-command.service.ts
+++ b/backend/src/modules/products/product-command.service.ts
@@ -3,11 +3,12 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { DataSource, EntityManager, ObjectLiteral, Repository } from 'typeorm';
+import { DataSource, EntityManager, In, ObjectLiteral, Repository } from 'typeorm';
 import { Product } from './entities/product.entity';
 import { ProductImage } from './entities/product-image.entity';
 import { ProductDetailImage } from './entities/product-detail-image.entity';
-import { CreateProductDto } from './dto/create-product.dto';
+import { ProductOption } from './entities/product-option.entity';
+import { CreateProductDto, ProductOptionInputDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
 import { CacheService } from '../cache/cache.service';
@@ -29,7 +30,7 @@ export class ProductCommandService {
   ) {}
 
   async create(dto: CreateProductDto): Promise<Product> {
-    const { images, detailImages, ...productData } = dto;
+    const { images, detailImages, options, ...productData } = dto;
 
     try {
       return await this.dataSource.transaction(async (manager: EntityManager) => {
@@ -75,6 +76,10 @@ export class ProductCommandService {
           });
         }
 
+        if (options !== undefined) {
+          await this.syncProductOptions(manager, saved.id, options);
+        }
+
         return saved;
       });
     } catch (err) {
@@ -84,7 +89,7 @@ export class ProductCommandService {
   }
 
   async update(id: number, dto: UpdateProductDto): Promise<Product> {
-    const { images, detailImages, ...productData } = dto;
+    const { images, detailImages, options, ...productData } = dto;
     const product = await this.findById(id);
     const previousStock = product.stock;
     Object.assign(product, productData);
@@ -125,6 +130,10 @@ export class ProductCommandService {
               isActive: true,
             }),
           });
+        }
+
+        if (options !== undefined) {
+          await this.syncProductOptions(manager, id, options);
         }
 
         return updatedProduct;
@@ -192,6 +201,46 @@ export class ProductCommandService {
 
     const entities = items.map((item, index) => manager.create(entityClass, mapInputToEntity(item, index)));
     await manager.save(entityClass, entities);
+  }
+
+  // 옵션은 cart_items 가 FK 로 참조하므로 전체 삭제 후 재생성 대신 (name, value) 기준으로 동기화한다.
+  private async syncProductOptions(
+    manager: EntityManager,
+    productId: number,
+    options: ProductOptionInputDto[],
+  ): Promise<void> {
+    const existing = await manager.find(ProductOption, { where: { productId } });
+    const existingByKey = new Map(existing.map((option) => [`${option.name}\u0000${option.value}`, option]));
+    const matchedIds = new Set<number>();
+    const toSave: ProductOption[] = [];
+
+    options.forEach((input, index) => {
+      const matched = existingByKey.get(`${input.name}\u0000${input.value}`);
+      if (matched) {
+        matchedIds.add(matched.id);
+        matched.priceAdjustment = input.priceAdjustment ?? 0;
+        matched.stock = input.stock ?? 0;
+        matched.sortOrder = input.sortOrder ?? index;
+        toSave.push(matched);
+        return;
+      }
+      toSave.push(manager.create(ProductOption, {
+        productId,
+        name: input.name,
+        value: input.value,
+        priceAdjustment: input.priceAdjustment ?? 0,
+        stock: input.stock ?? 0,
+        sortOrder: input.sortOrder ?? index,
+      }));
+    });
+
+    const removedIds = existing.filter((option) => !matchedIds.has(option.id)).map((option) => option.id);
+    if (removedIds.length > 0) {
+      await manager.delete(ProductOption, { id: In(removedIds) });
+    }
+    if (toSave.length > 0) {
+      await manager.save(ProductOption, toSave);
+    }
   }
 
   private rethrowIfDuplicateKey(err: unknown): void {

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -21,6 +21,7 @@ import { CategoriesController } from './categories.controller';
 import { AttributesController } from './attributes.controller';
 import { CacheModule } from '../cache/cache.module';
 import { RestockAlertsModule } from '../restock-alerts/restock-alerts.module';
+import { UploadModule } from '../upload/upload.module';
 import { RecentlyViewedProduct } from './entities/recently-viewed-product.entity';
 import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guard';
 
@@ -39,6 +40,7 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
     ]),
     CacheModule,
     RestockAlertsModule,
+    UploadModule,
   ],
   providers: [
     ProductsService,

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -360,9 +360,9 @@ export class SmartStoreProductImportService {
     errors: string[],
   ): ProductOptionInputDto[] {
     const valueLines = this.splitLines(valuesRaw);
-    const priceLines = this.splitLines(this.getCell(row, headerMap.optionPrices));
-    const stockLines = this.splitLines(this.getCell(row, headerMap.optionStocks));
-    const usableLines = this.splitLines(this.getCell(row, headerMap.optionUsables));
+    const priceLines = this.splitLinesPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionPrices));
+    const stockLines = this.splitLinesPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionStocks));
+    const usableLines = this.splitLinesPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionUsables));
     const options: ProductOptionInputDto[] = [];
 
     valueLines.forEach((line, index) => {
@@ -395,9 +395,9 @@ export class SmartStoreProductImportService {
 
     if (names.length === 1) {
       const values = this.splitList(valuesRaw);
-      const prices = this.splitList(this.getCell(row, headerMap.optionPrices));
-      const stocks = this.splitList(this.getCell(row, headerMap.optionStocks));
-      const usables = this.splitList(this.getCell(row, headerMap.optionUsables));
+      const prices = this.splitListPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionPrices));
+      const stocks = this.splitListPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionStocks));
+      const usables = this.splitListPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionUsables));
       values.forEach((value, index) => {
         if (!this.isOptionUsable(usables[index])) return;
         options.push({
@@ -416,15 +416,15 @@ export class SmartStoreProductImportService {
       errors.push('옵션값 줄 수가 옵션명 개수와 일치하지 않습니다.');
       return options;
     }
-    const priceLines = this.splitLines(this.getCell(row, headerMap.optionPrices));
-    const stockLines = this.splitLines(this.getCell(row, headerMap.optionStocks));
-    const usableLines = this.splitLines(this.getCell(row, headerMap.optionUsables));
+    const priceLines = this.splitLinesPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionPrices));
+    const stockLines = this.splitLinesPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionStocks));
+    const usableLines = this.splitLinesPreservingEmpty(this.getCellPreservingLineBoundaries(row, headerMap.optionUsables));
 
     names.forEach((name, nameIndex) => {
       const values = this.splitByComma(valueLines[nameIndex] ?? '');
-      const prices = this.splitByComma(priceLines[nameIndex] ?? '');
-      const stocks = this.splitByComma(stockLines[nameIndex] ?? '');
-      const usables = this.splitByComma(usableLines[nameIndex] ?? '');
+      const prices = this.splitByCommaPreservingEmpty(priceLines[nameIndex] ?? '');
+      const stocks = this.splitByCommaPreservingEmpty(stockLines[nameIndex] ?? '');
+      const usables = this.splitByCommaPreservingEmpty(usableLines[nameIndex] ?? '');
       values.forEach((value, valueIndex) => {
         if (!this.isOptionUsable(usables[valueIndex])) return;
         options.push({
@@ -593,6 +593,11 @@ export class SmartStoreProductImportService {
     return this.cellToString(row.getCell(columnNumber).value).trim();
   }
 
+  private getCellPreservingLineBoundaries(row: ExcelJS.Row, columnNumber: number | undefined): string {
+    if (!columnNumber) return '';
+    return this.cellToString(row.getCell(columnNumber).value).replace(/^[ \t]+|[ \t]+$/g, '');
+  }
+
   private cellToString(value: ExcelJS.CellValue): string {
     if (value === null || value === undefined) return '';
     if (value instanceof Date) return value.toISOString();
@@ -641,6 +646,13 @@ export class SmartStoreProductImportService {
       .filter(Boolean);
   }
 
+  private splitLinesPreservingEmpty(value: string): string[] {
+    if (!value) return [];
+    return value
+      .split(/\r?\n/)
+      .map((part) => part.trim());
+  }
+
   private splitByComma(value: string): string[] {
     if (!value) return [];
     return value
@@ -649,12 +661,26 @@ export class SmartStoreProductImportService {
       .filter(Boolean);
   }
 
+  private splitByCommaPreservingEmpty(value: string): string[] {
+    if (!value) return [];
+    return value
+      .split(',')
+      .map((part) => part.trim());
+  }
+
   private splitList(value: string): string[] {
     if (!value) return [];
     return value
       .split(/[\r\n,]/)
       .map((part) => part.trim())
       .filter(Boolean);
+  }
+
+  private splitListPreservingEmpty(value: string): string[] {
+    if (!value) return [];
+    return value
+      .split(/[\r\n,]/)
+      .map((part) => part.trim());
   }
 
   private slugify(value: string): string {

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -4,8 +4,10 @@ import * as ExcelJS from 'exceljs';
 import { In, Repository } from 'typeorm';
 import { Product, ProductStatus } from './entities/product.entity';
 import { ProductCommandService } from './product-command.service';
-import { CreateProductDto } from './dto/create-product.dto';
+import { CreateProductDto, ProductOptionInputDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
+import { RemoteImageIngestService } from '../upload/remote-image-ingest.service';
+import { UploadedFile } from '../upload/interfaces/storage.interface';
 
 export type SmartStoreImportAction = 'create' | 'update' | 'skip';
 
@@ -16,6 +18,9 @@ export interface SmartStoreImportRowResult {
   action: SmartStoreImportAction;
   status: 'valid' | 'failed' | 'success';
   productId?: number;
+  optionCount: number;
+  galleryImageCount: number;
+  detailImageCount: number;
   errors: string[];
 }
 
@@ -36,6 +41,9 @@ interface ParsedSmartStoreRow {
   identifier: string | null;
   productName: string | null;
   dto: CreateProductDto | null;
+  optionCount: number;
+  galleryImageCount: number;
+  detailImageCount: number;
   errors: string[];
 }
 
@@ -62,13 +70,24 @@ const HEADER_ALIASES = {
   productCondition: ['상품상태'],
   representativeImage: ['대표이미지', '대표 이미지', '대표이미지 URL', '대표 이미지 URL', '이미지 URL'],
   additionalImages: ['추가이미지', '추가 이미지', '추가이미지 URL', '추가 이미지 URL'],
+  detailImages: ['상세이미지', '상세 이미지', '상세이미지 URL', '상세 이미지 URL'],
   description: ['상세설명', '상품상세', '상품 상세', '상세페이지', '상세 HTML'],
   shortDescription: ['요약설명', '짧은설명', '간단설명'],
+  optionType: ['옵션형태'],
+  optionNames: ['옵션명'],
+  optionValues: ['옵션값'],
+  optionPrices: ['옵션가'],
+  optionStocks: ['옵션 재고수량', '옵션재고수량'],
+  optionUsables: ['옵션 사용여부', '옵션사용여부'],
 } as const;
 
 type HeaderKey = keyof typeof HEADER_ALIASES;
 
 type HeaderMap = Partial<Record<HeaderKey, number>>;
+
+const OPTION_TYPE_NONE = '설정안함';
+const OPTION_TYPE_SINGLE = '단독형';
+const OPTION_TYPE_COMBINATION = '조합형';
 
 @Injectable()
 export class SmartStoreProductImportService {
@@ -76,6 +95,7 @@ export class SmartStoreProductImportService {
     @InjectRepository(Product)
     private readonly productRepository: Repository<Product>,
     private readonly productCommandService: ProductCommandService,
+    private readonly remoteImageIngestService: RemoteImageIngestService,
   ) {}
 
   async preview(file: Express.Multer.File): Promise<SmartStoreImportResult> {
@@ -102,6 +122,7 @@ export class SmartStoreProductImportService {
     );
 
     const duplicateIdentifiers = this.findDuplicates(identifiers);
+    const ingestCache = new Map<string, Promise<UploadedFile>>();
     const rows: SmartStoreImportRowResult[] = [];
 
     for (const parsed of parsedRows) {
@@ -119,16 +140,20 @@ export class SmartStoreProductImportService {
         action,
         status: errors.length > 0 ? 'failed' : commit ? 'success' : 'valid',
         productId: existing?.id,
+        optionCount: parsed.optionCount,
+        galleryImageCount: parsed.galleryImageCount,
+        detailImageCount: parsed.detailImageCount,
         errors,
       };
 
       if (commit && errors.length === 0 && parsed.dto) {
         try {
+          const dto = await this.resolveRemoteImages(parsed.dto, ingestCache);
           const saved = existing
-            ? await this.productCommandService.update(existing.id, this.toUpdateDto(parsed.dto))
+            ? await this.productCommandService.update(existing.id, this.toUpdateDto(dto))
             : await this.productCommandService.create({
-                ...parsed.dto,
-                slug: await this.generateUniqueSlug(parsed.dto.slug),
+                ...dto,
+                slug: await this.generateUniqueSlug(dto.slug),
               });
           rowResult.productId = saved.id;
           rowResult.status = 'success';
@@ -250,8 +275,22 @@ export class SmartStoreProductImportService {
 
     const stock = this.parseInteger(this.getCell(row, headerMap.stock));
     const salePrice = this.parseMoney(this.getCell(row, headerMap.salePrice));
+    const description = this.getCell(row, headerMap.description);
+
+    const options = this.parseOptions(row, headerMap, errors);
     const representativeImage = this.getCell(row, headerMap.representativeImage);
     const additionalImages = this.splitImageUrls(this.getCell(row, headerMap.additionalImages));
+    const galleryUrls = this.collectValidImageUrls(
+      [representativeImage, ...additionalImages].filter(Boolean),
+      errors,
+    );
+    const detailUrls = this.collectValidImageUrls(
+      [
+        ...this.splitImageUrls(this.getCell(row, headerMap.detailImages)),
+        ...this.extractHtmlImageUrls(description),
+      ],
+      errors,
+    );
 
     const dto: CreateProductDto | null = errors.length > 0 || !identifier || !productName || price === null
       ? null
@@ -268,11 +307,208 @@ export class SmartStoreProductImportService {
             stock ?? 0,
           ),
           shortDescription: this.getCell(row, headerMap.shortDescription) || undefined,
-          description: this.getCell(row, headerMap.description) || undefined,
-          images: this.buildImages(productName, representativeImage, additionalImages),
+          description: description || undefined,
+          images: this.buildImages(productName, galleryUrls),
+          detailImages: detailUrls.length > 0
+            ? detailUrls.map((url, index) => ({ url, alt: productName, sortOrder: index }))
+            : undefined,
+          options,
         };
 
-    return { rowNumber, identifier, productName, dto, errors };
+    return {
+      rowNumber,
+      identifier,
+      productName,
+      dto,
+      optionCount: options?.length ?? 0,
+      galleryImageCount: galleryUrls.length,
+      detailImageCount: detailUrls.length,
+      errors,
+    };
+  }
+
+  // 옵션형태가 비어 있거나 '설정안함'이면 기존 옵션을 건드리지 않도록 undefined 를 반환한다.
+  private parseOptions(row: ExcelJS.Row, headerMap: HeaderMap, errors: string[]): ProductOptionInputDto[] | undefined {
+    const optionType = this.getCell(row, headerMap.optionType).replace(/\s/g, '');
+    if (!optionType || optionType === OPTION_TYPE_NONE) return undefined;
+    if (optionType !== OPTION_TYPE_SINGLE && optionType !== OPTION_TYPE_COMBINATION) {
+      errors.push(`지원하지 않는 옵션형태입니다: ${optionType}`);
+      return undefined;
+    }
+
+    const names = this.splitByComma(this.getCell(row, headerMap.optionNames));
+    if (names.length === 0) {
+      errors.push('옵션명이 필요합니다.');
+      return undefined;
+    }
+    const valuesRaw = this.getCell(row, headerMap.optionValues);
+    if (!valuesRaw) {
+      errors.push('옵션값이 필요합니다.');
+      return undefined;
+    }
+
+    return optionType === OPTION_TYPE_COMBINATION
+      ? this.parseCombinationOptions(row, headerMap, names, valuesRaw, errors)
+      : this.parseSingleOptions(row, headerMap, names, valuesRaw, errors);
+  }
+
+  private parseCombinationOptions(
+    row: ExcelJS.Row,
+    headerMap: HeaderMap,
+    names: string[],
+    valuesRaw: string,
+    errors: string[],
+  ): ProductOptionInputDto[] {
+    const valueLines = this.splitLines(valuesRaw);
+    const priceLines = this.splitLines(this.getCell(row, headerMap.optionPrices));
+    const stockLines = this.splitLines(this.getCell(row, headerMap.optionStocks));
+    const usableLines = this.splitLines(this.getCell(row, headerMap.optionUsables));
+    const options: ProductOptionInputDto[] = [];
+
+    valueLines.forEach((line, index) => {
+      const parts = this.splitByComma(line);
+      if (parts.length !== names.length) {
+        errors.push(`옵션값 형식이 옵션명 개수와 일치하지 않습니다: ${line}`);
+        return;
+      }
+      if (!this.isOptionUsable(usableLines[index])) return;
+      options.push({
+        name: names.join('/'),
+        value: parts.join('/'),
+        priceAdjustment: this.parseMoney(priceLines[index] ?? '') ?? 0,
+        stock: this.parseInteger(stockLines[index] ?? '') ?? 0,
+        sortOrder: options.length,
+      });
+    });
+
+    return options;
+  }
+
+  private parseSingleOptions(
+    row: ExcelJS.Row,
+    headerMap: HeaderMap,
+    names: string[],
+    valuesRaw: string,
+    errors: string[],
+  ): ProductOptionInputDto[] {
+    const options: ProductOptionInputDto[] = [];
+
+    if (names.length === 1) {
+      const values = this.splitList(valuesRaw);
+      const prices = this.splitList(this.getCell(row, headerMap.optionPrices));
+      const stocks = this.splitList(this.getCell(row, headerMap.optionStocks));
+      const usables = this.splitList(this.getCell(row, headerMap.optionUsables));
+      values.forEach((value, index) => {
+        if (!this.isOptionUsable(usables[index])) return;
+        options.push({
+          name: names[0],
+          value,
+          priceAdjustment: this.parseMoney(prices[index] ?? '') ?? 0,
+          stock: this.parseInteger(stocks[index] ?? '') ?? 0,
+          sortOrder: options.length,
+        });
+      });
+      return options;
+    }
+
+    const valueLines = this.splitLines(valuesRaw);
+    if (valueLines.length !== names.length) {
+      errors.push('옵션값 줄 수가 옵션명 개수와 일치하지 않습니다.');
+      return options;
+    }
+    const priceLines = this.splitLines(this.getCell(row, headerMap.optionPrices));
+    const stockLines = this.splitLines(this.getCell(row, headerMap.optionStocks));
+    const usableLines = this.splitLines(this.getCell(row, headerMap.optionUsables));
+
+    names.forEach((name, nameIndex) => {
+      const values = this.splitByComma(valueLines[nameIndex] ?? '');
+      const prices = this.splitByComma(priceLines[nameIndex] ?? '');
+      const stocks = this.splitByComma(stockLines[nameIndex] ?? '');
+      const usables = this.splitByComma(usableLines[nameIndex] ?? '');
+      values.forEach((value, valueIndex) => {
+        if (!this.isOptionUsable(usables[valueIndex])) return;
+        options.push({
+          name,
+          value,
+          priceAdjustment: this.parseMoney(prices[valueIndex] ?? '') ?? 0,
+          stock: this.parseInteger(stocks[valueIndex] ?? '') ?? 0,
+          sortOrder: options.length,
+        });
+      });
+    });
+
+    return options;
+  }
+
+  private isOptionUsable(raw: string | undefined): boolean {
+    if (!raw) return true;
+    const normalized = raw.replace(/\s/g, '').toLowerCase();
+    return !(normalized === 'n' || normalized === 'no' || normalized === '사용안함' || normalized === 'x');
+  }
+
+  private collectValidImageUrls(urls: string[], errors: string[]): string[] {
+    const unique = [...new Set(urls.map((url) => url.trim()).filter(Boolean))];
+    const valid: string[] = [];
+    for (const url of unique) {
+      try {
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          throw new Error('unsupported protocol');
+        }
+        valid.push(url);
+      } catch {
+        errors.push(`이미지 URL 형식이 올바르지 않습니다: ${url}`);
+      }
+    }
+    return valid;
+  }
+
+  private extractHtmlImageUrls(html: string): string[] {
+    if (!html || !html.includes('<img')) return [];
+    const urls: string[] = [];
+    const pattern = /<img\b[^>]*?src\s*=\s*["']([^"']+)["']/gi;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(html)) !== null) {
+      urls.push(match[1]);
+    }
+    return urls;
+  }
+
+  // 원격 이미지 URL 을 다운로드해 스토리지에 업로드하고 DTO 의 URL 을 업로드된 URL 로 치환한다.
+  // 같은 URL 은 커밋 한 번 동안 캐시를 공유해 중복 다운로드/저장을 방지한다.
+  private async resolveRemoteImages(
+    dto: CreateProductDto,
+    cache: Map<string, Promise<UploadedFile>>,
+  ): Promise<CreateProductDto> {
+    const resolved: CreateProductDto = { ...dto };
+
+    if (dto.images) {
+      const images: NonNullable<CreateProductDto['images']> = [];
+      for (const image of dto.images) {
+        const uploaded = await this.ingestCached(image.url, cache);
+        images.push({ ...image, url: uploaded.url });
+      }
+      resolved.images = images;
+    }
+
+    if (dto.detailImages) {
+      const detailImages: NonNullable<CreateProductDto['detailImages']> = [];
+      for (const detailImage of dto.detailImages) {
+        const uploaded = await this.ingestCached(detailImage.url, cache);
+        detailImages.push({ ...detailImage, url: uploaded.url });
+      }
+      resolved.detailImages = detailImages;
+    }
+
+    return resolved;
+  }
+
+  private ingestCached(url: string, cache: Map<string, Promise<UploadedFile>>): Promise<UploadedFile> {
+    const cached = cache.get(url);
+    if (cached) return cached;
+    const promise = this.remoteImageIngestService.ingest(url);
+    cache.set(url, promise);
+    return promise;
   }
 
   private buildIdentifier(sellerCode: string, productNumber: string): string | null {
@@ -281,8 +517,7 @@ export class SmartStoreProductImportService {
     return normalized || null;
   }
 
-  private buildImages(productName: string, representativeImage: string, additionalImages: string[]): CreateProductDto['images'] {
-    const urls = [representativeImage, ...additionalImages].filter(Boolean);
+  private buildImages(productName: string, urls: string[]): CreateProductDto['images'] {
     if (urls.length === 0) return undefined;
     return urls.map((url, index) => ({
       url,
@@ -395,6 +630,30 @@ export class SmartStoreProductImportService {
     return value
       .split(/[\n,;|]/)
       .map((url) => url.trim())
+      .filter(Boolean);
+  }
+
+  private splitLines(value: string): string[] {
+    if (!value) return [];
+    return value
+      .split(/\r?\n/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+
+  private splitByComma(value: string): string[] {
+    if (!value) return [];
+    return value
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+
+  private splitList(value: string): string[] {
+    if (!value) return [];
+    return value
+      .split(/[\r\n,]/)
+      .map((part) => part.trim())
       .filter(Boolean);
   }
 

--- a/backend/src/modules/upload/__tests__/remote-image-ingest.service.spec.ts
+++ b/backend/src/modules/upload/__tests__/remote-image-ingest.service.spec.ts
@@ -17,13 +17,21 @@ function createFetchResponse(overrides: {
   status?: number;
   headers?: Record<string, string>;
   body?: Buffer;
+  bodyChunks?: Buffer[];
 } = {}): Response {
-  const body = overrides.body ?? JPEG_BUFFER;
+  const bodyChunks = overrides.bodyChunks ?? [overrides.body ?? JPEG_BUFFER];
   return {
     status: overrides.status ?? 200,
     ok: (overrides.status ?? 200) >= 200 && (overrides.status ?? 200) < 300,
     headers: new Headers(overrides.headers ?? {}),
-    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of bodyChunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    }),
   } as unknown as Response;
 }
 
@@ -140,6 +148,28 @@ describe('RemoteImageIngestService', () => {
     }));
 
     await expect(service.ingest('https://cdn.example.com/huge.jpg')).rejects.toThrow(BadRequestException);
+    expect(uploadService.uploadImageBuffer).not.toHaveBeenCalled();
+  });
+
+  it('stops reading as soon as streamed response exceeds the size limit', async () => {
+    const cancel = jest.fn().mockResolvedValue(undefined);
+    fetchMock.mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      body: {
+        getReader: () => ({
+          read: jest.fn()
+            .mockResolvedValueOnce({ done: false, value: Buffer.alloc(5 * 1024 * 1024) })
+            .mockResolvedValueOnce({ done: false, value: Buffer.alloc(1) }),
+          cancel,
+          releaseLock: jest.fn(),
+        }),
+      },
+    } as unknown as Response);
+
+    await expect(service.ingest('https://cdn.example.com/huge.jpg')).rejects.toThrow(BadRequestException);
+    expect(cancel).toHaveBeenCalled();
     expect(uploadService.uploadImageBuffer).not.toHaveBeenCalled();
   });
 

--- a/backend/src/modules/upload/__tests__/remote-image-ingest.service.spec.ts
+++ b/backend/src/modules/upload/__tests__/remote-image-ingest.service.spec.ts
@@ -1,0 +1,151 @@
+import { BadRequestException } from '@nestjs/common';
+import { RemoteImageIngestService } from '../remote-image-ingest.service';
+import { UploadService } from '../upload.service';
+
+const JPEG_BUFFER = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+
+function createUploadServiceMock() {
+  return {
+    uploadImageBuffer: jest.fn().mockResolvedValue({
+      url: 'https://cdn.example.com/uploads/uuid.jpg',
+      filename: 'uuid.jpg',
+    }),
+  };
+}
+
+function createFetchResponse(overrides: {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: Buffer;
+} = {}): Response {
+  const body = overrides.body ?? JPEG_BUFFER;
+  return {
+    status: overrides.status ?? 200,
+    ok: (overrides.status ?? 200) >= 200 && (overrides.status ?? 200) < 300,
+    headers: new Headers(overrides.headers ?? {}),
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  } as unknown as Response;
+}
+
+describe('RemoteImageIngestService', () => {
+  let uploadService: ReturnType<typeof createUploadServiceMock>;
+  let service: RemoteImageIngestService;
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    uploadService = createUploadServiceMock();
+    service = new RemoteImageIngestService(uploadService as unknown as UploadService);
+    fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(createFetchResponse());
+    jest
+      .spyOn(service as unknown as { resolveHostAddresses: (hostname: string) => Promise<string[]> }, 'resolveHostAddresses')
+      .mockResolvedValue(['93.184.216.34']);
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  it('downloads a remote image and uploads it through the upload pipeline', async () => {
+    const result = await service.ingest('https://shop1.phinf.naver.net/some/path/image.jpg');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(uploadService.uploadImageBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      expect.stringContaining('image.jpg'),
+    );
+    expect(result.url).toBe('https://cdn.example.com/uploads/uuid.jpg');
+  });
+
+  it('rejects non-http(s) URLs', async () => {
+    await expect(service.ingest('ftp://example.com/a.jpg')).rejects.toThrow(BadRequestException);
+    await expect(service.ingest('file:///etc/passwd')).rejects.toThrow(BadRequestException);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed URLs', async () => {
+    await expect(service.ingest('not-a-url')).rejects.toThrow(BadRequestException);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects localhost and private IP hosts', async () => {
+    await expect(service.ingest('http://localhost/a.jpg')).rejects.toThrow(BadRequestException);
+    await expect(service.ingest('http://127.0.0.1/a.jpg')).rejects.toThrow(BadRequestException);
+    await expect(service.ingest('http://10.0.0.5/a.jpg')).rejects.toThrow(BadRequestException);
+    await expect(service.ingest('http://172.16.0.1/a.jpg')).rejects.toThrow(BadRequestException);
+    await expect(service.ingest('http://192.168.0.10/a.jpg')).rejects.toThrow(BadRequestException);
+    await expect(service.ingest('http://169.254.169.254/meta.jpg')).rejects.toThrow(BadRequestException);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects hostnames that resolve to private addresses', async () => {
+    jest
+      .spyOn(service as unknown as { resolveHostAddresses: (hostname: string) => Promise<string[]> }, 'resolveHostAddresses')
+      .mockResolvedValue(['10.0.0.8']);
+
+    await expect(service.ingest('https://internal.example.com/a.jpg')).rejects.toThrow(BadRequestException);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('follows redirects while re-validating each hop', async () => {
+    fetchMock
+      .mockResolvedValueOnce(createFetchResponse({
+        status: 302,
+        headers: { location: 'https://cdn2.example.com/moved.jpg' },
+      }))
+      .mockResolvedValueOnce(createFetchResponse());
+
+    await service.ingest('https://cdn.example.com/a.jpg');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1][0])).toBe('https://cdn2.example.com/moved.jpg');
+  });
+
+  it('rejects redirects to private addresses', async () => {
+    fetchMock.mockResolvedValueOnce(createFetchResponse({
+      status: 302,
+      headers: { location: 'http://169.254.169.254/latest/meta-data' },
+    }));
+
+    await expect(service.ingest('https://cdn.example.com/a.jpg')).rejects.toThrow(BadRequestException);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when redirect chain is too long', async () => {
+    fetchMock.mockResolvedValue(createFetchResponse({
+      status: 302,
+      headers: { location: 'https://cdn.example.com/loop.jpg' },
+    }));
+
+    await expect(service.ingest('https://cdn.example.com/a.jpg')).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects non-success HTTP responses', async () => {
+    fetchMock.mockResolvedValue(createFetchResponse({ status: 404 }));
+
+    await expect(service.ingest('https://cdn.example.com/missing.jpg')).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects downloads exceeding the size limit via content-length', async () => {
+    fetchMock.mockResolvedValue(createFetchResponse({
+      headers: { 'content-length': String(20 * 1024 * 1024) },
+    }));
+
+    await expect(service.ingest('https://cdn.example.com/huge.jpg')).rejects.toThrow(BadRequestException);
+    expect(uploadService.uploadImageBuffer).not.toHaveBeenCalled();
+  });
+
+  it('rejects downloads whose body exceeds the size limit', async () => {
+    fetchMock.mockResolvedValue(createFetchResponse({
+      body: Buffer.alloc(6 * 1024 * 1024, 1),
+    }));
+
+    await expect(service.ingest('https://cdn.example.com/huge.jpg')).rejects.toThrow(BadRequestException);
+    expect(uploadService.uploadImageBuffer).not.toHaveBeenCalled();
+  });
+
+  it('wraps network failures in BadRequestException', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(service.ingest('https://cdn.example.com/a.jpg')).rejects.toThrow(BadRequestException);
+  });
+});

--- a/backend/src/modules/upload/remote-image-ingest.service.ts
+++ b/backend/src/modules/upload/remote-image-ingest.service.ts
@@ -52,12 +52,7 @@ export class RemoteImageIngestService {
         throw new BadRequestException(`이미지 크기가 5MB를 초과합니다: ${current.href}`);
       }
 
-      const arrayBuffer = await response.arrayBuffer();
-      if (arrayBuffer.byteLength > MAX_UPLOAD_FILE_SIZE_BYTES) {
-        throw new BadRequestException(`이미지 크기가 5MB를 초과합니다: ${current.href}`);
-      }
-
-      return { buffer: Buffer.from(arrayBuffer), finalUrl: current };
+      return { buffer: await this.readLimitedBody(response, current), finalUrl: current };
     }
 
     throw new BadRequestException(`이미지 리다이렉트 횟수가 너무 많습니다: ${rawUrl}`);
@@ -96,6 +91,36 @@ export class RemoteImageIngestService {
     } catch {
       throw new BadRequestException(`이미지 호스트를 확인할 수 없습니다: ${hostname}`);
     }
+  }
+
+  private async readLimitedBody(response: Response, url: URL): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+
+    if (!response.body) {
+      throw new BadRequestException(`이미지 응답 본문이 없습니다: ${url.href}`);
+    }
+
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+
+        const chunk = Buffer.from(value);
+        totalBytes += chunk.length;
+        if (totalBytes > MAX_UPLOAD_FILE_SIZE_BYTES) {
+          await reader.cancel();
+          throw new BadRequestException(`이미지 크기가 5MB를 초과합니다: ${url.href}`);
+        }
+        chunks.push(chunk);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return Buffer.concat(chunks, totalBytes);
   }
 
   private filenameFromUrl(url: URL): string {

--- a/backend/src/modules/upload/remote-image-ingest.service.ts
+++ b/backend/src/modules/upload/remote-image-ingest.service.ts
@@ -1,0 +1,144 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import * as path from 'node:path';
+import { UploadService } from './upload.service';
+import { UploadedFile } from './interfaces/storage.interface';
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from './upload.constants';
+
+const MAX_REDIRECTS = 3;
+const DOWNLOAD_TIMEOUT_MS = 10_000;
+
+@Injectable()
+export class RemoteImageIngestService {
+  constructor(private readonly uploadService: UploadService) {}
+
+  async ingest(url: string): Promise<UploadedFile> {
+    const { buffer, finalUrl } = await this.download(url);
+    return this.uploadService.uploadImageBuffer(buffer, this.filenameFromUrl(finalUrl));
+  }
+
+  private async download(rawUrl: string): Promise<{ buffer: Buffer; finalUrl: URL }> {
+    let current = this.parseUrl(rawUrl);
+
+    for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+      await this.assertSafeUrl(current);
+
+      let response: Response;
+      try {
+        response = await fetch(current, {
+          redirect: 'manual',
+          signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+        });
+      } catch {
+        throw new BadRequestException(`이미지 URL에 접근할 수 없습니다: ${current.href}`);
+      }
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location');
+        if (!location) {
+          throw new BadRequestException(`이미지 리다이렉트 응답에 location 헤더가 없습니다: ${current.href}`);
+        }
+        current = new URL(location, current);
+        continue;
+      }
+
+      if (!response.ok) {
+        throw new BadRequestException(`이미지 다운로드에 실패했습니다. (HTTP ${response.status}): ${current.href}`);
+      }
+
+      const contentLength = Number(response.headers.get('content-length') ?? 0);
+      if (contentLength > MAX_UPLOAD_FILE_SIZE_BYTES) {
+        throw new BadRequestException(`이미지 크기가 5MB를 초과합니다: ${current.href}`);
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      if (arrayBuffer.byteLength > MAX_UPLOAD_FILE_SIZE_BYTES) {
+        throw new BadRequestException(`이미지 크기가 5MB를 초과합니다: ${current.href}`);
+      }
+
+      return { buffer: Buffer.from(arrayBuffer), finalUrl: current };
+    }
+
+    throw new BadRequestException(`이미지 리다이렉트 횟수가 너무 많습니다: ${rawUrl}`);
+  }
+
+  private parseUrl(rawUrl: string): URL {
+    let parsed: URL;
+    try {
+      parsed = new URL(rawUrl);
+    } catch {
+      throw new BadRequestException(`올바르지 않은 이미지 URL입니다: ${rawUrl}`);
+    }
+    return parsed;
+  }
+
+  private async assertSafeUrl(url: URL): Promise<void> {
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new BadRequestException(`http/https 이미지 URL만 지원합니다: ${url.href}`);
+    }
+
+    const hostname = url.hostname.replace(/^\[|\]$/g, '');
+    if (hostname.toLowerCase() === 'localhost' || hostname.toLowerCase().endsWith('.localhost')) {
+      throw new BadRequestException(`허용되지 않는 이미지 호스트입니다: ${url.hostname}`);
+    }
+
+    const addresses = isIP(hostname) ? [hostname] : await this.resolveHostAddresses(hostname);
+    if (addresses.some((address) => isPrivateAddress(address))) {
+      throw new BadRequestException(`허용되지 않는 이미지 호스트입니다: ${url.hostname}`);
+    }
+  }
+
+  private async resolveHostAddresses(hostname: string): Promise<string[]> {
+    try {
+      const results = await lookup(hostname, { all: true, verbatim: true });
+      return results.map((result) => result.address);
+    } catch {
+      throw new BadRequestException(`이미지 호스트를 확인할 수 없습니다: ${hostname}`);
+    }
+  }
+
+  private filenameFromUrl(url: URL): string {
+    const basename = path.basename(url.pathname);
+    return basename && basename !== '/' ? basename : 'remote-image';
+  }
+}
+
+function isPrivateAddress(address: string): boolean {
+  const version = isIP(address);
+  if (version === 4) return isPrivateIpv4(address);
+  if (version === 6) return isPrivateIpv6(address);
+  return true;
+}
+
+function isPrivateIpv4(address: string): boolean {
+  const [a, b] = address.split('.').map(Number);
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+function isPrivateIpv6(address: string): boolean {
+  const lower = address.toLowerCase();
+  if (lower === '::' || lower === '::1') return true;
+  if (lower.startsWith('::ffff:')) {
+    const mapped = lower.slice('::ffff:'.length);
+    return isIP(mapped) === 4 ? isPrivateIpv4(mapped) : true;
+  }
+  return (
+    lower.startsWith('fc') ||
+    lower.startsWith('fd') ||
+    lower.startsWith('fe8') ||
+    lower.startsWith('fe9') ||
+    lower.startsWith('fea') ||
+    lower.startsWith('feb')
+  );
+}

--- a/backend/src/modules/upload/upload.module.ts
+++ b/backend/src/modules/upload/upload.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { UploadController } from './upload.controller';
 import { UploadService } from './upload.service';
+import { RemoteImageIngestService } from './remote-image-ingest.service';
 import { LocalStorageAdapter } from './adapters/local.adapter';
 import { MockStorageAdapter } from './adapters/mock.adapter';
 import { S3StorageAdapter } from './adapters/s3.adapter';
@@ -11,10 +12,11 @@ import { storageConfigProvider } from '../../config/storage.config';
   providers: [
     storageConfigProvider,
     UploadService,
+    RemoteImageIngestService,
     LocalStorageAdapter,
     MockStorageAdapter,
     S3StorageAdapter,
   ],
-  exports: [UploadService],
+  exports: [UploadService, RemoteImageIngestService],
 })
 export class UploadModule {}

--- a/backend/src/modules/upload/upload.service.ts
+++ b/backend/src/modules/upload/upload.service.ts
@@ -57,6 +57,22 @@ export class UploadService {
     return this.uploadWithPipeline(file, 'saveCategoryImage');
   }
 
+  uploadImageBuffer(buffer: Buffer, originalname: string): Promise<UploadedFile> {
+    const detectedMime = detectMimeFromMagicBytes(buffer);
+    if (!detectedMime) {
+      throw new BadRequestException(
+        '허용되지 않는 이미지 형식입니다. (jpeg, png, webp만 허용)',
+      );
+    }
+    const file = {
+      buffer,
+      originalname,
+      mimetype: detectedMime,
+      size: buffer.length,
+    } as Express.Multer.File;
+    return this.uploadWithPipeline(file, 'save');
+  }
+
   private async uploadWithPipeline(
     file: Express.Multer.File | undefined,
     saveMethod: 'save' | 'saveCategoryImage',

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -240,6 +240,9 @@ export default function AdminProductsPage() {
                       <th className="px-3 py-2 text-left">{t('import.previewColumns.identifier')}</th>
                       <th className="px-3 py-2 text-left">{t('import.previewColumns.productName')}</th>
                       <th className="px-3 py-2 text-left">{t('import.previewColumns.action')}</th>
+                      <th className="px-3 py-2 text-right">{t('import.previewColumns.options')}</th>
+                      <th className="px-3 py-2 text-right">{t('import.previewColumns.galleryImages')}</th>
+                      <th className="px-3 py-2 text-right">{t('import.previewColumns.detailImages')}</th>
                       <th className="px-3 py-2 text-left">{t('import.previewColumns.result')}</th>
                     </tr>
                   </thead>
@@ -250,6 +253,9 @@ export default function AdminProductsPage() {
                         <td className="px-3 py-2">{row.identifier ?? '-'}</td>
                         <td className="px-3 py-2">{row.productName ?? '-'}</td>
                         <td className="px-3 py-2">{t(`import.actions.${row.action}`)}</td>
+                        <td className="px-3 py-2 text-right">{row.optionCount ?? 0}</td>
+                        <td className="px-3 py-2 text-right">{row.galleryImageCount ?? 0}</td>
+                        <td className="px-3 py-2 text-right">{row.detailImageCount ?? 0}</td>
                         <td className="px-3 py-2">
                           {row.errors.length > 0 ? row.errors.join(', ') : t(`import.status.${row.status}`)}
                         </td>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -747,7 +747,7 @@
         "title": "Import SmartStore Product Excel",
         "description": "Validate a SmartStore Excel file, then create new products and update existing SKU matches.",
         "supportedFormats": "Supported formats: product-list export XLSX and bulk-edit XLSX (bulk-edit sheet).",
-        "supportedScope": "Initial scope: basic product fields only. Options, detail images, and additional-image expansion remain follow-up work.",
+        "supportedScope": "Scope: basic product fields, options (single/combination), representative/additional images, and detail images. Images are downloaded and re-uploaded to store storage.",
         "fileLabel": "SmartStore product Excel file",
         "previewButton": "Preview upload",
         "previewing": "Validating...",
@@ -775,6 +775,9 @@
           "identifier": "Identifier",
           "productName": "Product",
           "action": "Action",
+          "options": "Options",
+          "galleryImages": "Images",
+          "detailImages": "Detail images",
           "result": "Result"
         },
         "actions": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -747,7 +747,7 @@
         "title": "스마트스토어 상품 엑셀 가져오기",
         "description": "스마트스토어에서 다운로드한 엑셀을 검증한 뒤 신규 상품을 추가하고 기존 SKU 상품을 수정합니다.",
         "supportedFormats": "지원 포맷: 상품목록 다운로드형 XLSX, 일괄수정 XLSX(일괄수정 시트).",
-        "supportedScope": "1차 지원 범위: 기본 상품 필드만 반영합니다. 옵션, 상세 이미지, 추가 이미지 확장은 후속 과제입니다.",
+        "supportedScope": "지원 범위: 기본 상품 필드, 옵션(단독형/조합형), 대표/추가 이미지, 상세 이미지를 반영합니다. 이미지는 다운로드 후 자사몰 스토리지에 업로드됩니다.",
         "fileLabel": "스마트스토어 상품 엑셀 파일",
         "previewButton": "업로드 미리보기",
         "previewing": "검증 중...",
@@ -775,6 +775,9 @@
           "identifier": "식별자",
           "productName": "상품명",
           "action": "작업",
+          "options": "옵션",
+          "galleryImages": "이미지",
+          "detailImages": "상세 이미지",
           "result": "결과"
         },
         "actions": {

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -47,6 +47,9 @@ export interface SmartStoreProductImportRow {
   action: SmartStoreImportAction;
   status: SmartStoreImportStatus;
   productId?: number;
+  optionCount: number;
+  galleryImageCount: number;
+  detailImageCount: number;
   errors: string[];
 }
 


### PR DESCRIPTION
## Summary
- Closes #966
- 스마트스토어 상품 엑셀 가져오기를 기본 필드에서 **옵션·대표/추가 이미지·상세 이미지(S3 업로드)** 까지 확장

### 주요 변경
- **원격 이미지 ingest** (`RemoteImageIngestService`, upload 모듈)
  - SSRF 방어: `http/https`만 허용, localhost·private/link-local IP 차단(DNS 조회 포함), 리다이렉트 최대 3회(홉마다 재검증), 10초 타임아웃, 5MB 크기 제한
  - 다운로드 후 기존 `UploadService` 파이프라인(매직바이트 검증 → sharp 리사이즈 → storage adapter) 재사용 (`uploadImageBuffer` 공개 메서드 추가)
- **옵션 가져오기**
  - `옵션형태` `설정안함`(또는 빈 값)은 옵션을 건드리지 않음, `단독형`/`조합형` 파싱 지원
  - `옵션명`(콤마)·`옵션값`(줄바꿈/콤마)·`옵션가`·`옵션 재고수량`·`옵션 사용여부` 정렬 매칭, `사용안함` 옵션은 제외
  - `CreateProductDto/UpdateProductDto.options` 신설, `ProductCommandService`가 **(name, value) 기준 동기화** — cart_items가 옵션을 FK 참조하므로 전체 삭제 후 재생성 대신 매칭 갱신/신규 삽입/미매칭 삭제
- **이미지 가져오기**
  - `대표이미지`는 썸네일, `추가이미지` 줄바꿈/콤마/세미콜론/파이프 다중 URL 순서대로 갤러리 등록, 중복 URL은 커밋 1회 동안 캐시로 중복 다운로드 방지
  - 상세 이미지: `상세설명` HTML `<img src>` 추출 + 커스텀 `상세이미지(URL)` 컬럼 파싱 → `ProductDetailImage` sortOrder 순 저장
- **미리보기/커밋 UX**
  - preview 행별 `optionCount`/`galleryImageCount`/`detailImageCount` + URL 형식·옵션 파싱 오류 표시 (다운로드는 commit 시에만 수행)
  - commit 중 이미지 다운로드/업로드 실패 시 해당 행만 실패 처리(실패 URL을 오류 메시지에 포함), 나머지 행은 계속 진행
  - 어드민 미리보기 테이블에 옵션/이미지/상세 이미지 컬럼 추가, 안내 문구 갱신 (ko/en)

### 갱신 정책 (기존 SKU 업데이트)
- 엑셀 셀이 비어 있으면 기존 값(이미지/상세이미지/옵션) 유지, 값이 있으면 교체/동기화

### 검증
- 실제 샘플 `일괄수정` XLSX(13행×94열, 헤더 2행/데이터 6행~)로 preview 검증: 8개 행 정상 인식, 행당 추가이미지 6~8장 파싱 확인

## Test plan
- [x] npm run lint && npm run build && npm run test:run (FE: 137 files / 789 tests)
- [x] cd backend && npm run lint && npm run build && npm run test (BE: 114 suites / 1157 tests)
- [x] 실제 스마트스토어 샘플 XLSX preview 스모크 테스트