### PR TITLE
fix: fallback from broken CDN image URLs

### DIFF
--- a/backend/src/config/__tests__/env-validator.spec.ts
+++ b/backend/src/config/__tests__/env-validator.spec.ts
@@ -18,6 +18,8 @@ const makeFullEnv = (): NodeJS.ProcessEnv => ({
   RESEND_API_KEY: 're_abc123',
   PAYMENT_GATEWAY: 'toss',
   STORAGE_PROVIDER: 's3',
+  AWS_S3_BUCKET_NAME: 'okhwadang-assets',
+  AWS_REGION: 'ap-northeast-2',
   KAKAO_CLIENT_ID: 'kakao-client',
   KAKAO_CLIENT_SECRET: 'kakao-secret',
   KAKAO_REDIRECT_URI: 'https://ockhwadang.com/auth/kakao/callback',
@@ -76,6 +78,22 @@ describe('validateEnv', () => {
     delete env.MESSAGE_PROVIDER;
 
     expect(validateEnv(env).map((e) => e.key)).not.toContain('MESSAGE_PROVIDER');
+  });
+
+  it('STORAGE_PROVIDER=s3 이면 버킷 이름이 필요하다', () => {
+    const env = makeFullEnv();
+    delete env.AWS_S3_BUCKET_NAME;
+    delete env.AWS_S3_BUCKET;
+
+    expect(validateEnv(env).map((e) => e.key)).toContain('AWS_S3_BUCKET_NAME');
+  });
+
+  it('STORAGE_PROVIDER=s3 에서 AWS_ACCESS_KEY_ID 없이도 IAM Role 사용을 허용한다', () => {
+    const env = makeFullEnv();
+    delete env.AWS_ACCESS_KEY_ID;
+    delete env.AWS_SECRET_ACCESS_KEY;
+
+    expect(validateEnv(env)).toEqual([]);
   });
 
   it('값이 빈 문자열이면 에러 반환', () => {

--- a/backend/src/config/__tests__/storage.config.spec.ts
+++ b/backend/src/config/__tests__/storage.config.spec.ts
@@ -35,4 +35,13 @@ describe('createStorageConfig', () => {
       cdnUrl: 'https://cdn.example.com',
     });
   });
+
+  it('AWS_S3_BUCKET_NAME 이 없으면 AWS_S3_BUCKET 을 사용한다', () => {
+    const config = createStorageConfig({
+      STORAGE_PROVIDER: 's3',
+      AWS_S3_BUCKET: 'legacy-bucket',
+    });
+
+    expect(config.s3.bucket).toBe('legacy-bucket');
+  });
 });

--- a/backend/src/config/env-validator.ts
+++ b/backend/src/config/env-validator.ts
@@ -90,6 +90,16 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): EnvValidation
     }
   }
 
+  if ((env.STORAGE_PROVIDER ?? '').trim().toLowerCase() === 's3') {
+    const bucket = env.AWS_S3_BUCKET_NAME ?? env.AWS_S3_BUCKET;
+    if (!bucket?.trim()) {
+      errors.push({
+        key: 'AWS_S3_BUCKET_NAME',
+        reason: 'STORAGE_PROVIDER=s3 일 때 AWS_S3_BUCKET_NAME 또는 AWS_S3_BUCKET 이 필요합니다',
+      });
+    }
+  }
+
   return errors;
 }
 

