### PR TITLE
#970 리뷰 어드민 및 스마트스토어 리뷰 업로드

### DIFF
--- a/backend/src/common/imports/excel-import.util.ts
+++ b/backend/src/common/imports/excel-import.util.ts
@@ -1,0 +1,48 @@
+import { BadRequestException } from '@nestjs/common';
+import * as ExcelJS from 'exceljs';
+
+export function assertXlsxFile(
+  file: Express.Multer.File | undefined,
+  description = '엑셀',
+): asserts file is Express.Multer.File {
+  if (!file) {
+    throw new BadRequestException(`업로드할 ${description} 파일을 선택해 주세요.`);
+  }
+
+  const hasXlsxName = file.originalname.toLowerCase().endsWith('.xlsx');
+  const hasXlsxMime = [
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/octet-stream',
+  ].includes(file.mimetype);
+
+  if (!hasXlsxName || !hasXlsxMime) {
+    throw new BadRequestException(`${description} 엑셀(.xlsx) 파일만 업로드할 수 있습니다.`);
+  }
+}
+
+export function cellToString(value: ExcelJS.CellValue): string {
+  if (value === null || value === undefined) return '';
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'object') {
+    if ('text' in value && typeof value.text === 'string') return value.text;
+    if ('result' in value) return cellToString(value.result as ExcelJS.CellValue);
+    if ('richText' in value && Array.isArray(value.richText)) {
+      return value.richText.map((part) => part.text).join('');
+    }
+    if ('hyperlink' in value && typeof value.hyperlink === 'string') return value.hyperlink;
+    return String(value);
+  }
+  return String(value);
+}
+
+export function normalizeExcelHeader(header: string): string {
+  return header.replace(/[\s_()\[\]{}./-]/g, '').toLowerCase();
+}
+
+export function splitExcelList(value: string): string[] {
+  if (!value) return [];
+  return value
+    .split(/[\r\n,;|]/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}

--- a/backend/src/common/imports/external-source.util.ts
+++ b/backend/src/common/imports/external-source.util.ts
@@ -1,0 +1,14 @@
+export const NAVER_SMARTSTORE_REVIEW_SOURCE = 'naver-smartstore' as const;
+export const LEGACY_SMARTSTORE_REVIEW_SOURCE = 'smartstore' as const;
+
+export type SmartStoreReviewSource =
+  typeof NAVER_SMARTSTORE_REVIEW_SOURCE | typeof LEGACY_SMARTSTORE_REVIEW_SOURCE;
+
+export function buildNaverExternalProductKey(
+  externalProductId: string | number | null | undefined,
+): string | null {
+  if (externalProductId === null || externalProductId === undefined) return null;
+  const raw = String(externalProductId).trim();
+  if (!raw) return null;
+  return raw.startsWith('naver-') ? raw : `naver-${raw}`;
+}

--- a/backend/src/database/migrations/1785200000000-AddExternalReviewAdminFields.ts
+++ b/backend/src/database/migrations/1785200000000-AddExternalReviewAdminFields.ts
@@ -1,0 +1,133 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddExternalReviewAdminFields1785200000000 implements MigrationInterface {
+  name = 'AddExternalReviewAdminFields1785200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.addColumnIfMissing(
+      queryRunner,
+      'review_type',
+      '`review_type` varchar(40) NULL AFTER `external_product_id`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'media_assets',
+      '`media_assets` json NULL AFTER `image_urls`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'helpful_count',
+      '`helpful_count` int UNSIGNED NOT NULL DEFAULT 0 AFTER `reviewer_name_masked`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'source_display_status',
+      '`source_display_status` varchar(40) NULL AFTER `helpful_count`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'is_best',
+      '`is_best` tinyint NOT NULL DEFAULT 0 AFTER `is_visible`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'best_selected_at',
+      '`best_selected_at` datetime NULL AFTER `is_best`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'related_review_external_id',
+      '`related_review_external_id` varchar(128) NULL AFTER `best_selected_at`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'related_review_content',
+      '`related_review_content` text NULL AFTER `related_review_external_id`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'order_no',
+      '`order_no` varchar(128) NULL AFTER `related_review_content`',
+    );
+    await this.addColumnIfMissing(queryRunner, 'raw_data', '`raw_data` json NULL AFTER `order_no`');
+    await this.addColumnIfMissing(
+      queryRunner,
+      'import_batch_id',
+      '`import_batch_id` varchar(64) NULL AFTER `raw_data`',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      'source_updated_at',
+      '`source_updated_at` datetime NULL AFTER `reviewed_at`',
+    );
+    await this.addIndexIfMissing(
+      queryRunner,
+      'IDX_external_reviews_import_batch',
+      'CREATE INDEX `IDX_external_reviews_import_batch` ON `external_reviews` (`import_batch_id`)',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await this.dropIndexIfExists(queryRunner, 'IDX_external_reviews_import_batch');
+    await this.dropColumnIfExists(queryRunner, 'source_updated_at');
+    await this.dropColumnIfExists(queryRunner, 'import_batch_id');
+    await this.dropColumnIfExists(queryRunner, 'raw_data');
+    await this.dropColumnIfExists(queryRunner, 'order_no');
+    await this.dropColumnIfExists(queryRunner, 'related_review_content');
+    await this.dropColumnIfExists(queryRunner, 'related_review_external_id');
+    await this.dropColumnIfExists(queryRunner, 'best_selected_at');
+    await this.dropColumnIfExists(queryRunner, 'is_best');
+    await this.dropColumnIfExists(queryRunner, 'source_display_status');
+    await this.dropColumnIfExists(queryRunner, 'helpful_count');
+    await this.dropColumnIfExists(queryRunner, 'media_assets');
+    await this.dropColumnIfExists(queryRunner, 'review_type');
+  }
+
+  private async addColumnIfMissing(
+    queryRunner: QueryRunner,
+    columnName: string,
+    definition: string,
+  ): Promise<void> {
+    const [row] = (await queryRunner.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'external_reviews' AND COLUMN_NAME = ?`,
+      [columnName],
+    )) as Array<{ COLUMN_NAME: string }>;
+    if (!row) {
+      await queryRunner.query(`ALTER TABLE \`external_reviews\` ADD COLUMN ${definition}`);
+    }
+  }
+
+  private async dropColumnIfExists(queryRunner: QueryRunner, columnName: string): Promise<void> {
+    const [row] = (await queryRunner.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'external_reviews' AND COLUMN_NAME = ?`,
+      [columnName],
+    )) as Array<{ COLUMN_NAME: string }>;
+    if (row) {
+      await queryRunner.query(`ALTER TABLE \`external_reviews\` DROP COLUMN \`${columnName}\``);
+    }
+  }
+
+  private async addIndexIfMissing(
+    queryRunner: QueryRunner,
+    indexName: string,
+    createSql: string,
+  ): Promise<void> {
+    const [row] = (await queryRunner.query(
+      `SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'external_reviews' AND INDEX_NAME = ?`,
+      [indexName],
+    )) as Array<{ INDEX_NAME: string }>;
+    if (!row) {
+      await queryRunner.query(createSql);
+    }
+  }
+
+  private async dropIndexIfExists(queryRunner: QueryRunner, indexName: string): Promise<void> {
+    const [row] = (await queryRunner.query(
+      `SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'external_reviews' AND INDEX_NAME = ?`,
+      [indexName],
+    )) as Array<{ INDEX_NAME: string }>;
+    if (row) {
+      await queryRunner.query(`DROP INDEX \`${indexName}\` ON \`external_reviews\``);
+    }
+  }
+}

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -8,6 +8,8 @@ import { CreateProductDto, ProductNoticeInfoType, ProductOptionInputDto } from '
 import { UpdateProductDto } from './dto/update-product.dto';
 import { RemoteImageIngestService } from '../upload/remote-image-ingest.service';
 import { UploadedFile } from '../upload/interfaces/storage.interface';
+import { assertXlsxFile, cellToString, normalizeExcelHeader } from '../../common/imports/excel-import.util';
+import { buildNaverExternalProductKey } from '../../common/imports/external-source.util';
 
 export type SmartStoreImportAction = 'create' | 'update' | 'skip';
 
@@ -194,17 +196,7 @@ export class SmartStoreProductImportService {
   }
 
   private assertExcelFile(file: Express.Multer.File | undefined): asserts file is Express.Multer.File {
-    if (!file) {
-      throw new BadRequestException('업로드할 엑셀 파일을 선택해 주세요.');
-    }
-    const hasXlsxName = file.originalname.toLowerCase().endsWith('.xlsx');
-    const hasXlsxMime = [
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'application/octet-stream',
-    ].includes(file.mimetype);
-    if (!hasXlsxName || !hasXlsxMime) {
-      throw new BadRequestException('스마트스토어 상품 엑셀(.xlsx) 파일만 업로드할 수 있습니다.');
-    }
+    assertXlsxFile(file, '스마트스토어 상품');
   }
 
   private async parseWorkbook(buffer: Buffer): Promise<ParsedSmartStoreRow[]> {
@@ -544,7 +536,7 @@ export class SmartStoreProductImportService {
   }
 
   private buildIdentifier(sellerCode: string, productNumber: string): string | null {
-    const raw = sellerCode || (productNumber ? `naver-${productNumber}` : '');
+    const raw = sellerCode || buildNaverExternalProductKey(productNumber) || '';
     const normalized = raw.trim();
     return normalized || null;
   }
@@ -683,22 +675,11 @@ export class SmartStoreProductImportService {
   }
 
   private cellToString(value: ExcelJS.CellValue): string {
-    if (value === null || value === undefined) return '';
-    if (value instanceof Date) return value.toISOString();
-    if (typeof value === 'object') {
-      if ('text' in value && typeof value.text === 'string') return value.text;
-      if ('result' in value) return this.cellToString(value.result as ExcelJS.CellValue);
-      if ('richText' in value && Array.isArray(value.richText)) {
-        return value.richText.map((part) => part.text).join('');
-      }
-      if ('hyperlink' in value && typeof value.hyperlink === 'string') return value.hyperlink;
-      return String(value);
-    }
-    return String(value);
+    return cellToString(value);
   }
 
   private normalizeHeader(header: string): string {
-    return header.replace(/[\s_()\[\]{}./-]/g, '').toLowerCase();
+    return normalizeExcelHeader(header);
   }
 
   private parseMoney(value: string): number | null {

--- a/backend/src/modules/reviews/__tests__/smartstore-review-import.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/smartstore-review-import.service.spec.ts
@@ -1,0 +1,257 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as ExcelJS from 'exceljs';
+import { SmartStoreReviewImportService } from '../smartstore-review-import.service';
+import { Product } from '../../products/entities/product.entity';
+import { ExternalReview } from '../entities/external-review.entity';
+import { RemoteImageIngestService } from '../../upload/remote-image-ingest.service';
+import { NAVER_SMARTSTORE_REVIEW_SOURCE } from '../../../common/imports/external-source.util';
+
+function makeFile(buffer: Buffer): Express.Multer.File {
+  return {
+    originalname: 'review.xlsx',
+    mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    buffer,
+    size: buffer.length,
+  } as Express.Multer.File;
+}
+
+async function makeWorkbook(rows: Array<Array<string | number>>): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet('reviews');
+  rows.forEach((row) => sheet.addRow(row));
+  const buffer = await workbook.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}
+
+const header = [
+  '상품번호',
+  '상품명',
+  '리뷰구분',
+  '구매자평점',
+  '포토/영상',
+  '리뷰상세내용',
+  '리뷰도움수',
+  '등록자',
+  '리뷰등록일',
+  '최종수정일',
+  '리뷰글번호',
+  '관련리뷰글번호',
+  '관련리뷰상세내용',
+  '전시상태',
+  '답글여부',
+  '답글등록일시',
+  '베스트리뷰',
+  '베스트리뷰선정일시',
+  '이벤트번호',
+  '혜택지급',
+  '혜택지급일시',
+  '유저정보 등록 항목',
+  '상품주문번호',
+  '풀필먼트사',
+  '리뷰이동일',
+];
+
+describe('SmartStoreReviewImportService', () => {
+  let service: SmartStoreReviewImportService;
+
+  const productRepository = {
+    find: jest.fn(),
+    manager: { query: jest.fn() },
+  };
+  const externalReviewRepository = {
+    find: jest.fn(),
+    create: jest.fn((value: Partial<ExternalReview>) => value),
+    save: jest.fn(async (value: Partial<ExternalReview>) => ({ id: 10, ...value })),
+  };
+  const remoteImageIngestService = {
+    ingest: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SmartStoreReviewImportService,
+        { provide: getRepositoryToken(Product), useValue: productRepository },
+        { provide: getRepositoryToken(ExternalReview), useValue: externalReviewRepository },
+        { provide: RemoteImageIngestService, useValue: remoteImageIngestService },
+      ],
+    }).compile();
+
+    service = module.get(SmartStoreReviewImportService);
+    jest.clearAllMocks();
+    productRepository.find.mockResolvedValue([
+      { id: 7, sku: 'naver-13629303355', name: '옥화당 자사호' },
+    ]);
+    externalReviewRepository.find.mockResolvedValue([]);
+    remoteImageIngestService.ingest.mockResolvedValue({
+      url: 'https://cdn.example.com/reviews/naver.jpg',
+      filename: 'reviews/naver.jpg',
+    });
+    productRepository.manager.query.mockResolvedValue(undefined);
+  });
+
+  it('previews SmartStore review rows and matches products by naver-prefixed SKU', async () => {
+    const file = makeFile(
+      await makeWorkbook([
+        header,
+        [
+          '13629303355',
+          '옥화당 자사호',
+          '일반',
+          5,
+          'https://phinf.pstatic.net/review.jpg',
+          '&quot;좋아요&quot; &hellip;',
+          3,
+          'da**',
+          '2026.06.27. 16:37:03',
+          '',
+          '5008298806',
+          '',
+          '',
+          '정상',
+          'N',
+          '',
+          'Y',
+          '2026.06.28',
+          '',
+          '',
+          '',
+          '',
+          '2026062172779571',
+          '',
+          '',
+        ],
+      ]),
+    );
+
+    const result = await service.preview(file);
+
+    expect(productRepository.find).toHaveBeenCalledWith({
+      where: { sku: expect.objectContaining({ _value: ['naver-13629303355'] }) },
+    });
+    expect(result.rows[0]).toMatchObject({
+      externalReviewId: '5008298806',
+      externalProductKey: 'naver-13629303355',
+      matchedProductId: 7,
+      action: 'create',
+      status: 'valid',
+      rating: 5,
+      mediaCount: 1,
+      isVisible: true,
+    });
+    expect(remoteImageIngestService.ingest).not.toHaveBeenCalled();
+  });
+
+  it('commits rows with S3 media, upserts by review id, and preserves manual visibility on update', async () => {
+    externalReviewRepository.find.mockResolvedValue([
+      {
+        id: 44,
+        source: 'smartstore',
+        externalReviewId: '5008298806',
+        productId: 7,
+        isVisible: false,
+      },
+    ]);
+    const file = makeFile(
+      await makeWorkbook([
+        header,
+        [
+          '13629303355',
+          '옥화당 자사호',
+          '일반',
+          5,
+          'https://phinf.pstatic.net/review.jpg',
+          '좋아요',
+          1,
+          'da**',
+          '2026.06.27. 16:37:03',
+          '',
+          '5008298806',
+          '',
+          '',
+          '정상',
+          'N',
+          '',
+          'N',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '2026062172779571',
+          '',
+          '',
+        ],
+      ]),
+    );
+
+    const result = await service.commit(file);
+
+    expect(result.summary).toMatchObject({
+      totalRows: 1,
+      updateCount: 1,
+      successCount: 1,
+      mediaFailureCount: 0,
+    });
+    expect(externalReviewRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 44,
+        source: NAVER_SMARTSTORE_REVIEW_SOURCE,
+        productId: 7,
+        externalReviewId: '5008298806',
+        isVisible: false,
+        imageUrls: ['https://cdn.example.com/reviews/naver.jpg'],
+        mediaAssets: [
+          expect.objectContaining({
+            originalUrl: 'https://phinf.pstatic.net/review.jpg',
+            status: 'uploaded',
+          }),
+        ],
+      }),
+    );
+    expect(productRepository.manager.query).toHaveBeenCalled();
+  });
+
+  it('reports row failures without aborting the whole upload', async () => {
+    productRepository.find.mockResolvedValue([]);
+    const file = makeFile(
+      await makeWorkbook([
+        header,
+        [
+          '999',
+          '알 수 없는 상품',
+          '일반',
+          5,
+          '',
+          '좋아요',
+          '',
+          'da**',
+          '2026.06.27. 16:37:03',
+          '',
+          '5008298806',
+        ],
+        [
+          '13629303355',
+          '옥화당 자사호',
+          '일반',
+          5,
+          '',
+          '좋아요',
+          '',
+          'da**',
+          '2026.06.27. 16:37:03',
+          '',
+          '',
+        ],
+      ]),
+    );
+
+    const result = await service.preview(file);
+
+    expect(result.summary.failureCount).toBe(2);
+    expect(result.summary.unmatchedProductCount).toBe(2);
+    expect(result.rows[0].errors.join(' ')).toContain('상품번호와 연결된 상품을 찾을 수 없습니다');
+    expect(result.rows[1].errors.join(' ')).toContain('리뷰글번호가 필요합니다');
+  });
+});

