### PR TITLE
feat: #973 네이버 커머스API 상품 업데이트 미리보기/반영

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 NEXT_PUBLIC_GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
 
 # PayPal uses backend-created Orders API redirect flow; no frontend SDK key is required.
+
+# Naver Commerce API sync is executed by the backend; frontend keeps key names only for setup visibility.
+NAVER_COMMERCE_APP_ID=
+NAVER_COMMERCE_APP_SECRET=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -66,6 +66,10 @@ NAVERPAY_PARTNER_ID=  # REQUIRED in production checkout
 NAVERPAY_CLIENT_ID=  # REQUIRED in production checkout
 NAVERPAY_CLIENT_SECRET=  # REQUIRED in production checkout
 NAVERPAY_CHAIN_ID=  # REQUIRED in production checkout
+# Naver Commerce API (SmartStore product sync)
+NAVER_COMMERCE_APP_ID=
+NAVER_COMMERCE_APP_SECRET=
+NAVER_COMMERCE_API_BASE_URL=https://api.commerce.naver.com/external
 # Shipping carrier API
 CJ_TRACKING_API_URL=
 CJ_TRACKING_API_KEY=

--- a/backend/src/modules/products/__tests__/naver-commerce-api.client.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-api.client.spec.ts
@@ -1,0 +1,133 @@
+import { BadRequestException } from '@nestjs/common';
+import { NaverCommerceApiClient } from '../naver-commerce-api.client';
+
+const ORIGINAL_ENV = process.env;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('NaverCommerceApiClient', () => {
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NAVER_COMMERCE_APP_ID: 'test-client-id',
+      NAVER_COMMERCE_APP_SECRET: '$2a$10$abcdefghijklmnopqrstuv',
+      NAVER_COMMERCE_API_BASE_URL: 'https://naver-commerce.test/external',
+    };
+    jest.spyOn(Date, 'now').mockReturnValue(1643961623299);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('issues a form-encoded OAuth token request, searches products, and loads origin-product details', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'access-token', expires_in: 10_800 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          contents: [
+            { originProductNo: 1001, name: '목록 상품 A' },
+            { originProductNo: '1002', name: '목록 상품 B' },
+          ],
+          totalPages: 1,
+          last: true,
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ originProduct: { name: '상세 상품 A' } }))
+      .mockResolvedValueOnce(jsonResponse({ originProduct: { name: '상세 상품 B' } }));
+    global.fetch = fetchMock;
+
+    const client = new NaverCommerceApiClient();
+    const products = await client.fetchProductsWithDetails();
+
+    expect(products).toHaveLength(2);
+    expect(products[0]).toMatchObject({
+      rowNumber: 1,
+      detailProduct: { originProduct: { name: '상세 상품 A' } },
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://naver-commerce.test/external/v1/oauth2/token',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const tokenBody = fetchMock.mock.calls[0][1].body as URLSearchParams;
+    expect(tokenBody.get('client_id')).toBe('test-client-id');
+    expect(tokenBody.get('timestamp')).toBe('1643961623299');
+    expect(tokenBody.get('grant_type')).toBe('client_credentials');
+    expect(tokenBody.get('type')).toBe('SELF');
+    expect(tokenBody.get('client_secret_sign')).toBeTruthy();
+    expect(tokenBody.get('client_secret_sign')).not.toContain(
+      process.env.NAVER_COMMERCE_APP_SECRET as string,
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://naver-commerce.test/external/v1/products/search',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer access-token' }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'https://naver-commerce.test/external/v2/products/origin-products/1001',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer access-token' }),
+      }),
+    );
+  });
+
+  it('returns product-level detail errors instead of aborting the whole sync', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'access-token', expires_in: 10_800 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          contents: [{ originProductNo: 1001, name: '목록 상품' }],
+          totalPages: 1,
+          last: true,
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ message: 'detail failed' }, 500));
+
+    const client = new NaverCommerceApiClient();
+    const products = await client.fetchProductsWithDetails();
+
+    expect(products[0]).toMatchObject({ detailProduct: null, error: 'detail failed' });
+  });
+
+  it('returns a safe error when the configured client secret cannot sign token requests', async () => {
+    process.env.NAVER_COMMERCE_APP_SECRET = 'not-a-bcrypt-salt';
+    const client = new NaverCommerceApiClient();
+
+    await expect(client.fetchProductsWithDetails()).rejects.toThrow(
+      '자격증명 형식이 올바르지 않습니다',
+    );
+  });
+
+  it('wraps token network failures in a safe gateway error', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('socket includes secret-ish details'));
+    const client = new NaverCommerceApiClient();
+
+    await expect(client.fetchProductsWithDetails()).rejects.toThrow(
+      '인증 토큰 요청에 실패했습니다',
+    );
+  });
+
+  it('throws a safe configuration error when credentials are missing', async () => {
+    delete process.env.NAVER_COMMERCE_APP_ID;
+    delete process.env.NAVER_COMMERCE_APP_SECRET;
+    const client = new NaverCommerceApiClient();
+
+    await expect(client.fetchProductsWithDetails()).rejects.toThrow(BadRequestException);
+    await expect(client.fetchProductsWithDetails()).rejects.toThrow(
+      '자격증명이 설정되지 않았습니다',
+    );
+  });
+});

