### PR TITLE
#978 이미지 업로드 제한 10MB 상향

### DIFF
--- a/backend/src/modules/upload/__tests__/remote-image-ingest.service.spec.ts
+++ b/backend/src/modules/upload/__tests__/remote-image-ingest.service.spec.ts
@@ -133,9 +133,23 @@ describe('RemoteImageIngestService', () => {
     await expect(service.ingest('https://cdn.example.com/missing.jpg')).rejects.toThrow(BadRequestException);
   });
 
+  it('accepts downloads at the 10MB size limit', async () => {
+    fetchMock.mockResolvedValue(createFetchResponse({
+      headers: { 'content-length': String(10 * 1024 * 1024) },
+      body: Buffer.alloc(10 * 1024 * 1024, 1),
+    }));
+
+    await service.ingest('https://cdn.example.com/large.jpg');
+
+    expect(uploadService.uploadOriginalImageBuffer).toHaveBeenCalledWith(
+      expect.objectContaining({ length: 10 * 1024 * 1024 }),
+      expect.stringContaining('large.jpg'),
+    );
+  });
+
   it('rejects downloads exceeding the size limit via content-length', async () => {
     fetchMock.mockResolvedValue(createFetchResponse({
-      headers: { 'content-length': String(20 * 1024 * 1024) },
+      headers: { 'content-length': String(10 * 1024 * 1024 + 1) },
     }));
 
     await expect(service.ingest('https://cdn.example.com/huge.jpg')).rejects.toThrow(BadRequestException);
@@ -144,7 +158,7 @@ describe('RemoteImageIngestService', () => {
 
   it('rejects downloads whose body exceeds the size limit', async () => {
     fetchMock.mockResolvedValue(createFetchResponse({
-      body: Buffer.alloc(6 * 1024 * 1024, 1),
+      body: Buffer.alloc(10 * 1024 * 1024 + 1, 1),
     }));
 
     await expect(service.ingest('https://cdn.example.com/huge.jpg')).rejects.toThrow(BadRequestException);
@@ -160,7 +174,7 @@ describe('RemoteImageIngestService', () => {
       body: {
         getReader: () => ({
           read: jest.fn()
-            .mockResolvedValueOnce({ done: false, value: Buffer.alloc(5 * 1024 * 1024) })
+            .mockResolvedValueOnce({ done: false, value: Buffer.alloc(10 * 1024 * 1024) })
             .mockResolvedValueOnce({ done: false, value: Buffer.alloc(1) }),
           cancel,
           releaseLock: jest.fn(),

--- a/backend/src/modules/upload/__tests__/upload.service.spec.ts
+++ b/backend/src/modules/upload/__tests__/upload.service.spec.ts
@@ -100,8 +100,15 @@ describe('UploadService', () => {
     await expect(service.uploadImage(file)).rejects.toThrow(BadRequestException);
   });
 
-  it('파일 크기 초과 — 5MB 이상 거부', async () => {
-    const file = makeFile({ size: 6 * 1024 * 1024 });
+  it('파일 크기 제한 — 10MB 이하 허용', async () => {
+    const file = makeFile({ size: 10 * 1024 * 1024 });
+    const result = await service.uploadImage(file);
+
+    expect(result.url).toBeDefined();
+  });
+
+  it('파일 크기 초과 — 10MB 초과 거부', async () => {
+    const file = makeFile({ size: 10 * 1024 * 1024 + 1 });
     await expect(service.uploadImage(file)).rejects.toThrow(PayloadTooLargeException);
   });
 
@@ -176,11 +183,18 @@ describe('UploadService', () => {
       );
     });
 
-    it('파일 크기 초과 — 5MB 이상 거부', async () => {
-      const file = makeFile({ size: 6 * 1024 * 1024 });
+    it('파일 크기 제한 — 10MB 이하 허용', async () => {
+      const file = makeFile({ size: 10 * 1024 * 1024 });
+      const result = await service.uploadCategoryImage(file);
+
+      expect(result.url).toBeDefined();
+    });
+
+    it('파일 크기 초과 — 10MB 초과 거부', async () => {
+      const file = makeFile({ size: 10 * 1024 * 1024 + 1 });
       await expect(service.uploadCategoryImage(file)).rejects.toThrow(PayloadTooLargeException);
       await expect(service.uploadCategoryImage(file)).rejects.toThrow(
-        '파일 크기는 5MB를 초과할 수 없습니다.',
+        '파일 크기는 10MB를 초과할 수 없습니다.',
       );
     });
 

--- a/backend/src/modules/upload/remote-image-ingest.service.ts
+++ b/backend/src/modules/upload/remote-image-ingest.service.ts
@@ -4,7 +4,7 @@ import { isIP } from 'node:net';
 import * as path from 'node:path';
 import { UploadService } from './upload.service';
 import { UploadedFile } from './interfaces/storage.interface';
-import { MAX_UPLOAD_FILE_SIZE_BYTES } from './upload.constants';
+import { MAX_UPLOAD_FILE_SIZE_BYTES, MAX_UPLOAD_FILE_SIZE_LABEL } from './upload.constants';
 
 const MAX_REDIRECTS = 3;
 const DOWNLOAD_TIMEOUT_MS = 10_000;
@@ -49,7 +49,9 @@ export class RemoteImageIngestService {
 
       const contentLength = Number(response.headers.get('content-length') ?? 0);
       if (contentLength > MAX_UPLOAD_FILE_SIZE_BYTES) {
-        throw new BadRequestException(`이미지 크기가 5MB를 초과합니다: ${current.href}`);
+        throw new BadRequestException(
+          `이미지 크기가 ${MAX_UPLOAD_FILE_SIZE_LABEL}를 초과합니다: ${current.href}`,
+        );
       }
 
       return { buffer: await this.readLimitedBody(response, current), finalUrl: current };
@@ -112,7 +114,9 @@ export class RemoteImageIngestService {
         totalBytes += chunk.length;
         if (totalBytes > MAX_UPLOAD_FILE_SIZE_BYTES) {
           await reader.cancel();
-          throw new BadRequestException(`이미지 크기가 5MB를 초과합니다: ${url.href}`);
+          throw new BadRequestException(
+            `이미지 크기가 ${MAX_UPLOAD_FILE_SIZE_LABEL}를 초과합니다: ${url.href}`,
+          );
         }
         chunks.push(chunk);
       }

--- a/backend/src/modules/upload/upload.constants.ts
+++ b/backend/src/modules/upload/upload.constants.ts
@@ -1,4 +1,6 @@
 export const ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
-export const MAX_UPLOAD_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+export const MAX_UPLOAD_FILE_SIZE_MB = 10;
+export const MAX_UPLOAD_FILE_SIZE_BYTES = MAX_UPLOAD_FILE_SIZE_MB * 1024 * 1024;
+export const MAX_UPLOAD_FILE_SIZE_LABEL = `${MAX_UPLOAD_FILE_SIZE_MB}MB`;
 export const MAX_UPLOAD_IMAGE_WIDTH = 1920;
 export const MAX_UPLOAD_IMAGE_HEIGHT = 1920;

--- a/backend/src/modules/upload/upload.service.ts
+++ b/backend/src/modules/upload/upload.service.ts
@@ -16,6 +16,7 @@ import { S3StorageAdapter } from './adapters/s3.adapter';
 import {
   ALLOWED_IMAGE_MIME_TYPES,
   MAX_UPLOAD_FILE_SIZE_BYTES,
+  MAX_UPLOAD_FILE_SIZE_LABEL,
   MAX_UPLOAD_IMAGE_HEIGHT,
   MAX_UPLOAD_IMAGE_WIDTH,
 } from './upload.constants';
@@ -158,7 +159,9 @@ export class UploadService {
     }
 
     if (file.size > MAX_UPLOAD_FILE_SIZE_BYTES) {
-      throw new PayloadTooLargeException('파일 크기는 5MB를 초과할 수 없습니다.');
+      throw new PayloadTooLargeException(
+        `파일 크기는 ${MAX_UPLOAD_FILE_SIZE_LABEL}를 초과할 수 없습니다.`,
+      );
     }
 
     const detectedMime = detectMimeFromMagicBytes(file.buffer);

--- a/src/components/shared/admin/ProductImageUploader.tsx
+++ b/src/components/shared/admin/ProductImageUploader.tsx
@@ -69,7 +69,7 @@ export default function ProductImageUploader({
           <div className="flex flex-col items-center gap-2 text-muted-foreground">
             <span className="text-4xl">+</span>
             <p className="text-sm">클릭하거나 드래그하여 이미지 업로드</p>
-            <p className="text-xs">JPEG, PNG, WebP · 최대 5MB</p>
+            <p className="text-xs">JPEG, PNG, WebP · 최대 10MB</p>
           </div>
         )}
         {uploading && (

--- a/src/components/shared/admin/__tests__/ProductImageUploader.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductImageUploader.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ProductImageUploader from '../ProductImageUploader';
+
+vi.mock('@/lib/api', () => ({
+  uploadApi: {
+    uploadImage: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('ProductImageUploader', () => {
+  it('shows the 10MB image upload limit in the helper copy', () => {
+    render(<ProductImageUploader imageUrl="" onChange={vi.fn()} />);
+
+    expect(screen.getByText('JPEG, PNG, WebP · 최대 10MB')).toBeInTheDocument();
+    expect(screen.queryByText(/최대 5MB/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- 직접 이미지 업로드 제한을 5MB에서 10MB로 상향했습니다.
- 원격 이미지 수집의 `Content-Length` 사전 검증과 스트리밍 누적 크기 검증도 10MB 기준으로 맞췄습니다.
- 관리자 이미지 업로더 안내 문구를 `최대 10MB`로 갱신했습니다.
- 10MB 경계/초과 케이스와 안내 문구 회귀 테스트를 추가했습니다.

Closes #978

## Verification
- `bash scripts/codex-project-guard.sh`
- `npm run lint && npm run test:run && npm run test:coverage && npm run build`
- `cd backend && npm run lint && npm run test && npm run build`
- `cd backend && npx jest src/modules/upload/__tests__/upload.service.spec.ts src/modules/upload/__tests__/remote-image-ingest.service.spec.ts --runInBand`
- `npx vitest run src/components/shared/admin/__tests__/ProductImageUploader.test.tsx`
- `git diff --check`

## Notes
- 실제 운영 S3 버킷에 10MB 근접 파일을 업로드하는 수동 검증은 하지 않았습니다.
