### PR TITLE
feat: #977 상품명 키워드 자동 매핑

### DIFF
--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -4,6 +4,8 @@ import { NaverCommerceProductImportService } from '../naver-commerce-product-imp
 import { ProductCommandService } from '../product-command.service';
 import { SmartStoreProductImportService } from '../smartstore-product-import.service';
 import { RemoteImageIngestService } from '../../upload/remote-image-ingest.service';
+import { ProductKeywordMappingService } from '../product-keyword-mapping.service';
+import { AttributesService } from '../attributes.service';
 
 function createRepositoryMock(existingProducts: Product[] = []) {
   return {
@@ -28,6 +30,29 @@ function createIngestServiceMock() {
   };
 }
 
+function createCategoryRepositoryMock() {
+  return {
+    find: jest.fn().mockResolvedValue([{ id: 1, slug: 'teapot', name: '자사호', isActive: true }]),
+  };
+}
+
+function createAttributeTypeRepositoryMock() {
+  return {
+    find: jest.fn().mockResolvedValue([
+      { id: 10, code: 'clay_type', isActive: true },
+      { id: 11, code: 'teapot_shape', isActive: true },
+      { id: 14, code: 'clay_origin', isActive: true },
+    ]),
+  };
+}
+
+function createAttributesServiceMock() {
+  return {
+    setProductAttributes: jest.fn().mockResolvedValue([]),
+    createOrUpdateProductAttribute: jest.fn().mockResolvedValue({}),
+  };
+}
+
 function createService(
   fetchedProducts: NaverCommerceFetchedProduct[],
   existingProducts: Product[] = [],
@@ -38,10 +63,15 @@ function createService(
   const repository = createRepositoryMock(existingProducts);
   const commandService = createCommandServiceMock();
   const ingestService = createIngestServiceMock();
+  const attributesService = createAttributesServiceMock();
   const smartStoreImportService = new SmartStoreProductImportService(
     repository as never,
+    createCategoryRepositoryMock() as never,
+    createAttributeTypeRepositoryMock() as never,
     commandService as unknown as ProductCommandService,
     ingestService as unknown as RemoteImageIngestService,
+    new ProductKeywordMappingService(),
+    attributesService as unknown as AttributesService,
   );
   return {
     service: new NaverCommerceProductImportService(
@@ -61,7 +91,7 @@ const NAVER_PRODUCTS: NaverCommerceFetchedProduct[] = [
     listProduct: { originProductNo: 1001, channelProducts: [{ sellerManagementCode: 'SKU-1' }] },
     detailProduct: {
       originProduct: {
-        name: '네이버 상품 A',
+        name: '옥화당 자사호 황룡산 노단니 연자호 110cc',
         salePrice: 50000,
         stockQuantity: 3,
         statusType: 'SALE',
@@ -123,6 +153,13 @@ describe('NaverCommerceProductImportService', () => {
       galleryImageCount: 2,
       isFreeShipping: true,
       hasNoticeInfo: true,
+      automaticMapping: expect.objectContaining({
+        category: expect.objectContaining({ slug: 'teapot', categoryId: 1 }),
+        attributes: expect.arrayContaining([
+          expect.objectContaining({ code: 'clay_type', value: 'old_duanni', attributeTypeId: 10 }),
+          expect.objectContaining({ code: 'teapot_shape', value: 'lianzi', attributeTypeId: 11 }),
+        ]),
+      }),
     });
     expect(result.rows[1]).toMatchObject({ identifier: 'SKU-2', action: 'skip', status: 'valid' });
     expect(result.rows[1].errors.join(' ')).toContain('업데이트 대상에서 제외');
@@ -146,7 +183,7 @@ describe('NaverCommerceProductImportService', () => {
     expect(commandService.update).toHaveBeenCalledWith(
       7,
       expect.objectContaining({
-        name: '네이버 상품 A',
+        name: '옥화당 자사호 황룡산 노단니 연자호 110cc',
         sku: 'SKU-1',
         price: 50000,
         stock: 3,

--- a/backend/src/modules/products/__tests__/product-keyword-mapping.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-keyword-mapping.service.spec.ts
@@ -1,0 +1,57 @@
+import { ProductNoticeInfoType } from '../dto/create-product.dto';
+import { ProductKeywordMappingService } from '../product-keyword-mapping.service';
+
+describe('ProductKeywordMappingService', () => {
+  const service = new ProductKeywordMappingService();
+
+  it('normalizes product names before matching aliases and units', () => {
+    const result = service.analyzeProductName('옥화당 (老段泥) 120 mL');
+
+    expect(result.normalizedName).toBe('옥화당 老段泥 120 ml');
+    expect(result.attributes).toEqual([
+      expect.objectContaining({ code: 'clay_type', value: 'old_duanni', displayValue: '노단니' }),
+    ]);
+    expect(result.options).toEqual([
+      expect.objectContaining({ name: '용량', value: '120ml' }),
+    ]);
+  });
+
+  it('prefers more specific clay keywords such as 노단니 over 단니', () => {
+    const result = service.analyzeProductName('옥화당 자사호 황룡산 노단니 연자호 110cc');
+
+    expect(result.category).toEqual(expect.objectContaining({ slug: 'teapot', displayName: '자사호' }));
+    expect(result.attributes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'clay_type', value: 'old_duanni', displayValue: '노단니' }),
+      expect.objectContaining({ code: 'teapot_shape', value: 'lianzi', displayValue: '연자호' }),
+      expect.objectContaining({ code: 'clay_origin', value: 'huanglongshan', displayValue: '황룡산' }),
+    ]));
+    expect(result.attributes).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'clay_type', value: 'duanni' }),
+    ]));
+    expect(result.warnings.join(' ')).toContain('단니');
+    expect(result.noticeInfoType).toBe(ProductNoticeInfoType.TEAWARE);
+    expect(result.options).toEqual([expect.objectContaining({ name: '용량', value: '110cc' })]);
+  });
+
+  it('extracts all deterministic mappings from a SmartStore teapot product name', () => {
+    const result = service.analyzeProductName('옥화당 자사호 황룡산 강파니 방고호 130cc');
+
+    expect(result).toMatchObject({
+      category: { slug: 'teapot' },
+      noticeInfoType: ProductNoticeInfoType.TEAWARE,
+    });
+    expect(result.attributes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'clay_type', value: 'jiangponi' }),
+      expect.objectContaining({ code: 'teapot_shape', value: 'fanggu' }),
+      expect.objectContaining({ code: 'clay_origin', value: 'huanglongshan' }),
+    ]));
+    expect(result.options).toEqual([expect.objectContaining({ value: '130cc' })]);
+  });
+
+  it('maps tea names to tea notice information', () => {
+    const result = service.analyzeProductName('옥화당 보이차 생차 200g');
+
+    expect(result.category).toEqual(expect.objectContaining({ slug: 'puerh-tea' }));
+    expect(result.noticeInfoType).toBe(ProductNoticeInfoType.TEA);
+  });
+});

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -4,11 +4,34 @@ import { ProductStatus, Product } from '../entities/product.entity';
 import { SmartStoreProductImportService } from '../smartstore-product-import.service';
 import { ProductCommandService } from '../product-command.service';
 import { RemoteImageIngestService } from '../../upload/remote-image-ingest.service';