--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -1,0 +1,228 @@
+import { Product } from '../entities/product.entity';
+import { NaverCommerceApiClient, NaverCommerceFetchedProduct } from '../naver-commerce-api.client';
+import { NaverCommerceProductImportService } from '../naver-commerce-product-import.service';
+import { ProductCommandService } from '../product-command.service';
+import { SmartStoreProductImportService } from '../smartstore-product-import.service';
+import { RemoteImageIngestService } from '../../upload/remote-image-ingest.service';
+
+function createRepositoryMock(existingProducts: Product[] = []) {
+  return {
+    find: jest.fn().mockResolvedValue(existingProducts),
+    findOne: jest.fn().mockResolvedValue(null),
+  };
+}
+
+function createCommandServiceMock() {
+  return {
+    create: jest.fn().mockImplementation(async (dto) => ({ id: 100, ...dto })),
+    update: jest.fn().mockImplementation(async (id, dto) => ({ id, ...dto })),
+  };
+}
+
+function createIngestServiceMock() {
+  return {
+    ingest: jest.fn().mockImplementation(async (url: string) => ({
+      url: `https://cdn.okhwadang.com/uploads/${encodeURIComponent(url)}`,
+      filename: 'uploaded.jpg',
+    })),
+  };
+}
+
+function createService(
+  fetchedProducts: NaverCommerceFetchedProduct[],
+  existingProducts: Product[] = [],
+) {
+  const naverClient = {
+    fetchProductsWithDetails: jest.fn().mockResolvedValue(fetchedProducts),
+  };
+  const repository = createRepositoryMock(existingProducts);
+  const commandService = createCommandServiceMock();
+  const ingestService = createIngestServiceMock();
+  const smartStoreImportService = new SmartStoreProductImportService(
+    repository as never,
+    commandService as unknown as ProductCommandService,
+    ingestService as unknown as RemoteImageIngestService,
+  );
+  return {
+    service: new NaverCommerceProductImportService(
+      naverClient as unknown as NaverCommerceApiClient,
+      smartStoreImportService,
+    ),
+    naverClient,
+    repository,
+    commandService,
+    ingestService,
+  };
+}
+
+const NAVER_PRODUCTS: NaverCommerceFetchedProduct[] = [
+  {
+    rowNumber: 1,
+    listProduct: { originProductNo: 1001, channelProducts: [{ sellerManagementCode: 'SKU-1' }] },
+    detailProduct: {
+      originProduct: {
+        name: '네이버 상품 A',
+        salePrice: 50000,
+        stockQuantity: 3,
+        statusType: 'SALE',
+        detailContent: '<p>상세</p>',
+        images: {
+          representativeImage: { url: 'https://img.example.com/rep.jpg' },
+          optionalImages: [{ url: 'https://img.example.com/a.jpg' }],
+        },
+        deliveryInfo: { deliveryFee: { deliveryFeeType: 'FREE', baseFee: 0 } },
+        detailAttribute: {
+          manufacturerName: '옥화당',
+          originAreaInfo: { content: '중국' },
+          afterServiceInfo: {
+            afterServiceTelephoneNumber: '010-0000-0000',
+            afterServiceGuideContent: '품질 보증 안내',
+          },
+        },
+        optionInfo: {
+          optionCombinations: [
+            { optionName: '용량', optionValue: '100cc', price: 0, stockQuantity: 2, usable: 'Y' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    rowNumber: 2,
+    listProduct: { originProductNo: 1002, channelProducts: [{ sellerManagementCode: 'SKU-2' }] },
+    detailProduct: {
+      originProduct: {
+        name: '미매칭 상품',
+        salePrice: 30000,
+        stockQuantity: 1,
+        statusType: 'SALE',
+      },
+    },
+  },
+];
+
+describe('NaverCommerceProductImportService', () => {
+  it('previews Naver Commerce products with the shared SmartStore row format without saving', async () => {
+    const existing = { id: 7, sku: 'SKU-1', slug: 'old-product' } as Product;
+    const { service, commandService } = createService(NAVER_PRODUCTS, [existing]);
+
+    const result = await service.preview();
+
+    expect(result.summary).toMatchObject({
+      totalRows: 2,
+      createCount: 0,
+      updateCount: 1,
+      skipCount: 1,
+      failureCount: 0,
+    });
+    expect(result.rows[0]).toMatchObject({
+      identifier: 'SKU-1',
+      action: 'update',
+      productId: 7,
+      optionCount: 1,
+      galleryImageCount: 2,
+      isFreeShipping: true,
+      hasNoticeInfo: true,
+    });
+    expect(result.rows[1]).toMatchObject({ identifier: 'SKU-2', action: 'skip', status: 'valid' });
+    expect(result.rows[1].errors.join(' ')).toContain('업데이트 대상에서 제외');
+    expect(commandService.update).not.toHaveBeenCalled();
+    expect(commandService.create).not.toHaveBeenCalled();
+  });
+
+  it('commits only SKU-matched Naver products and never creates unmatched API rows', async () => {
+    const existing = { id: 7, sku: 'SKU-1', slug: 'old-product' } as Product;
+    const { service, commandService, ingestService } = createService(NAVER_PRODUCTS, [existing]);
+
+    const result = await service.commit();
+
+    expect(result.summary).toMatchObject({
+      updateCount: 1,
+      createCount: 0,
+      skipCount: 1,
+      successCount: 1,
+      failureCount: 0,
+    });
+    expect(commandService.update).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        name: '네이버 상품 A',
+        sku: 'SKU-1',
+        price: 50000,
+        stock: 3,
+        isFreeShipping: true,
+        description: '<p>상세</p>',
+        noticeInfo: expect.objectContaining({ manufacturer: '옥화당', countryOfOrigin: '중국' }),
+        options: [expect.objectContaining({ name: '용량', value: '100cc', stock: 2 })],
+        images: [
+          expect.objectContaining({
+            url: expect.stringContaining(encodeURIComponent('https://img.example.com/rep.jpg')),
+            isThumbnail: true,
+          }),
+          expect.objectContaining({
+            url: expect.stringContaining(encodeURIComponent('https://img.example.com/a.jpg')),
+            isThumbnail: false,
+          }),
+        ],
+      }),
+    );
+    expect(commandService.create).not.toHaveBeenCalled();
+    expect(ingestService.ingest).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the SmartStore channel product number as the fallback SKU-compatible identifier', async () => {
+    const existing = { id: 8, sku: 'naver-2001', slug: 'old-channel-product' } as Product;
+    const fetchedProducts: NaverCommerceFetchedProduct[] = [
+      {
+        rowNumber: 1,
+        listProduct: { originProductNo: 1001, channelProducts: [{ channelProductNo: 2001 }] },
+        detailProduct: {
+          originProduct: {
+            name: '채널번호 상품',
+            salePrice: 12000,
+            stockQuantity: 1,
+            statusType: 'SALE',
+          },
+        },
+      },
+    ];
+    const { service, commandService } = createService(fetchedProducts, [existing]);
+
+    const result = await service.commit();
+
+    expect(result.rows[0]).toMatchObject({
+      identifier: 'naver-2001',
+      action: 'update',
+      productId: 8,
+    });
+    expect(commandService.update).toHaveBeenCalledWith(
+      8,
+      expect.objectContaining({ sku: 'naver-2001' }),
+    );
+    expect(commandService.create).not.toHaveBeenCalled();
+  });
+
+  it('marks product detail failures as row-level failures while keeping other rows processable', async () => {
+    const existing = { id: 7, sku: 'SKU-1', slug: 'old-product' } as Product;
+    const failingProducts: NaverCommerceFetchedProduct[] = [
+      NAVER_PRODUCTS[0],
+      {
+        rowNumber: 2,
+        listProduct: {
+          originProductNo: 1003,
+          channelProducts: [{ sellerManagementCode: 'SKU-3' }],
+        },
+        detailProduct: null,
+        error: '네이버 상품 상세 조회에 실패했습니다.',
+      },
+    ];
+    const { service, commandService } = createService(failingProducts, [existing]);
+
+    const result = await service.commit();
+
+    expect(result.summary).toMatchObject({ successCount: 1, failureCount: 1 });
+    expect(result.rows[1]).toMatchObject({ action: 'skip', status: 'failed' });
+    expect(result.rows[1].errors.join(' ')).toContain('상세 조회에 실패');
+    expect(commandService.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/modules/products/naver-commerce-api.client.ts
+++ b/backend/src/modules/products/naver-commerce-api.client.ts
@@ -1,0 +1,260 @@
+import { BadGatewayException, BadRequestException, Injectable } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+
+const DEFAULT_NAVER_COMMERCE_API_BASE_URL = 'https://api.commerce.naver.com/external';
+const DEFAULT_PAGE_SIZE = 100;
+const MAX_SYNC_PRODUCTS = 500;
+
+export interface NaverCommerceFetchedProduct {
+  rowNumber: number;
+  listProduct: Record<string, unknown>;
+  detailProduct: Record<string, unknown> | null;
+  error?: string;
+}
+
+interface NaverTokenResponse {
+  access_token?: unknown;
+  expires_in?: unknown;
+}
+
+interface NaverSearchResponse {
+  contents?: unknown;
+  totalPages?: unknown;
+  last?: unknown;
+}
+
+@Injectable()
+export class NaverCommerceApiClient {
+  private accessToken: string | null = null;
+  private accessTokenExpiresAt = 0;
+
+  async fetchProductsWithDetails(): Promise<NaverCommerceFetchedProduct[]> {
+    this.assertConfigured();
+    const listProducts = await this.searchAllProducts();
+    const products: NaverCommerceFetchedProduct[] = [];
+
+    for (let index = 0; index < listProducts.length; index += 1) {
+      const listProduct = listProducts[index];
+      const originProductNo = this.getNumberLike(listProduct, 'originProductNo');
+      if (!originProductNo) {
+        products.push({
+          rowNumber: index + 1,
+          listProduct,
+          detailProduct: null,
+          error: '네이버 상품 목록 응답에 원상품번호가 없어 상세 조회를 건너뜁니다.',
+        });
+        continue;
+      }
+
+      try {
+        const detailProduct = await this.request<Record<string, unknown>>(
+          `/v2/products/origin-products/${originProductNo}`,
+          {
+            method: 'GET',
+          },
+        );
+        products.push({ rowNumber: index + 1, listProduct, detailProduct });
+      } catch (err) {
+        products.push({
+          rowNumber: index + 1,
+          listProduct,
+          detailProduct: null,
+          error: err instanceof Error ? err.message : '네이버 상품 상세 조회에 실패했습니다.',
+        });
+      }
+    }
+
+    return products;
+  }
+
+  private async searchAllProducts(): Promise<Array<Record<string, unknown>>> {
+    const products: Array<Record<string, unknown>> = [];
+    let page = 1;
+    let totalPages = 1;
+
+    while (page <= totalPages && products.length < MAX_SYNC_PRODUCTS) {
+      const response = await this.request<NaverSearchResponse>('/v1/products/search', {
+        method: 'POST',
+        body: JSON.stringify({ page, size: DEFAULT_PAGE_SIZE }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const contents = Array.isArray(response.contents) ? response.contents : [];
+      products.push(...contents.filter(this.isRecord));
+
+      const responseTotalPages =
+        typeof response.totalPages === 'number' && Number.isFinite(response.totalPages)
+          ? Math.max(1, Math.trunc(response.totalPages))
+          : totalPages;
+      totalPages = response.last === true ? page : responseTotalPages;
+      page += 1;
+
+      if (contents.length === 0) break;
+    }
+
+    return products.slice(0, MAX_SYNC_PRODUCTS);
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const token = await this.getAccessToken();
+    return this.requestWithToken<T>(path, init, token, true);
+  }
+
+  private async requestWithToken<T>(
+    path: string,
+    init: RequestInit,
+    token: string,
+    allowAuthRetry: boolean,
+  ): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.getBaseUrl()}${path}`, {
+        ...init,
+        headers: {
+          ...(init.headers as Record<string, string> | undefined),
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    } catch {
+      throw new BadGatewayException(
+        '네이버 커머스API 요청에 실패했습니다. 네트워크 상태를 확인해 주세요.',
+      );
+    }
+    const payload = await this.parseResponseBody(response);
+
+    if (response.status === 401 && allowAuthRetry && this.getErrorCode(payload) === 'GW.AUTHN') {
+      this.accessToken = null;
+      const refreshed = await this.getAccessToken();
+      return this.requestWithToken<T>(path, init, refreshed, false);
+    }
+
+    if (!response.ok) {
+      throw new BadGatewayException(
+        this.safeErrorMessage(
+          payload,
+          `네이버 커머스API 요청에 실패했습니다. (HTTP ${response.status})`,
+        ),
+      );
+    }
+
+    return payload as T;
+  }
+
+  private async getAccessToken(): Promise<string> {
+    const now = Date.now();
+    if (this.accessToken && this.accessTokenExpiresAt - now > 60_000) {
+      return this.accessToken;
+    }
+
+    const clientId = this.getEnv('NAVER_COMMERCE_APP_ID');
+    const clientSecret = this.getEnv('NAVER_COMMERCE_APP_SECRET');
+    if (!clientId || !clientSecret) {
+      throw new BadRequestException(
+        '네이버 커머스API 자격증명이 설정되지 않았습니다. 관리자 환경변수를 확인해 주세요.',
+      );
+    }
+
+    const timestamp = String(now);
+    const clientSecretSign = this.generateSignature(clientId, clientSecret, timestamp);
+    const body = new URLSearchParams({
+      client_id: clientId,
+      timestamp,
+      client_secret_sign: clientSecretSign,
+      grant_type: 'client_credentials',
+      type: 'SELF',
+    });
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.getBaseUrl()}/v1/oauth2/token`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body,
+      });
+    } catch {
+      throw new BadGatewayException(
+        '네이버 커머스API 인증 토큰 요청에 실패했습니다. 네트워크 상태를 확인해 주세요.',
+      );
+    }
+    const payload = (await this.parseResponseBody(response)) as NaverTokenResponse;
+
+    if (!response.ok || typeof payload.access_token !== 'string') {
+      throw new BadGatewayException(
+        this.safeErrorMessage(payload, '네이버 커머스API 인증 토큰 발급에 실패했습니다.'),
+      );
+    }
+
+    const expiresInSeconds =
+      typeof payload.expires_in === 'number' && Number.isFinite(payload.expires_in)
+        ? payload.expires_in
+        : 10_800;
+    this.accessToken = payload.access_token;
+    this.accessTokenExpiresAt = now + Math.max(60, expiresInSeconds - 60) * 1000;
+    return this.accessToken;
+  }
+
+  private assertConfigured(): void {
+    if (!this.getEnv('NAVER_COMMERCE_APP_ID') || !this.getEnv('NAVER_COMMERCE_APP_SECRET')) {
+      throw new BadRequestException(
+        '네이버 커머스API 자격증명이 설정되지 않았습니다. 관리자 환경변수를 확인해 주세요.',
+      );
+    }
+  }
+
+  private generateSignature(clientId: string, clientSecret: string, timestamp: string): string {
+    const password = `${clientId}_${timestamp}`;
+    try {
+      const hashed = bcrypt.hashSync(password, clientSecret);
+      return Buffer.from(hashed, 'utf-8').toString('base64');
+    } catch {
+      throw new BadRequestException(
+        '네이버 커머스API 자격증명 형식이 올바르지 않습니다. 관리자 환경변수를 확인해 주세요.',
+      );
+    }
+  }
+
+  private getBaseUrl(): string {
+    return this.getEnv('NAVER_COMMERCE_API_BASE_URL') || DEFAULT_NAVER_COMMERCE_API_BASE_URL;
+  }
+
+  private getEnv(key: string): string {
+    return (process.env[key] ?? '').trim();
+  }
+
+  private async parseResponseBody(response: Response): Promise<unknown> {
+    if (response.status === 204) return {};
+    const text = await response.text();
+    if (!text) return {};
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      return { message: text };
+    }
+  }
+
+  private safeErrorMessage(payload: unknown, fallback: string): string {
+    const record = this.isRecord(payload) ? payload : {};
+    const message = typeof record.message === 'string' ? record.message : fallback;
+    return message
+      .replace(this.getEnv('NAVER_COMMERCE_APP_ID'), '[REDACTED]')
+      .replace(this.getEnv('NAVER_COMMERCE_APP_SECRET'), '[REDACTED]');
+  }
+
+  private getErrorCode(payload: unknown): string | null {
+    if (!this.isRecord(payload)) return null;
+    return typeof payload.code === 'string' ? payload.code : null;
+  }
+
+  private getNumberLike(record: Record<string, unknown>, key: string): string | null {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    if (typeof value === 'number' && Number.isFinite(value)) return String(Math.trunc(value));
+    return null;
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+}

--- a/backend/src/modules/products/naver-commerce-product-import.service.ts
+++ b/backend/src/modules/products/naver-commerce-product-import.service.ts
@@ -1,0 +1,413 @@
+import { Injectable } from '@nestjs/common';
+import {
+  CreateProductDto,
+  ProductNoticeInfoType,
+  ProductOptionInputDto,
+} from './dto/create-product.dto';
+import { ProductStatus } from './entities/product.entity';
+import { NaverCommerceApiClient, NaverCommerceFetchedProduct } from './naver-commerce-api.client';
+import {
+  SmartStoreImportResult,
+  SmartStoreParsedProductRow,
+  SmartStoreProductImportService,
+} from './smartstore-product-import.service';
+import { buildNaverExternalProductKey } from '../../common/imports/external-source.util';
+
+@Injectable()
+export class NaverCommerceProductImportService {
+  constructor(
+    private readonly naverCommerceApiClient: NaverCommerceApiClient,
+    private readonly smartStoreProductImportService: SmartStoreProductImportService,
+  ) {}
+
+  async preview(): Promise<SmartStoreImportResult> {
+    return this.process(false);
+  }
+
+  async commit(): Promise<SmartStoreImportResult> {
+    return this.process(true);
+  }
+
+  private async process(commit: boolean): Promise<SmartStoreImportResult> {
+    const fetchedProducts = await this.naverCommerceApiClient.fetchProductsWithDetails();
+    const parsedRows = fetchedProducts.map((product) => this.toParsedRow(product));
+    const options = {
+      unmatchedAction: 'skip' as const,
+      unmatchedSkipMessage: (identifier: string | null) =>
+        identifier
+          ? `SKU가 ${identifier}인 자사몰 상품이 없어 업데이트 대상에서 제외했습니다.`
+          : '네이버 상품 식별자를 찾지 못해 업데이트 대상에서 제외했습니다.',
+    };
+    return commit
+      ? this.smartStoreProductImportService.commitParsedRows(parsedRows, options)
+      : this.smartStoreProductImportService.previewParsedRows(parsedRows, options);
+  }
+
+  private toParsedRow(fetchedProduct: NaverCommerceFetchedProduct): SmartStoreParsedProductRow {
+    const product = this.mergeProduct(fetchedProduct.listProduct, fetchedProduct.detailProduct);
+    const errors = fetchedProduct.error ? [fetchedProduct.error] : [];
+    const productName = this.firstString(product, [
+      'originProduct.name',
+      'name',
+      'productName',
+      'channelProducts.0.name',
+      'channelProducts.0.productName',
+    ]);
+    const naverProductNumber = this.firstNumberLike(product, [
+      'channelProducts.0.channelProductNo',
+      'channelProducts.0.productNo',
+      'originProduct.channelProducts.0.channelProductNo',
+      'originProductNo',
+      'originProduct.originProductNo',
+    ]);
+    const sellerCode = this.firstString(product, [
+      'sellerManagementCode',
+      'originProduct.sellerManagementCode',
+      'channelProducts.0.sellerManagementCode',
+      'channelProducts.0.sellerManagementCodeNo',
+    ]);
+    const identifier = this.buildIdentifier(sellerCode, naverProductNumber);
+    const price = this.firstNumber(product, [
+      'originProduct.salePrice',
+      'salePrice',
+      'channelProducts.0.salePrice',
+      'channelProducts.0.price',
+    ]);
+    const stock = this.firstNumber(product, [
+      'originProduct.stockQuantity',
+      'stockQuantity',
+      'originProduct.optionInfo.stockQuantity',
+      'channelProducts.0.stockQuantity',
+    ]);
+    const salePrice = this.resolveSalePrice(product, price);
+    const description = this.firstString(product, [
+      'originProduct.detailContent',
+      'originProduct.description',
+      'detailContent',
+      'description',
+    ]);
+    const representativeImage = this.firstString(product, [
+      'originProduct.images.representativeImage.url',
+      'originProduct.images.representativeImageUrl',
+      'representativeImage.url',
+      'representativeImageUrl',
+    ]);
+    const galleryUrls = this.uniqueStrings([
+      representativeImage,
+      ...this.stringArray(product, [
+        'originProduct.images.optionalImages.*.url',
+        'originProduct.images.optionalImageUrls.*',
+        'optionalImages.*.url',
+        'additionalImages.*.url',
+      ]),
+    ]);
+    const detailUrls = this.uniqueStrings(
+      this.stringArray(product, [
+        'originProduct.detailImages.*.url',
+        'originProduct.detailImageUrls.*',
+        'detailImages.*.url',
+        'detailImageUrls.*',
+      ]),
+    );
+    const noticeInfo = this.buildNoticeInfo(product, productName);
+    const options = this.buildOptions(product);
+
+    if (!identifier) errors.push('네이버 상품번호 또는 판매자 상품코드가 필요합니다.');
+    if (!productName) errors.push('네이버 상품명이 필요합니다.');
+    if (price === null || price < 1) errors.push('네이버 판매가는 1원 이상이어야 합니다.');
+
+    const dto: CreateProductDto | null =
+      errors.length > 0 || !identifier || !productName || price === null
+        ? null
+        : {
+            name: productName,
+            slug: this.slugify(identifier),
+            sku: identifier,
+            price,
+            salePrice: salePrice ?? undefined,
+            stock: stock ?? 0,
+            status: this.mapStatus(
+              this.firstString(product, [
+                'originProduct.statusType',
+                'statusType',
+                'channelProducts.0.statusType',
+                'channelProducts.0.channelProductStatusType',
+              ]),
+              stock ?? 0,
+            ),
+            description: description || undefined,
+            isFreeShipping: this.resolveFreeShipping(product),
+            noticeInfo,
+            images: this.buildImages(productName, galleryUrls),
+            detailImages: detailUrls.map((url, index) => ({
+              url,
+              alt: productName,
+              sortOrder: index,
+            })),
+            options,
+          };
+
+    if (dto?.detailImages?.length === 0) delete dto.detailImages;
+
+    return {
+      rowNumber: fetchedProduct.rowNumber,
+      identifier,
+      productName,
+      dto,
+      optionCount: options?.length ?? 0,
+      galleryImageCount: galleryUrls.length,
+      detailImageCount: detailUrls.length,
+      price,
+      salePrice: salePrice ?? null,
+      hasDiscount: salePrice !== undefined && price !== null && salePrice < price,
+      isFreeShipping: this.resolveFreeShipping(product) ?? null,
+      hasNoticeInfo: Boolean(noticeInfo),
+      errors,
+    };
+  }
+
+  private mergeProduct(
+    listProduct: Record<string, unknown>,
+    detailProduct: Record<string, unknown> | null,
+  ): Record<string, unknown> {
+    return detailProduct ? { ...listProduct, ...detailProduct } : listProduct;
+  }
+
+  private buildIdentifier(
+    sellerCode: string | null,
+    originProductNo: string | null,
+  ): string | null {
+    const raw = sellerCode || buildNaverExternalProductKey(originProductNo ?? '') || '';
+    const normalized = raw.trim();
+    return normalized || null;
+  }
+
+  private resolveSalePrice(
+    product: Record<string, unknown>,
+    price: number | null,
+  ): number | undefined {
+    const discounted = this.firstNumber(product, [
+      'originProduct.discountedSalePrice',
+      'discountedSalePrice',
+      'channelProducts.0.discountedSalePrice',
+    ]);
+    if (discounted !== null) return discounted;
+    if (price === null) return undefined;
+
+    const discountValue = this.firstNumber(product, [
+      'originProduct.customerBenefit.immediateDiscountPolicy.discountMethod.value',
+      'originProduct.detailAttribute.customerBenefit.immediateDiscountPolicy.discountMethod.value',
+      'customerBenefit.immediateDiscountPolicy.discountMethod.value',
+    ]);
+    if (discountValue === null || discountValue <= 0) return undefined;
+    const unit = this.firstString(product, [
+      'originProduct.customerBenefit.immediateDiscountPolicy.discountMethod.unitType',
+      'originProduct.detailAttribute.customerBenefit.immediateDiscountPolicy.discountMethod.unitType',
+      'customerBenefit.immediateDiscountPolicy.discountMethod.unitType',
+    ])?.toUpperCase();
+    if (unit === 'PERCENT' || unit === 'PERCENTAGE' || unit === '%') {
+      return Math.max(0, Math.round((price * (100 - discountValue)) / 100));
+    }
+    return Math.max(0, price - discountValue);
+  }
+
+  private resolveFreeShipping(product: Record<string, unknown>): boolean | undefined {
+    const deliveryFeeType = this.firstString(product, [
+      'originProduct.deliveryInfo.deliveryFee.deliveryFeeType',
+      'originProduct.deliveryInfo.deliveryFeeType',
+      'deliveryInfo.deliveryFee.deliveryFeeType',
+      'deliveryFeeType',
+    ])?.toUpperCase();
+    if (deliveryFeeType) {
+      if (deliveryFeeType.includes('FREE') || deliveryFeeType.includes('무료')) return true;
+      if (
+        deliveryFeeType.includes('PAID') ||
+        deliveryFeeType.includes('CONDITIONAL') ||
+        deliveryFeeType.includes('유료')
+      )
+        return false;
+    }
+
+    const baseFee = this.firstNumber(product, [
+      'originProduct.deliveryInfo.deliveryFee.baseFee',
+      'originProduct.deliveryInfo.baseFee',
+      'deliveryInfo.deliveryFee.baseFee',
+      'baseFee',
+    ]);
+    if (baseFee === 0) return true;
+    if (baseFee !== null && baseFee > 0) return false;
+    return undefined;
+  }
+
+  private buildNoticeInfo(
+    product: Record<string, unknown>,
+    productName: string | null,
+  ): CreateProductDto['noticeInfo'] {
+    const manufacturer = this.firstString(product, [
+      'originProduct.detailAttribute.manufacturerName',
+      'originProduct.manufacturerName',
+      'manufacturerName',
+    ]);
+    const origin = this.firstString(product, [
+      'originProduct.detailAttribute.originAreaInfo.content',
+      'originProduct.originAreaInfo.content',
+      'originAreaInfo.content',
+      'origin',
+    ]);
+    const asPhone = this.firstString(product, [
+      'originProduct.detailAttribute.afterServiceInfo.afterServiceTelephoneNumber',
+      'afterServiceInfo.afterServiceTelephoneNumber',
+      'asPhone',
+    ]);
+    const asGuide = this.firstString(product, [
+      'originProduct.detailAttribute.afterServiceInfo.afterServiceGuideContent',
+      'afterServiceInfo.afterServiceGuideContent',
+      'asGuide',
+    ]);
+
+    if (!manufacturer && !origin && !asPhone && !asGuide) return undefined;
+    return {
+      type: ProductNoticeInfoType.TEAWARE,
+      productName: productName ?? undefined,
+      manufacturer: manufacturer ?? undefined,
+      countryOfOrigin: origin ?? undefined,
+      origin: origin ?? undefined,
+      asContact: [asPhone, asGuide].filter(Boolean).join(' / ') || undefined,
+      warrantyPolicy: asGuide ?? undefined,
+    };
+  }
+
+  private buildOptions(product: Record<string, unknown>): ProductOptionInputDto[] | undefined {
+    const combinations = this.firstArray(product, [
+      'originProduct.optionInfo.optionCombinations',
+      'optionInfo.optionCombinations',
+      'optionCombinations',
+    ]);
+    if (!combinations || combinations.length === 0) return undefined;
+
+    const options: ProductOptionInputDto[] = [];
+    for (const item of combinations) {
+      if (!this.isRecord(item)) continue;
+      const usable = this.firstString(item, ['usable', 'isUsable', 'useYn']);
+      if (usable && ['N', 'NO', 'FALSE', '사용안함'].includes(usable.toUpperCase())) continue;
+      const optionName = this.firstString(item, ['optionName', 'name']) ?? '옵션';
+      const optionValue = this.firstString(item, [
+        'optionValue',
+        'value',
+        'optionValue1',
+        'optionName1',
+      ]);
+      if (!optionValue) continue;
+      options.push({
+        name: optionName,
+        value: optionValue,
+        priceAdjustment: this.firstNumber(item, ['price', 'priceAdjustment', 'optionPrice']) ?? 0,
+        stock: this.firstNumber(item, ['stockQuantity', 'stock']) ?? 0,
+        sortOrder: options.length,
+      });
+    }
+
+    return options.length > 0 ? options : undefined;
+  }
+
+  private mapStatus(status: string | null, stock: number): ProductStatus {
+    const normalized = (status ?? '').replace(/[\s_-]/g, '').toUpperCase();
+    if (
+      ['SUSPENSION', 'SALEPROHIBITION', 'CLOSE', 'DELETE', 'HIDDEN'].some((value) =>
+        normalized.includes(value),
+      )
+    ) {
+      return ProductStatus.HIDDEN;
+    }
+    if (['OUTOFSTOCK', 'SOLDOUT'].some((value) => normalized.includes(value)))
+      return ProductStatus.SOLDOUT;
+    if (['WAIT', 'DRAFT'].some((value) => normalized.includes(value))) return ProductStatus.DRAFT;
+    return stock === 0 ? ProductStatus.SOLDOUT : ProductStatus.ACTIVE;
+  }
+
+  private buildImages(productName: string, urls: string[]): CreateProductDto['images'] {
+    if (urls.length === 0) return undefined;
+    return urls.map((url, index) => ({
+      url,
+      alt: productName,
+      sortOrder: index,
+      isThumbnail: index === 0,
+    }));
+  }
+
+  private firstString(record: Record<string, unknown>, paths: string[]): string | null {
+    for (const path of paths) {
+      const value = this.readPath(record, path);
+      if (typeof value === 'string' && value.trim()) return value.trim();
+      if (typeof value === 'number' && Number.isFinite(value)) return String(Math.trunc(value));
+    }
+    return null;
+  }
+
+  private firstNumber(record: Record<string, unknown>, paths: string[]): number | null {
+    for (const path of paths) {
+      const value = this.readPath(record, path);
+      if (typeof value === 'number' && Number.isFinite(value)) return value;
+      if (typeof value === 'string') {
+        const parsed = Number(value.replace(/[^0-9.-]/g, ''));
+        if (Number.isFinite(parsed)) return parsed;
+      }
+    }
+    return null;
+  }
+
+  private firstNumberLike(record: Record<string, unknown>, paths: string[]): string | null {
+    return this.firstString(record, paths);
+  }
+
+  private firstArray(record: Record<string, unknown>, paths: string[]): unknown[] | null {
+    for (const path of paths) {
+      const value = this.readPath(record, path);
+      if (Array.isArray(value)) return value;
+    }
+    return null;
+  }
+
+  private stringArray(record: Record<string, unknown>, paths: string[]): string[] {
+    return paths.flatMap((path) => {
+      if (!path.includes('.*')) {
+        const value = this.readPath(record, path);
+        return typeof value === 'string' && value.trim() ? [value.trim()] : [];
+      }
+      const [arrayPath, childPath] = path.split('.*.');
+      const value = this.readPath(record, arrayPath.replace(/\.\*$/, ''));
+      if (!Array.isArray(value)) return [];
+      return value.flatMap((item) => {
+        const candidate = childPath ? this.readPath(item, childPath) : item;
+        return typeof candidate === 'string' && candidate.trim() ? [candidate.trim()] : [];
+      });
+    });
+  }
+
+  private uniqueStrings(values: Array<string | null>): string[] {
+    return [...new Set(values.filter((value): value is string => Boolean(value)))];
+  }
+
+  private readPath(value: unknown, path: string): unknown {
+    return path.split('.').reduce<unknown>((current, segment) => {
+      if (current === undefined || current === null) return undefined;
+      if (/^\d+$/.test(segment) && Array.isArray(current)) return current[Number(segment)];
+      if (!this.isRecord(current)) return undefined;
+      return current[segment];
+    }, value);
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  private slugify(value: string): string {
+    const slug = value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9가-힣]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 240);
+    return slug || 'naver-commerce-product';
+  }
+}

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -39,6 +39,7 @@ import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
 import { CreateRestockAlertDto } from '../restock-alerts/dto/create-restock-alert.dto';
 import { RecentlyViewedService } from './recently-viewed.service';
 import { SmartStoreProductImportService } from './smartstore-product-import.service';
+import { NaverCommerceProductImportService } from './naver-commerce-product-import.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { createSingleFileMemoryUploadOptions } from '../../common/multer/single-file-upload.options';
 import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guard';
@@ -51,6 +52,7 @@ export class ProductsController {
     private readonly restockAlertsService: RestockAlertsService,
     private readonly recentlyViewedService: RecentlyViewedService,
     private readonly smartStoreProductImportService: SmartStoreProductImportService,
+    private readonly naverCommerceProductImportService: NaverCommerceProductImportService,
   ) {}
 
   @Get()
@@ -147,6 +149,31 @@ export class ProductsController {
   ))
   commitSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
     return this.smartStoreProductImportService.commit(file);
+  }
+
+
+  @Post('imports/naver-commerce/preview')
+  @Roles('admin')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '네이버 커머스API 상품 업데이트 미리보기', description: '네이버 커머스API로 스마트스토어 상품을 조회하고 SKU가 일치하는 자사몰 상품 업데이트 예정 내역을 반환합니다.' })
+  @ApiResponse({ status: 201, description: '네이버 커머스API 가져오기 미리보기 성공' })
+  @ApiResponse({ status: 400, description: '네이버 커머스API 자격증명 누락 또는 잘못된 요청' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  previewNaverCommerceImport() {
+    return this.naverCommerceProductImportService.preview();
+  }
+
+  @Post('imports/naver-commerce/commit')
+  @Roles('admin')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '네이버 커머스API 상품 업데이트 반영', description: '네이버 커머스API 미리보기와 동일한 매칭/매핑 기준으로 SKU가 일치하는 자사몰 상품을 업데이트합니다.' })
+  @ApiResponse({ status: 201, description: '네이버 커머스API 가져오기 반영 성공' })
+  @ApiResponse({ status: 400, description: '네이버 커머스API 자격증명 누락 또는 잘못된 요청' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  commitNaverCommerceImport() {
+    return this.naverCommerceProductImportService.commit();
   }
 
   @Post()

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -15,6 +15,8 @@ import { CategoriesService } from './categories.service';
 import { AttributesService } from './attributes.service';
 import { RecentlyViewedService } from './recently-viewed.service';
 import { SmartStoreProductImportService } from './smartstore-product-import.service';
+import { NaverCommerceApiClient } from './naver-commerce-api.client';
+import { NaverCommerceProductImportService } from './naver-commerce-product-import.service';
 import { ProductsController } from './products.controller';
 import { AdminProductsController } from './admin-products.controller';
 import { CategoriesController } from './categories.controller';
@@ -50,6 +52,8 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
     AttributesService,
     RecentlyViewedService,
     SmartStoreProductImportService,
+    NaverCommerceApiClient,
+    NaverCommerceProductImportService,
     OptionalJwtAuthGuard,
   ],
   controllers: [ProductsController, AdminProductsController, CategoriesController, AttributesController],
@@ -61,6 +65,8 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
     AttributesService,
     RecentlyViewedService,
     SmartStoreProductImportService,
+    NaverCommerceApiClient,
+    NaverCommerceProductImportService,
     OptionalJwtAuthGuard,
   ],
 })

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -43,7 +43,7 @@ export interface SmartStoreImportResult {
   rows: SmartStoreImportRowResult[];
 }
 
