### PR TITLE
[codex] Prevent hidden products from public exposure

### DIFF
--- a/backend/src/modules/cart/__tests__/cart.service.spec.ts
+++ b/backend/src/modules/cart/__tests__/cart.service.spec.ts
@@ -29,6 +29,7 @@ const buildQueryBuilder = (items: CartItem[]) => {
   const qb = {
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockResolvedValue(items),
   };
@@ -78,12 +79,14 @@ describe('CartService', () => {
         },
       ] as CartItem[];
 
-      mockCartItemRepo.createQueryBuilder.mockReturnValue(
-        buildQueryBuilder(mockItems),
-      );
+      const qb = buildQueryBuilder(mockItems);
+      mockCartItemRepo.createQueryBuilder.mockReturnValue(qb);
 
       const result = await service.findAll(1);
 
+      expect(qb.andWhere).toHaveBeenCalledWith('product.status = :status', {
+        status: 'active',
+      });
       expect(result.items).toHaveLength(1);
       expect(result.items[0].unitPrice).toBe(25000);
       expect(result.items[0].subtotal).toBe(50000);
@@ -116,6 +119,9 @@ describe('CartService', () => {
 
       await service.add(1, { productId: 1, productOptionId: null, quantity: 1 });
 
+      expect(mockProductRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 1, status: 'active' },
+      });
       expect(mockCartItemRepo.create).toHaveBeenCalledWith({
         userId: 1,
         productId: 1,
@@ -148,6 +154,18 @@ describe('CartService', () => {
       await expect(
         service.add(1, { productId: 999999, productOptionId: null, quantity: 1 }),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('does not add hidden products to cart', async () => {
+      mockProductRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.add(1, { productId: 2, productOptionId: null, quantity: 1 }),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockProductRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 2, status: 'active' },
+      });
+      expect(mockCartItemRepo.create).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/cart/cart.service.ts
+++ b/backend/src/modules/cart/cart.service.ts
@@ -63,6 +63,7 @@ export class CartService {
       )
       .leftJoinAndSelect('cartItem.option', 'option')
       .where('cartItem.userId = :userId', { userId })
+      .andWhere('product.status = :status', { status: ProductStatus.ACTIVE })
       .orderBy('cartItem.createdAt', 'DESC')
       .getMany();
 
@@ -101,7 +102,11 @@ export class CartService {
   }
 
   async add(userId: number, dto: AddToCartDto, locale?: string): Promise<CartResponse> {
-    await findOrThrow(this.productRepository, { id: dto.productId }, '상품을 찾을 수 없습니다.');
+    await findOrThrow(
+      this.productRepository,
+      { id: dto.productId, status: ProductStatus.ACTIVE },
+      '상품을 찾을 수 없습니다.',
+    );
 
     if (dto.productOptionId != null) {
       const option = await this.productOptionRepository.findOne({

--- a/backend/src/modules/products/__tests__/product-query.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-query.service.spec.ts
@@ -340,6 +340,30 @@ describe('ProductQueryService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe(1);
     });
+
+    it('비관리자 bulk cache hit 에도 hidden 상품을 반환하지 않는다', async () => {
+      cacheService.get.mockResolvedValue([
+        { id: 1, status: ProductStatus.ACTIVE } as Product,
+        { id: 2, status: ProductStatus.HIDDEN } as Product,
+      ]);
+
+      const result = await service.findBulk([1, 2], false);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(1);
+      expect(productRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('관리자 bulk cache 는 hidden 상품도 반환한다', async () => {
+      cacheService.get.mockResolvedValue([
+        { id: 1, status: ProductStatus.ACTIVE } as Product,
+        { id: 2, status: ProductStatus.HIDDEN } as Product,
+      ]);
+
+      const result = await service.findBulk([1, 2], true);
+
+      expect(result).toHaveLength(2);
+    });
   });
 
   describe('autocomplete', () => {

--- a/backend/src/modules/products/__tests__/recently-viewed.service.spec.ts
+++ b/backend/src/modules/products/__tests__/recently-viewed.service.spec.ts
@@ -88,7 +88,10 @@ describe('RecentlyViewedService', () => {
       await service.findAll(10, 200);
 
       expect(mockRepo.findAndCount).toHaveBeenCalledWith(
-        expect.objectContaining({ take: 100 }),
+        expect.objectContaining({
+          take: 100,
+          where: expect.objectContaining({ product: { status: 'active' } }),
+        }),
       );
     });
 

--- a/backend/src/modules/products/product-cache.util.ts
+++ b/backend/src/modules/products/product-cache.util.ts
@@ -1,4 +1,5 @@
 export const PRODUCT_LIST_CACHE_PATTERN = 'products:list:*';
+export const PRODUCT_BULK_CACHE_PATTERN = 'products:bulk:*';
 
 export function getProductListCacheKey(query: unknown, isAdmin: boolean): string {
   const hash = Buffer.from(JSON.stringify({ ...asRecord(query), isAdmin })).toString(
@@ -11,8 +12,8 @@ export function getProductDetailCacheKey(id: number): string {
   return `products:detail:${id}`;
 }
 
-export function getProductBulkCacheKey(ids: number[]): string {
-  return `products:bulk:${[...ids].sort().join(',')}`;
+export function getProductBulkCacheKey(ids: number[], isAdmin: boolean): string {
+  return `products:bulk:${isAdmin ? 'admin' : 'public'}:${[...ids].sort().join(',')}`;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/backend/src/modules/products/product-command.service.ts
+++ b/backend/src/modules/products/product-command.service.ts
@@ -15,6 +15,7 @@ import { CacheService } from '../cache/cache.service';
 import { findOrThrow } from '../../common/utils/repository.util';
 import {
   getProductDetailCacheKey,
+  PRODUCT_BULK_CACHE_PATTERN,
   PRODUCT_LIST_CACHE_PATTERN,
 } from './product-cache.util';
 
@@ -33,7 +34,7 @@ export class ProductCommandService {
     const { images, detailImages, options, ...productData } = dto;
 
     try {
-      return await this.dataSource.transaction(async (manager: EntityManager) => {
+      const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
         const product = manager.create(Product, {
           ...productData,
           categoryId: dto.categoryId ?? null,
@@ -82,6 +83,8 @@ export class ProductCommandService {
 
         return saved;
       });
+      await this.invalidateProductCollectionsCache();
+      return saved;
     } catch (err) {
       this.rethrowIfDuplicateKey(err);
       throw err;
@@ -171,6 +174,14 @@ export class ProductCommandService {
     await Promise.all([
       this.cacheService.del(getProductDetailCacheKey(productId)),
       this.cacheService.delPattern(PRODUCT_LIST_CACHE_PATTERN),
+      this.cacheService.delPattern(PRODUCT_BULK_CACHE_PATTERN),
+    ]);
+  }
+
+  private async invalidateProductCollectionsCache(): Promise<void> {
+    await Promise.all([
+      this.cacheService.delPattern(PRODUCT_LIST_CACHE_PATTERN),
+      this.cacheService.delPattern(PRODUCT_BULK_CACHE_PATTERN),
     ]);
   }
 

--- a/backend/src/modules/products/product-query.service.ts
+++ b/backend/src/modules/products/product-query.service.ts
@@ -174,13 +174,14 @@ export class ProductQueryService {
       return [];
     }
 
-    const cacheKey = getProductBulkCacheKey(ids);
+    const cacheKey = getProductBulkCacheKey(ids, isAdmin);
     const cached = await this.cacheService.get<
       (Product & { rating: number; reviewCount: number })[]
     >(cacheKey);
 
     if (cached) {
-      const localized = cached.map((product) => this.applyLocale(product, locale));
+      const visible = this.filterVisibleForPublic(cached, isAdmin);
+      const localized = visible.map((product) => this.applyLocale(product, locale));
       return localized as (Product & { rating: number; reviewCount: number })[];
     }
 
@@ -257,6 +258,15 @@ export class ProductQueryService {
       });
     }
     return map;
+  }
+
+  private filterVisibleForPublic<T extends { status: ProductStatus }>(
+    items: T[],
+    isAdmin: boolean,
+  ): T[] {
+    return isAdmin
+      ? items
+      : items.filter((product) => product.status === ProductStatus.ACTIVE);
   }
 
   private applyReviewStats<T extends { id: number }>(

--- a/backend/src/modules/products/recently-viewed.service.ts
+++ b/backend/src/modules/products/recently-viewed.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { RecentlyViewedProduct } from './entities/recently-viewed-product.entity';
+import { ProductStatus } from './entities/product.entity';
 
 export interface RecentlyViewedItem {
   productId: number;
@@ -47,7 +48,7 @@ export class RecentlyViewedService {
     const safeLimit = Math.min(Math.max(1, limit), 100);
 
     const [items, total] = await this.recentlyViewedRepo.findAndCount({
-      where: { userId },
+      where: { userId, product: { status: ProductStatus.ACTIVE } },
       relations: ['product', 'product.images'],
       order: { viewedAt: 'DESC' },
       take: safeLimit,

--- a/backend/src/modules/wishlist/__tests__/wishlist.service.spec.ts
+++ b/backend/src/modules/wishlist/__tests__/wishlist.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConflictException, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { WishlistService } from '../wishlist.service';
 import { Wishlist } from '../entities/wishlist.entity';
+import { Product } from '../../products/entities/product.entity';
 
 const mockRepo = {
   findAndCount: jest.fn(),
@@ -10,6 +11,10 @@ const mockRepo = {
   create: jest.fn(),
   save: jest.fn(),
   remove: jest.fn(),
+};
+
+const mockProductRepo = {
+  findOne: jest.fn(),
 };
 
 describe('WishlistService', () => {
@@ -20,11 +25,13 @@ describe('WishlistService', () => {
       providers: [
         WishlistService,
         { provide: getRepositoryToken(Wishlist), useValue: mockRepo },
+        { provide: getRepositoryToken(Product), useValue: mockProductRepo },
       ],
     }).compile();
 
     service = module.get<WishlistService>(WishlistService);
     jest.clearAllMocks();
+    mockProductRepo.findOne.mockResolvedValue({ id: 5, status: 'active' });
   });
 
   describe('findAll', () => {
@@ -49,6 +56,11 @@ describe('WishlistService', () => {
 
       const result = await service.findAll(10);
 
+      expect(mockRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 10, product: { status: 'active' } },
+        }),
+      );
       expect(result.total).toBe(1);
       expect(result.data).toHaveLength(1);
       expect(result.data[0].productId).toBe(5);
@@ -59,6 +71,10 @@ describe('WishlistService', () => {
     it('should return isWishlisted=true when item exists', async () => {
       mockRepo.findOne.mockResolvedValue({ id: 1, userId: 10, productId: 5 });
       const result = await service.check(10, 5);
+      expect(mockRepo.findOne).toHaveBeenCalledWith({
+        where: { userId: 10, productId: 5, product: { status: 'active' } },
+        relations: ['product'],
+      });
       expect(result.isWishlisted).toBe(true);
       expect(result.wishlistId).toBe(1);
     });
@@ -80,6 +96,9 @@ describe('WishlistService', () => {
 
       const result = await service.create(10, { productId: 5 });
 
+      expect(mockProductRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 5, status: 'active' },
+      });
       expect(result.id).toBe(1);
       expect(result.productId).toBe(5);
     });
@@ -88,6 +107,13 @@ describe('WishlistService', () => {
       mockRepo.findOne.mockResolvedValue({ id: 1 });
 
       await expect(service.create(10, { productId: 5 })).rejects.toThrow(ConflictException);
+    });
+
+    it('should throw NotFoundException when product is hidden', async () => {
+      mockProductRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.create(10, { productId: 5 })).rejects.toThrow(NotFoundException);
+      expect(mockRepo.create).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/wishlist/wishlist.module.ts
+++ b/backend/src/modules/wishlist/wishlist.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Wishlist } from './entities/wishlist.entity';
+import { Product } from '../products/entities/product.entity';
 import { WishlistController } from './wishlist.controller';
 import { WishlistService } from './wishlist.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Wishlist])],
+  imports: [TypeOrmModule.forFeature([Wishlist, Product])],
   controllers: [WishlistController],
   providers: [WishlistService],
   exports: [WishlistService],

--- a/backend/src/modules/wishlist/wishlist.service.ts
+++ b/backend/src/modules/wishlist/wishlist.service.ts
@@ -6,6 +6,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Wishlist } from './entities/wishlist.entity';
+import { Product, ProductStatus } from '../products/entities/product.entity';
 import { CreateWishlistDto } from './dto/create-wishlist.dto';
 import { findOrThrow } from '../../common/utils/repository.util';
 import { assertOwnership } from '../../common/utils/ownership.util';
@@ -42,6 +43,8 @@ export class WishlistService {
   constructor(
     @InjectRepository(Wishlist)
     private readonly wishlistRepo: Repository<Wishlist>,
+    @InjectRepository(Product)
+    private readonly productRepo: Repository<Product>,
   ) {}
 
   private toResponse(w: Wishlist): WishlistItemResponse {
@@ -72,7 +75,7 @@ export class WishlistService {
 
   async findAll(userId: number): Promise<WishlistListResult> {
     const [items, total] = await this.wishlistRepo.findAndCount({
-      where: { userId },
+      where: { userId, product: { status: ProductStatus.ACTIVE } },
       relations: ['product', 'product.images'],
       order: { createdAt: 'DESC' },
     });
@@ -85,7 +88,8 @@ export class WishlistService {
 
   async check(userId: number, productId: number): Promise<WishlistCheckResult> {
     const item = await this.wishlistRepo.findOne({
-      where: { userId, productId },
+      where: { userId, productId, product: { status: ProductStatus.ACTIVE } },
+      relations: ['product'],
     });
 
     return {
@@ -95,6 +99,12 @@ export class WishlistService {
   }
 
   async create(userId: number, dto: CreateWishlistDto): Promise<WishlistItemResponse> {
+    await findOrThrow(
+      this.productRepo,
+      { id: dto.productId, status: ProductStatus.ACTIVE },
+      '상품을 찾을 수 없습니다.',
+    );
+
     const existing = await this.wishlistRepo.findOne({
       where: { userId, productId: dto.productId },
     });


### PR DESCRIPTION
## Summary
- Prevent public bulk product lookup from leaking admin-hidden products through shared cache entries.
- Hide inactive products from cart, wishlist, and recently viewed product surfaces.
- Invalidate product bulk caches on product create/update/delete.
- Add regression coverage for cached bulk lookup, cart add/list, wishlist, and recently viewed filters.

## Root cause
Public product detail/list paths already status-gated hidden products, but adjacent customer-facing surfaces could still expose hidden products through bulk lookup caching or relation-backed lists such as cart, wishlist, and recently viewed products.

## Validation
- `npm --prefix backend run build`
- `npm --prefix backend run test -- --runInBand`

## Notes
- Backend status filtering is intentional. UI-only filtering would still leave hidden products visible through API responses or stale cache data.