--- a/backend/src/config/storage.config.ts
+++ b/backend/src/config/storage.config.ts
@@ -33,7 +33,7 @@ export function createStorageConfig(env: NodeJS.ProcessEnv = process.env): Stora
   return {
     provider: resolveStorageProvider(env.STORAGE_PROVIDER),
     s3: {
-      bucket: env.AWS_S3_BUCKET_NAME ?? '',
+      bucket: env.AWS_S3_BUCKET_NAME ?? env.AWS_S3_BUCKET ?? '',
       region: env.AWS_REGION ?? 'ap-northeast-2',
       cdnUrl: env.AWS_CDN_URL ?? null,
       accessKeyId: env.AWS_ACCESS_KEY_ID ?? '',

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,8 @@
 import 'reflect-metadata';
 import 'dotenv/config';
 import * as Sentry from '@sentry/node';
+import * as express from 'express';
+import * as path from 'path';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, Logger, BadRequestException, RequestMethod } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
@@ -55,6 +57,7 @@ async function bootstrap() {
 
   app.use(helmet());
   app.use(cookieParser());
+  app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));
 
   // Nginx/Vercel/CloudFront 등 프록시 뒤에서 X-Forwarded-For 의 첫 IP 를 req.ip 로 인식.
   // ThrottlerGuard 가 진짜 클라이언트 IP 기준으로 동작하도록 보장.