+import { ProductKeywordMappingService } from '../product-keyword-mapping.service';
+import { AttributesService } from '../attributes.service';
 
 function createRepositoryMock(existingProducts: Product[] = []) {
   return {
     find: jest.fn().mockResolvedValue(existingProducts),
     findOne: jest.fn().mockResolvedValue(null),
+  };
+}
+
+function createCategoryRepositoryMock() {
+  return {
+    find: jest.fn().mockResolvedValue([
+      { id: 1, slug: 'teapot', name: '자사호', isActive: true },
+      { id: 2, slug: 'puerh-tea', name: '보이차', isActive: true },
+    ]),
+  };
+}
+
+function createAttributeTypeRepositoryMock() {
+  return {
+    find: jest.fn().mockResolvedValue([
+      { id: 10, code: 'clay_type', isActive: true },
+      { id: 11, code: 'teapot_shape', isActive: true },
+      { id: 12, code: 'capacity', isActive: true },
+      { id: 13, code: 'craft_method', isActive: true },
+      { id: 14, code: 'clay_origin', isActive: true },
+    ]),
   };
 }
 
@@ -28,6 +51,13 @@ function createIngestServiceMock() {
   };
 }
 
+function createAttributesServiceMock() {
+  return {
+    setProductAttributes: jest.fn().mockResolvedValue([]),
+    createOrUpdateProductAttribute: jest.fn().mockResolvedValue({}),
+  };
+}
+
 function ingestedUrl(url: string): string {
   return `https://cdn.okhwadang.com/uploads/${encodeURIComponent(url)}`;
 }
@@ -36,11 +66,18 @@ function createService(
   repository: ReturnType<typeof createRepositoryMock>,
   commandService: ReturnType<typeof createCommandServiceMock>,
   ingestService: ReturnType<typeof createIngestServiceMock> = createIngestServiceMock(),
+  categoryRepository: ReturnType<typeof createCategoryRepositoryMock> = createCategoryRepositoryMock(),
+  attributeTypeRepository: ReturnType<typeof createAttributeTypeRepositoryMock> = createAttributeTypeRepositoryMock(),
+  attributesService: ReturnType<typeof createAttributesServiceMock> = createAttributesServiceMock(),
 ) {
   return new SmartStoreProductImportService(
     repository as never,
+    categoryRepository as never,
+    attributeTypeRepository as never,
     commandService as unknown as ProductCommandService,
     ingestService as unknown as RemoteImageIngestService,
+    new ProductKeywordMappingService(),
+    attributesService as unknown as AttributesService,
   );
 }
 