-interface ParsedSmartStoreRow {
+export interface SmartStoreParsedProductRow {
   rowNumber: number;
   identifier: string | null;
   productName: string | null;
@@ -60,6 +60,11 @@ interface ParsedSmartStoreRow {
 }
 
 const MAX_IMPORT_ROWS = 500;
+
+interface SmartStoreParsedRowsProcessOptions {
+  unmatchedAction?: SmartStoreImportAction;
+  unmatchedSkipMessage?: (identifier: string | null) => string;
+}
 
 type SmartStoreImportFormat = 'smartstore-list-export' | 'smartstore-bulk-edit';
 
@@ -126,9 +131,31 @@ export class SmartStoreProductImportService {
     return this.process(file, true);
   }
 
+  async previewParsedRows(
+    parsedRows: SmartStoreParsedProductRow[],
+    options: SmartStoreParsedRowsProcessOptions = {},
+  ): Promise<SmartStoreImportResult> {
+    return this.processParsedRows(parsedRows, false, options);
+  }
+
+  async commitParsedRows(
+    parsedRows: SmartStoreParsedProductRow[],
+    options: SmartStoreParsedRowsProcessOptions = {},
+  ): Promise<SmartStoreImportResult> {
+    return this.processParsedRows(parsedRows, true, options);
+  }
+
   private async process(file: Express.Multer.File, commit: boolean): Promise<SmartStoreImportResult> {
     this.assertExcelFile(file);
     const parsedRows = await this.parseWorkbook(file.buffer);
+    return this.processParsedRows(parsedRows, commit);
+  }
+
+  private async processParsedRows(
+    parsedRows: SmartStoreParsedProductRow[],
+    commit: boolean,
+    options: SmartStoreParsedRowsProcessOptions = {},
+  ): Promise<SmartStoreImportResult> {
     const identifiers = parsedRows
       .map((row) => row.identifier)
       .filter((identifier): identifier is string => Boolean(identifier));
@@ -150,15 +177,19 @@ export class SmartStoreProductImportService {
       if (parsed.identifier && duplicateIdentifiers.has(parsed.identifier)) {
         errors.push(`파일 안에서 중복된 상품 식별자입니다: ${parsed.identifier}`);
       }
+      const hasBlockingErrors = errors.length > 0;
 
       const existing = parsed.identifier ? existingBySku.get(parsed.identifier) : undefined;
-      const action: SmartStoreImportAction = errors.length > 0 ? 'skip' : existing ? 'update' : 'create';
+      const action: SmartStoreImportAction = hasBlockingErrors ? 'skip' : existing ? 'update' : (options.unmatchedAction ?? 'create');
+      if (!existing && !hasBlockingErrors && action === 'skip') {
+        errors.push(options.unmatchedSkipMessage?.(parsed.identifier) ?? '일치하는 자사몰 상품이 없어 스킵합니다.');
+      }
       const rowResult: SmartStoreImportRowResult = {
         rowNumber: parsed.rowNumber,
         identifier: parsed.identifier,
         productName: parsed.productName,
         action,
-        status: errors.length > 0 ? 'failed' : commit ? 'success' : 'valid',
+        status: hasBlockingErrors ? 'failed' : commit && action !== 'skip' ? 'success' : 'valid',
         productId: existing?.id,
         optionCount: parsed.optionCount,
         galleryImageCount: parsed.galleryImageCount,
@@ -171,7 +202,7 @@ export class SmartStoreProductImportService {
         errors,
       };
 
-      if (commit && errors.length === 0 && parsed.dto) {
+      if (commit && !hasBlockingErrors && action !== 'skip' && parsed.dto) {
         try {
           const dto = await this.resolveRemoteImages(parsed.dto, ingestCache);
           const saved = existing
@@ -199,7 +230,7 @@ export class SmartStoreProductImportService {
     assertXlsxFile(file, '스마트스토어 상품');
   }
 
-  private async parseWorkbook(buffer: Buffer): Promise<ParsedSmartStoreRow[]> {
+  private async parseWorkbook(buffer: Buffer): Promise<SmartStoreParsedProductRow[]> {
     const workbook = new ExcelJS.Workbook();
     await workbook.xlsx.load(buffer);
     const format = this.detectFormat(workbook);
@@ -208,7 +239,7 @@ export class SmartStoreProductImportService {
       throw new BadRequestException('필수 컬럼을 찾을 수 없습니다: 상품명, 판매가. 지원 포맷은 스마트스토어 상품목록 다운로드형 또는 일괄수정 XLSX형입니다.');
     }
 
-    const rows: ParsedSmartStoreRow[] = [];
+    const rows: SmartStoreParsedProductRow[] = [];
     const seenDataRows = format.worksheet.rowCount - format.dataStartRowNumber + 1;
     if (seenDataRows > MAX_IMPORT_ROWS) {
       throw new BadRequestException(`한 번에 최대 ${MAX_IMPORT_ROWS}개 상품까지만 업로드할 수 있습니다.`);
@@ -275,7 +306,7 @@ export class SmartStoreProductImportService {
     return headerMap;
   }
 
-  private parseRow(row: ExcelJS.Row, rowNumber: number, headerMap: HeaderMap): ParsedSmartStoreRow {
+  private parseRow(row: ExcelJS.Row, rowNumber: number, headerMap: HeaderMap): SmartStoreParsedProductRow {
     const productNumber = this.getCell(row, headerMap.productNumber);
     const sellerCode = this.getCell(row, headerMap.sellerCode);
     const productName = this.getCell(row, headerMap.name);

--- a/docs/infrastructure/ENVIRONMENT_VARIABLES.md
+++ b/docs/infrastructure/ENVIRONMENT_VARIABLES.md
@@ -142,6 +142,9 @@ backend/.env.example      # 키 목록 (커밋 O, 값 없음)
 | `NAVERPAY_CLIENT_ID` | — | NaverPay client ID (프로덕션 체크아웃 필수) |
 | `NAVERPAY_CLIENT_SECRET` | — | NaverPay client secret (프로덕션 체크아웃 필수) |
 | `NAVERPAY_CHAIN_ID` | — | NaverPay chain ID (프로덕션 체크아웃 필수) |
+| `NAVER_COMMERCE_APP_ID` | — | 네이버 커머스API 애플리케이션 ID (스마트스토어 상품 동기화용) |
+| `NAVER_COMMERCE_APP_SECRET` | — | 네이버 커머스API 애플리케이션 시크릿. 실제 값은 secret/env에만 보관 |
+| `NAVER_COMMERCE_API_BASE_URL` | `https://api.commerce.naver.com/external` | 네이버 커머스API 호스트 override (테스트/장애 대응용) |
 | `PAYPAL_CLIENT_ID` | — | PayPal REST API client ID (프로덕션 체크아웃 필수) |
 | `PAYPAL_CLIENT_SECRET` | — | PayPal REST API client secret (프로덕션 체크아웃 필수) |
 | `PAYPAL_WEBHOOK_ID` | — | PayPal webhook signature verification ID |

--- a/src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx
+++ b/src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AdminProductsPage from '../page';
+import type { Product, SmartStoreProductImportResult } from '@/lib/api';
+
+const mockUseAdminGuard = vi.fn();
+const mockGetList = vi.fn();
+const mockUpdate = vi.fn();
+const mockRemove = vi.fn();
+const mockPreviewSmartStoreImport = vi.fn();
+const mockCommitSmartStoreImport = vi.fn();
+const mockPreviewNaverCommerceImport = vi.fn();
+const mockCommitNaverCommerceImport = vi.fn();
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string | number>) => {
+    if (!values) return key;
+    return `${key}:${JSON.stringify(values)}`;
+  },
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@/components/shared/hooks/useAdminGuard', () => ({
+  useAdminGuard: () => mockUseAdminGuard(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  adminProductsApi: {
+    getList: (...args: unknown[]) => mockGetList(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+    remove: (...args: unknown[]) => mockRemove(...args),
+    previewSmartStoreImport: (...args: unknown[]) => mockPreviewSmartStoreImport(...args),
+    commitSmartStoreImport: (...args: unknown[]) => mockCommitSmartStoreImport(...args),
+    previewNaverCommerceImport: (...args: unknown[]) => mockPreviewNaverCommerceImport(...args),
+    commitNaverCommerceImport: (...args: unknown[]) => mockCommitNaverCommerceImport(...args),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const product: Product = {
+  id: 7,
+  name: '옥화당 자사호',
+  slug: 'okhwadang-pot',
+  price: 50000,
+  salePrice: null,
+  shortDescription: null,
+  rating: 0,
+  reviewCount: 0,
+  status: 'active',
+  isFeatured: false,
+  isFreeShipping: true,
+  viewCount: 0,
+  category: null,
+  images: [],
+};
+
+const naverResult: SmartStoreProductImportResult = {
+  summary: {
+    totalRows: 1,
+    createCount: 0,
+    updateCount: 1,
+    skipCount: 0,
+    successCount: 0,
+    failureCount: 0,
+  },
+  rows: [
+    {
+      rowNumber: 1,
+      identifier: 'SKU-1',
+      productName: '네이버 상품',
+      action: 'update',
+      status: 'valid',
+      productId: 7,
+      optionCount: 1,
+      galleryImageCount: 2,
+      detailImageCount: 0,
+      price: 50000,
+      salePrice: null,
+      hasDiscount: false,
+      isFreeShipping: true,
+      hasNoticeInfo: true,
+      errors: [],
+    },
+  ],
+};
+
+describe('AdminProductsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAdminGuard.mockReturnValue({
+      user: { id: 1, email: 'admin@test.com', name: 'Admin', role: 'admin' },
+      isLoading: false,
+      isAdmin: true,
+    });
+    mockGetList.mockResolvedValue({ items: [product], total: 1, page: 1, limit: 20 });
+    mockUpdate.mockResolvedValue(product);
+    mockRemove.mockResolvedValue({ message: 'deleted' });
+    mockPreviewSmartStoreImport.mockResolvedValue(naverResult);
+    mockCommitSmartStoreImport.mockResolvedValue({
+      ...naverResult,
+      summary: { ...naverResult.summary, successCount: 1 },
+      rows: [{ ...naverResult.rows[0], status: 'success' }],
+    });
+    mockPreviewNaverCommerceImport.mockResolvedValue(naverResult);
+    mockCommitNaverCommerceImport.mockResolvedValue({
+      ...naverResult,
+      summary: { ...naverResult.summary, successCount: 1 },
+      rows: [{ ...naverResult.rows[0], status: 'success' }],
+    });
+  });
+
+  it('previews and commits Naver Commerce API updates in the shared import table', async () => {
+    render(<AdminProductsPage />);
+
+    expect(await screen.findByText('옥화당 자사호')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'naverCommerce.previewButton' }));
+
+    await waitFor(() => {
+      expect(mockPreviewNaverCommerceImport).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByText('SKU-1')).toBeInTheDocument();
+    expect(screen.getByText('네이버 상품')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'naverCommerce.commitButton' }));
+
+    await waitFor(() => {
+      expect(mockCommitNaverCommerceImport).toHaveBeenCalledTimes(1);
+    });
+    expect(mockCommitSmartStoreImport).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -27,6 +27,7 @@ export default function AdminProductsPage() {
   const [smartStoreFile, setSmartStoreFile] = useState<File | null>(null);
   const [importPreview, setImportPreview] = useState<SmartStoreProductImportResult | null>(null);
   const [importResult, setImportResult] = useState<SmartStoreProductImportResult | null>(null);
+  const [activeImportSource, setActiveImportSource] = useState<'smartstore-excel' | 'naver-commerce' | null>(null);
   const [showAllImportRows, setShowAllImportRows] = useState(false);
   const [showFailedImportRowsOnly, setShowFailedImportRowsOnly] = useState(false);
   const { page, setPage, filters, setFilter } = useAdminListPage({
@@ -75,6 +76,7 @@ export default function AdminProductsPage() {
       const result = await adminProductsApi.previewSmartStoreImport(file);
       setImportPreview(result);
       setImportResult(null);
+      setActiveImportSource('smartstore-excel');
     },
     { successMessage: t('import.previewSuccess'), errorMessage: t('import.previewError') },
   );
@@ -84,9 +86,33 @@ export default function AdminProductsPage() {
       const result = await adminProductsApi.commitSmartStoreImport(file);
       setImportResult(result);
       setImportPreview(null);
+      setActiveImportSource('smartstore-excel');
       void fetchProducts();
     },
     { successMessage: t('import.commitSuccess'), errorMessage: t('import.commitError') },
+  );
+
+  const { execute: previewNaverCommerceImport, isLoading: previewingNaverCommerce } = useAsyncAction(
+    async () => {
+      const result = await adminProductsApi.previewNaverCommerceImport();
+      setImportPreview(result);
+      setImportResult(null);
+      setActiveImportSource('naver-commerce');
+      setShowAllImportRows(false);
+      setShowFailedImportRowsOnly(false);
+    },
+    { successMessage: t('naverCommerce.previewSuccess'), errorMessage: t('naverCommerce.previewError') },
+  );
+
+  const { execute: commitNaverCommerceImport, isLoading: committingNaverCommerce } = useAsyncAction(
+    async () => {
+      const result = await adminProductsApi.commitNaverCommerceImport();
+      setImportResult(result);
+      setImportPreview(null);
+      setActiveImportSource('naver-commerce');
+      void fetchProducts();
+    },
+    { successMessage: t('naverCommerce.commitSuccess'), errorMessage: t('naverCommerce.commitError') },
   );
 
   const { execute: toggleStatus } = useAsyncAction(
@@ -112,6 +138,7 @@ export default function AdminProductsPage() {
     setSmartStoreFile(file);
     setImportPreview(null);
     setImportResult(null);
+    setActiveImportSource(null);
     setShowAllImportRows(false);
     setShowFailedImportRowsOnly(false);
   };
@@ -132,6 +159,14 @@ export default function AdminProductsPage() {
     void commitSmartStoreImport(smartStoreFile);
   };
 
+  const handlePreviewNaverCommerce = () => {
+    void previewNaverCommerceImport();
+  };
+
+  const handleCommitNaverCommerce = () => {
+    void commitNaverCommerceImport();
+  };
+
   const handleToggleStatus = (product: Product) => void toggleStatus(product);
 
   const handleDelete = (product: Product) => {
@@ -146,7 +181,7 @@ export default function AdminProductsPage() {
     ? allImportRows.filter((row) => row.status === 'failed')
     : allImportRows;
   const importRows = showAllImportRows ? visibleImportRows : visibleImportRows.slice(0, 5);
-  const isImporting = previewingImport || committingImport;
+  const isImporting = previewingImport || committingImport || previewingNaverCommerce || committingNaverCommerce;
 
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
@@ -206,11 +241,39 @@ export default function AdminProductsPage() {
             <button
               type="button"
               onClick={handleCommitImport}
-              disabled={!smartStoreFile || isImporting || !importPreview}
+              disabled={!smartStoreFile || isImporting || !importPreview || activeImportSource !== 'smartstore-excel'}
               className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {committingImport ? t('import.committing') : t('import.commitButton')}
             </button>
+          </div>
+        </div>
+
+        <div className="mt-4 border-t pt-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-1">
+              <h3 className="font-semibold typo-body-sm">{t('naverCommerce.title')}</h3>
+              <p className="text-sm text-muted-foreground">{t('naverCommerce.description')}</p>
+              <p className="text-sm text-muted-foreground">{t('naverCommerce.credentialsHint')}</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handlePreviewNaverCommerce}
+                disabled={isImporting}
+                className="rounded border px-4 py-2 text-sm hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {previewingNaverCommerce ? t('naverCommerce.previewing') : t('naverCommerce.previewButton')}
+              </button>
+              <button
+                type="button"
+                onClick={handleCommitNaverCommerce}
+                disabled={isImporting || !importPreview || activeImportSource !== 'naver-commerce'}
+                className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {committingNaverCommerce ? t('naverCommerce.committing') : t('naverCommerce.commitButton')}
+              </button>
+            </div>
           </div>
         </div>
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -814,6 +814,19 @@
           "productLink": "View product #{id}",
           "notLinked": "New product"
         }
+      },
+      "naverCommerce": {
+        "title": "Naver Commerce API product update",
+        "description": "Fetch SmartStore products from the Naver Commerce API without Excel and preview updates only for existing store products with matching SKUs.",
+        "credentialsHint": "Required environment variables: NAVER_COMMERCE_APP_ID and NAVER_COMMERCE_APP_SECRET. Secret values are never shown in responses or logs.",
+        "previewButton": "Preview API sync",
+        "previewing": "Fetching...",
+        "commitButton": "Apply API result",
+        "committing": "Applying...",
+        "previewSuccess": "Naver Commerce API products validated.",
+        "previewError": "Failed to validate Naver Commerce API products.",
+        "commitSuccess": "Naver Commerce API products applied to the store.",
+        "commitError": "Failed to apply Naver Commerce API products."
       }
     },
     "productForm": {
@@ -1450,7 +1463,11 @@
     "title": "Shipping, Exchange & Refund Policy",
     "description": "Detailed shipping, exchange/return, and refund standards beyond the product-detail summary.",
     "effectiveDate": "Effective date: June 12, 2026",
-    "sectionKeys": ["shipping", "exchangeReturn", "refund"],
+    "sectionKeys": [
+      "shipping",
+      "exchangeReturn",
+      "refund"
+    ],
     "sections": {
       "shipping": {
         "title": "Shipping Policy",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -814,6 +814,19 @@
           "productLink": "상품 #{id} 보기",
           "notLinked": "신규 예정"
         }
+      },
+      "naverCommerce": {
+        "title": "네이버 커머스API 상품 업데이트",
+        "description": "엑셀 파일 없이 네이버 커머스API에서 스마트스토어 상품을 조회해 SKU가 일치하는 기존 자사몰 상품만 업데이트 후보로 미리보기합니다.",
+        "credentialsHint": "필요 환경변수: NAVER_COMMERCE_APP_ID, NAVER_COMMERCE_APP_SECRET. 실제 시크릿 값은 응답과 로그에 표시하지 않습니다.",
+        "previewButton": "API 미리보기",
+        "previewing": "조회 중...",
+        "commitButton": "API 결과 반영",
+        "committing": "반영 중...",
+        "previewSuccess": "네이버 커머스API 상품을 검증했습니다.",
+        "previewError": "네이버 커머스API 상품 검증에 실패했습니다.",
+        "commitSuccess": "네이버 커머스API 상품을 자사몰에 반영했습니다.",
+        "commitError": "네이버 커머스API 상품 반영에 실패했습니다."
       }
     },
     "productForm": {
@@ -1450,7 +1463,11 @@
     "title": "배송/교환/환불 정책",
     "description": "상품 상세의 요약 안내보다 더 자세한 배송, 교환·반품, 환불 기준을 안내합니다.",
     "effectiveDate": "시행일: 2026년 6월 12일",
-    "sectionKeys": ["shipping", "exchangeReturn", "refund"],
+    "sectionKeys": [
+      "shipping",
+      "exchangeReturn",
+      "refund"
+    ],
     "sections": {
       "shipping": {
         "title": "배송 정책",

--- a/src/lib/__tests__/products-api.test.ts
+++ b/src/lib/__tests__/products-api.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { adminProductsApi } from '@/lib/api/admin/products';
 import { apiClient } from '@/lib/api/core';
 import { productsApi } from '@/lib/api/products';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('productsApi', () => {
   it('passes attrs to the product list request params', async () => {
@@ -12,7 +16,6 @@ describe('productsApi', () => {
     expect(getSpy).toHaveBeenCalledWith('/products', {
       params: { attrs: 'clay_type:junni', price_min: 10000 },
     });
-    getSpy.mockRestore();
   });
 });
 
@@ -25,6 +28,19 @@ describe('adminProductsApi', () => {
     expect(getSpy).toHaveBeenCalledWith('/admin/products/42', {
       params: undefined,
     });
-    getSpy.mockRestore();
+  });
+
+  it('calls Naver Commerce preview and commit endpoints without raw fetches', async () => {
+    const response = {
+      summary: { totalRows: 0, createCount: 0, updateCount: 0, skipCount: 0, successCount: 0, failureCount: 0 },
+      rows: [],
+    };
+    const postSpy = vi.spyOn(apiClient, 'post').mockResolvedValue(response);
+
+    await adminProductsApi.previewNaverCommerceImport();
+    await adminProductsApi.commitNaverCommerceImport();
+
+    expect(postSpy).toHaveBeenNthCalledWith(1, '/products/imports/naver-commerce/preview');
+    expect(postSpy).toHaveBeenNthCalledWith(2, '/products/imports/naver-commerce/commit');
   });
 });

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -89,4 +89,8 @@ export const adminProductsApi = {
     apiClient.uploadFile<SmartStoreProductImportResult>('/products/imports/smartstore/preview', file),
   commitSmartStoreImport: (file: File) =>
     apiClient.uploadFile<SmartStoreProductImportResult>('/products/imports/smartstore/commit', file),
+  previewNaverCommerceImport: () =>
+    apiClient.post<SmartStoreProductImportResult>('/products/imports/naver-commerce/preview'),
+  commitNaverCommerceImport: () =>
+    apiClient.post<SmartStoreProductImportResult>('/products/imports/naver-commerce/commit'),
 };


### PR DESCRIPTION
## 요약
- 네이버 커머스API OAuth 클라이언트와 상품 목록/원상품 상세 조회 기반 미리보기·반영 API를 추가했습니다.
- 기존 스마트스토어 엑셀 import의 row/summary/result 처리와 상품 저장·이미지 ingest 매핑을 API 동기화에서도 재사용하도록 공통 parsed-row 경로를 열었습니다.
- 어드민 상품 화면에 네이버 커머스API 연동 섹션을 추가하고 기존 import 표/요약 포맷으로 결과를 표시합니다.
- `NAVER_COMMERCE_APP_ID`, `NAVER_COMMERCE_APP_SECRET`, `NAVER_COMMERCE_API_BASE_URL` 키 이름을 예시 env/docs에 정리했습니다.

## 보안/동작
- 실제 secret 값은 커밋하지 않고, 자격증명 누락/인증 실패 메시지는 secret을 노출하지 않습니다.
- API 동기화는 SKU가 일치하는 기존 자사몰 상품만 업데이트하며, 미매칭 네이버 상품은 생성하지 않고 skip으로 표시합니다.
- 판매자 상품코드를 우선 매칭하고 없으면 스마트스토어 채널상품번호, 그 다음 원상품번호를 `naver-{번호}` fallback으로 사용합니다.

## 테스트
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `npm run lint`
- `cd backend && npm run lint`
- `bash scripts/codex-project-guard.sh`

Closes #973