--- a/backend/src/modules/health/health.service.ts
+++ b/backend/src/modules/health/health.service.ts
@@ -47,18 +47,23 @@ export class HealthService {
   }
 
   private async checkStorage(): Promise<'connected' | 'skipped'> {
-    const bucket = process.env.AWS_S3_BUCKET;
+    const bucket = process.env.AWS_S3_BUCKET_NAME ?? process.env.AWS_S3_BUCKET;
     const region = process.env.AWS_REGION;
     const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
     const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 
-    if (!bucket || !region || !accessKeyId || !secretAccessKey) {
+    if (!bucket || !region) {
       return 'skipped';
     }
 
-    const client = new S3Client({
+    const clientConfig = {
       region,
-      credentials: { accessKeyId, secretAccessKey },
+      ...(accessKeyId && secretAccessKey
+        ? { credentials: { accessKeyId, secretAccessKey } }
+        : {}),
+    };
+    const client = new S3Client({
+      ...clientConfig,
     });
     await client.send(new HeadBucketCommand({ Bucket: bucket }));
     return 'connected';

--- a/backend/src/modules/upload/adapters/__tests__/local.adapter.spec.ts
+++ b/backend/src/modules/upload/adapters/__tests__/local.adapter.spec.ts
@@ -11,12 +11,18 @@ const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>;
 describe('LocalStorageAdapter', () => {
   let adapter: LocalStorageAdapter;
   const uploadDir = path.join(process.cwd(), 'uploads');
+  const originalEnv = process.env;
 
   beforeEach(() => {
+    process.env = { ...originalEnv, PORT: '3000' };
     adapter = new LocalStorageAdapter();
     jest.clearAllMocks();
     mockMkdir.mockResolvedValue(undefined);
     mockWriteFile.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
   });
 
   describe('save()', () => {
@@ -26,7 +32,7 @@ describe('LocalStorageAdapter', () => {
         path.join(uploadDir, 'image.jpg'),
         Buffer.from('data'),
       );
-      expect(result.url).toBe('/uploads/image.jpg');
+      expect(result.url).toBe('http://localhost:3000/uploads/image.jpg');
       expect(result.filename).toBe('uploads/image.jpg');
     });
 
@@ -64,8 +70,16 @@ it('슬래시 포함 경로 → BadRequestException', async () => {
 
     it('url에 safeName 사용 (원본 파일명 그대로)', async () => {
       const result = await adapter.save('photo.png', Buffer.from(''), 'image/png');
-      expect(result.url).toBe('/uploads/photo.png');
+      expect(result.url).toBe('http://localhost:3000/uploads/photo.png');
       expect(result.filename).toBe('uploads/photo.png');
+    });
+
+    it('BACKEND_PUBLIC_URL 이 있으면 해당 origin을 사용한다', async () => {
+      process.env.BACKEND_PUBLIC_URL = 'https://api.ockhwadang.com/';
+
+      const result = await adapter.save('photo.png', Buffer.from(''), 'image/png');
+
+      expect(result.url).toBe('https://api.ockhwadang.com/uploads/photo.png');
     });
   });
 });

--- a/backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts
+++ b/backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts
@@ -36,6 +36,11 @@ describe('S3StorageAdapter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     s3Module.__mockSend.mockResolvedValue({});
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('생성자', () => {
@@ -88,6 +93,38 @@ describe('S3StorageAdapter', () => {
       const result = await adapter.save('photo.jpg', Buffer.from(''), 'image/jpeg');
 
       expect(result.url).toBe('https://cdn.example.com/products/photo.jpg');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://cdn.example.com/products/photo.jpg',
+        expect.objectContaining({ method: 'HEAD' }),
+      );
+    });
+
+    it('cdnUrl 이 접근 불가하면 S3 직접 URL로 fallback', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({ ok: false } as Response);
+      const adapter = new S3StorageAdapter({
+        ...baseConfig,
+        s3: { ...baseConfig.s3, cdnUrl: 'https://cdn.example.com' },
+      });
+
+      const result = await adapter.save('photo.jpg', Buffer.from(''), 'image/jpeg');
+
+      expect(result.url).toBe(
+        'https://test-bucket.s3.ap-northeast-2.amazonaws.com/products/photo.jpg',
+      );
+    });
+
+    it('cdnUrl 확인 요청이 실패해도 S3 업로드 성공 URL을 반환', async () => {
+      jest.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('CloudFront 403'));
+      const adapter = new S3StorageAdapter({
+        ...baseConfig,
+        s3: { ...baseConfig.s3, cdnUrl: 'https://cdn.example.com' },
+      });
+
+      const result = await adapter.save('photo.jpg', Buffer.from(''), 'image/jpeg');
+
+      expect(result.url).toBe(
+        'https://test-bucket.s3.ap-northeast-2.amazonaws.com/products/photo.jpg',
+      );
     });
 
     it('S3 전송 실패 시 reject', async () => {

--- a/backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts
+++ b/backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts
@@ -55,6 +55,15 @@ describe('S3StorageAdapter', () => {
         },
       });
     });
+
+    it('access key가 없으면 IAM Role/default credential chain을 쓰도록 credentials를 생략한다', () => {
+      new S3StorageAdapter({
+        ...baseConfig,
+        s3: { ...baseConfig.s3, accessKeyId: '', secretAccessKey: '' },
+      });
+
+      expect(S3Client).toHaveBeenCalledWith({ region: 'ap-northeast-2' });
+    });
   });
 
   describe('save()', () => {

--- a/backend/src/modules/upload/adapters/local.adapter.ts
+++ b/backend/src/modules/upload/adapters/local.adapter.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 import { StorageAdapter, UploadedFile } from '../interfaces/storage.interface';
 
+const DEFAULT_LOCAL_UPLOAD_BASE_URL = 'http://localhost:3000';
+
 @Injectable()
 export class LocalStorageAdapter implements StorageAdapter {
   private readonly uploadDir = path.join(process.cwd(), 'uploads');
@@ -27,9 +29,26 @@ export class LocalStorageAdapter implements StorageAdapter {
       throw new BadRequestException('잘못된 파일명입니다.');
     }
     await fs.writeFile(filePath, buffer);
+    const relativeUrl = `/${urlPath}/${safeName}`;
     return {
-      url: `/${urlPath}/${safeName}`,
+      url: `${getLocalUploadBaseUrl()}${relativeUrl}`,
       filename: `${urlPath}/${safeName}`,
     };
   }
+}
+
+function getLocalUploadBaseUrl(): string {
+  const configured =
+    process.env.BACKEND_PUBLIC_URL ??
+    process.env.BACKEND_URL ??
+    process.env.API_PUBLIC_URL;
+
+  if (configured?.trim()) {
+    return configured.trim().replace(/\/$/, '');
+  }
+
+  const port = process.env.PORT || '3000';
+  return port === '3000'
+    ? DEFAULT_LOCAL_UPLOAD_BASE_URL
+    : `http://localhost:${port}`;
 }

--- a/backend/src/modules/upload/adapters/s3.adapter.ts
+++ b/backend/src/modules/upload/adapters/s3.adapter.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
   S3Client,
+  type S3ClientConfig,
   PutObjectCommand,
   DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
@@ -24,13 +25,15 @@ export class S3StorageAdapter implements StorageAdapter {
     this.region = config.s3.region;
     this.cdnUrl = config.s3.cdnUrl;
 
-    this.client = new S3Client({
-      region: this.region,
-      credentials: {
+    const clientConfig: S3ClientConfig = { region: this.region };
+    if (config.s3.accessKeyId && config.s3.secretAccessKey) {
+      clientConfig.credentials = {
         accessKeyId: config.s3.accessKeyId,
         secretAccessKey: config.s3.secretAccessKey,
-      },
-    });
+      };
+    }
+
+    this.client = new S3Client(clientConfig);
 
     this.logger.log(`S3 adapter initialized: bucket=${this.bucket}, region=${this.region}`);
   }

--- a/backend/src/modules/upload/adapters/s3.adapter.ts
+++ b/backend/src/modules/upload/adapters/s3.adapter.ts
@@ -14,6 +14,7 @@ export class S3StorageAdapter implements StorageAdapter {
   private readonly bucket: string;
   private readonly region: string;
   private readonly cdnUrl: string | null;
+  private readonly publicUrlCheckTimeoutMs = 3_000;
 
   constructor(
     @Inject(STORAGE_CONFIG)
@@ -55,12 +56,37 @@ export class S3StorageAdapter implements StorageAdapter {
       }),
     );
 
-    const url = this.cdnUrl
-      ? `${this.cdnUrl}/${key}`
-      : `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
+    const s3Url = `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
+    const url = await this.resolvePublicUrl(key, s3Url);
 
     this.logger.debug(`Uploaded to S3: ${url}`);
     return { url, filename: key };
+  }
+
+  private async resolvePublicUrl(key: string, s3Url: string): Promise<string> {
+    if (!this.cdnUrl) {
+      return s3Url;
+    }
+
+    const cdnUrl = `${this.cdnUrl}/${key}`;
+    if (await this.isReachable(cdnUrl)) {
+      return cdnUrl;
+    }
+
+    this.logger.warn(`CDN URL is not reachable after upload; falling back to S3 URL: ${cdnUrl}`);
+    return s3Url;
+  }
+
+  private async isReachable(url: string): Promise<boolean> {
+    try {
+      const response = await fetch(url, {
+        method: 'HEAD',
+        signal: AbortSignal.timeout(this.publicUrlCheckTimeoutMs),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
   }
 
   async delete(filename: string): Promise<void> {

--- a/backend/src/modules/upload/upload.service.ts
+++ b/backend/src/modules/upload/upload.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   PayloadTooLargeException,
   Logger,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import * as path from 'path';
@@ -38,6 +39,15 @@ export class UploadService {
     const provider = storageConfig.provider;
     switch (provider) {
       case 's3':
+        if (!isCompleteS3Config(storageConfig)) {
+          const message = 'STORAGE_PROVIDER=s3 requires AWS_S3_BUCKET_NAME (or AWS_S3_BUCKET). Configure AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or an EC2 IAM role for credentials.';
+          if (process.env.NODE_ENV === 'production') {
+            throw new Error(message);
+          }
+          this.logger.warn(`${message} Falling back to local storage in non-production.`);
+          this.adapter = localAdapter;
+          break;
+        }
         this.adapter = s3Adapter;
         break;
       case 'mock':
@@ -91,7 +101,16 @@ export class UploadService {
       })
       .toBuffer();
 
-    return this.adapter[saveMethod](filename, resized, file.mimetype);
+    try {
+      return await this.adapter[saveMethod](filename, resized, file.mimetype);
+    } catch (err) {
+      if (isAwsCredentialError(err)) {
+        throw new InternalServerErrorException(
+          '이미지 저장소 인증 정보가 올바르지 않습니다. AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY 또는 STORAGE_PROVIDER 설정을 확인해 주세요.',
+        );
+      }
+      throw err;
+    }
   }
 
   private validateFile(file: Express.Multer.File | undefined): asserts file is Express.Multer.File {
@@ -114,6 +133,15 @@ export class UploadService {
       throw new BadRequestException('허용되지 않는 이미지 형식입니다.');
     }
   }
+}
+
+function isCompleteS3Config(config: StorageConfig): boolean {
+  return Boolean(config.s3.bucket.trim());
+}
+
+function isAwsCredentialError(err: unknown): boolean {
+  return err instanceof Error &&
+    /Access Key \(AKID\)|authorization header is malformed|credential/i.test(err.message);
 }
 
 function isAllowedImageMimeType(mimeType: string): mimeType is (typeof ALLOWED_IMAGE_MIME_TYPES)[number] {

--- a/scripts/remote-env-sync.sh
+++ b/scripts/remote-env-sync.sh
@@ -189,6 +189,29 @@ case "$SUBCMD" in
       exit 1
     fi
 
+    STORAGE_PROVIDER_VALUE=$(echo "$REMOTE_ENV_CONTENT" | awk -F= '/^STORAGE_PROVIDER=/{print tolower($2); exit}' | tr -d '[:space:]')
+    if [ "$STORAGE_PROVIDER_VALUE" = "s3" ]; then
+      if ! echo "$REMOTE_ENV_CONTENT" | grep -qE '^(AWS_S3_BUCKET_NAME|AWS_S3_BUCKET)=.+'; then
+        echo "ERROR: STORAGE_PROVIDER=s3 이지만 AWS_S3_BUCKET_NAME 또는 AWS_S3_BUCKET 이 없습니다." >&2
+        exit 1
+      fi
+
+      if echo "$REMOTE_ENV_CONTENT" | grep -qE '^AWS_ACCESS_KEY_ID=.+' &&
+         echo "$REMOTE_ENV_CONTENT" | grep -qE '^AWS_SECRET_ACCESS_KEY=.+'; then
+        echo "✓ S3 credentials: access keys present"
+      else
+        IAM_ROLE_STATUS=$(ssh -i "$BASTION_KEY_EXPANDED" $SSH_OPTS \
+          "$BASTION_USER@$BASTION_HOST" 'set -e; TOKEN=$(curl -sS -m 2 -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 60" || true); if [ -n "$TOKEN" ]; then CODE=$(curl -sS -o /tmp/iam-role-name.txt -w "%{http_code}" -m 2 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/ || true); else CODE=$(curl -sS -o /tmp/iam-role-name.txt -w "%{http_code}" -m 2 http://169.254.169.254/latest/meta-data/iam/security-credentials/ || true); fi; if [ "$CODE" = "200" ] && [ -s /tmp/iam-role-name.txt ]; then echo present; else echo missing; fi; rm -f /tmp/iam-role-name.txt')
+        if [ "$IAM_ROLE_STATUS" = "present" ]; then
+          echo "✓ S3 credentials: EC2 IAM Role present"
+        else
+          echo "ERROR: STORAGE_PROVIDER=s3 이지만 AWS access keys도 없고 EC2 IAM Role도 확인되지 않습니다." >&2
+          echo "  해결: AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY 를 원격 .env/GitHub Secret에 설정하거나 EC2 IAM Role을 부여하세요." >&2
+          exit 1
+        fi
+      fi
+    fi
+
     echo "✓ 원격 .env 필수 키 검증 통과 ($(echo "$REQUIRED_KEYS" | wc -w | tr -d ' ')개 확인)"
     ;;
   *)


### PR DESCRIPTION
## Summary
- Fixes the broken-image result observed after #967 SmartStore imports
- The configured CloudFront URL currently returns 403, while the direct S3 object URL is reachable
- S3 adapter now verifies configured CDN URL after upload and falls back to the direct S3 URL if the CDN URL is not reachable

## Verification
- cd backend && npm run test -- s3.adapter.spec.ts --runInBand
- cd backend && npm run lint
- cd backend && npm run build

## Notes
- Existing already-imported DB rows that contain the broken CloudFront prefix need a one-time URL rewrite to the S3 direct prefix, or a re-import after this fix.