@@ -68,6 +105,100 @@ function createFile(buffer: Buffer, overrides: Partial<Express.Multer.File> = {}
 }
 
 describe('SmartStoreProductImportService', () => {
+
+  it('previews keyword-based category, attribute, option, and notice mappings without saving', async () => {
+    const repository = createRepositoryMock([]);
+    const commandService = createCommandServiceMock();
+    const attributesService = createAttributesServiceMock();
+    const service = createService(
+      repository,
+      commandService,
+      createIngestServiceMock(),
+      createCategoryRepositoryMock(),
+      createAttributeTypeRepositoryMock(),
+      attributesService,
+    );
+    const buffer = await createWorkbookBuffer([
+      ['판매자상품코드', '상품명', '판매가'],
+      ['SKU-1', '옥화당 자사호 황룡산 노단니 연자호 110cc', 12000],
+    ]);
+
+    const result = await service.preview(createFile(buffer));
+
+    expect(result.rows[0].automaticMapping).toMatchObject({
+      status: 'needs_review',
+      category: { slug: 'teapot', displayName: '자사호', categoryId: 1 },
+      attributes: expect.arrayContaining([
+        expect.objectContaining({ code: 'clay_type', value: 'old_duanni', displayValue: '노단니', attributeTypeId: 10 }),
+        expect.objectContaining({ code: 'teapot_shape', value: 'lianzi', displayValue: '연자호', attributeTypeId: 11 }),
+        expect.objectContaining({ code: 'clay_origin', value: 'huanglongshan', displayValue: '황룡산', attributeTypeId: 14 }),
+      ]),
+      options: [expect.objectContaining({ name: '용량', value: '110cc' })],
+      noticeInfoType: 'teaware',
+    });
+    expect(result.rows[0].mappingWarnings.join(' ')).toContain('단니');
+    expect(commandService.create).not.toHaveBeenCalled();
+    expect(attributesService.createOrUpdateProductAttribute).not.toHaveBeenCalled();
+  });
+
+  it('commits keyword mappings to categoryId, generated options, notice info, and product_attributes', async () => {
+    const repository = createRepositoryMock([]);
+    const commandService = createCommandServiceMock();
+    const attributesService = createAttributesServiceMock();
+    const service = createService(
+      repository,
+      commandService,
+      createIngestServiceMock(),
+      createCategoryRepositoryMock(),
+      createAttributeTypeRepositoryMock(),
+      attributesService,
+    );
+    const buffer = await createWorkbookBuffer([
+      ['판매자상품코드', '상품명', '판매가'],
+      ['SKU-1', '옥화당 자사호 황룡산 강파니 방고호 130cc', 12000],
+    ]);
+
+    await service.commit(createFile(buffer));
+
+    expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+      categoryId: 1,
+      noticeInfo: expect.objectContaining({ type: 'teaware', productName: '옥화당 자사호 황룡산 강파니 방고호 130cc', sizeCapacity: '130cc' }),
+      options: [expect.objectContaining({ name: '용량', value: '130cc', priceAdjustment: 0, stock: 0 })],
+    }));
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(100, 10, expect.objectContaining({
+      attributeTypeId: 10,
+      value: 'jiangponi',
+      displayValue: '강파니',
+    }));
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(100, 11, expect.objectContaining({
+      attributeTypeId: 11,
+      value: 'fanggu',
+      displayValue: '방고호',
+    }));
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(100, 14, expect.objectContaining({
+      attributeTypeId: 14,
+      value: 'huanglongshan',
+      displayValue: '황룡산',
+    }));
+  });
+
+  it('keeps explicit SmartStore options over keyword option candidates', async () => {
+    const repository = createRepositoryMock([]);
+    const commandService = createCommandServiceMock();
+    const service = createService(repository, commandService);
+    const buffer = await createWorkbookBuffer([
+      ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값'],
+      ['SKU-1', '옥화당 자사호 노단니 연자호 120cc', 10000, '단독형', '색상', '노단니'],
+    ]);
+
+    const result = await service.commit(createFile(buffer));
+
+    expect(result.rows[0].mappingWarnings.join(' ')).toContain('명시 옵션');
+    expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+      options: [expect.objectContaining({ name: '색상', value: '노단니' })],
+    }));
+  });
+
   it('previews create and update actions by SKU without saving', async () => {
     const existing = { id: 7, sku: 'SKU-2', slug: 'old-product' } as Product;
     const repository = createRepositoryMock([existing]);

--- a/backend/src/modules/products/product-keyword-mapping.service.ts
+++ b/backend/src/modules/products/product-keyword-mapping.service.ts
@@ -1,0 +1,263 @@
+import { Injectable } from '@nestjs/common';
+import { ProductNoticeInfoType, ProductOptionInputDto } from './dto/create-product.dto';
+
+export type KeywordMappingTargetType = 'category' | 'attribute' | 'option' | 'noticeInfo';
+
+export interface ProductKeywordAttributeMapping {
+  code: string;
+  value: string;
+  displayValue: string;
+  keyword: string;
+}
+
+export interface ProductKeywordCategoryMapping {
+  slug: string;
+  displayName: string;
+  keyword: string;
+}
+
+export interface ProductKeywordOptionMapping extends ProductOptionInputDto {
+  keyword: string;
+}
+
+export interface ProductKeywordMappingResult {
+  normalizedName: string;
+  category?: ProductKeywordCategoryMapping;
+  attributes: ProductKeywordAttributeMapping[];
+  options: ProductKeywordOptionMapping[];
+  noticeInfoType?: ProductNoticeInfoType;
+  warnings: string[];
+}
+
+interface BaseKeywordRule {
+  keywords: string[];
+  priority: number;
+}
+
+interface CategoryKeywordRule extends BaseKeywordRule {
+  type: 'category';
+  slug: string;
+  displayName: string;
+}
+
+interface AttributeKeywordRule extends BaseKeywordRule {
+  type: 'attribute';
+  code: string;
+  value: string;
+  displayValue: string;
+}
+
+interface NoticeInfoKeywordRule extends BaseKeywordRule {
+  type: 'noticeInfo';
+  noticeInfoType: ProductNoticeInfoType;
+}
+
+type StaticKeywordRule = CategoryKeywordRule | AttributeKeywordRule | NoticeInfoKeywordRule;
+
+interface MatchedRule<TRule extends StaticKeywordRule> {
+  rule: TRule;
+  keyword: string;
+  index: number;
+}
+
+const STATIC_RULES: StaticKeywordRule[] = [
+  category(['자사호', '차호', '다관'], 100, 'teapot', '자사호'),
+  category(['개완'], 95, 'gaiwan', '개완'),
+  category(['공도배', '숙우'], 95, 'fairness-cup', '공도배'),
+  category(['차판', '다반'], 95, 'tea-tray', '차판'),
+  category(['찻잔', '다완', '잔', '배'], 80, 'teacup', '찻잔'),
+  category(['보이차'], 100, 'puerh-tea', '보이차'),
+  category(['생차'], 95, 'sheng-puerh', '생차'),
+  category(['숙차'], 95, 'shou-puerh', '숙차'),
+  category(['백차', '백모단', '수미'], 90, 'white-tea', '백차'),
+  category(['우롱차', '암차', '철관음'], 90, 'oolong-tea', '우롱차'),
+
+  attribute('clay_type', 'hongwei_zhuni', '홍위주니', ['홍위주니'], 230),
+  attribute('clay_type', 'benshan_luni', '본산녹니', ['본산녹니'], 230),
+  attribute('clay_type', 'old_qingshuini', '노청수니', ['노청수니'], 230),
+  attribute('clay_type', 'old_duanni', '노단니', ['노단니', '老段泥', 'old duanni'], 230),
+  attribute('clay_type', 'dicaoqing', '저조청', ['저조청', '底槽青'], 220),
+  attribute('clay_type', 'qinghuini', '청회니', ['청회니', '青灰泥'], 220),
+  attribute('clay_type', 'qingshuini', '청수니', ['청수니'], 210),
+  attribute('clay_type', 'jiangponi', '강파니', ['강파니'], 210),
+  attribute('clay_type', 'yubaini', '옥백니', ['옥백니'], 210),
+  attribute('clay_type', 'duanni', '단니', ['단니', '段泥', 'duanni'], 180),
+  attribute('clay_type', 'zhuni', '주니', ['주니', '朱泥', 'zhuni'], 180),
+  attribute('clay_type', 'hongni', '홍니', ['홍니', '紅泥', 'hongni'], 180),
+  attribute('clay_type', 'zini', '자니', ['자니', '紫泥', 'zini'], 180),
+  attribute('clay_type', 'heini', '흑니', ['흑니', '黑泥'], 180),
+  attribute('clay_type', 'luni', '녹니', ['녹니', '綠泥'], 170),
+  attribute('clay_type', 'wuni', '오니', ['오니'], 170),
+
+  attribute('teapot_shape', 'pinggai_lianzi', '평개연자호', ['평개연자호'], 230),
+  attribute('teapot_shape', 'lianzi', '연자호', ['연자호', '연자', '蓮子壺'], 200),
+  attribute('teapot_shape', 'xishi', '서시', ['서시', '西施'], 200),
+  attribute('teapot_shape', 'shipiao', '석표', ['석표', '石瓢'], 200),
+  attribute('teapot_shape', 'fanggu', '방고호', ['방고호', '방고', '仿古'], 200),
+  attribute('teapot_shape', 'shuiping', '수평', ['수평', '水平'], 200),
+  attribute('teapot_shape', 'longdan', '용단', ['용단', '龍蛋'], 200),
+  attribute('teapot_shape', 'banyue', '반월', ['반월', '半月'], 200),
+  attribute('teapot_shape', 'xubian', '허편', ['허편', '虛扁'], 200),
+  attribute('teapot_shape', 'hanwa', '한와호', ['한와호'], 200),
+  attribute('teapot_shape', 'tieqiu', '철구호', ['철구호'], 200),
+
+  attribute('craft_method', 'handmade', '전수공', ['전수공'], 150),
+  attribute('clay_origin', 'huanglongshan', '황룡산', ['황룡산'], 150),
+
+  notice(['자사호', '차호', '다관', '개완', '찻잔', '다완', '공도배', '숙우', '차판', '다반'], 100, ProductNoticeInfoType.TEAWARE),
+  notice(['보이차', '생차', '숙차', '백차', '우롱차', '홍차', '녹차'], 100, ProductNoticeInfoType.TEA),
+];
+
+@Injectable()
+export class ProductKeywordMappingService {
+  analyzeProductName(productName: string | null | undefined): ProductKeywordMappingResult {
+    const normalizedName = this.normalizeProductName(productName ?? '');
+    if (!normalizedName) {
+      return { normalizedName, attributes: [], options: [], warnings: [] };
+    }
+
+    const warnings: string[] = [];
+    const category = this.selectCategory(normalizedName, warnings);
+    const attributes = this.selectAttributes(normalizedName, warnings);
+    const noticeInfoType = this.selectNoticeInfoType(normalizedName);
+    const options = this.extractOptions(normalizedName);
+
+    return {
+      normalizedName,
+      ...(category ? { category } : {}),
+      attributes,
+      options,
+      ...(noticeInfoType ? { noticeInfoType } : {}),
+      warnings,
+    };
+  }
+
+  normalizeProductName(value: string): string {
+    return value
+      .normalize('NFKC')
+      .toLowerCase()
+      .replace(/[()[\]{}【】<>〈〉《》]/g, ' ')
+      .replace(/[·ㆍ_/|,+:;~-]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private selectCategory(normalizedName: string, warnings: string[]): ProductKeywordCategoryMapping | undefined {
+    const matches = this.findMatches<CategoryKeywordRule>(normalizedName, 'category');
+    if (!matches.length) return undefined;
+    const selected = this.selectBest(matches);
+    const conflicted = matches.filter((match) => match.rule.slug !== selected.rule.slug);
+    conflicted.forEach((match) => {
+      warnings.push(`카테고리 후보 '${match.rule.displayName}'은 '${selected.rule.displayName}'보다 우선순위가 낮아 제외되었습니다.`);
+    });
+    return {
+      slug: selected.rule.slug,
+      displayName: selected.rule.displayName,
+      keyword: selected.keyword,
+    };
+  }
+
+  private selectAttributes(normalizedName: string, warnings: string[]): ProductKeywordAttributeMapping[] {
+    const matches = this.findMatches<AttributeKeywordRule>(normalizedName, 'attribute');
+    const byCode = new Map<string, Array<MatchedRule<AttributeKeywordRule>>>();
+    matches.forEach((match) => {
+      const items = byCode.get(match.rule.code) ?? [];
+      items.push(match);
+      byCode.set(match.rule.code, items);
+    });
+
+    return [...byCode.entries()].map(([code, items]) => {
+      const selected = this.selectBest(items);
+      items
+        .filter((match) => match.rule.value !== selected.rule.value)
+        .forEach((match) => {
+          warnings.push(`속성 '${code}' 후보 '${match.rule.displayValue}'은 '${selected.rule.displayValue}'보다 우선순위가 낮아 제외되었습니다.`);
+        });
+      return {
+        code: selected.rule.code,
+        value: selected.rule.value,
+        displayValue: selected.rule.displayValue,
+        keyword: selected.keyword,
+      };
+    });
+  }
+
+  private selectNoticeInfoType(normalizedName: string): ProductNoticeInfoType | undefined {
+    const matches = this.findMatches<NoticeInfoKeywordRule>(normalizedName, 'noticeInfo');
+    return matches.length > 0 ? this.selectBest(matches).rule.noticeInfoType : undefined;
+  }
+
+  private extractOptions(normalizedName: string): ProductKeywordOptionMapping[] {
+    const options: ProductKeywordOptionMapping[] = [];
+    const capacityMatch = /\b(\d{2,4})\s?(cc|ml)\b/i.exec(normalizedName);
+    if (capacityMatch) {
+      options.push({
+        name: '용량',
+        value: `${capacityMatch[1]}${capacityMatch[2].toLowerCase()}`,
+        priceAdjustment: 0,
+        stock: 0,
+        sortOrder: 0,
+        keyword: capacityMatch[0],
+      });
+    }
+
+    const setMatch = /\b(\d+)\s?개\s?세트\b/.exec(normalizedName) ?? /\b세트\b/.exec(normalizedName);
+    if (setMatch) {
+      options.push({
+        name: '구성',
+        value: setMatch[1] ? `${setMatch[1]}개 세트` : '세트',
+        priceAdjustment: 0,
+        stock: 0,
+        sortOrder: options.length,
+        keyword: setMatch[0],
+      });
+    }
+
+    return options;
+  }
+
+  private findMatches<TRule extends StaticKeywordRule>(normalizedName: string, type: TRule['type']): Array<MatchedRule<TRule>> {
+    const matches: Array<MatchedRule<TRule>> = [];
+    STATIC_RULES
+      .filter((rule): rule is TRule => rule.type === type)
+      .forEach((rule) => {
+        rule.keywords.forEach((keyword) => {
+          const normalizedKeyword = this.normalizeProductName(keyword);
+          if (!normalizedKeyword) return;
+          const index = normalizedName.indexOf(normalizedKeyword);
+          if (index >= 0) {
+            matches.push({ rule, keyword, index });
+          }
+        });
+      });
+    return matches;
+  }
+
+  private selectBest<TRule extends StaticKeywordRule>(matches: Array<MatchedRule<TRule>>): MatchedRule<TRule> {
+    return [...matches].sort((a, b) => {
+      if (b.rule.priority !== a.rule.priority) return b.rule.priority - a.rule.priority;
+      const bLength = this.normalizeProductName(b.keyword).length;
+      const aLength = this.normalizeProductName(a.keyword).length;
+      if (bLength !== aLength) return bLength - aLength;
+      return a.index - b.index;
+    })[0];
+  }
+}
+
+function category(keywords: string[], priority: number, slug: string, displayName: string): CategoryKeywordRule {
+  return { type: 'category', keywords, priority, slug, displayName };
+}
+
+function attribute(
+  code: string,
+  value: string,
+  displayValue: string,
+  keywords: string[],
+  priority: number,
+): AttributeKeywordRule {
+  return { type: 'attribute', keywords, priority, code, value, displayValue };
+}
+
+function notice(keywords: string[], priority: number, noticeInfoType: ProductNoticeInfoType): NoticeInfoKeywordRule {
+  return { type: 'noticeInfo', keywords, priority, noticeInfoType };
+}

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -17,6 +17,7 @@ import { RecentlyViewedService } from './recently-viewed.service';
 import { SmartStoreProductImportService } from './smartstore-product-import.service';
 import { NaverCommerceApiClient } from './naver-commerce-api.client';
 import { NaverCommerceProductImportService } from './naver-commerce-product-import.service';
+import { ProductKeywordMappingService } from './product-keyword-mapping.service';
 import { ProductsController } from './products.controller';
 import { AdminProductsController } from './admin-products.controller';
 import { CategoriesController } from './categories.controller';
@@ -54,6 +55,7 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
     SmartStoreProductImportService,
     NaverCommerceApiClient,
     NaverCommerceProductImportService,
+    ProductKeywordMappingService,
     OptionalJwtAuthGuard,
   ],
   controllers: [ProductsController, AdminProductsController, CategoriesController, AttributesController],
@@ -67,6 +69,7 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
     SmartStoreProductImportService,
     NaverCommerceApiClient,
     NaverCommerceProductImportService,
+    ProductKeywordMappingService,
     OptionalJwtAuthGuard,
   ],
 })

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -3,6 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import * as ExcelJS from 'exceljs';
 import { In, Repository } from 'typeorm';
 import { Product, ProductStatus } from './entities/product.entity';
