### PR TITLE
fix: #974 이미지 확대보기 맞춤과 팬 이동 보장

### DIFF
--- a/src/components/shared/hooks/__tests__/useLightboxInteraction.test.tsx
+++ b/src/components/shared/hooks/__tests__/useLightboxInteraction.test.tsx
@@ -1,13 +1,13 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { useLightboxInteraction } from '@/components/shared/hooks/useLightboxInteraction';
 
 function mouseEvent(clientX: number, clientY: number) {
-  return { clientX, clientY } as React.MouseEvent;
+  return { clientX, clientY, preventDefault: vi.fn() } as unknown as React.MouseEvent;
 }
 
 function touchEvent(clientX: number, clientY: number) {
-  return { touches: [{ clientX, clientY }] } as unknown as React.TouchEvent;
+  return { touches: [{ clientX, clientY }], cancelable: true, preventDefault: vi.fn() } as unknown as React.TouchEvent;
 }
 
 describe('useLightboxInteraction', () => {
@@ -35,6 +35,7 @@ describe('useLightboxInteraction', () => {
     });
 
     expect(result.current.lightboxPan).toEqual({ x: 150, y: -150 });
+    expect(result.current.lightboxDragMovedRef.current).toBe(true);
 
     act(() => {
       result.current.handleLightboxMouseUp();
@@ -64,5 +65,6 @@ describe('useLightboxInteraction', () => {
     expect(result.current.lightboxZoomed).toBe(false);
     expect(result.current.lightboxPan).toEqual({ x: 0, y: 0 });
     expect(result.current.lightboxPanRef.current).toEqual({ x: 0, y: 0 });
+    expect(result.current.lightboxDragMovedRef.current).toBe(false);
   });
 });

--- a/src/components/shared/hooks/useLightboxInteraction.ts
+++ b/src/components/shared/hooks/useLightboxInteraction.ts
@@ -7,17 +7,21 @@ export function useLightboxInteraction() {
   const [lightboxPan, setLightboxPan] = useState({ x: 0, y: 0 })
   const lightboxPanRef = useRef({ x: 0, y: 0 })
   const isDragging = useRef(false)
+  const lightboxDragMovedRef = useRef(false)
   const dragStart = useRef({ x: 0, y: 0 })
 
   const resetLightboxState = useCallback(() => {
     setLightboxZoomed(false)
     setLightboxPan({ x: 0, y: 0 })
     lightboxPanRef.current = { x: 0, y: 0 }
+    lightboxDragMovedRef.current = false
   }, [])
 
   const handleLightboxMouseDown = useCallback((e: React.MouseEvent) => {
     if (!lightboxZoomed) return
+    e.preventDefault()
     isDragging.current = true
+    lightboxDragMovedRef.current = false
     dragStart.current = {
       x: e.clientX - lightboxPanRef.current.x,
       y: e.clientY - lightboxPanRef.current.y,
@@ -26,9 +30,13 @@ export function useLightboxInteraction() {
 
   const handleLightboxMouseMove = useCallback((e: React.MouseEvent) => {
     if (!isDragging.current || !lightboxZoomed) return
+    e.preventDefault()
     const maxPan = 150
     const newX = Math.min(maxPan, Math.max(-maxPan, e.clientX - dragStart.current.x))
     const newY = Math.min(maxPan, Math.max(-maxPan, e.clientY - dragStart.current.y))
+    if (Math.abs(newX - lightboxPanRef.current.x) > 3 || Math.abs(newY - lightboxPanRef.current.y) > 3) {
+      lightboxDragMovedRef.current = true
+    }
     lightboxPanRef.current = { x: newX, y: newY }
     setLightboxPan({ x: newX, y: newY })
   }, [lightboxZoomed])
@@ -40,6 +48,7 @@ export function useLightboxInteraction() {
   const handleLightboxTouchStart = useCallback((e: React.TouchEvent) => {
     if (lightboxZoomed) {
       isDragging.current = true
+      lightboxDragMovedRef.current = false
       dragStart.current = {
         x: e.touches[0].clientX - lightboxPanRef.current.x,
         y: e.touches[0].clientY - lightboxPanRef.current.y,
@@ -49,9 +58,13 @@ export function useLightboxInteraction() {
 
   const handleLightboxTouchMove = useCallback((e: React.TouchEvent) => {
     if (!isDragging.current || !lightboxZoomed) return
+    if (e.cancelable) e.preventDefault()
     const maxPan = 100
     const newX = Math.min(maxPan, Math.max(-maxPan, e.touches[0].clientX - dragStart.current.x))
     const newY = Math.min(maxPan, Math.max(-maxPan, e.touches[0].clientY - dragStart.current.y))
+    if (Math.abs(newX - lightboxPanRef.current.x) > 3 || Math.abs(newY - lightboxPanRef.current.y) > 3) {
+      lightboxDragMovedRef.current = true
+    }
     lightboxPanRef.current = { x: newX, y: newY }
     setLightboxPan({ x: newX, y: newY })
   }, [lightboxZoomed])
@@ -67,6 +80,7 @@ export function useLightboxInteraction() {
     setLightboxPan,
     lightboxPanRef,
     isDragging,
+    lightboxDragMovedRef,
     handleLightboxMouseDown,
     handleLightboxMouseMove,
     handleLightboxMouseUp,

--- a/src/components/shared/products/ImageGallery.tsx
+++ b/src/components/shared/products/ImageGallery.tsx
@@ -79,6 +79,7 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
     lightboxPan,
     lightboxPanRef,
     isDragging,
+    lightboxDragMovedRef,
     handleLightboxMouseDown,
     handleLightboxMouseMove,
     handleLightboxMouseUp,
@@ -365,6 +366,7 @@ export default function ImageGallery({ images: rawImages, isLoading, error, onRe
         handleLightboxTouchMove={handleLightboxTouchMove}
         handleLightboxTouchEnd={handleLightboxTouchEnd}
         isDragging={isDragging}
+        lightboxDragMovedRef={lightboxDragMovedRef}
       />
     </>
   )

--- a/src/components/shared/products/LightboxOverlay.tsx
+++ b/src/components/shared/products/LightboxOverlay.tsx
@@ -31,6 +31,7 @@ interface LightboxOverlayProps {
   handleLightboxTouchMove: (e: React.TouchEvent) => void
   handleLightboxTouchEnd: (e: React.TouchEvent) => void
   isDragging: React.MutableRefObject<boolean>
+  lightboxDragMovedRef: React.MutableRefObject<boolean>
 }
 
 export default function LightboxOverlay({
@@ -52,6 +53,7 @@ export default function LightboxOverlay({
   handleLightboxTouchMove,
   handleLightboxTouchEnd,
   isDragging,
+  lightboxDragMovedRef,
 }: LightboxOverlayProps) {
   if (!lightboxOpen) return null
 
@@ -97,15 +99,17 @@ export default function LightboxOverlay({
       </button>
 
       <div
-        className="relative z-10 max-h-[85vh] max-w-[90vw]"
+        className="relative z-10 h-[85vh] w-[90vw] max-w-[90vw] touch-none select-none overflow-hidden"
         onClick={(e) => {
           e.stopPropagation()
-          if (!isDragging.current) {
-            if (lightboxZoomed) {
-              lightboxPanRef.current = { x: 0, y: 0 }
-            }
-            setLightboxZoomed(!lightboxZoomed)
+          if (isDragging.current || lightboxDragMovedRef.current) {
+            lightboxDragMovedRef.current = false
+            return
           }
+          if (lightboxZoomed) {
+            lightboxPanRef.current = { x: 0, y: 0 }
+          }
+          setLightboxZoomed(!lightboxZoomed)
         }}
         onMouseDown={handleLightboxMouseDown}
         onMouseMove={handleLightboxMouseMove}
@@ -113,16 +117,15 @@ export default function LightboxOverlay({
         onMouseLeave={handleLightboxMouseUp}
         style={{ cursor: lightboxZoomed ? (isDragging.current ? 'grabbing' : 'grab') : 'zoom-in' }}
       >
-        <div
-          className="relative transition-transform duration-200"
-          style={{ width: '90vw', height: 'auto', maxHeight: '85vh', aspectRatio: 'auto' }}
-        >
+        <div className="relative h-full w-full">
           <Image
             src={selectedImage.url}
             alt={selectedImage.alt ?? localMessage('product.defaultImage')}
-            width={900}
-            height={900}
-            className="object-contain w-full h-full"
+            fill
+            sizes="90vw"
+            className="object-contain select-none"
+            draggable={false}
+            onDragStart={(e) => e.preventDefault()}
             style={lightboxImageStyle}
             priority
           />

--- a/src/components/shared/products/__tests__/LightboxOverlay.test.tsx
+++ b/src/components/shared/products/__tests__/LightboxOverlay.test.tsx
@@ -14,6 +14,7 @@ function makeBaseProps(overrides: Partial<React.ComponentProps<typeof LightboxOv
   // 기본 ref 들
   const lightboxPanRef = { current: { x: 0, y: 0 } } as React.MutableRefObject<{ x: number; y: number }>;
   const isDragging = { current: false } as React.MutableRefObject<boolean>;
+  const lightboxDragMovedRef = { current: false } as React.MutableRefObject<boolean>;
 
   return {
     images: sampleImages,
@@ -34,6 +35,7 @@ function makeBaseProps(overrides: Partial<React.ComponentProps<typeof LightboxOv
     handleLightboxTouchMove: vi.fn(),
     handleLightboxTouchEnd: vi.fn(),
     isDragging,
+    lightboxDragMovedRef,
     ...overrides,
   };
 }
@@ -56,6 +58,19 @@ describe('LightboxOverlay', () => {
     const overlay = screen.getByText('1 / 3').closest('.product-lightbox-top-layer');
     expect(overlay).toBeInTheDocument();
     expect(overlay?.parentElement).toBe(document.body);
+  });
+
+
+  it('긴 세로 이미지도 뷰포트 안에 맞도록 고정 contain 영역을 사용한다', () => {
+    render(<LightboxOverlay {...makeBaseProps()} />);
+    const image = screen.getByAltText('이미지1');
+    const interactiveContainer = image.closest('[style*="cursor"]') as HTMLElement;
+    const imageFrame = image.parentElement as HTMLElement;
+
+    expect(interactiveContainer).toHaveClass('h-[85vh]', 'w-[90vw]', 'overflow-hidden');
+    expect(imageFrame).toHaveClass('h-full', 'w-full');
+    expect(image).toHaveClass('object-contain');
+    expect(image).toHaveAttribute('draggable', 'false');
   });
 
   it('이미지 1장이면 prev/next 버튼/도트 미렌더', () => {
@@ -139,6 +154,20 @@ describe('LightboxOverlay', () => {
     expect(setLightboxZoomed).not.toHaveBeenCalled();
   });
 
+
+  it('드래그로 pan 한 직후 발생한 click은 확대 토글로 처리하지 않는다', async () => {
+    const setLightboxZoomed = vi.fn();
+    const lightboxDragMovedRef = { current: true } as React.MutableRefObject<boolean>;
+    render(<LightboxOverlay {...makeBaseProps({ lightboxZoomed: true, lightboxDragMovedRef, setLightboxZoomed })} />);
+
+    const image = screen.getByAltText('이미지1');
+    const interactiveContainer = image.closest('[style*="cursor"]') as HTMLElement;
+    await userEvent.click(interactiveContainer);
+
+    expect(setLightboxZoomed).not.toHaveBeenCalled();
+    expect(lightboxDragMovedRef.current).toBe(false);
+  });
+
   it('확대 상태 cursor는 드래그 여부에 따라 grab/grabbing으로 표시된다', () => {
     const { unmount } = render(<LightboxOverlay {...makeBaseProps({ lightboxZoomed: true })} />);
     const grabbedImage = screen.getByAltText('이미지1');
@@ -203,29 +232,32 @@ describe('useLightboxInteraction', () => {
       result.current.handleLightboxMouseDown({
         clientX: 0,
         clientY: 0,
-      } as React.MouseEvent);
+        preventDefault: vi.fn(),
+      } as unknown as React.MouseEvent);
     });
     act(() => {
       result.current.handleLightboxMouseMove({
         clientX: 50,
         clientY: 30,
-      } as React.MouseEvent);
+        preventDefault: vi.fn(),
+      } as unknown as React.MouseEvent);
     });
     expect(result.current.lightboxPan).toEqual({ x: 50, y: 30 });
+    expect(result.current.lightboxDragMovedRef.current).toBe(true);
   });
 
   it('mouseMove pan 은 maxPan=150 으로 클램핑', () => {
     const { result } = renderHook(() => useLightboxInteraction());
     act(() => result.current.setLightboxZoomed(true));
-    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0 } as React.MouseEvent));
-    act(() => result.current.handleLightboxMouseMove({ clientX: 9999, clientY: -9999 } as React.MouseEvent));
+    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0, preventDefault: vi.fn() } as unknown as React.MouseEvent));
+    act(() => result.current.handleLightboxMouseMove({ clientX: 9999, clientY: -9999, preventDefault: vi.fn() } as unknown as React.MouseEvent));
     expect(result.current.lightboxPan).toEqual({ x: 150, y: -150 });
   });
 
   it('zoomed=false 면 mouseMove 무시', () => {
     const { result } = renderHook(() => useLightboxInteraction());
     act(() => {
-      result.current.handleLightboxMouseMove({ clientX: 100, clientY: 100 } as React.MouseEvent);
+      result.current.handleLightboxMouseMove({ clientX: 100, clientY: 100, preventDefault: vi.fn() } as unknown as React.MouseEvent);
     });
     expect(result.current.lightboxPan).toEqual({ x: 0, y: 0 });
   });
@@ -233,7 +265,7 @@ describe('useLightboxInteraction', () => {
   it('mouseUp → isDragging.current=false', () => {
     const { result } = renderHook(() => useLightboxInteraction());
     act(() => result.current.setLightboxZoomed(true));
-    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0 } as React.MouseEvent));
+    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0, preventDefault: vi.fn() } as unknown as React.MouseEvent));
     expect(result.current.isDragging.current).toBe(true);
     act(() => result.current.handleLightboxMouseUp());
     expect(result.current.isDragging.current).toBe(false);
@@ -242,8 +274,8 @@ describe('useLightboxInteraction', () => {
   it('resetLightboxState → zoom 초기화 + pan 초기화', () => {
     const { result } = renderHook(() => useLightboxInteraction());
     act(() => result.current.setLightboxZoomed(true));
-    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0 } as React.MouseEvent));
-    act(() => result.current.handleLightboxMouseMove({ clientX: 30, clientY: 30 } as React.MouseEvent));
+    act(() => result.current.handleLightboxMouseDown({ clientX: 0, clientY: 0, preventDefault: vi.fn() } as unknown as React.MouseEvent));
+    act(() => result.current.handleLightboxMouseMove({ clientX: 30, clientY: 30, preventDefault: vi.fn() } as unknown as React.MouseEvent));
     expect(result.current.lightboxPan).toEqual({ x: 30, y: 30 });
 
     act(() => result.current.resetLightboxState());
@@ -263,6 +295,8 @@ describe('useLightboxInteraction', () => {
     act(() => {
       result.current.handleLightboxTouchMove({
         touches: [{ clientX: 500, clientY: -500 }],
+        cancelable: true,
+        preventDefault: vi.fn(),
       } as unknown as React.TouchEvent);
     });
     expect(result.current.lightboxPan).toEqual({ x: 100, y: -100 });


### PR DESCRIPTION
## Summary
- Fix product lightbox image frame to use a stable `90vw x 85vh` contain area so tall images fit inside the viewport without being clipped.
- Disable native image dragging and track drag movement separately so zoomed lightbox images can actually pan via mouse/touch drag.
- Prevent the click event after a drag from toggling zoom/closing the intended pan interaction.

Closes #974

## Verification
- `npx vitest run src/components/shared/products/__tests__/LightboxOverlay.test.tsx src/components/shared/hooks/__tests__/useLightboxInteraction.test.tsx --reporter=verbose`
- `bash scripts/start-local.sh`; `curl /api/health`; `curl -I /ko/products/preview`
- Headless Chrome smoke: opened `/ko/products/preview`, clicked image lightbox, verified `h-[85vh] w-[90vw] overflow-hidden` + `object-fit: contain`, then zoomed and dragged to `translate(80px, 40px)`
- `bash scripts/codex-project-guard.sh && npm run build && npm run test:run`
- `npm run test:coverage`
- `cd backend && npm run build && npm run test`

## Review
- Local code-review pass: no blockers; scope limited to frontend lightbox layout/interaction and tests.