--- a/backend/src/modules/reviews/admin-reviews.controller.ts
+++ b/backend/src/modules/reviews/admin-reviews.controller.ts
@@ -1,0 +1,129 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  ApiBody,
+  ApiConsumes,
+  ApiCookieAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { createSingleFileMemoryUploadOptions } from '../../common/multer/single-file-upload.options';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { AdminReviewQueryDto } from './dto/admin-review-query.dto';
+import {
+  BulkUpdateReviewVisibilityDto,
+  UpdateReviewVisibilityDto,
+} from './dto/update-review-visibility.dto';
+import { AdminReviewsService } from './admin-reviews.service';
+import { SmartStoreReviewImportService } from './smartstore-review-import.service';
+
+const REVIEW_IMPORT_INTERCEPTOR = FileInterceptor(
+  'file',
+  createSingleFileMemoryUploadOptions({ fileSize: 10 * 1024 * 1024 }),
+);
+
+@ApiTags('관리자 - 리뷰')
+@Controller('admin/reviews')
+@Roles('admin', 'super_admin')
+export class AdminReviewsController {
+  constructor(
+    private readonly adminReviewsService: AdminReviewsService,
+    private readonly smartStoreReviewImportService: SmartStoreReviewImportService,
+  ) {}
+
+  @Get()
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '관리자 리뷰 목록 조회',
+    description: '스마트스토어 외부 리뷰를 검색/필터링하여 조회합니다.',
+  })
+  @ApiResponse({ status: 200, description: '관리자 리뷰 목록 조회 성공' })
+  findAll(@Query() query: AdminReviewQueryDto) {
+    return this.adminReviewsService.findAll(query);
+  }
+
+  @Post('imports/smartstore/preview')
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '스마트스토어 리뷰 엑셀 미리보기',
+    description: '스마트스토어 리뷰 엑셀 파일을 검증하고 상품 매칭/반영 예정 내역을 반환합니다.',
+  })
+  @ApiResponse({ status: 201, description: '리뷰 가져오기 미리보기 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 파일 또는 리뷰 데이터' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  @UseInterceptors(REVIEW_IMPORT_INTERCEPTOR)
+  previewSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
+    return this.smartStoreReviewImportService.preview(file);
+  }
+
+  @Post('imports/smartstore/commit')
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '스마트스토어 리뷰 엑셀 반영',
+    description:
+      '검증된 스마트스토어 리뷰 엑셀 파일을 상품에 연결하고 사진을 S3/스토리지에 적재합니다.',
+  })
+  @ApiResponse({ status: 201, description: '리뷰 가져오기 반영 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 파일 또는 리뷰 데이터' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  @UseInterceptors(REVIEW_IMPORT_INTERCEPTOR)
+  commitSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
+    return this.smartStoreReviewImportService.commit(file);
+  }
+
+  @Post('bulk-visibility')
+  @HttpCode(HttpStatus.OK)
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '리뷰 일괄 숨김/노출 처리' })
+  @ApiResponse({ status: 200, description: '일괄 처리 성공' })
+  bulkSetVisibility(@Body() dto: BulkUpdateReviewVisibilityDto) {
+    return this.adminReviewsService.bulkSetVisibility(dto.ids, dto.isVisible);
+  }
+
+  @Get(':id')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '관리자 리뷰 상세 조회' })
+  @ApiResponse({ status: 200, description: '관리자 리뷰 상세 조회 성공' })
+  @ApiParam({ name: 'id', type: Number, description: '외부 리뷰 ID' })
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.adminReviewsService.findOne(id);
+  }
+
+  @Patch(':id/visibility')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '리뷰 숨김/노출 처리' })
+  @ApiResponse({ status: 200, description: '리뷰 숨김/노출 처리 성공' })
+  @ApiParam({ name: 'id', type: Number, description: '외부 리뷰 ID' })
+  setVisibility(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateReviewVisibilityDto) {
+    return this.adminReviewsService.setVisibility(id, dto.isVisible);
+  }
+}