+import { Category } from './entities/category.entity';
+import { AttributeType } from './entities/attribute-type.entity';
 import { ProductCommandService } from './product-command.service';
 import { CreateProductDto, ProductNoticeInfoType, ProductOptionInputDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
@@ -10,6 +12,13 @@ import { RemoteImageIngestService } from '../upload/remote-image-ingest.service'
 import { UploadedFile } from '../upload/interfaces/storage.interface';
 import { assertXlsxFile, cellToString, normalizeExcelHeader } from '../../common/imports/excel-import.util';
 import { buildNaverExternalProductKey } from '../../common/imports/external-source.util';
+import { AttributesService } from './attributes.service';
+import {
+  ProductKeywordAttributeMapping,
+  ProductKeywordCategoryMapping,
+  ProductKeywordMappingService,
+  ProductKeywordOptionMapping,
+} from './product-keyword-mapping.service';
 
 export type SmartStoreImportAction = 'create' | 'update' | 'skip';
 
@@ -28,6 +37,8 @@ export interface SmartStoreImportRowResult {
   hasDiscount: boolean;
   isFreeShipping: boolean | null;
   hasNoticeInfo: boolean;
+  automaticMapping: SmartStoreAutomaticMappingResult;
+  mappingWarnings: string[];
   errors: string[];
 }
 
@@ -57,6 +68,21 @@ export interface SmartStoreParsedProductRow {
   isFreeShipping: boolean | null;
   hasNoticeInfo: boolean;
   errors: string[];
+}
+
+export interface SmartStoreAutomaticMappingResult {
+  status: 'none' | 'mapped' | 'needs_review';
+  category?: { slug: string; displayName: string; categoryId?: number };
+  attributes: Array<{ code: string; value: string; displayValue: string; attributeTypeId?: number }>;
+  options: Array<{ name: string; value: string }>;
+  noticeInfoType?: ProductNoticeInfoType;
+}
+
+interface ResolvedProductKeywordMapping extends SmartStoreAutomaticMappingResult {
+  category?: { slug: string; displayName: string; categoryId?: number };
+  attributes: Array<{ code: string; value: string; displayValue: string; attributeTypeId?: number }>;
+  options: ProductKeywordOptionMapping[];
+  warnings: string[];
 }
 
 const MAX_IMPORT_ROWS = 500;
@@ -119,8 +145,14 @@ export class SmartStoreProductImportService {
   constructor(
     @InjectRepository(Product)
     private readonly productRepository: Repository<Product>,
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+    @InjectRepository(AttributeType)
+    private readonly attributeTypeRepository: Repository<AttributeType>,
     private readonly productCommandService: ProductCommandService,
     private readonly remoteImageIngestService: RemoteImageIngestService,
+    private readonly productKeywordMappingService: ProductKeywordMappingService,
+    private readonly attributesService: AttributesService,
   ) {}
 
   async preview(file: Express.Multer.File): Promise<SmartStoreImportResult> {
@@ -169,10 +201,12 @@ export class SmartStoreProductImportService {
     );
 
     const duplicateIdentifiers = this.findDuplicates(identifiers);
+    const resolvedMappings = await this.resolveKeywordMappings(parsedRows);
     const ingestCache = new Map<string, Promise<UploadedFile>>();
     const rows: SmartStoreImportRowResult[] = [];
 
     for (const parsed of parsedRows) {
+      const keywordMapping = resolvedMappings.get(parsed.rowNumber) ?? this.emptyResolvedMapping();
       const errors = [...parsed.errors];
       if (parsed.identifier && duplicateIdentifiers.has(parsed.identifier)) {
         errors.push(`파일 안에서 중복된 상품 식별자입니다: ${parsed.identifier}`);
@@ -199,18 +233,22 @@ export class SmartStoreProductImportService {
         hasDiscount: parsed.hasDiscount,
         isFreeShipping: parsed.isFreeShipping,
         hasNoticeInfo: parsed.hasNoticeInfo,
+        automaticMapping: this.toRowAutomaticMapping(keywordMapping),
+        mappingWarnings: keywordMapping.warnings,
         errors,
       };
 
       if (commit && !hasBlockingErrors && action !== 'skip' && parsed.dto) {
         try {
-          const dto = await this.resolveRemoteImages(parsed.dto, ingestCache);
+          const mappedDto = this.applyKeywordMapping(parsed.dto, keywordMapping);
+          const dto = await this.resolveRemoteImages(mappedDto, ingestCache);
           const saved = existing
             ? await this.productCommandService.update(existing.id, this.toUpdateDto(dto))
             : await this.productCommandService.create({
                 ...dto,
                 slug: await this.generateUniqueSlug(dto.slug),
               });
+          await this.syncKeywordAttributes(saved.id, keywordMapping);
           rowResult.productId = saved.id;
           rowResult.status = 'success';
         } catch (err) {
@@ -379,6 +417,141 @@ export class SmartStoreProductImportService {
       isFreeShipping: isFreeShipping ?? null,
       hasNoticeInfo: Boolean(noticeInfo),
       errors,
+    };
+  }
+
+  private async resolveKeywordMappings(parsedRows: SmartStoreParsedProductRow[]): Promise<Map<number, ResolvedProductKeywordMapping>> {
+    const analyzed = parsedRows.map((row) => ({
+      rowNumber: row.rowNumber,
+      result: this.productKeywordMappingService.analyzeProductName(row.productName),
+      hasExplicitOptions: (row.optionCount ?? 0) > 0,
+    }));
+    const categorySlugs = [...new Set(analyzed.map((item) => item.result.category?.slug).filter((slug): slug is string => Boolean(slug)))];
+    const attributeCodes = [...new Set(analyzed.flatMap((item) => item.result.attributes.map((attribute) => attribute.code)))];
+
+    const categories = categorySlugs.length > 0
+      ? await this.categoryRepository.find({ where: { slug: In(categorySlugs), isActive: true } })
+      : [];
+    const attributeTypes = attributeCodes.length > 0
+      ? await this.attributeTypeRepository.find({ where: { code: In(attributeCodes), isActive: true } })
+      : [];
+    const categoryBySlug = new Map(categories.map((category) => [category.slug, category]));
+    const attributeTypeByCode = new Map(attributeTypes.map((type) => [type.code, type]));
+    const resolved = new Map<number, ResolvedProductKeywordMapping>();
+
+    analyzed.forEach((item) => {
+      const warnings = [...item.result.warnings];
+      const category = item.result.category ? this.resolveCategoryMapping(item.result.category, categoryBySlug, warnings) : undefined;
+      const attributes = item.result.attributes.map((attribute) => this.resolveAttributeMapping(attribute, attributeTypeByCode, warnings));
+      const options = item.result.options;
+      if (item.hasExplicitOptions && options.length > 0) {
+        warnings.push('원본 파일에 명시 옵션이 있어 상품명 기반 옵션 후보는 미리보기만 표시하고 자동 반영하지 않습니다.');
+      }
+      resolved.set(item.rowNumber, {
+        status: this.resolveAutomaticMappingStatus(category, attributes, options, item.result.noticeInfoType, warnings),
+        ...(category ? { category } : {}),
+        attributes,
+        options,
+        ...(item.result.noticeInfoType ? { noticeInfoType: item.result.noticeInfoType } : {}),
+        warnings,
+      });
+    });
+
+    return resolved;
+  }
+
+  private resolveCategoryMapping(
+    category: ProductKeywordCategoryMapping,
+    categoryBySlug: Map<string, Category>,
+    warnings: string[],
+  ): ResolvedProductKeywordMapping['category'] {
+    const matched = categoryBySlug.get(category.slug);
+    if (!matched) {
+      warnings.push(`자동 매핑 카테고리 '${category.displayName}'(${category.slug})를 찾을 수 없어 categoryId는 반영하지 않습니다.`);
+      return { slug: category.slug, displayName: category.displayName };
+    }
+    return { slug: category.slug, displayName: category.displayName, categoryId: Number(matched.id) };
+  }
+
+  private resolveAttributeMapping(
+    attribute: ProductKeywordAttributeMapping,
+    attributeTypeByCode: Map<string, AttributeType>,
+    warnings: string[],
+  ): ResolvedProductKeywordMapping['attributes'][number] {
+    const matched = attributeTypeByCode.get(attribute.code);
+    if (!matched) {
+      warnings.push(`자동 매핑 속성 타입 '${attribute.code}'를 찾을 수 없어 해당 속성은 저장하지 않습니다.`);
+      return { code: attribute.code, value: attribute.value, displayValue: attribute.displayValue };
+    }
+    return { code: attribute.code, value: attribute.value, displayValue: attribute.displayValue, attributeTypeId: Number(matched.id) };
+  }
+
+  private resolveAutomaticMappingStatus(
+    category: ResolvedProductKeywordMapping['category'] | undefined,
+    attributes: ResolvedProductKeywordMapping['attributes'],
+    options: ProductKeywordOptionMapping[],
+    noticeInfoType: ProductNoticeInfoType | undefined,
+    warnings: string[],
+  ): SmartStoreAutomaticMappingResult['status'] {
+    const hasMapping = Boolean(category) || attributes.length > 0 || options.length > 0 || Boolean(noticeInfoType);
+    if (!hasMapping) return 'none';
+    return warnings.length > 0 ? 'needs_review' : 'mapped';
+  }
+
+  private applyKeywordMapping(dto: CreateProductDto, mapping: ResolvedProductKeywordMapping): CreateProductDto {
+    const noticeInfo = mapping.noticeInfoType || mapping.options.length > 0
+      ? {
+          ...(dto.noticeInfo ?? {}),
+          ...(mapping.noticeInfoType ? { type: mapping.noticeInfoType } : {}),
+          productName: dto.noticeInfo?.productName ?? dto.name,
+          sizeCapacity: dto.noticeInfo?.sizeCapacity ?? mapping.options.find((option) => option.name === '용량')?.value,
+        }
+      : dto.noticeInfo;
+
+    return {
+      ...dto,
+      ...(mapping.category?.categoryId ? { categoryId: mapping.category.categoryId } : {}),
+      ...(noticeInfo ? { noticeInfo } : {}),
+      ...(dto.options === undefined && mapping.options.length > 0
+        ? { options: mapping.options.map(({ keyword: _keyword, ...option }) => option) }
+        : {}),
+    };
+  }
+
+  private async syncKeywordAttributes(productId: number, mapping: ResolvedProductKeywordMapping): Promise<void> {
+    const attributes = mapping.attributes
+      .filter((attribute): attribute is Required<ResolvedProductKeywordMapping['attributes'][number]> => attribute.attributeTypeId !== undefined)
+      .map((attribute, index) => ({
+        attributeTypeId: attribute.attributeTypeId,
+        value: attribute.value,
+        displayValue: attribute.displayValue,
+        sortOrder: index,
+      }));
+    if (attributes.length === 0) return;
+    await Promise.all(
+      attributes.map((attribute) =>
+        this.attributesService.createOrUpdateProductAttribute(productId, attribute.attributeTypeId, {
+          productId,
+          attributeTypeId: attribute.attributeTypeId,
+          value: attribute.value,
+          displayValue: attribute.displayValue,
+          sortOrder: attribute.sortOrder,
+        }),
+      ),
+    );
+  }
+
+  private emptyResolvedMapping(): ResolvedProductKeywordMapping {
+    return { status: 'none', attributes: [], options: [], warnings: [] };
+  }
+
+  private toRowAutomaticMapping(mapping: ResolvedProductKeywordMapping): SmartStoreAutomaticMappingResult {
+    return {
+      status: mapping.status,
+      ...(mapping.category ? { category: mapping.category } : {}),
+      attributes: mapping.attributes,
+      options: mapping.options.map((option) => ({ name: option.name, value: option.value })),
+      ...(mapping.noticeInfoType ? { noticeInfoType: mapping.noticeInfoType } : {}),
     };
   }
 

--- a/src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx
+++ b/src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx
@@ -87,6 +87,8 @@ const naverResult: SmartStoreProductImportResult = {
       hasDiscount: false,
       isFreeShipping: true,
       hasNoticeInfo: true,
+      automaticMapping: { status: 'none', attributes: [], options: [] },
+      mappingWarnings: [],
       errors: [],
     },
   ],

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -325,6 +325,7 @@ export default function AdminProductsPage() {
                       <th className="px-3 py-2 text-left">{t('import.previewColumns.discount')}</th>
                       <th className="px-3 py-2 text-left">{t('import.previewColumns.freeShipping')}</th>
                       <th className="px-3 py-2 text-left">{t('import.previewColumns.noticeInfo')}</th>
+                      <th className="px-3 py-2 text-left">{t('import.previewColumns.automaticMapping')}</th>
                       <th className="px-3 py-2 text-right">{t('import.previewColumns.options')}</th>
                       <th className="px-3 py-2 text-right">{t('import.previewColumns.galleryImages')}</th>
                       <th className="px-3 py-2 text-right">{t('import.previewColumns.detailImages')}</th>
@@ -364,6 +365,9 @@ export default function AdminProductsPage() {
                               : t('import.previewValues.no')}
                         </td>
                         <td className="px-3 py-2">{row.hasNoticeInfo ? t('import.previewValues.yes') : t('import.previewValues.no')}</td>
+                        <td className="min-w-56 px-3 py-2">
+                          <ImportMappingSummary row={row} t={t} />
+                        </td>
                         <td className="px-3 py-2 text-right">{row.optionCount ?? 0}</td>
                         <td className="px-3 py-2 text-right">{row.galleryImageCount ?? 0}</td>
                         <td className="px-3 py-2 text-right">{row.detailImageCount ?? 0}</td>
@@ -467,6 +471,38 @@ function ImportSummaryItem({ label, value }: { label: string; value: number }) {
     <div className="rounded border bg-background p-3">
       <div className="text-xs text-muted-foreground">{label}</div>
       <div className="text-lg font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function ImportMappingSummary({
+  row,
+  t,
+}: {
+  row: SmartStoreProductImportResult['rows'][number];
+  t: ReturnType<typeof useTranslations<'admin.products'>>;
+}) {
+  const mapping = row.automaticMapping;
+  if (!mapping || mapping.status === 'none') {
+    return <span className="text-muted-foreground">{t('import.mappingStatus.none')}</span>;
+  }
+
+  const parts = [
+    mapping.category ? t('import.mappingValues.category', { value: mapping.category.displayName }) : null,
+    ...mapping.attributes.map((attribute) => `${attribute.code}: ${attribute.displayValue}`),
+    ...mapping.options.map((option) => `${option.name}: ${option.value}`),
+    mapping.noticeInfoType ? t('import.mappingValues.noticeInfo', { value: t(`import.noticeInfoTypes.${mapping.noticeInfoType}`) }) : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return (
+    <div className="space-y-1">
+      <span className={mapping.status === 'needs_review' ? 'font-medium text-amber-700' : 'font-medium text-tea'}>
+        {t(`import.mappingStatus.${mapping.status}`)}
+      </span>
+      <p className="text-muted-foreground">{parts.join(' · ')}</p>
+      {row.mappingWarnings.length > 0 && (
+        <p className="text-amber-700">{row.mappingWarnings.join(' / ')}</p>
+      )}
     </div>
   );
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -783,7 +783,8 @@
           "discount": "Discount",
           "freeShipping": "Free shipping",
           "noticeInfo": "Notice info",
-          "matchedProduct": "Matched product"
+          "matchedProduct": "Matched product",
+          "automaticMapping": "Auto mapping"
         },
         "actions": {
           "create": "Create",
@@ -813,6 +814,19 @@
           "discountNone": "No",
           "productLink": "View product #{id}",
           "notLinked": "New product"
+        },
+        "mappingStatus": {
+          "none": "None",
+          "mapped": "Auto mapped",
+          "needs_review": "Needs review"
+        },
+        "mappingValues": {
+          "category": "Category {value}",
+          "noticeInfo": "Notice {value}"
+        },
+        "noticeInfoTypes": {
+          "teaware": "Teaware",
+          "tea": "Tea"
         }
       },
       "naverCommerce": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -783,7 +783,8 @@
           "discount": "할인 반영",
           "freeShipping": "무료배송",
           "noticeInfo": "고시정보",
-          "matchedProduct": "연결 상품"
+          "matchedProduct": "연결 상품",
+          "automaticMapping": "자동 매핑"
         },
         "actions": {
           "create": "신규 추가",
@@ -813,6 +814,19 @@
           "discountNone": "미반영",
           "productLink": "상품 #{id} 보기",
           "notLinked": "신규 예정"
+        },
+        "mappingStatus": {
+          "none": "없음",
+          "mapped": "자동 분류됨",
+          "needs_review": "확인 필요"
+        },
+        "mappingValues": {
+          "category": "카테고리 {value}",
+          "noticeInfo": "고시정보 {value}"
+        },
+        "noticeInfoTypes": {
+          "teaware": "다구",
+          "tea": "차류"
         }
       },
       "naverCommerce": {

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -40,6 +40,14 @@ export type UpdateProductData = Partial<CreateProductData>;
 export type SmartStoreImportAction = 'create' | 'update' | 'skip';
 export type SmartStoreImportStatus = 'valid' | 'failed' | 'success';
 
+export interface SmartStoreAutomaticMappingResult {
+  status: 'none' | 'mapped' | 'needs_review';
+  category?: { slug: string; displayName: string; categoryId?: number };
+  attributes: Array<{ code: string; value: string; displayValue: string; attributeTypeId?: number }>;
+  options: Array<{ name: string; value: string }>;
+  noticeInfoType?: 'teaware' | 'tea';
+}
+
 export interface SmartStoreProductImportRow {
   rowNumber: number;
   identifier: string | null;
@@ -55,6 +63,8 @@ export interface SmartStoreProductImportRow {
   hasDiscount: boolean;
   isFreeShipping: boolean | null;
   hasNoticeInfo: boolean;
+  automaticMapping: SmartStoreAutomaticMappingResult;
+  mappingWarnings: string[];
   errors: string[];
 }
 


### PR DESCRIPTION
## 요약\n- 상품명 키워드 기반 자동 매핑 엔진 추가\n- 스마트스토어 엑셀 및 네이버 커머스API parsed-row 가져오기 경로에서 같은 매핑 결과 사용\n- preview 표에 자동 매핑/확인 필요 상태와 경고 표시\n- commit 시에만 카테고리, 옵션, 고시정보, product_attributes 반영\n\nCloses #977\n\n## 검증\n- cd backend && npx jest src/modules/products/__tests__/product-keyword-mapping.service.spec.ts src/modules/products/__tests__/smartstore-product-import.service.spec.ts src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts --runInBand\n- cd backend && npm run build\n- cd backend && npm run test -- --runInBand\n- npm run test:run\n- bash scripts/codex-project-guard.sh\n- BACKEND_URL=http://127.0.0.1:3000 npm run build\n- curl http://localhost:3000/api/health\n- curl -I http://localhost:5173/ko\n- curl -I http://localhost:5173/en/products\n