--- a/backend/src/modules/reviews/admin-reviews.service.ts
+++ b/backend/src/modules/reviews/admin-reviews.service.ts
@@ -1,0 +1,224 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Brackets, In, Repository, SelectQueryBuilder } from 'typeorm';
+import { AdminReviewQueryDto } from './dto/admin-review-query.dto';
+import { ExternalReview } from './entities/external-review.entity';
+
+export interface AdminReviewProductSummary {
+  id: number;
+  name: string;
+  sku: string | null;
+}
+
+export interface AdminReviewItem {
+  id: number;
+  source: string;
+  externalReviewId: string;
+  externalProductId: string | null;
+  product: AdminReviewProductSummary | null;
+  reviewType: string | null;
+  rating: number;
+  content: string | null;
+  reviewerNameMasked: string;
+  helpfulCount: number;
+  imageUrls: string[] | null;
+  mediaCount: number;
+  mediaFailureCount: number;
+  sourceDisplayStatus: string | null;
+  isVisible: boolean;
+  isBest: boolean;
+  reviewedAt: Date;
+  sourceUpdatedAt: Date | null;
+  lastSyncedAt: Date;
+  importBatchId: string | null;
+  orderNo: string | null;
+  relatedReviewExternalId: string | null;
+  relatedReviewContent: string | null;
+}
+
+export interface AdminReviewListResult {
+  items: AdminReviewItem[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+@Injectable()
+export class AdminReviewsService {
+  constructor(
+    @InjectRepository(ExternalReview)
+    private readonly externalReviewRepository: Repository<ExternalReview>,
+  ) {}
+
+  async findAll(query: AdminReviewQueryDto): Promise<AdminReviewListResult> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const qb = this.externalReviewRepository
+      .createQueryBuilder('review')
+      .leftJoinAndSelect('review.product', 'product');
+
+    this.applyFilters(qb, query);
+    this.applySort(qb, query);
+    qb.skip((page - 1) * limit).take(limit);
+
+    const [reviews, total] = await qb.getManyAndCount();
+    return {
+      items: reviews.map((review) => this.toItem(review)),
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async findOne(id: number): Promise<AdminReviewItem> {
+    const review = await this.externalReviewRepository.findOne({
+      where: { id },
+      relations: ['product'],
+    });
+    if (!review) {
+      throw new NotFoundException('리뷰를 찾을 수 없습니다.');
+    }
+    return this.toItem(review);
+  }
+
+  async setVisibility(id: number, isVisible: boolean): Promise<AdminReviewItem> {
+    const review = await this.externalReviewRepository.findOne({
+      where: { id },
+      relations: ['product'],
+    });
+    if (!review) {
+      throw new NotFoundException('리뷰를 찾을 수 없습니다.');
+    }
+    review.isVisible = isVisible;
+    const saved = await this.externalReviewRepository.save(review);
+    await this.refreshProductReviewStats(Number(saved.productId));
+    return this.toItem(saved);
+  }
+
+  async bulkSetVisibility(ids: number[], isVisible: boolean): Promise<{ updated: number }> {
+    if (ids.length === 0) return { updated: 0 };
+    const reviews = await this.externalReviewRepository.find({
+      select: ['id', 'productId'],
+      where: { id: In(ids) },
+    });
+    const result = await this.externalReviewRepository.update({ id: In(ids) }, { isVisible });
+    await Promise.all(
+      [...new Set(reviews.map((review) => Number(review.productId)))].map((productId) =>
+        this.refreshProductReviewStats(productId),
+      ),
+    );
+    return { updated: result.affected ?? 0 };
+  }
+
+  private async refreshProductReviewStats(productId: number): Promise<void> {
+    await this.externalReviewRepository.manager.query(
+      `UPDATE products p
+       LEFT JOIN (
+         SELECT product_id, COUNT(*) AS review_count, COALESCE(AVG(rating), 0) AS avg_rating
+         FROM (
+           SELECT product_id, rating FROM reviews WHERE product_id = ? AND is_visible = 1
+           UNION ALL
+           SELECT product_id, rating FROM external_reviews WHERE product_id = ? AND is_visible = 1
+         ) all_reviews
+         GROUP BY product_id
+       ) rs ON rs.product_id = p.id
+       SET p.review_count = COALESCE(rs.review_count, 0),
+           p.avg_rating = COALESCE(rs.avg_rating, 0)
+       WHERE p.id = ?`,
+      [productId, productId, productId],
+    );
+  }
+
+  private applyFilters(qb: SelectQueryBuilder<ExternalReview>, query: AdminReviewQueryDto): void {
+    const search = query.search?.trim();
+    if (search) {
+      qb.andWhere(
+        new Brackets((sub) => {
+          sub
+            .where('review.external_review_id LIKE :search', { search: `%${search}%` })
+            .orWhere('review.external_product_id LIKE :search', { search: `%${search}%` })
+            .orWhere('review.reviewer_name_masked LIKE :search', { search: `%${search}%` })
+            .orWhere('review.content LIKE :search', { search: `%${search}%` })
+            .orWhere('product.name LIKE :search', { search: `%${search}%` })
+            .orWhere('product.sku LIKE :search', { search: `%${search}%` });
+        }),
+      );
+    }
+
+    if (query.visibility === 'visible') {
+      qb.andWhere('review.is_visible = :visible', { visible: true });
+    }
+    if (query.visibility === 'hidden') {
+      qb.andWhere('review.is_visible = :visible', { visible: false });
+    }
+    if (query.rating) {
+      qb.andWhere('review.rating = :rating', { rating: query.rating });
+    }
+    if (query.reviewType?.trim()) {
+      qb.andWhere('review.review_type = :reviewType', { reviewType: query.reviewType.trim() });
+    }
+    if (query.importBatchId?.trim()) {
+      qb.andWhere('review.import_batch_id = :importBatchId', {
+        importBatchId: query.importBatchId.trim(),
+      });
+    }
+    if (query.hasMedia === 'true') {
+      qb.andWhere('review.image_urls IS NOT NULL AND JSON_LENGTH(review.image_urls) > 0');
+    }
+    if (query.hasMedia === 'false') {
+      qb.andWhere('(review.image_urls IS NULL OR JSON_LENGTH(review.image_urls) = 0)');
+    }
+  }
+
+  private applySort(qb: SelectQueryBuilder<ExternalReview>, query: AdminReviewQueryDto): void {
+    const order = String(query.order ?? 'DESC').toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
+    switch (query.sort ?? 'reviewedAt') {
+      case 'rating':
+        qb.orderBy('review.rating', order).addOrderBy('review.reviewed_at', 'DESC');
+        break;
+      case 'helpful':
+        qb.orderBy('review.helpful_count', order).addOrderBy('review.reviewed_at', 'DESC');
+        break;
+      case 'importedAt':
+        qb.orderBy('review.last_synced_at', order).addOrderBy('review.reviewed_at', 'DESC');
+        break;
+      default:
+        qb.orderBy('review.reviewed_at', order);
+    }
+  }
+
+  private toItem(review: ExternalReview): AdminReviewItem {
+    const mediaAssets = review.mediaAssets ?? [];
+    return {
+      id: Number(review.id),
+      source: review.source,
+      externalReviewId: review.externalReviewId,
+      externalProductId: review.externalProductId,
+      product: review.product
+        ? {
+            id: Number(review.product.id),
+            name: review.product.name,
+            sku: review.product.sku,
+          }
+        : null,
+      reviewType: review.reviewType,
+      rating: review.rating,
+      content: review.content,
+      reviewerNameMasked: review.reviewerNameMasked,
+      helpfulCount: review.helpfulCount,
+      imageUrls: review.imageUrls,
+      mediaCount: mediaAssets.length || review.imageUrls?.length || 0,
+      mediaFailureCount: mediaAssets.filter((asset) => asset.status === 'failed').length,
+      sourceDisplayStatus: review.sourceDisplayStatus,
+      isVisible: review.isVisible,
+      isBest: review.isBest,
+      reviewedAt: review.reviewedAt,
+      sourceUpdatedAt: review.sourceUpdatedAt,
+      lastSyncedAt: review.lastSyncedAt,
+      importBatchId: review.importBatchId,
+      orderNo: review.orderNo,
+      relatedReviewExternalId: review.relatedReviewExternalId,
+      relatedReviewContent: review.relatedReviewContent,
+    };
+  }
+}

--- a/backend/src/modules/reviews/dto/admin-review-query.dto.ts
+++ b/backend/src/modules/reviews/dto/admin-review-query.dto.ts
@@ -1,0 +1,72 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsBooleanString, IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export type AdminReviewVisibilityFilter = 'all' | 'visible' | 'hidden';
+export type AdminReviewSort = 'reviewedAt' | 'rating' | 'helpful' | 'importedAt';
+
+export class AdminReviewQueryDto {
+  @ApiPropertyOptional({ example: 1, description: '페이지 번호' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ example: 20, description: '페이지당 개수' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    example: '연자호',
+    description: '상품명/상품번호/리뷰글번호/등록자/본문 검색어',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ enum: ['all', 'visible', 'hidden'], description: '노출 상태 필터' })
+  @IsOptional()
+  @IsIn(['all', 'visible', 'hidden'])
+  visibility?: AdminReviewVisibilityFilter;
+
+  @ApiPropertyOptional({ example: 5, description: '평점 필터' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating?: number;
+
+  @ApiPropertyOptional({ example: '일반', description: '리뷰구분 필터' })
+  @IsOptional()
+  @IsString()
+  reviewType?: string;
+
+  @ApiPropertyOptional({ example: true, description: '포토/영상 여부 필터' })
+  @IsOptional()
+  @IsBooleanString()
+  hasMedia?: string;
+
+  @ApiPropertyOptional({ example: 'naver-review-20260703-abc123', description: '업로드 배치 ID' })
+  @IsOptional()
+  @IsString()
+  importBatchId?: string;
+
+  @ApiPropertyOptional({
+    enum: ['reviewedAt', 'rating', 'helpful', 'importedAt'],
+    description: '정렬 기준',
+  })
+  @IsOptional()
+  @IsIn(['reviewedAt', 'rating', 'helpful', 'importedAt'])
+  sort?: AdminReviewSort;
+
+  @ApiPropertyOptional({ enum: ['ASC', 'DESC'], description: '정렬 방향' })
+  @IsOptional()
+  @IsIn(['ASC', 'DESC', 'asc', 'desc'])
+  order?: 'ASC' | 'DESC' | 'asc' | 'desc';
+}

--- a/backend/src/modules/reviews/dto/update-review-visibility.dto.ts
+++ b/backend/src/modules/reviews/dto/update-review-visibility.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMaxSize, IsArray, IsBoolean, IsInt } from 'class-validator';
+
+export class UpdateReviewVisibilityDto {
+  @ApiProperty({ example: true, description: '노출 여부' })
+  @IsBoolean()
+  isVisible!: boolean;
+}
+
+export class BulkUpdateReviewVisibilityDto extends UpdateReviewVisibilityDto {
+  @ApiProperty({ example: [1, 2, 3], description: '외부 리뷰 ID 목록' })
+  @IsArray()
+  @ArrayMaxSize(200)
+  @IsInt({ each: true })
+  ids!: number[];
+}

--- a/backend/src/modules/reviews/entities/external-review.entity.ts
+++ b/backend/src/modules/reviews/entities/external-review.entity.ts
@@ -9,12 +9,25 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { Product } from '../../products/entities/product.entity';
+import type { SmartStoreReviewSource } from '../../../common/imports/external-source.util';
 
-export type ExternalReviewSource = 'smartstore';
+export type ExternalReviewSource = SmartStoreReviewSource;
+
+export type ExternalReviewMediaStatus = 'uploaded' | 'failed';
+
+export interface ExternalReviewMediaAsset {
+  type: 'image' | 'video' | 'unknown';
+  originalUrl: string;
+  s3Url: string | null;
+  s3Key: string | null;
+  status: ExternalReviewMediaStatus;
+  error?: string;
+}
 
 @Entity('external_reviews')
 @Index(['productId'])
 @Index(['source', 'externalReviewId'], { unique: true })
+@Index(['importBatchId'])
 export class ExternalReview {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id!: number;
@@ -31,6 +44,9 @@ export class ExternalReview {
   @Column({ name: 'external_product_id', type: 'varchar', length: 128, nullable: true })
   externalProductId!: string | null;
 
+  @Column({ name: 'review_type', type: 'varchar', length: 40, nullable: true })
+  reviewType!: string | null;
+
   @Column({ type: 'tinyint', unsigned: true })
   rating!: number;
 
@@ -40,14 +56,52 @@ export class ExternalReview {
   @Column({ name: 'image_urls', type: 'json', nullable: true })
   imageUrls!: string[] | null;
 
-  @Column({ name: 'reviewer_name_masked', type: 'varchar', length: 80, default: '스마트스토어 구매자' })
+  @Column({ name: 'media_assets', type: 'json', nullable: true })
+  mediaAssets!: ExternalReviewMediaAsset[] | null;
+
+  @Column({
+    name: 'reviewer_name_masked',
+    type: 'varchar',
+    length: 80,
+    default: '스마트스토어 구매자',
+  })
   reviewerNameMasked!: string;
+
+  @Column({ name: 'helpful_count', type: 'int', unsigned: true, default: 0 })
+  helpfulCount!: number;
+
+  @Column({ name: 'source_display_status', type: 'varchar', length: 40, nullable: true })
+  sourceDisplayStatus!: string | null;
 
   @Column({ name: 'is_visible', type: 'boolean', default: true })
   isVisible!: boolean;
 
+  @Column({ name: 'is_best', type: 'boolean', default: false })
+  isBest!: boolean;
+
+  @Column({ name: 'best_selected_at', type: 'datetime', nullable: true })
+  bestSelectedAt!: Date | null;
+
+  @Column({ name: 'related_review_external_id', type: 'varchar', length: 128, nullable: true })
+  relatedReviewExternalId!: string | null;
+
+  @Column({ name: 'related_review_content', type: 'text', nullable: true })
+  relatedReviewContent!: string | null;
+
+  @Column({ name: 'order_no', type: 'varchar', length: 128, nullable: true })
+  orderNo!: string | null;
+
+  @Column({ name: 'raw_data', type: 'json', nullable: true })
+  rawData!: Record<string, string | null> | null;
+
+  @Column({ name: 'import_batch_id', type: 'varchar', length: 64, nullable: true })
+  importBatchId!: string | null;
+
   @Column({ name: 'reviewed_at', type: 'datetime' })
   reviewedAt!: Date;
+
+  @Column({ name: 'source_updated_at', type: 'datetime', nullable: true })
+  sourceUpdatedAt!: Date | null;
 
   @Column({ name: 'last_synced_at', type: 'datetime' })
   lastSyncedAt!: Date;

--- a/backend/src/modules/reviews/reviews.module.ts
+++ b/backend/src/modules/reviews/reviews.module.ts
@@ -4,21 +4,25 @@ import { Review } from './entities/review.entity';
 import { ExternalReview } from './entities/external-review.entity';
 import { OrderItem } from '../orders/entities/order-item.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
+import { Product } from '../products/entities/product.entity';
 import { ReviewsController } from './reviews.controller';
+import { AdminReviewsController } from './admin-reviews.controller';
 import { ReviewsService } from './reviews.service';
+import { AdminReviewsService } from './admin-reviews.service';
+import { SmartStoreReviewImportService } from './smartstore-review-import.service';
 import { UploadModule } from '../upload/upload.module';
 import { SettingsModule } from '../settings/settings.module';
 import { PointsModule } from '../points/points.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Review, ExternalReview, OrderItem, PointHistory]),
+    TypeOrmModule.forFeature([Review, ExternalReview, OrderItem, PointHistory, Product]),
     UploadModule,
     SettingsModule,
     PointsModule,
   ],
-  controllers: [ReviewsController],
-  providers: [ReviewsService],
-  exports: [ReviewsService],
+  controllers: [ReviewsController, AdminReviewsController],
+  providers: [ReviewsService, AdminReviewsService, SmartStoreReviewImportService],
+  exports: [ReviewsService, AdminReviewsService, SmartStoreReviewImportService],
 })
 export class ReviewsModule {}

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -145,11 +145,15 @@ export class ReviewsService {
     switch (sort) {
       case 'rating_high':
         qb.orderBy('review.rating', 'DESC').addOrderBy('review.createdAt', 'DESC');
-        externalQb.orderBy('externalReview.rating', 'DESC').addOrderBy('externalReview.reviewedAt', 'DESC');
+        externalQb
+          .orderBy('externalReview.rating', 'DESC')
+          .addOrderBy('externalReview.reviewedAt', 'DESC');
         break;
       case 'rating_low':
         qb.orderBy('review.rating', 'ASC').addOrderBy('review.createdAt', 'DESC');
-        externalQb.orderBy('externalReview.rating', 'ASC').addOrderBy('externalReview.reviewedAt', 'DESC');
+        externalQb
+          .orderBy('externalReview.rating', 'ASC')
+          .addOrderBy('externalReview.reviewedAt', 'DESC');
         break;
       default:
         qb.orderBy('review.createdAt', 'DESC');
@@ -172,7 +176,11 @@ export class ReviewsService {
     };
   }
 
-  private compareReviews(a: ReviewResponse, b: ReviewResponse, sort: ReviewQueryDto['sort']): number {
+  private compareReviews(
+    a: ReviewResponse,
+    b: ReviewResponse,
+    sort: ReviewQueryDto['sort'],
+  ): number {
     if (sort === 'rating_high' && b.rating !== a.rating) return b.rating - a.rating;
     if (sort === 'rating_low' && a.rating !== b.rating) return a.rating - b.rating;
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -344,10 +352,17 @@ export class ReviewsService {
       return saved;
     });
 
-    this.logger.log(`Review created: id=${result.id}, userId=${userId}, productId=${dto.productId}`);
+    this.logger.log(
+      `Review created: id=${result.id}, userId=${userId}, productId=${dto.productId}`,
+    );
 
     // Reload with user
-    const loaded = await findOrThrow(this.reviewRepo, { id: result.id }, '리뷰를 찾을 수 없습니다.', ['user']);
+    const loaded = await findOrThrow(
+      this.reviewRepo,
+      { id: result.id },
+      '리뷰를 찾을 수 없습니다.',
+      ['user'],
+    );
 
     return this.toResponse(loaded);
   }
@@ -371,7 +386,11 @@ export class ReviewsService {
   async remove(id: number, userId: number, userRole: string): Promise<void> {
     const review = await findOrThrow(this.reviewRepo, { id }, '리뷰를 찾을 수 없습니다.');
 
-    if (Number(review.userId) !== Number(userId) && userRole !== 'admin' && userRole !== 'super_admin') {
+    if (
+      Number(review.userId) !== Number(userId) &&
+      userRole !== 'admin' &&
+      userRole !== 'super_admin'
+    ) {
       throw new ForbiddenException('권한이 없습니다.');
     }
 
@@ -434,14 +453,17 @@ export class ReviewsService {
       `UPDATE products p
        LEFT JOIN (
          SELECT product_id, COUNT(*) AS review_count, COALESCE(AVG(rating), 0) AS avg_rating
-         FROM reviews
-         WHERE product_id = ? AND is_visible = 1
+         FROM (
+           SELECT product_id, rating FROM reviews WHERE product_id = ? AND is_visible = 1
+           UNION ALL
+           SELECT product_id, rating FROM external_reviews WHERE product_id = ? AND is_visible = 1
+         ) all_reviews
          GROUP BY product_id
        ) rs ON rs.product_id = p.id
        SET p.review_count = COALESCE(rs.review_count, 0),
            p.avg_rating = COALESCE(rs.avg_rating, 0)
        WHERE p.id = ?`,
-      [productId, productId],
+      [productId, productId, productId],
     );
   }
 }

--- a/backend/src/modules/reviews/smartstore-review-import.service.ts
+++ b/backend/src/modules/reviews/smartstore-review-import.service.ts
@@ -1,0 +1,651 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as ExcelJS from 'exceljs';
+import { In, Repository } from 'typeorm';
+import {
+  assertXlsxFile,
+  cellToString,
+  normalizeExcelHeader,
+  splitExcelList,
+} from '../../common/imports/excel-import.util';
+import {
+  buildNaverExternalProductKey,
+  LEGACY_SMARTSTORE_REVIEW_SOURCE,
+  NAVER_SMARTSTORE_REVIEW_SOURCE,
+} from '../../common/imports/external-source.util';
+import { Product } from '../products/entities/product.entity';
+import { RemoteImageIngestService } from '../upload/remote-image-ingest.service';
+import { UploadedFile } from '../upload/interfaces/storage.interface';
+import { ExternalReview, ExternalReviewMediaAsset } from './entities/external-review.entity';
+
+export type SmartStoreReviewImportAction = 'create' | 'update' | 'skip';
+export type SmartStoreReviewImportStatus = 'valid' | 'failed' | 'success';
+
+export interface SmartStoreReviewImportRowResult {
+  rowNumber: number;
+  externalReviewId: string | null;
+  externalProductId: string | null;
+  externalProductKey: string | null;
+  productName: string | null;
+  matchedProductId?: number;
+  action: SmartStoreReviewImportAction;
+  status: SmartStoreReviewImportStatus;
+  rating: number | null;
+  reviewType: string | null;
+  reviewedAt: string | null;
+  mediaCount: number;
+  mediaSuccessCount: number;
+  mediaFailureCount: number;
+  isVisible: boolean | null;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface SmartStoreReviewImportResult {
+  importBatchId: string | null;
+  summary: {
+    totalRows: number;
+    createCount: number;
+    updateCount: number;
+    skipCount: number;
+    successCount: number;
+    failureCount: number;
+    unmatchedProductCount: number;
+    mediaFailureCount: number;
+  };
+  rows: SmartStoreReviewImportRowResult[];
+}
+
+interface ParsedReviewRow {
+  rowNumber: number;
+  externalReviewId: string | null;
+  externalProductId: string | null;
+  externalProductKey: string | null;
+  productName: string | null;
+  reviewType: string | null;
+  rating: number | null;
+  mediaUrls: string[];
+  content: string | null;
+  helpfulCount: number;
+  reviewerNameMasked: string | null;
+  reviewedAt: Date | null;
+  sourceUpdatedAt: Date | null;
+  sourceDisplayStatus: string | null;
+  isVisible: boolean | null;
+  isBest: boolean;
+  bestSelectedAt: Date | null;
+  relatedReviewExternalId: string | null;
+  relatedReviewContent: string | null;
+  orderNo: string | null;
+  rawData: Record<string, string | null>;
+  errors: string[];
+}
+
+type HeaderKey =
+  | 'externalProductId'
+  | 'productName'
+  | 'reviewType'
+  | 'rating'
+  | 'mediaUrls'
+  | 'content'
+  | 'helpfulCount'
+  | 'reviewerNameMasked'
+  | 'reviewedAt'
+  | 'sourceUpdatedAt'
+  | 'externalReviewId'
+  | 'relatedReviewExternalId'
+  | 'relatedReviewContent'
+  | 'sourceDisplayStatus'
+  | 'replyEnabled'
+  | 'replyCreatedAt'
+  | 'isBest'
+  | 'bestSelectedAt'
+  | 'benefit'
+  | 'benefitGivenAt'
+  | 'orderNo';
+
+type HeaderMap = Partial<Record<HeaderKey, number>>;
+
+const HEADER_ALIASES: Record<HeaderKey, readonly string[]> = {
+  externalProductId: ['상품번호', '스마트스토어 상품번호', '네이버상품번호'],
+  productName: ['상품명', '상품 이름', '제품명'],
+  reviewType: ['리뷰구분', '리뷰 구분'],
+  rating: ['구매자평점', '평점', '별점'],
+  mediaUrls: ['포토/영상', '포토영상', '사진/동영상', '이미지 URL'],
+  content: ['리뷰상세내용', '리뷰 상세내용', '리뷰내용', '내용'],
+  helpfulCount: ['리뷰도움수', '도움수'],
+  reviewerNameMasked: ['등록자', '작성자', '구매자'],
+  reviewedAt: ['리뷰등록일', '리뷰 등록일', '작성일'],
+  sourceUpdatedAt: ['최종수정일', '최종 수정일', '수정일'],
+  externalReviewId: ['리뷰글번호', '리뷰 글번호', '리뷰번호'],
+  relatedReviewExternalId: ['관련리뷰글번호', '관련 리뷰글번호'],
+  relatedReviewContent: ['관련리뷰상세내용', '관련 리뷰상세내용'],
+  sourceDisplayStatus: ['전시상태', '전시 상태'],
+  replyEnabled: ['답글여부', '답글 여부'],
+  replyCreatedAt: ['답글등록일시', '답글 등록일시'],
+  isBest: ['베스트리뷰', '베스트 리뷰'],
+  bestSelectedAt: ['베스트리뷰선정일시', '베스트 리뷰 선정일시'],
+  benefit: ['혜택지급', '혜택 지급'],
+  benefitGivenAt: ['혜택지급일시', '혜택 지급일시'],
+  orderNo: ['상품주문번호', '상품 주문번호'],
+};
+
+const MAX_IMPORT_ROWS = 2000;
+const DEFAULT_REVIEWER_NAME = '스마트스토어 구매자';
+
+@Injectable()
+export class SmartStoreReviewImportService {
+  private readonly logger = new Logger(SmartStoreReviewImportService.name);
+
+  constructor(
+    @InjectRepository(Product)
+    private readonly productRepository: Repository<Product>,
+    @InjectRepository(ExternalReview)
+    private readonly externalReviewRepository: Repository<ExternalReview>,
+    private readonly remoteImageIngestService: RemoteImageIngestService,
+  ) {}
+
+  async preview(file: Express.Multer.File): Promise<SmartStoreReviewImportResult> {
+    return this.process(file, false);
+  }
+
+  async commit(file: Express.Multer.File): Promise<SmartStoreReviewImportResult> {
+    return this.process(file, true);
+  }
+
+  private async process(
+    file: Express.Multer.File,
+    commit: boolean,
+  ): Promise<SmartStoreReviewImportResult> {
+    assertXlsxFile(file, '스마트스토어 리뷰');
+    const parsedRows = await this.parseWorkbook(file.buffer);
+    const duplicates = this.findDuplicates(
+      parsedRows.map((row) => row.externalReviewId).filter((id): id is string => Boolean(id)),
+    );
+    const productsBySku = await this.findProductsByExternalKey(parsedRows);
+    const existingByReviewId = await this.findExistingReviews(parsedRows);
+    const importBatchId = commit ? this.createImportBatchId() : null;
+    const mediaCache = new Map<string, Promise<UploadedFile>>();
+    const rows: SmartStoreReviewImportRowResult[] = [];
+    const touchedProductIds = new Set<number>();
+
+    for (const parsed of parsedRows) {
+      const errors = [...parsed.errors];
+      if (parsed.externalReviewId && duplicates.has(parsed.externalReviewId)) {
+        errors.push(`파일 안에서 중복된 리뷰글번호입니다: ${parsed.externalReviewId}`);
+      }
+
+      const matchedProduct = parsed.externalProductKey
+        ? productsBySku.get(parsed.externalProductKey)
+        : undefined;
+      if (!matchedProduct) {
+        errors.push(
+          `상품번호와 연결된 상품을 찾을 수 없습니다: ${parsed.externalProductKey ?? '-'}`,
+        );
+      }
+
+      const existing = parsed.externalReviewId
+        ? existingByReviewId.get(parsed.externalReviewId)
+        : undefined;
+      const action: SmartStoreReviewImportAction =
+        errors.length > 0 ? 'skip' : existing ? 'update' : 'create';
+      const rowResult = this.toRowResult(parsed, matchedProduct?.id, action, errors);
+
+      if (commit && errors.length === 0 && matchedProduct && parsed.externalReviewId) {
+        await this.commitRow({
+          parsed,
+          existing,
+          productId: matchedProduct.id,
+          importBatchId: importBatchId!,
+          mediaCache,
+          rowResult,
+        });
+        touchedProductIds.add(Number(matchedProduct.id));
+      }
+
+      rows.push(rowResult);
+    }
+
+    if (commit && touchedProductIds.size > 0) {
+      await Promise.all(
+        [...touchedProductIds].map((productId) => this.refreshProductReviewStats(productId)),
+      );
+    }
+
+    const result = this.buildResult(importBatchId, rows);
+    if (commit) {
+      this.logger.log(
+        `SmartStore review import committed: batch=${importBatchId}, total=${result.summary.totalRows}, success=${result.summary.successCount}, failure=${result.summary.failureCount}`,
+      );
+    }
+    return result;
+  }
+
+  private async parseWorkbook(buffer: Buffer): Promise<ParsedReviewRow[]> {
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer);
+    const worksheet = workbook.worksheets[0];
+    if (!worksheet) {
+      throw new BadRequestException('리뷰 엑셀 시트를 찾을 수 없습니다.');
+    }
+
+    const headerMap = this.buildHeaderMap(worksheet.getRow(1));
+    if (!headerMap.externalProductId || !headerMap.externalReviewId || !headerMap.rating) {
+      throw new BadRequestException(
+        '필수 컬럼을 찾을 수 없습니다: 상품번호, 리뷰글번호, 구매자평점.',
+      );
+    }
+
+    const dataRowCount = Math.max(0, worksheet.rowCount - 1);
+    if (dataRowCount > MAX_IMPORT_ROWS) {
+      throw new BadRequestException(
+        `한 번에 최대 ${MAX_IMPORT_ROWS}개 리뷰까지만 업로드할 수 있습니다.`,
+      );
+    }
+
+    const rows: ParsedReviewRow[] = [];
+    for (let rowNumber = 2; rowNumber <= worksheet.rowCount; rowNumber += 1) {
+      const row = worksheet.getRow(rowNumber);
+      if (!row.hasValues) continue;
+      const parsed = this.parseRow(row, rowNumber, headerMap);
+      if (
+        parsed.externalReviewId ||
+        parsed.externalProductId ||
+        parsed.content ||
+        parsed.errors.length > 0
+      ) {
+        rows.push(parsed);
+      }
+    }
+
+    if (rows.length === 0) {
+      throw new BadRequestException('가져올 리뷰 행이 없습니다.');
+    }
+    return rows;
+  }
+
+  private buildHeaderMap(row: ExcelJS.Row): HeaderMap {
+    const headerMap: HeaderMap = {};
+    row.eachCell((cell, colNumber) => {
+      const normalized = normalizeExcelHeader(cellToString(cell.value));
+      if (!normalized) return;
+      for (const [key, aliases] of Object.entries(HEADER_ALIASES) as Array<
+        [HeaderKey, readonly string[]]
+      >) {
+        if (headerMap[key]) continue;
+        if (aliases.some((alias) => normalizeExcelHeader(alias) === normalized)) {
+          headerMap[key] = colNumber;
+        }
+      }
+    });
+    return headerMap;
+  }
+
+  private parseRow(row: ExcelJS.Row, rowNumber: number, headerMap: HeaderMap): ParsedReviewRow {
+    const externalProductId = this.getCell(row, headerMap.externalProductId);
+    const externalReviewId = this.getCell(row, headerMap.externalReviewId);
+    const rating = this.parseInteger(this.getCell(row, headerMap.rating));
+    const reviewedAt = this.parseSmartStoreDate(this.getCell(row, headerMap.reviewedAt));
+    const sourceUpdatedAt = this.parseSmartStoreDate(this.getCell(row, headerMap.sourceUpdatedAt));
+    const sourceDisplayStatus = this.getCell(row, headerMap.sourceDisplayStatus) || null;
+    const bestValue = this.getCell(row, headerMap.isBest);
+    const rawData = this.buildRawData(row, headerMap);
+    const errors: string[] = [];
+
+    if (!externalProductId) errors.push('상품번호가 필요합니다.');
+    if (!externalReviewId) errors.push('리뷰글번호가 필요합니다.');
+    if (rating === null || rating < 1 || rating > 5)
+      errors.push('구매자평점은 1~5 사이여야 합니다.');
+    if (!reviewedAt) errors.push('리뷰등록일을 해석할 수 없습니다.');
+
+    return {
+      rowNumber,
+      externalReviewId: externalReviewId || null,
+      externalProductId: externalProductId || null,
+      externalProductKey: buildNaverExternalProductKey(externalProductId),
+      productName: this.getCell(row, headerMap.productName) || null,
+      reviewType: this.getCell(row, headerMap.reviewType) || null,
+      rating,
+      mediaUrls: this.collectValidMediaUrls(this.getCell(row, headerMap.mediaUrls), errors),
+      content: decodeHtmlEntities(this.getCell(row, headerMap.content)) || null,
+      helpfulCount: this.parseInteger(this.getCell(row, headerMap.helpfulCount)) ?? 0,
+      reviewerNameMasked: this.getCell(row, headerMap.reviewerNameMasked) || null,
+      reviewedAt,
+      sourceUpdatedAt,
+      sourceDisplayStatus,
+      isVisible: sourceDisplayStatus ? this.isSourceVisible(sourceDisplayStatus) : true,
+      isBest: this.parseBooleanFlag(bestValue),
+      bestSelectedAt: this.parseSmartStoreDate(this.getCell(row, headerMap.bestSelectedAt)),
+      relatedReviewExternalId: this.getCell(row, headerMap.relatedReviewExternalId) || null,
+      relatedReviewContent:
+        decodeHtmlEntities(this.getCell(row, headerMap.relatedReviewContent)) || null,
+      orderNo: this.getCell(row, headerMap.orderNo) || null,
+      rawData,
+      errors,
+    };
+  }
+
+  private async findProductsByExternalKey(rows: ParsedReviewRow[]): Promise<Map<string, Product>> {
+    const keys = rows
+      .map((row) => row.externalProductKey)
+      .filter((key): key is string => Boolean(key));
+    const unique = [...new Set(keys)];
+    if (unique.length === 0) return new Map();
+    const products = await this.productRepository.find({ where: { sku: In(unique) } });
+    return new Map(
+      products.filter((product) => product.sku).map((product) => [product.sku as string, product]),
+    );
+  }
+
+  private async findExistingReviews(rows: ParsedReviewRow[]): Promise<Map<string, ExternalReview>> {
+    const ids = rows.map((row) => row.externalReviewId).filter((id): id is string => Boolean(id));
+    const unique = [...new Set(ids)];
+    if (unique.length === 0) return new Map();
+    const reviews = await this.externalReviewRepository.find({
+      where: {
+        source: In([NAVER_SMARTSTORE_REVIEW_SOURCE, LEGACY_SMARTSTORE_REVIEW_SOURCE]),
+        externalReviewId: In(unique),
+      },
+    });
+    return new Map(reviews.map((review) => [review.externalReviewId, review]));
+  }
+
+  private toRowResult(
+    parsed: ParsedReviewRow,
+    matchedProductId: number | undefined,
+    action: SmartStoreReviewImportAction,
+    errors: string[],
+  ): SmartStoreReviewImportRowResult {
+    return {
+      rowNumber: parsed.rowNumber,
+      externalReviewId: parsed.externalReviewId,
+      externalProductId: parsed.externalProductId,
+      externalProductKey: parsed.externalProductKey,
+      productName: parsed.productName,
+      matchedProductId,
+      action,
+      status: errors.length > 0 ? 'failed' : 'valid',
+      rating: parsed.rating,
+      reviewType: parsed.reviewType,
+      reviewedAt: parsed.reviewedAt?.toISOString() ?? null,
+      mediaCount: parsed.mediaUrls.length,
+      mediaSuccessCount: 0,
+      mediaFailureCount: 0,
+      isVisible: parsed.isVisible,
+      errors,
+      warnings: [],
+    };
+  }
+
+  private async commitRow(args: {
+    parsed: ParsedReviewRow;
+    existing: ExternalReview | undefined;
+    productId: number;
+    importBatchId: string;
+    mediaCache: Map<string, Promise<UploadedFile>>;
+    rowResult: SmartStoreReviewImportRowResult;
+  }): Promise<void> {
+    const { parsed, existing, productId, importBatchId, mediaCache, rowResult } = args;
+    const mediaAssets = await this.resolveMediaAssets(parsed.mediaUrls, mediaCache, rowResult);
+    const imageUrls = mediaAssets
+      .filter((asset) => asset.status === 'uploaded' && asset.s3Url)
+      .map((asset) => asset.s3Url as string);
+
+    const now = new Date();
+    const patch: Partial<ExternalReview> = {
+      productId,
+      source: NAVER_SMARTSTORE_REVIEW_SOURCE,
+      externalReviewId: parsed.externalReviewId!,
+      externalProductId: parsed.externalProductId,
+      reviewType: parsed.reviewType,
+      rating: parsed.rating!,
+      content: parsed.content,
+      imageUrls: imageUrls.length > 0 ? imageUrls : null,
+      mediaAssets: mediaAssets.length > 0 ? mediaAssets : null,
+      reviewerNameMasked: parsed.reviewerNameMasked?.trim() || DEFAULT_REVIEWER_NAME,
+      helpfulCount: parsed.helpfulCount,
+      sourceDisplayStatus: parsed.sourceDisplayStatus,
+      isVisible: existing ? existing.isVisible : (parsed.isVisible ?? true),
+      isBest: parsed.isBest,
+      bestSelectedAt: parsed.bestSelectedAt,
+      relatedReviewExternalId: parsed.relatedReviewExternalId,
+      relatedReviewContent: parsed.relatedReviewContent,
+      orderNo: parsed.orderNo,
+      rawData: parsed.rawData,
+      importBatchId,
+      reviewedAt: parsed.reviewedAt!,
+      sourceUpdatedAt: parsed.sourceUpdatedAt,
+      lastSyncedAt: now,
+    };
+
+    try {
+      const entity = existing
+        ? this.externalReviewRepository.create({ ...existing, ...patch })
+        : this.externalReviewRepository.create(patch);
+      const saved = await this.externalReviewRepository.save(entity);
+      rowResult.matchedProductId = Number(saved.productId);
+      rowResult.status = 'success';
+    } catch (err) {
+      rowResult.status = 'failed';
+      rowResult.action = 'skip';
+      rowResult.errors.push(err instanceof Error ? err.message : '리뷰 저장에 실패했습니다.');
+    }
+  }
+
+  private async resolveMediaAssets(
+    urls: string[],
+    cache: Map<string, Promise<UploadedFile>>,
+    rowResult: SmartStoreReviewImportRowResult,
+  ): Promise<ExternalReviewMediaAsset[]> {
+    const mediaAssets: ExternalReviewMediaAsset[] = [];
+    for (const url of urls) {
+      try {
+        const uploaded = await this.ingestCached(url, cache);
+        rowResult.mediaSuccessCount += 1;
+        mediaAssets.push({
+          type: this.guessMediaType(url),
+          originalUrl: url,
+          s3Url: uploaded.url,
+          s3Key: uploaded.filename,
+          status: 'uploaded',
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : '이미지 업로드에 실패했습니다.';
+        rowResult.mediaFailureCount += 1;
+        rowResult.warnings.push(message);
+        mediaAssets.push({
+          type: this.guessMediaType(url),
+          originalUrl: url,
+          s3Url: null,
+          s3Key: null,
+          status: 'failed',
+          error: message,
+        });
+      }
+    }
+    return mediaAssets;
+  }
+
+  private ingestCached(
+    url: string,
+    cache: Map<string, Promise<UploadedFile>>,
+  ): Promise<UploadedFile> {
+    const cached = cache.get(url);
+    if (cached) return cached;
+    const promise = this.remoteImageIngestService.ingest(url);
+    cache.set(url, promise);
+    return promise;
+  }
+
+  private async refreshProductReviewStats(productId: number): Promise<void> {
+    await this.productRepository.manager.query(
+      `UPDATE products p
+       LEFT JOIN (
+         SELECT product_id, COUNT(*) AS review_count, COALESCE(AVG(rating), 0) AS avg_rating
+         FROM (
+           SELECT product_id, rating FROM reviews WHERE product_id = ? AND is_visible = 1
+           UNION ALL
+           SELECT product_id, rating FROM external_reviews WHERE product_id = ? AND is_visible = 1
+         ) all_reviews
+         GROUP BY product_id
+       ) rs ON rs.product_id = p.id
+       SET p.review_count = COALESCE(rs.review_count, 0),
+           p.avg_rating = COALESCE(rs.avg_rating, 0)
+       WHERE p.id = ?`,
+      [productId, productId, productId],
+    );
+  }
+
+  private buildResult(
+    importBatchId: string | null,
+    rows: SmartStoreReviewImportRowResult[],
+  ): SmartStoreReviewImportResult {
+    const summary = rows.reduce(
+      (acc, row) => {
+        acc.totalRows += 1;
+        if (row.action === 'create') acc.createCount += 1;
+        if (row.action === 'update') acc.updateCount += 1;
+        if (row.action === 'skip') acc.skipCount += 1;
+        if (row.status === 'success') acc.successCount += 1;
+        if (row.status === 'failed') acc.failureCount += 1;
+        if (row.errors.some((error) => error.includes('연결된 상품을 찾을 수 없습니다'))) {
+          acc.unmatchedProductCount += 1;
+        }
+        acc.mediaFailureCount += row.mediaFailureCount;
+        return acc;
+      },
+      {
+        totalRows: 0,
+        createCount: 0,
+        updateCount: 0,
+        skipCount: 0,
+        successCount: 0,
+        failureCount: 0,
+        unmatchedProductCount: 0,
+        mediaFailureCount: 0,
+      },
+    );
+    return { importBatchId, summary, rows };
+  }
+
+  private getCell(row: ExcelJS.Row, columnNumber: number | undefined): string {
+    if (!columnNumber) return '';
+    return cellToString(row.getCell(columnNumber).value).trim();
+  }
+
+  private buildRawData(row: ExcelJS.Row, headerMap: HeaderMap): Record<string, string | null> {
+    return Object.fromEntries(
+      Object.entries(headerMap).map(([key, column]) => [
+        key,
+        column ? this.getCell(row, column) || null : null,
+      ]),
+    );
+  }
+
+  private parseInteger(value: string): number | null {
+    if (!value) return null;
+    const normalized = value.replace(/[^0-9.-]/g, '');
+    if (!normalized) return null;
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? Math.trunc(parsed) : null;
+  }
+
+  private parseSmartStoreDate(value: string): Date | null {
+    if (!value) return null;
+    const trimmed = value.trim();
+    const match = trimmed.match(
+      /^(\d{4})\.(\d{1,2})\.(\d{1,2})\.?(?:\s+(\d{1,2}):(\d{2}):(\d{2}))?$/,
+    );
+    if (match) {
+      const [, year, month, day, hour = '0', minute = '0', second = '0'] = match;
+      const normalized = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T${hour.padStart(2, '0')}:${minute}:${second}+09:00`;
+      const date = new Date(normalized);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    const iso = new Date(trimmed);
+    return Number.isNaN(iso.getTime()) ? null : iso;
+  }
+
+  private collectValidMediaUrls(value: string, errors: string[]): string[] {
+    const unique = [...new Set(splitExcelList(value))];
+    const urls: string[] = [];
+    for (const url of unique) {
+      try {
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          throw new Error('unsupported protocol');
+        }
+        urls.push(url);
+      } catch {
+        errors.push(`포토/영상 URL 형식이 올바르지 않습니다: ${url}`);
+      }
+    }
+    return urls;
+  }
+
+  private isSourceVisible(value: string): boolean {
+    const normalized = value.replace(/\s/g, '').toLowerCase();
+    if (!normalized) return true;
+    return !(
+      normalized.includes('숨김') ||
+      normalized.includes('미전시') ||
+      normalized.includes('비전시') ||
+      normalized.includes('삭제') ||
+      normalized.includes('hidden')
+    );
+  }
+
+  private parseBooleanFlag(value: string): boolean {
+    const normalized = value.trim().toLowerCase();
+    return (
+      normalized === 'y' || normalized === 'yes' || normalized === 'true' || normalized === '1'
+    );
+  }
+
+  private guessMediaType(url: string): ExternalReviewMediaAsset['type'] {
+    const pathname = new URL(url).pathname.toLowerCase();
+    if (/\.(jpe?g|png|webp|gif|bmp)$/.test(pathname)) return 'image';
+    if (/\.(mp4|mov|webm)$/.test(pathname)) return 'video';
+    return 'unknown';
+  }
+
+  private findDuplicates(values: string[]): Set<string> {
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const value of values) {
+      if (seen.has(value)) duplicates.add(value);
+      seen.add(value);
+    }
+    return duplicates;
+  }
+
+  private createImportBatchId(): string {
+    return `naver-review-${new Date()
+      .toISOString()
+      .replace(/[-:.TZ]/g, '')
+      .slice(0, 14)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+}
+
+function decodeHtmlEntities(value: string): string {
+  if (!value) return '';
+  const named: Record<string, string> = {
+    quot: '"',
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    apos: "'",
+    nbsp: ' ',
+    hellip: '…',
+  };
+  return value.replace(/&(#\d+|#x[0-9a-fA-F]+|[a-zA-Z]+);/g, (entity, code: string) => {
+    if (code.startsWith('#x')) {
+      return String.fromCodePoint(Number.parseInt(code.slice(2), 16));
+    }
+    if (code.startsWith('#')) {
+      return String.fromCodePoint(Number.parseInt(code.slice(1), 10));
+    }
+    return named[code] ?? entity;
+  });
+}

--- a/src/app/[locale]/admin/reviews/__tests__/AdminReviewsPage.test.tsx
+++ b/src/app/[locale]/admin/reviews/__tests__/AdminReviewsPage.test.tsx
@@ -1,0 +1,286 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AdminReviewsPage from '../page';
+import type { AdminReviewItem } from '@/lib/api';
+
+const mockUseAdminGuard = vi.fn();
+const mockGetList = vi.fn();
+const mockSetVisibility = vi.fn();
+const mockBulkSetVisibility = vi.fn();
+const mockPreviewSmartStoreImport = vi.fn();
+const mockCommitSmartStoreImport = vi.fn();
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'ko',
+  useTranslations: () => (key: string, values?: Record<string, string | number>) => {
+    if (!values) return key;
+    return `${key}:${JSON.stringify(values)}`;
+  },
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/shared/hooks/useAdminGuard', () => ({
+  useAdminGuard: () => mockUseAdminGuard(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  adminReviewsApi: {
+    getList: (...args: unknown[]) => mockGetList(...args),
+    setVisibility: (...args: unknown[]) => mockSetVisibility(...args),
+    bulkSetVisibility: (...args: unknown[]) => mockBulkSetVisibility(...args),
+    previewSmartStoreImport: (...args: unknown[]) => mockPreviewSmartStoreImport(...args),
+    commitSmartStoreImport: (...args: unknown[]) => mockCommitSmartStoreImport(...args),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const makeReview = (overrides: Partial<AdminReviewItem> = {}): AdminReviewItem => ({
+  id: 1,
+  source: 'naver-smartstore',
+  externalReviewId: '5008298806',
+  externalProductId: '13629303355',
+  product: { id: 7, name: '옥화당 자사호', sku: 'naver-13629303355' },
+  reviewType: '일반',
+  rating: 5,
+  content: '아주 좋아요',
+  reviewerNameMasked: 'da**',
+  helpfulCount: 3,
+  imageUrls: ['https://cdn.example.com/review.jpg'],
+  mediaCount: 1,
+  mediaFailureCount: 0,
+  sourceDisplayStatus: '정상',
+  isVisible: true,
+  isBest: false,
+  reviewedAt: '2026-06-27T07:37:03.000Z',
+  sourceUpdatedAt: null,
+  lastSyncedAt: '2026-07-03T00:00:00.000Z',
+  importBatchId: 'naver-review-1',
+  orderNo: '2026062172779571',
+  relatedReviewExternalId: null,
+  relatedReviewContent: null,
+  ...overrides,
+});
+
+describe('AdminReviewsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAdminGuard.mockReturnValue({
+      user: { id: 1, email: 'admin@test.com', name: 'Admin', role: 'admin' },
+      isLoading: false,
+      isAdmin: true,
+    });
+    mockGetList.mockResolvedValue({ items: [makeReview()], total: 1, page: 1, limit: 20 });
+    mockSetVisibility.mockResolvedValue(makeReview({ isVisible: false }));
+    mockBulkSetVisibility.mockResolvedValue({ updated: 1 });
+    mockPreviewSmartStoreImport.mockResolvedValue({
+      importBatchId: null,
+      summary: {
+        totalRows: 1,
+        createCount: 1,
+        updateCount: 0,
+        skipCount: 0,
+        successCount: 0,
+        failureCount: 0,
+        unmatchedProductCount: 0,
+        mediaFailureCount: 0,
+      },
+      rows: [
+        {
+          rowNumber: 2,
+          externalReviewId: '5008298806',
+          externalProductId: '13629303355',
+          externalProductKey: 'naver-13629303355',
+          productName: '옥화당 자사호',
+          matchedProductId: 7,
+          action: 'create',
+          status: 'valid',
+          rating: 5,
+          reviewType: '일반',
+          reviewedAt: '2026-06-27T07:37:03.000Z',
+          mediaCount: 1,
+          mediaSuccessCount: 0,
+          mediaFailureCount: 0,
+          isVisible: true,
+          errors: [],
+          warnings: [],
+        },
+      ],
+    });
+    mockCommitSmartStoreImport.mockResolvedValue({
+      importBatchId: 'naver-review-20260703-abc123',
+      summary: {
+        totalRows: 1,
+        createCount: 1,
+        updateCount: 0,
+        skipCount: 0,
+        successCount: 1,
+        failureCount: 0,
+        unmatchedProductCount: 0,
+        mediaFailureCount: 0,
+      },
+      rows: [
+        {
+          rowNumber: 2,
+          externalReviewId: '5008298806',
+          externalProductId: '13629303355',
+          externalProductKey: 'naver-13629303355',
+          productName: '옥화당 자사호',
+          matchedProductId: 7,
+          action: 'create',
+          status: 'success',
+          rating: 5,
+          reviewType: '일반',
+          reviewedAt: '2026-06-27T07:37:03.000Z',
+          mediaCount: 1,
+          mediaSuccessCount: 1,
+          mediaFailureCount: 0,
+          isVisible: true,
+          errors: [],
+          warnings: [],
+        },
+      ],
+    });
+  });
+
+  it('loads the admin review list and toggles single-review visibility', async () => {
+    render(<AdminReviewsPage />);
+
+    expect(await screen.findByText('아주 좋아요')).toBeInTheDocument();
+    expect(mockGetList).toHaveBeenCalledWith({ page: 1, limit: 20, visibility: 'all' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'actions.hide' }));
+
+    await waitFor(() => {
+      expect(mockSetVisibility).toHaveBeenCalledWith(1, false);
+    });
+  });
+
+  it('previews SmartStore review Excel upload and renders row-level results', async () => {
+    render(<AdminReviewsPage />);
+    await screen.findByText('아주 좋아요');
+
+    const file = new File(['dummy'], 'review.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    fireEvent.change(screen.getByLabelText('import.fileLabel'), { target: { files: [file] } });
+    fireEvent.click(screen.getByRole('button', { name: 'import.previewButton' }));
+
+    await waitFor(() => {
+      expect(mockPreviewSmartStoreImport).toHaveBeenCalledWith(file);
+    });
+    expect(await screen.findByText('naver-13629303355')).toBeInTheDocument();
+  });
+
+  it('commits the previewed SmartStore review file and shows the import batch id', async () => {
+    render(<AdminReviewsPage />);
+    await screen.findByText('아주 좋아요');
+
+    const file = new File(['dummy'], 'review.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    fireEvent.change(screen.getByLabelText('import.fileLabel'), { target: { files: [file] } });
+    fireEvent.click(screen.getByRole('button', { name: 'import.previewButton' }));
+
+    await waitFor(() => {
+      expect(mockPreviewSmartStoreImport).toHaveBeenCalledWith(file);
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'import.commitButton' }));
+
+    await waitFor(() => {
+      expect(mockCommitSmartStoreImport).toHaveBeenCalledWith(file);
+    });
+    expect(
+      await screen.findByText('import.batchId:{"id":"naver-review-20260703-abc123"}'),
+    ).toBeInTheDocument();
+  });
+
+  it('applies search, rating, media, and review type filters to the list request', async () => {
+    render(<AdminReviewsPage />);
+    await screen.findByText('아주 좋아요');
+    mockGetList.mockClear();
+
+    fireEvent.change(screen.getByLabelText('filters.searchLabel'), {
+      target: { value: '5008298806' },
+    });
+    fireEvent.change(screen.getByLabelText('filters.ratingLabel'), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText('filters.mediaLabel'), { target: { value: 'true' } });
+    fireEvent.change(screen.getByLabelText('filters.reviewTypeLabel'), {
+      target: { value: '일반' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'filters.searchButton' }));
+
+    await waitFor(() => {
+      expect(mockGetList).toHaveBeenCalledWith({
+        page: 1,
+        limit: 20,
+        visibility: 'all',
+        search: '5008298806',
+        rating: 5,
+        hasMedia: true,
+        reviewType: '일반',
+      });
+    });
+  });
+
+  it('renders hidden unmatched review details without media links', async () => {
+    mockGetList.mockResolvedValue({
+      items: [
+        makeReview({
+          product: null,
+          content: null,
+          imageUrls: null,
+          mediaCount: 0,
+          mediaFailureCount: 2,
+          isVisible: false,
+          isBest: true,
+          sourceDisplayStatus: null,
+          orderNo: null,
+          importBatchId: null,
+          reviewType: null,
+          relatedReviewContent: '관련 리뷰 본문',
+        }),
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    render(<AdminReviewsPage />);
+
+    expect(await screen.findAllByText('table.unmatchedProduct')).toHaveLength(1);
+    expect(screen.getByText('status.hidden')).toBeInTheDocument();
+    expect(screen.getByText('status.best')).toBeInTheDocument();
+    expect(screen.getByText('table.mediaFailure:{"count":2}')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'actions.detail' }));
+
+    expect(await screen.findByText('관련 리뷰 본문')).toBeInTheDocument();
+    expect(screen.getAllByText('table.noContent')).toHaveLength(2);
+  });
+
+  it('bulk hides selected reviews through the admin API', async () => {
+    render(<AdminReviewsPage />);
+    await screen.findByText('아주 좋아요');
+
+    fireEvent.click(screen.getByLabelText('table.selectOne:{"id":"5008298806"}'));
+    fireEvent.click(screen.getByRole('button', { name: 'bulk.hide' }));
+
+    await waitFor(() => {
+      expect(mockBulkSetVisibility).toHaveBeenCalledWith([1], false);
+    });
+  });
+});

--- a/src/app/[locale]/admin/reviews/error.tsx
+++ b/src/app/[locale]/admin/reviews/error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+export default function AdminReviewsError({ reset }: { error: Error; reset: () => void }) {
+  const t = useTranslations('admin.reviews.error');
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 text-center">
+      <h1 className="typo-h2 font-semibold">{t('title')}</h1>
+      <p className="mt-3 typo-body-sm text-muted-foreground">{t('description')}</p>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-6 rounded bg-primary px-4 py-2 typo-body-sm text-primary-foreground"
+      >
+        {t('retry')}
+      </button>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/reviews/page.tsx
+++ b/src/app/[locale]/admin/reviews/page.tsx
@@ -1,0 +1,661 @@
+'use client';
+
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
+import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
+import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
+import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
+import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
+import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
+import { adminReviewsApi } from '@/lib/api';
+import type { AdminReviewItem, AdminReviewsParams, SmartStoreReviewImportResult } from '@/lib/api';
+
+const PAGE_SIZE = 20;
+
+type ReviewFilters = {
+  visibility: 'all' | 'visible' | 'hidden';
+  rating: string;
+  reviewType: string;
+  hasMedia: string;
+};
+
+export default function AdminReviewsPage() {
+  const t = useTranslations('admin.reviews');
+  const locale = useLocale();
+  const { isAdmin } = useAdminGuard();
+  const [reviews, setReviews] = useState<AdminReviewItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(() => new Set());
+  const [selectedReview, setSelectedReview] = useState<AdminReviewItem | null>(null);
+  const [smartStoreFile, setSmartStoreFile] = useState<File | null>(null);
+  const [importPreview, setImportPreview] = useState<SmartStoreReviewImportResult | null>(null);
+  const [importResult, setImportResult] = useState<SmartStoreReviewImportResult | null>(null);
+  const [showAllImportRows, setShowAllImportRows] = useState(false);
+  const [showFailedImportRowsOnly, setShowFailedImportRowsOnly] = useState(false);
+  const { page, setPage, keyword, searchInput, setSearchInput, filters, setFilter, submitSearch } =
+    useAdminListPage<ReviewFilters>({
+      initialFilters: {
+        visibility: 'all',
+        rating: '',
+        reviewType: '',
+        hasMedia: '',
+      },
+    });
+
+  const visibilityFilters = [
+    { label: t('filters.visibility.all'), value: 'all' },
+    { label: t('filters.visibility.visible'), value: 'visible' },
+    { label: t('filters.visibility.hidden'), value: 'hidden' },
+  ] as const;
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+    [locale],
+  );
+
+  const { execute: fetchReviews, isLoading: loading } = useAsyncAction(
+    async () => {
+      const params: AdminReviewsParams = {
+        page,
+        limit: PAGE_SIZE,
+        visibility: filters.visibility,
+      };
+      if (keyword) params.search = keyword;
+      if (filters.rating) params.rating = Number(filters.rating);
+      if (filters.reviewType) params.reviewType = filters.reviewType;
+      if (filters.hasMedia) params.hasMedia = filters.hasMedia === 'true';
+
+      const response = await adminReviewsApi.getList(params);
+      setReviews(response.items);
+      setTotal(response.total);
+      setSelectedIds(new Set());
+    },
+    { errorMessage: t('loadError') },
+  );
+
+  useEffect(() => {
+    if (isAdmin) void fetchReviews();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isAdmin,
+    page,
+    keyword,
+    filters.visibility,
+    filters.rating,
+    filters.reviewType,
+    filters.hasMedia,
+  ]);
+
+  const { execute: previewSmartStoreImport, isLoading: previewingImport } = useAsyncAction(
+    async (file: File) => {
+      const result = await adminReviewsApi.previewSmartStoreImport(file);
+      setImportPreview(result);
+      setImportResult(null);
+    },
+    { successMessage: t('import.previewSuccess'), errorMessage: t('import.previewError') },
+  );
+
+  const { execute: commitSmartStoreImport, isLoading: committingImport } = useAsyncAction(
+    async (file: File) => {
+      const result = await adminReviewsApi.commitSmartStoreImport(file);
+      setImportResult(result);
+      setImportPreview(null);
+      void fetchReviews();
+    },
+    { successMessage: t('import.commitSuccess'), errorMessage: t('import.commitError') },
+  );
+
+  const { execute: setVisibility } = useAsyncAction(
+    async ({ id, isVisible }: { id: number; isVisible: boolean }) => {
+      await adminReviewsApi.setVisibility(id, isVisible);
+      toast.success(isVisible ? t('actions.showSuccess') : t('actions.hideSuccess'));
+      void fetchReviews();
+    },
+    { errorMessage: t('actions.visibilityError') },
+  );
+
+  const { execute: bulkSetVisibility, isLoading: bulkUpdating } = useAsyncAction(
+    async (isVisible: boolean) => {
+      const ids = [...selectedIds];
+      if (ids.length === 0) {
+        toast.error(t('bulk.selectFirst'));
+        return;
+      }
+      const result = await adminReviewsApi.bulkSetVisibility(ids, isVisible);
+      toast.success(
+        isVisible
+          ? t('bulk.showSuccess', { count: result.updated })
+          : t('bulk.hideSuccess', { count: result.updated }),
+      );
+      void fetchReviews();
+    },
+    { errorMessage: t('bulk.error') },
+  );
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    setSmartStoreFile(file);
+    setImportPreview(null);
+    setImportResult(null);
+    setShowAllImportRows(false);
+    setShowFailedImportRowsOnly(false);
+  };
+
+  const handlePreviewImport = () => {
+    if (!smartStoreFile) {
+      toast.error(t('import.selectFileFirst'));
+      return;
+    }
+    void previewSmartStoreImport(smartStoreFile);
+  };
+
+  const handleCommitImport = () => {
+    if (!smartStoreFile) {
+      toast.error(t('import.selectFileFirst'));
+      return;
+    }
+    void commitSmartStoreImport(smartStoreFile);
+  };
+
+  const toggleSelected = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAllVisibleRows = () => {
+    setSelectedIds((prev) => {
+      const visibleIds = reviews.map((review) => review.id);
+      const allSelected = visibleIds.length > 0 && visibleIds.every((id) => prev.has(id));
+      if (allSelected) return new Set([...prev].filter((id) => !visibleIds.includes(id)));
+      return new Set([...prev, ...visibleIds]);
+    });
+  };
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const importSummary = importResult?.summary ?? importPreview?.summary;
+  const allImportRows = importResult?.rows ?? importPreview?.rows ?? [];
+  const visibleImportRows = showFailedImportRowsOnly
+    ? allImportRows.filter((row) => row.status === 'failed')
+    : allImportRows;
+  const importRows = showAllImportRows ? visibleImportRows : visibleImportRows.slice(0, 5);
+  const isImporting = previewingImport || committingImport;
+  const allVisibleRowsSelected =
+    reviews.length > 0 && reviews.every((review) => selectedIds.has(review.id));
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
+      <AdminPageHeader title={t('title')} />
+
+      <section className="rounded-lg border bg-card p-4 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <h2 className="typo-body font-semibold">{t('import.title')}</h2>
+            <p className="typo-body-sm text-muted-foreground">{t('import.description')}</p>
+            <ul className="grid gap-1.5 rounded-md bg-secondary/40 p-3 text-xs leading-relaxed text-muted-foreground sm:grid-cols-2">
+              {['match', 'upsert', 'media', 'manualVisibility'].map((key) => (
+                <li key={key} className="flex gap-2">
+                  <span
+                    aria-hidden="true"
+                    className="mt-1 size-1.5 flex-shrink-0 rounded-full bg-foreground/40"
+                  />
+                  <span>{t(`import.scopeDetails.${key}`)}</span>
+                </li>
+              ))}
+            </ul>
+            <input
+              type="file"
+              accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              onChange={handleFileChange}
+              className="block w-full text-sm file:mr-4 file:rounded-md file:border-0 file:bg-secondary file:px-3 file:py-2 file:text-sm file:font-medium"
+              aria-label={t('import.fileLabel')}
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handlePreviewImport}
+              disabled={!smartStoreFile || isImporting}
+              className="rounded border px-4 py-2 typo-body-sm hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {previewingImport ? t('import.previewing') : t('import.previewButton')}
+            </button>
+            <button
+              type="button"
+              onClick={handleCommitImport}
+              disabled={!smartStoreFile || isImporting || !importPreview}
+              className="rounded bg-primary px-4 py-2 typo-body-sm text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {committingImport ? t('import.committing') : t('import.commitButton')}
+            </button>
+          </div>
+        </div>
+
+        {importSummary && (
+          <div className="mt-4 space-y-3 rounded-lg bg-secondary/40 p-4 typo-body-sm">
+            {importResult?.importBatchId && (
+              <p className="text-muted-foreground">
+                {t('import.batchId', { id: importResult.importBatchId })}
+              </p>
+            )}
+            <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-7">
+              <ImportSummaryItem
+                label={t('import.summary.total')}
+                value={importSummary.totalRows}
+              />
+              <ImportSummaryItem
+                label={t('import.summary.create')}
+                value={importSummary.createCount}
+              />
+              <ImportSummaryItem
+                label={t('import.summary.update')}
+                value={importSummary.updateCount}
+              />
+              <ImportSummaryItem label={t('import.summary.skip')} value={importSummary.skipCount} />
+              <ImportSummaryItem
+                label={t('import.summary.success')}
+                value={importSummary.successCount}
+              />
+              <ImportSummaryItem
+                label={t('import.summary.failure')}
+                value={importSummary.failureCount}
+              />
+              <ImportSummaryItem
+                label={t('import.summary.mediaFailure')}
+                value={importSummary.mediaFailureCount}
+              />
+            </div>
+            {importRows.length > 0 && (
+              <div className="space-y-2">
+                <div className="flex flex-wrap gap-2">
+                  {visibleImportRows.length > 5 && (
+                    <button
+                      type="button"
+                      onClick={() => setShowAllImportRows((value) => !value)}
+                      className="rounded border px-3 py-1 text-xs hover:bg-secondary"
+                    >
+                      {showAllImportRows
+                        ? t('import.showTopRows')
+                        : t('import.showAllRows', { count: visibleImportRows.length })}
+                    </button>
+                  )}
+                  {allImportRows.some((row) => row.status === 'failed') && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setShowFailedImportRowsOnly((value) => !value);
+                        setShowAllImportRows(true);
+                      }}
+                      className="rounded border px-3 py-1 text-xs hover:bg-secondary"
+                    >
+                      {showFailedImportRowsOnly
+                        ? t('import.showAllResults')
+                        : t('import.showFailedRows')}
+                    </button>
+                  )}
+                </div>
+                <div className="overflow-x-auto rounded border bg-background">
+                  <table className="w-full text-xs">
+                    <thead className="bg-secondary">
+                      <tr>
+                        <th className="px-3 py-2 text-left">{t('import.columns.row')}</th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.columns.externalReviewId')}
+                        </th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.columns.externalProductKey')}
+                        </th>
+                        <th className="px-3 py-2 text-left">{t('import.columns.productName')}</th>
+                        <th className="px-3 py-2 text-left">{t('import.columns.action')}</th>
+                        <th className="px-3 py-2 text-right">{t('import.columns.rating')}</th>
+                        <th className="px-3 py-2 text-right">{t('import.columns.media')}</th>
+                        <th className="px-3 py-2 text-left">{t('import.columns.result')}</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                      {importRows.map((row) => (
+                        <tr key={`${row.rowNumber}-${row.externalReviewId ?? 'empty'}`}>
+                          <td className="px-3 py-2">{row.rowNumber}</td>
+                          <td className="px-3 py-2">{row.externalReviewId ?? t('emptyValue')}</td>
+                          <td className="px-3 py-2">{row.externalProductKey ?? t('emptyValue')}</td>
+                          <td className="px-3 py-2">{row.productName ?? t('emptyValue')}</td>
+                          <td className="px-3 py-2">{t(`import.actions.${row.action}`)}</td>
+                          <td className="px-3 py-2 text-right">{row.rating ?? t('emptyValue')}</td>
+                          <td className="px-3 py-2 text-right">
+                            {t('import.mediaCount', {
+                              success: row.mediaSuccessCount,
+                              total: row.mediaCount,
+                            })}
+                          </td>
+                          <td className="px-3 py-2">
+                            {row.errors.length > 0
+                              ? row.errors.join(', ')
+                              : row.warnings.length > 0
+                                ? row.warnings.join(', ')
+                                : t(`import.status.${row.status}`)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-3 rounded-lg border bg-card p-4 shadow-sm">
+        <form onSubmit={submitSearch} className="flex flex-col gap-3 lg:flex-row lg:items-end">
+          <label className="flex-1 space-y-1">
+            <span className="typo-label text-muted-foreground">{t('filters.searchLabel')}</span>
+            <input
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              placeholder={t('filters.searchPlaceholder')}
+              className="w-full rounded border bg-background px-3 py-2 typo-body-sm"
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="typo-label text-muted-foreground">{t('filters.ratingLabel')}</span>
+            <select
+              value={filters.rating}
+              onChange={(event) => setFilter('rating', event.target.value)}
+              className="w-full rounded border bg-background px-3 py-2 typo-body-sm lg:w-32"
+            >
+              <option value="">{t('filters.ratingAll')}</option>
+              {[5, 4, 3, 2, 1].map((rating) => (
+                <option key={rating} value={String(rating)}>
+                  {t('filters.ratingOption', { rating })}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1">
+            <span className="typo-label text-muted-foreground">{t('filters.mediaLabel')}</span>
+            <select
+              value={filters.hasMedia}
+              onChange={(event) => setFilter('hasMedia', event.target.value)}
+              className="w-full rounded border bg-background px-3 py-2 typo-body-sm lg:w-36"
+            >
+              <option value="">{t('filters.mediaAll')}</option>
+              <option value="true">{t('filters.mediaOnly')}</option>
+              <option value="false">{t('filters.textOnly')}</option>
+            </select>
+          </label>
+          <label className="space-y-1">
+            <span className="typo-label text-muted-foreground">{t('filters.reviewTypeLabel')}</span>
+            <input
+              value={filters.reviewType}
+              onChange={(event) => setFilter('reviewType', event.target.value)}
+              placeholder={t('filters.reviewTypePlaceholder')}
+              className="w-full rounded border bg-background px-3 py-2 typo-body-sm lg:w-40"
+            />
+          </label>
+          <button
+            type="submit"
+            className="rounded bg-primary px-4 py-2 typo-body-sm text-primary-foreground hover:bg-primary/90"
+          >
+            {t('filters.searchButton')}
+          </button>
+        </form>
+
+        <AdminFilterChips
+          items={visibilityFilters}
+          value={filters.visibility}
+          onToggle={(value) => setFilter('visibility', value)}
+          ariaLabel={t('filters.visibilityAria')}
+          size="sm"
+        />
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="typo-body-sm text-muted-foreground">
+            {t('bulk.selectedCount', { count: selectedIds.size })}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void bulkSetVisibility(false)}
+              disabled={selectedIds.size === 0 || bulkUpdating}
+              className="rounded border px-3 py-1.5 typo-body-sm hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {t('bulk.hide')}
+            </button>
+            <button
+              type="button"
+              onClick={() => void bulkSetVisibility(true)}
+              disabled={selectedIds.size === 0 || bulkUpdating}
+              className="rounded border px-3 py-1.5 typo-body-sm hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {t('bulk.show')}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <PaginatedAdminTableShell
+        loading={loading}
+        loadingMessage={t('loading')}
+        isEmpty={reviews.length === 0}
+        emptyMessage={t('noReviews')}
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+      >
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="bg-secondary">
+              <tr>
+                <th className="px-4 py-3 text-left">
+                  <input
+                    type="checkbox"
+                    checked={allVisibleRowsSelected}
+                    onChange={toggleAllVisibleRows}
+                    aria-label={t('table.selectAll')}
+                  />
+                </th>
+                <th className="px-4 py-3 text-left">{t('table.product')}</th>
+                <th className="px-4 py-3 text-left">{t('table.rating')}</th>
+                <th className="px-4 py-3 text-left">{t('table.content')}</th>
+                <th className="px-4 py-3 text-left">{t('table.reviewer')}</th>
+                <th className="px-4 py-3 text-left">{t('table.reviewedAt')}</th>
+                <th className="px-4 py-3 text-left">{t('table.media')}</th>
+                <th className="px-4 py-3 text-left">{t('table.status')}</th>
+                <th className="px-4 py-3 text-right">{t('table.actions')}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {reviews.map((review) => (
+                <tr key={review.id} className="hover:bg-secondary/30">
+                  <td className="px-4 py-3">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(review.id)}
+                      onChange={() => toggleSelected(review.id)}
+                      aria-label={t('table.selectOne', { id: review.externalReviewId })}
+                    />
+                  </td>
+                  <td className="px-4 py-3">
+                    {review.product ? (
+                      <Link
+                        href={`/admin/products/${review.product.id}/edit`}
+                        className="font-medium text-primary underline-offset-2 hover:underline"
+                      >
+                        {review.product.name}
+                      </Link>
+                    ) : (
+                      <span className="text-muted-foreground">{t('table.unmatchedProduct')}</span>
+                    )}
+                    <div className="text-xs text-muted-foreground">
+                      {review.externalProductId ?? t('emptyValue')}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">{t('table.ratingValue', { rating: review.rating })}</td>
+                  <td className="max-w-sm px-4 py-3">
+                    <p className="line-clamp-2">{review.content ?? t('table.noContent')}</p>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {review.externalReviewId}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">{review.reviewerNameMasked}</td>
+                  <td className="px-4 py-3">{dateFormatter.format(new Date(review.reviewedAt))}</td>
+                  <td className="px-4 py-3">
+                    {review.mediaCount > 0
+                      ? t('table.mediaValue', { count: review.mediaCount })
+                      : t('emptyValue')}
+                    {review.mediaFailureCount > 0 && (
+                      <div className="text-xs text-destructive">
+                        {t('table.mediaFailure', { count: review.mediaFailureCount })}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={
+                        review.isVisible
+                          ? 'rounded bg-primary/10 px-2 py-1 text-xs text-primary'
+                          : 'rounded bg-destructive/10 px-2 py-1 text-xs text-destructive'
+                      }
+                    >
+                      {review.isVisible ? t('status.visible') : t('status.hidden')}
+                    </span>
+                    {review.isBest && (
+                      <div className="mt-1 text-xs text-muted-foreground">{t('status.best')}</div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setSelectedReview(review)}
+                        className="rounded border px-2 py-1 text-xs hover:bg-secondary"
+                      >
+                        {t('actions.detail')}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          void setVisibility({ id: review.id, isVisible: !review.isVisible })
+                        }
+                        className="rounded border px-2 py-1 text-xs hover:bg-secondary"
+                      >
+                        {review.isVisible ? t('actions.hide') : t('actions.show')}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </PaginatedAdminTableShell>
+
+      {selectedReview && (
+        <section className="rounded-lg border bg-card p-4 shadow-sm">
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <h2 className="typo-body font-semibold">
+              {t('detail.title', { id: selectedReview.externalReviewId })}
+            </h2>
+            <button
+              type="button"
+              onClick={() => setSelectedReview(null)}
+              className="rounded border px-3 py-1 typo-body-sm hover:bg-secondary"
+            >
+              {t('detail.close')}
+            </button>
+          </div>
+          <dl className="grid gap-3 typo-body-sm md:grid-cols-2">
+            <DetailItem
+              label={t('detail.product')}
+              value={selectedReview.product?.name ?? t('table.unmatchedProduct')}
+            />
+            <DetailItem
+              label={t('detail.orderNo')}
+              value={selectedReview.orderNo ?? t('emptyValue')}
+            />
+            <DetailItem
+              label={t('detail.reviewType')}
+              value={selectedReview.reviewType ?? t('emptyValue')}
+            />
+            <DetailItem
+              label={t('detail.helpfulCount')}
+              value={String(selectedReview.helpfulCount)}
+            />
+            <DetailItem
+              label={t('detail.sourceDisplayStatus')}
+              value={selectedReview.sourceDisplayStatus ?? t('emptyValue')}
+            />
+            <DetailItem
+              label={t('detail.importBatchId')}
+              value={selectedReview.importBatchId ?? t('emptyValue')}
+            />
+          </dl>
+          <div className="mt-4 space-y-2">
+            <h3 className="typo-label text-muted-foreground">{t('detail.content')}</h3>
+            <p className="whitespace-pre-wrap rounded border bg-background p-3 typo-body-sm">
+              {selectedReview.content ?? t('table.noContent')}
+            </p>
+          </div>
+          {selectedReview.relatedReviewContent && (
+            <div className="mt-4 space-y-2">
+              <h3 className="typo-label text-muted-foreground">{t('detail.relatedContent')}</h3>
+              <p className="whitespace-pre-wrap rounded border bg-background p-3 typo-body-sm">
+                {selectedReview.relatedReviewContent}
+              </p>
+            </div>
+          )}
+          {selectedReview.imageUrls && selectedReview.imageUrls.length > 0 && (
+            <div className="mt-4 space-y-2">
+              <h3 className="typo-label text-muted-foreground">{t('detail.media')}</h3>
+              <ul className="space-y-1 typo-body-sm">
+                {selectedReview.imageUrls.map((url) => (
+                  <li key={url}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary underline-offset-2 hover:underline"
+                    >
+                      {url}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function ImportSummaryItem({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded border bg-background p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="typo-h3 font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function DetailItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border bg-background p-3">
+      <dt className="typo-label text-muted-foreground">{label}</dt>
+      <dd className="mt-1 break-words">{value}</dd>
+    </div>
+  );
+}

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -53,6 +53,7 @@ const NAV_ITEMS: NavItem[] = [
     children: [
       { labelKey: 'orders', href: '/admin/orders' },
       { labelKey: 'members', href: '/admin/members' },
+      { labelKey: 'reviews', href: '/admin/reviews' },
       { labelKey: 'inquiries', href: '/admin/inquiries' },
     ],
   },
@@ -98,8 +99,8 @@ type SidebarContentProps = {
 function SidebarContent({ onClose }: SidebarContentProps) {
   const pathname = usePathname();
   const t = useTranslations('admin.sidebar');
-  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(
-    () => getInitialOpenGroups(pathname),
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() =>
+    getInitialOpenGroups(pathname),
   );
 
   const toggleGroup = (labelKey: string) => {
@@ -225,11 +226,7 @@ export function AdminSidebar({ open, onClose }: AdminSidebarProps) {
       {/* 모바일: 오버레이 사이드바 */}
       {open && (
         <div className="fixed inset-0 z-40 lg:hidden">
-          <div
-            className="absolute inset-0 bg-black/40"
-            onClick={onClose}
-            aria-hidden="true"
-          />
+          <div className="absolute inset-0 bg-black/40" onClick={onClose} aria-hidden="true" />
           <div className="relative z-50 h-full">
             <SidebarContent onClose={onClose} />
           </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -914,13 +914,153 @@
       "archives": "Archives",
       "business": "Business Info",
       "close": "Close sidebar",
-      "cmsGroup": "CMS"
+      "cmsGroup": "CMS",
+      "reviews": "Reviews"
     },
     "navigation": {
       "title": "Navigation Management"
     },
     "categories": {
       "title": "Category Management"
+    },
+    "reviews": {
+      "title": "Review Management",
+      "loading": "Loading reviews.",
+      "noReviews": "No reviews found.",
+      "loadError": "Failed to load reviews.",
+      "emptyValue": "-",
+      "status": {
+        "visible": "Visible",
+        "hidden": "Hidden",
+        "best": "Best"
+      },
+      "filters": {
+        "searchLabel": "Search",
+        "searchPlaceholder": "Search product, product no., review no., reviewer, or content",
+        "searchButton": "Search",
+        "ratingLabel": "Rating",
+        "ratingAll": "All",
+        "ratingOption": "{rating} stars",
+        "mediaLabel": "Photo/video",
+        "mediaAll": "All",
+        "mediaOnly": "With media",
+        "textOnly": "Text only",
+        "reviewTypeLabel": "Review type",
+        "reviewTypePlaceholder": "General, one-month",
+        "visibilityAria": "Review visibility filter",
+        "visibility": {
+          "all": "All",
+          "visible": "Visible",
+          "hidden": "Hidden"
+        }
+      },
+      "bulk": {
+        "selectedCount": "{count} selected",
+        "hide": "Hide selected",
+        "show": "Show selected",
+        "selectFirst": "Select reviews to update.",
+        "hideSuccess": "Hidden {count} reviews.",
+        "showSuccess": "Shown {count} reviews.",
+        "error": "Bulk update failed."
+      },
+      "table": {
+        "selectAll": "Select all reviews on this page",
+        "selectOne": "Select review {id}",
+        "product": "Product",
+        "rating": "Rating",
+        "ratingValue": "{rating} stars",
+        "content": "Content",
+        "reviewer": "Reviewer",
+        "reviewedAt": "Reviewed at",
+        "media": "Media",
+        "mediaValue": "{count}",
+        "mediaFailure": "Failed {count}",
+        "status": "Status",
+        "actions": "Actions",
+        "unmatchedProduct": "No linked product",
+        "noContent": "No content"
+      },
+      "actions": {
+        "detail": "Details",
+        "hide": "Hide",
+        "show": "Show",
+        "hideSuccess": "Review hidden.",
+        "showSuccess": "Review shown.",
+        "visibilityError": "Failed to update review visibility."
+      },
+      "detail": {
+        "title": "Review detail: {id}",
+        "close": "Close",
+        "product": "Product",
+        "orderNo": "Order item no.",
+        "reviewType": "Review type",
+        "helpfulCount": "Helpful count",
+        "sourceDisplayStatus": "Source display status",
+        "importBatchId": "Import batch",
+        "content": "Review content",
+        "relatedContent": "Related review content",
+        "media": "Stored media"
+      },
+      "import": {
+        "title": "Naver SmartStore review Excel upload",
+        "description": "Validate a SmartStore review workbook, match product numbers to naver-product-number SKUs, and import reviews.",
+        "scopeDetails": {
+          "match": "Product numbers match internal product SKUs in naver-product-number form.",
+          "upsert": "Re-uploads update by review number without creating duplicates.",
+          "media": "Photo/video URLs are stored in storage while keeping original URLs.",
+          "manualVisibility": "Manual hidden/visible states are preserved on re-upload."
+        },
+        "fileLabel": "Select SmartStore review Excel file",
+        "previewButton": "Preview",
+        "commitButton": "Commit",
+        "previewing": "Validating...",
+        "committing": "Committing...",
+        "selectFileFirst": "Select an Excel file first.",
+        "previewSuccess": "Review workbook validation completed.",
+        "previewError": "Review workbook validation failed.",
+        "commitSuccess": "Review workbook import completed.",
+        "commitError": "Review workbook import failed.",
+        "batchId": "Import batch: {id}",
+        "summary": {
+          "total": "Total",
+          "create": "Create",
+          "update": "Update",
+          "skip": "Skip",
+          "success": "Success",
+          "failure": "Failure",
+          "mediaFailure": "Media failures"
+        },
+        "showTopRows": "Show top rows",
+        "showAllRows": "Show all {count}",
+        "showFailedRows": "Show failed rows",
+        "showAllResults": "Show all results",
+        "mediaCount": "{success}/{total}",
+        "columns": {
+          "row": "Row",
+          "externalReviewId": "Review no.",
+          "externalProductKey": "Product key",
+          "productName": "Product name",
+          "action": "Action",
+          "rating": "Rating",
+          "media": "Media",
+          "result": "Result"
+        },
+        "actions": {
+          "create": "Create",
+          "update": "Update",
+          "skip": "Skip"
+        },
+        "status": {
+          "valid": "Valid",
+          "failed": "Failed",
+          "success": "Imported"
+        }
+      },
+      "error": {
+        "title": "Could not load review management.",
+        "description": "Please try again shortly.",
+        "retry": "Retry"
+      }
     }
   },
   "search": {
@@ -1310,11 +1450,7 @@
     "title": "Shipping, Exchange & Refund Policy",
     "description": "Detailed shipping, exchange/return, and refund standards beyond the product-detail summary.",
     "effectiveDate": "Effective date: June 12, 2026",
-    "sectionKeys": [
-      "shipping",
-      "exchangeReturn",
-      "refund"
-    ],
+    "sectionKeys": ["shipping", "exchangeReturn", "refund"],
     "sections": {
       "shipping": {
         "title": "Shipping Policy",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -914,13 +914,153 @@
       "archives": "아카이브관리",
       "business": "사업자 정보",
       "close": "사이드바 닫기",
-      "cmsGroup": "CMS"
+      "cmsGroup": "CMS",
+      "reviews": "리뷰관리"
     },
     "navigation": {
       "title": "네비게이션 관리"
     },
     "categories": {
       "title": "카테고리 관리"
+    },
+    "reviews": {
+      "title": "리뷰 관리",
+      "loading": "리뷰를 불러오는 중입니다.",
+      "noReviews": "등록된 리뷰가 없습니다.",
+      "loadError": "리뷰 목록을 불러오지 못했습니다.",
+      "emptyValue": "-",
+      "status": {
+        "visible": "노출",
+        "hidden": "숨김",
+        "best": "베스트"
+      },
+      "filters": {
+        "searchLabel": "검색",
+        "searchPlaceholder": "상품명, 상품번호, 리뷰글번호, 등록자, 본문 검색",
+        "searchButton": "검색",
+        "ratingLabel": "평점",
+        "ratingAll": "전체",
+        "ratingOption": "{rating}점",
+        "mediaLabel": "포토/영상",
+        "mediaAll": "전체",
+        "mediaOnly": "포토만",
+        "textOnly": "텍스트만",
+        "reviewTypeLabel": "리뷰구분",
+        "reviewTypePlaceholder": "일반, 한달사용",
+        "visibilityAria": "리뷰 노출 상태 필터",
+        "visibility": {
+          "all": "전체",
+          "visible": "노출",
+          "hidden": "숨김"
+        }
+      },
+      "bulk": {
+        "selectedCount": "선택 {count}개",
+        "hide": "선택 숨김",
+        "show": "선택 노출",
+        "selectFirst": "처리할 리뷰를 선택해 주세요.",
+        "hideSuccess": "{count}개 리뷰를 숨김 처리했습니다.",
+        "showSuccess": "{count}개 리뷰를 노출 처리했습니다.",
+        "error": "일괄 처리에 실패했습니다."
+      },
+      "table": {
+        "selectAll": "현재 페이지 리뷰 전체 선택",
+        "selectOne": "리뷰 {id} 선택",
+        "product": "상품",
+        "rating": "평점",
+        "ratingValue": "{rating}점",
+        "content": "내용",
+        "reviewer": "등록자",
+        "reviewedAt": "등록일",
+        "media": "포토/영상",
+        "mediaValue": "{count}개",
+        "mediaFailure": "실패 {count}개",
+        "status": "상태",
+        "actions": "관리",
+        "unmatchedProduct": "연결 상품 없음",
+        "noContent": "내용 없음"
+      },
+      "actions": {
+        "detail": "상세",
+        "hide": "숨김",
+        "show": "노출",
+        "hideSuccess": "리뷰를 숨김 처리했습니다.",
+        "showSuccess": "리뷰를 노출 처리했습니다.",
+        "visibilityError": "리뷰 상태 변경에 실패했습니다."
+      },
+      "detail": {
+        "title": "리뷰 상세: {id}",
+        "close": "닫기",
+        "product": "상품",
+        "orderNo": "상품주문번호",
+        "reviewType": "리뷰구분",
+        "helpfulCount": "도움수",
+        "sourceDisplayStatus": "원본 전시상태",
+        "importBatchId": "업로드 배치",
+        "content": "리뷰 내용",
+        "relatedContent": "관련 리뷰 내용",
+        "media": "저장된 미디어"
+      },
+      "import": {
+        "title": "네이버 스마트스토어 리뷰 엑셀 업로드",
+        "description": "스마트스토어 리뷰 엑셀을 검증한 뒤 상품번호를 naver-상품번호 SKU와 자동 매칭해 리뷰를 등록합니다.",
+        "scopeDetails": {
+          "match": "상품번호는 내부 상품 SKU naver-상품번호와 매칭합니다.",
+          "upsert": "리뷰글번호 기준으로 재업로드 시 중복 생성 없이 갱신합니다.",
+          "media": "포토/영상 URL은 스토리지에 적재하고 원본 URL도 보존합니다.",
+          "manualVisibility": "기존 리뷰의 수동 숨김/노출 상태는 재업로드로 덮어쓰지 않습니다."
+        },
+        "fileLabel": "스마트스토어 리뷰 엑셀 파일 선택",
+        "previewButton": "미리보기",
+        "commitButton": "반영하기",
+        "previewing": "검증 중...",
+        "committing": "반영 중...",
+        "selectFileFirst": "엑셀 파일을 먼저 선택해 주세요.",
+        "previewSuccess": "리뷰 엑셀 검증이 완료되었습니다.",
+        "previewError": "리뷰 엑셀 검증에 실패했습니다.",
+        "commitSuccess": "리뷰 엑셀 반영이 완료되었습니다.",
+        "commitError": "리뷰 엑셀 반영에 실패했습니다.",
+        "batchId": "업로드 배치: {id}",
+        "summary": {
+          "total": "전체",
+          "create": "생성",
+          "update": "수정",
+          "skip": "스킵",
+          "success": "성공",
+          "failure": "실패",
+          "mediaFailure": "미디어 실패"
+        },
+        "showTopRows": "상위 행만 보기",
+        "showAllRows": "전체 {count}개 보기",
+        "showFailedRows": "실패 행만 보기",
+        "showAllResults": "전체 결과 보기",
+        "mediaCount": "{success}/{total}",
+        "columns": {
+          "row": "행",
+          "externalReviewId": "리뷰글번호",
+          "externalProductKey": "상품 매칭키",
+          "productName": "상품명",
+          "action": "작업",
+          "rating": "평점",
+          "media": "미디어",
+          "result": "결과"
+        },
+        "actions": {
+          "create": "생성",
+          "update": "수정",
+          "skip": "스킵"
+        },
+        "status": {
+          "valid": "검증 성공",
+          "failed": "실패",
+          "success": "반영 성공"
+        }
+      },
+      "error": {
+        "title": "리뷰 관리 화면을 불러오지 못했습니다.",
+        "description": "잠시 후 다시 시도해 주세요.",
+        "retry": "다시 시도"
+      }
     }
   },
   "search": {
@@ -1310,11 +1450,7 @@
     "title": "배송/교환/환불 정책",
     "description": "상품 상세의 요약 안내보다 더 자세한 배송, 교환·반품, 환불 기준을 안내합니다.",
     "effectiveDate": "시행일: 2026년 6월 12일",
-    "sectionKeys": [
-      "shipping",
-      "exchangeReturn",
-      "refund"
-    ],
+    "sectionKeys": ["shipping", "exchangeReturn", "refund"],
     "sections": {
       "shipping": {
         "title": "배송 정책",

--- a/src/lib/__tests__/admin-reviews-api.test.ts
+++ b/src/lib/__tests__/admin-reviews-api.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { adminReviewsApi } from '@/lib/api/admin/reviews';
+import { apiClient } from '@/lib/api/core';
+
+describe('adminReviewsApi', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads review list with boolean media filter serialized for query params', async () => {
+    const response = { items: [], total: 0, page: 1, limit: 20 };
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue(response);
+
+    const result = await adminReviewsApi.getList({
+      page: 2,
+      limit: 20,
+      search: '5008298806',
+      visibility: 'hidden',
+      rating: 5,
+      hasMedia: true,
+      sort: 'helpful',
+      order: 'DESC',
+    });
+
+    expect(getSpy).toHaveBeenCalledWith('/admin/reviews', {
+      params: {
+        page: 2,
+        limit: 20,
+        search: '5008298806',
+        visibility: 'hidden',
+        rating: 5,
+        hasMedia: 'true',
+        sort: 'helpful',
+        order: 'DESC',
+      },
+    });
+    expect(result).toBe(response);
+  });
+
+  it('omits params for default list requests and serializes false media filters', async () => {
+    const response = { items: [], total: 0, page: 1, limit: 20 };
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue(response);
+
+    await adminReviewsApi.getList();
+    await adminReviewsApi.getList({ hasMedia: false });
+
+    expect(getSpy).toHaveBeenNthCalledWith(1, '/admin/reviews', { params: undefined });
+    expect(getSpy).toHaveBeenNthCalledWith(2, '/admin/reviews', {
+      params: { hasMedia: 'false' },
+    });
+  });
+
+  it('delegates detail and visibility mutations to admin review routes', async () => {
+    const review = { id: 7, isVisible: false };
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue(review);
+    const patchSpy = vi.spyOn(apiClient, 'patch').mockResolvedValue({ ...review, isVisible: true });
+    const postSpy = vi.spyOn(apiClient, 'post').mockResolvedValue({ updated: 2 });
+
+    await adminReviewsApi.getById(7);
+    await adminReviewsApi.setVisibility(7, true);
+    await adminReviewsApi.bulkSetVisibility([7, 8], false);
+
+    expect(getSpy).toHaveBeenCalledWith('/admin/reviews/7');
+    expect(patchSpy).toHaveBeenCalledWith('/admin/reviews/7/visibility', { isVisible: true });
+    expect(postSpy).toHaveBeenCalledWith('/admin/reviews/bulk-visibility', {
+      ids: [7, 8],
+      isVisible: false,
+    });
+  });
+
+  it('uploads SmartStore review Excel files to preview and commit endpoints', async () => {
+    const file = new File(['xlsx'], 'review.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    const response = {
+      importBatchId: null,
+      summary: {
+        totalRows: 0,
+        createCount: 0,
+        updateCount: 0,
+        skipCount: 0,
+        successCount: 0,
+        failureCount: 0,
+        unmatchedProductCount: 0,
+        mediaFailureCount: 0,
+      },
+      rows: [],
+    };
+    const uploadSpy = vi.spyOn(apiClient, 'uploadFile').mockResolvedValue(response);
+
+    await adminReviewsApi.previewSmartStoreImport(file);
+    await adminReviewsApi.commitSmartStoreImport(file);
+
+    expect(uploadSpy).toHaveBeenNthCalledWith(
+      1,
+      '/admin/reviews/imports/smartstore/preview',
+      file,
+    );
+    expect(uploadSpy).toHaveBeenNthCalledWith(
+      2,
+      '/admin/reviews/imports/smartstore/commit',
+      file,
+    );
+  });
+});

--- a/src/lib/api/admin/reviews.ts
+++ b/src/lib/api/admin/reviews.ts
@@ -1,0 +1,123 @@
+import { apiClient } from '../core';
+
+export type AdminReviewVisibility = 'all' | 'visible' | 'hidden';
+export type AdminReviewSort = 'reviewedAt' | 'rating' | 'helpful' | 'importedAt';
+export type SmartStoreReviewImportAction = 'create' | 'update' | 'skip';
+export type SmartStoreReviewImportStatus = 'valid' | 'failed' | 'success';
+
+export interface AdminReviewsParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  visibility?: AdminReviewVisibility;
+  rating?: number;
+  reviewType?: string;
+  hasMedia?: boolean;
+  importBatchId?: string;
+  sort?: AdminReviewSort;
+  order?: 'ASC' | 'DESC';
+}
+
+export interface AdminReviewProductSummary {
+  id: number;
+  name: string;
+  sku: string | null;
+}
+
+export interface AdminReviewItem {
+  id: number;
+  source: string;
+  externalReviewId: string;
+  externalProductId: string | null;
+  product: AdminReviewProductSummary | null;
+  reviewType: string | null;
+  rating: number;
+  content: string | null;
+  reviewerNameMasked: string;
+  helpfulCount: number;
+  imageUrls: string[] | null;
+  mediaCount: number;
+  mediaFailureCount: number;
+  sourceDisplayStatus: string | null;
+  isVisible: boolean;
+  isBest: boolean;
+  reviewedAt: string;
+  sourceUpdatedAt: string | null;
+  lastSyncedAt: string;
+  importBatchId: string | null;
+  orderNo: string | null;
+  relatedReviewExternalId: string | null;
+  relatedReviewContent: string | null;
+}
+
+export interface AdminReviewListResponse {
+  items: AdminReviewItem[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface SmartStoreReviewImportRow {
+  rowNumber: number;
+  externalReviewId: string | null;
+  externalProductId: string | null;
+  externalProductKey: string | null;
+  productName: string | null;
+  matchedProductId?: number;
+  action: SmartStoreReviewImportAction;
+  status: SmartStoreReviewImportStatus;
+  rating: number | null;
+  reviewType: string | null;
+  reviewedAt: string | null;
+  mediaCount: number;
+  mediaSuccessCount: number;
+  mediaFailureCount: number;
+  isVisible: boolean | null;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface SmartStoreReviewImportResult {
+  importBatchId: string | null;
+  summary: {
+    totalRows: number;
+    createCount: number;
+    updateCount: number;
+    skipCount: number;
+    successCount: number;
+    failureCount: number;
+    unmatchedProductCount: number;
+    mediaFailureCount: number;
+  };
+  rows: SmartStoreReviewImportRow[];
+}
+
+function toParams(
+  params?: AdminReviewsParams,
+): Record<string, string | number | undefined> | undefined {
+  if (!params) return undefined;
+  return {
+    ...params,
+    hasMedia: params.hasMedia === undefined ? undefined : String(params.hasMedia),
+  } as Record<string, string | number | undefined>;
+}
+
+export const adminReviewsApi = {
+  getList: (params?: AdminReviewsParams) =>
+    apiClient.get<AdminReviewListResponse>('/admin/reviews', { params: toParams(params) }),
+  getById: (id: number) => apiClient.get<AdminReviewItem>(`/admin/reviews/${id}`),
+  setVisibility: (id: number, isVisible: boolean) =>
+    apiClient.patch<AdminReviewItem>(`/admin/reviews/${id}/visibility`, { isVisible }),
+  bulkSetVisibility: (ids: number[], isVisible: boolean) =>
+    apiClient.post<{ updated: number }>('/admin/reviews/bulk-visibility', { ids, isVisible }),
+  previewSmartStoreImport: (file: File) =>
+    apiClient.uploadFile<SmartStoreReviewImportResult>(
+      '/admin/reviews/imports/smartstore/preview',
+      file,
+    ),
+  commitSmartStoreImport: (file: File) =>
+    apiClient.uploadFile<SmartStoreReviewImportResult>(
+      '/admin/reviews/imports/smartstore/commit',
+      file,
+    ),
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -35,6 +35,7 @@ export * from './journals';
 // Admin modules
 export * from './admin/categories';
 export * from './admin/products';
+export * from './admin/reviews';
 export * from './admin/orders';
 export * from './admin/members';
 export * from './admin/dashboard';


### PR DESCRIPTION
## Summary
- 리뷰 전용 관리자 목록/상세/단건·일괄 숨김/노출 UI와 API를 추가했습니다.
- 네이버 스마트스토어 리뷰 엑셀을 미리보기/반영할 수 있게 하고, 상품 엑셀 등록의 `naver-<상품번호>` SKU와 리뷰 `상품번호`를 자동 매칭합니다.
- 리뷰 사진 URL은 기존 원격 이미지 수집/스토리지 경로로 업로드하고, 원본/S3 URL·키·실패 사유를 외부 리뷰 메타데이터로 보존합니다.
- 상품/리뷰 엑셀 처리에서 재사용할 공통 엑셀 셀/헤더/목록 파싱 유틸과 네이버 외부 상품 키 유틸을 분리했습니다.

Closes #970

## Verification
- `bash scripts/codex-project-guard.sh`
- `npm run lint && npm run test:run && npm run build`
- `cd backend && npm run lint && npm run test && npm run build`
- `bash scripts/test.sh e2e`
- `git diff --check`

## Notes
- 실제 운영 S3 자격 증명으로 네이버 이미지 다운로드/업로드는 로컬에서 직접 검증하지 못했고, 기존 원격 이미지 수집 서비스 경로와 테스트 더블로 검증했습니다.
