### PR TITLE
fix: #981 스마트스토어 리뷰 통계 반영

### DIFF
--- a/backend/src/modules/products/__tests__/product-query.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-query.service.spec.ts
@@ -7,6 +7,7 @@ import { Product, ProductStatus } from '../entities/product.entity';
 import { Category } from '../entities/category.entity';
 import { AttributeType } from '../entities/attribute-type.entity';
 import { Review } from '../../reviews/entities/review.entity';
+import { ExternalReview } from '../../reviews/entities/external-review.entity';
 import { CacheService } from '../../cache/cache.service';
 import { ProductSort } from '../dto/query-products.dto';
 
@@ -69,15 +70,18 @@ describe('ProductQueryService', () => {
   let productRepo: RepoMock<Product>;
   let categoryRepo: RepoMock<Category>;
   let reviewRepo: RepoMock<Review>;
+  let externalReviewRepo: RepoMock<ExternalReview>;
   let attrTypeRepo: RepoMock<AttributeType>;
   let cacheService: { get: jest.Mock; set: jest.Mock; del: jest.Mock; delPattern: jest.Mock };
   let qb: QueryBuilderMock;
   let reviewQb: QueryBuilderMock;
+  let externalReviewQb: QueryBuilderMock;
 
   beforeEach(async () => {
     productRepo = createRepoMock<Product>();
     categoryRepo = createRepoMock<Category>();
     reviewRepo = createRepoMock<Review>();
+    externalReviewRepo = createRepoMock<ExternalReview>();
     attrTypeRepo = createRepoMock<AttributeType>();
     cacheService = {
       get: jest.fn().mockResolvedValue(null),
@@ -88,9 +92,13 @@ describe('ProductQueryService', () => {
 
     qb = createQueryBuilderMock();
     reviewQb = createQueryBuilderMock();
+    externalReviewQb = createQueryBuilderMock();
 
     productRepo.createQueryBuilder.mockReturnValue(qb as unknown as SelectQueryBuilder<Product>);
     reviewRepo.createQueryBuilder.mockReturnValue(reviewQb as unknown as SelectQueryBuilder<Review>);
+    externalReviewRepo.createQueryBuilder.mockReturnValue(
+      externalReviewQb as unknown as SelectQueryBuilder<ExternalReview>,
+    );
     categoryRepo.find.mockResolvedValue([]);
     attrTypeRepo.createQueryBuilder.mockReturnValue(qb as unknown as SelectQueryBuilder<AttributeType>);
 
@@ -100,6 +108,7 @@ describe('ProductQueryService', () => {
         { provide: getRepositoryToken(Product), useValue: productRepo },
         { provide: getRepositoryToken(Category), useValue: categoryRepo },
         { provide: getRepositoryToken(Review), useValue: reviewRepo },
+        { provide: getRepositoryToken(ExternalReview), useValue: externalReviewRepo },
         { provide: getRepositoryToken(AttributeType), useValue: attrTypeRepo },
         { provide: CacheService, useValue: cacheService },
       ],
@@ -313,6 +322,21 @@ describe('ProductQueryService', () => {
       await service.findOne(1);
 
       expect(cacheService.set).toHaveBeenCalled();
+    });
+
+    it('상품 상세 평점에 스마트스토어 리뷰를 함께 반영한다', async () => {
+      qb.getOne.mockResolvedValue({ id: 1, status: ProductStatus.ACTIVE } as Product);
+      reviewQb.getRawMany.mockResolvedValue([
+        { productId: '1', avgRating: '4.0', reviewCount: '1' },
+      ]);
+      externalReviewQb.getRawMany.mockResolvedValue([
+        { productId: '1', avgRating: '5.0', reviewCount: '1' },
+      ]);
+
+      const result = await service.findOne(1);
+
+      expect(result.rating).toBe(4.5);
+      expect(result.reviewCount).toBe(2);
     });
 
     it('cache hit 인 draft 상품이라도 비관리자는 NotFoundException', async () => {

--- a/backend/src/modules/products/__tests__/products.search.spec.ts
+++ b/backend/src/modules/products/__tests__/products.search.spec.ts
@@ -8,6 +8,7 @@ import { ProductCommandService } from '../product-command.service';
 import { Product, ProductStatus } from '../entities/product.entity';
 import { Category } from '../entities/category.entity';
 import { Review } from '../../reviews/entities/review.entity';
+import { ExternalReview } from '../../reviews/entities/external-review.entity';
 import { ProductImage } from '../entities/product-image.entity';
 import { ProductDetailImage } from '../entities/product-detail-image.entity';
 import { AttributeType } from '../entities/attribute-type.entity';
@@ -27,6 +28,9 @@ function makeFulltextError(): QueryFailedError {
 }
 
 const mockSelect = jest.fn().mockReturnThis();
+const mockAddSelect = jest.fn().mockReturnThis();
+const mockGroupBy = jest.fn().mockReturnThis();
+const mockGetRawMany = jest.fn().mockResolvedValue([]);
 const mockOrderBy = jest.fn().mockReturnThis();
 const mockAddOrderBy = jest.fn().mockReturnThis();
 const mockAndWhere = jest.fn().mockReturnThis();
@@ -42,6 +46,9 @@ const mockInnerJoin = jest.fn().mockReturnThis();
 
 const mockQueryBuilder = {
   select: mockSelect,
+  addSelect: mockAddSelect,
+  groupBy: mockGroupBy,
+  getRawMany: mockGetRawMany,
   leftJoinAndSelect: mockLeftJoinAndSelect,
   andWhere: mockAndWhere,
   where: mockWhere,
@@ -88,6 +95,10 @@ describe('ProductsService — Search', () => {
           useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) },
         },
         {
+          provide: getRepositoryToken(ExternalReview),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder) },
+        },
+        {
           provide: getRepositoryToken(ProductImage),
           useValue: mockRepository,
         },
@@ -121,6 +132,9 @@ describe('ProductsService — Search', () => {
     service = module.get<ProductsService>(ProductsService);
     mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
     mockSelect.mockReturnThis();
+    mockAddSelect.mockReturnThis();
+    mockGroupBy.mockReturnThis();
+    mockGetRawMany.mockResolvedValue([]);
     mockLeftJoinAndSelect.mockReturnThis();
     mockAndWhere.mockReturnThis();
     mockWhere.mockReturnThis();

--- a/backend/src/modules/products/__tests__/products.service.spec.ts
+++ b/backend/src/modules/products/__tests__/products.service.spec.ts
@@ -10,6 +10,7 @@ import { Category } from '../entities/category.entity';
 import { ProductImage } from '../entities/product-image.entity';
 import { ProductDetailImage } from '../entities/product-detail-image.entity';
 import { Review } from '../../reviews/entities/review.entity';
+import { ExternalReview } from '../../reviews/entities/external-review.entity';
 import { AttributeType } from '../entities/attribute-type.entity';
 import { ProductAttribute } from '../entities/product-attribute.entity';
 import { ProductSort } from '../dto/query-products.dto';
@@ -79,6 +80,19 @@ describe('ProductsService', () => {
         },
         {
           provide: getRepositoryToken(Review),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue({
+              select: jest.fn().mockReturnThis(),
+              addSelect: jest.fn().mockReturnThis(),
+              where: jest.fn().mockReturnThis(),
+              andWhere: jest.fn().mockReturnThis(),
+              groupBy: jest.fn().mockReturnThis(),
+              getRawMany: jest.fn().mockResolvedValue([]),
+            }),
+          },
+        },
+        {
+          provide: getRepositoryToken(ExternalReview),
           useValue: {
             createQueryBuilder: jest.fn().mockReturnValue({
               select: jest.fn().mockReturnThis(),

--- a/backend/src/modules/products/product-query.service.ts
+++ b/backend/src/modules/products/product-query.service.ts
@@ -13,6 +13,7 @@ import {
 import { Product, ProductStatus } from './entities/product.entity';
 import { Category } from './entities/category.entity';
 import { Review } from '../reviews/entities/review.entity';
+import { ExternalReview } from '../reviews/entities/external-review.entity';
 import { AttributeType } from './entities/attribute-type.entity';
 import { QueryProductsDto, ProductSort } from './dto/query-products.dto';
 import { CacheService } from '../cache/cache.service';
@@ -38,6 +39,8 @@ export class ProductQueryService {
     private readonly categoryRepository: Repository<Category>,
     @InjectRepository(Review)
     private readonly reviewRepository: Repository<Review>,
+    @InjectRepository(ExternalReview)
+    private readonly externalReviewRepository: Repository<ExternalReview>,
     @InjectRepository(AttributeType)
     private readonly attributeTypeRepository: Repository<AttributeType>,
     private readonly cacheService: CacheService,
@@ -240,21 +243,43 @@ export class ProductQueryService {
       return new Map();
     }
 
-    const stats = await this.reviewRepository
-      .createQueryBuilder('review')
-      .select('review.product_id', 'productId')
-      .addSelect('AVG(review.rating)', 'avgRating')
-      .addSelect('COUNT(review.id)', 'reviewCount')
-      .where('review.product_id IN (:...productIds)', { productIds })
-      .andWhere('review.is_visible = :visible', { visible: true })
-      .groupBy('review.product_id')
-      .getRawMany<{ productId: string; avgRating: string; reviewCount: string }>();
+    const [internalStats, externalStats] = await Promise.all([
+      this.reviewRepository
+        .createQueryBuilder('review')
+        .select('review.product_id', 'productId')
+        .addSelect('AVG(review.rating)', 'avgRating')
+        .addSelect('COUNT(review.id)', 'reviewCount')
+        .where('review.product_id IN (:...productIds)', { productIds })
+        .andWhere('review.is_visible = :visible', { visible: true })
+        .groupBy('review.product_id')
+        .getRawMany<{ productId: string; avgRating: string; reviewCount: string }>(),
+      this.externalReviewRepository
+        .createQueryBuilder('externalReview')
+        .select('externalReview.product_id', 'productId')
+        .addSelect('AVG(externalReview.rating)', 'avgRating')
+        .addSelect('COUNT(externalReview.id)', 'reviewCount')
+        .where('externalReview.product_id IN (:...productIds)', { productIds })
+        .andWhere('externalReview.is_visible = :visible', { visible: true })
+        .groupBy('externalReview.product_id')
+        .getRawMany<{ productId: string; avgRating: string; reviewCount: string }>(),
+    ]);
+
+    const aggregates = new Map<number, { ratingSum: number; reviewCount: number }>();
+    for (const row of [...internalStats, ...externalStats]) {
+      const productId = parseInt(row.productId, 10);
+      const reviewCount = parseInt(row.reviewCount, 10);
+      const avgRating = row.avgRating ? parseFloat(row.avgRating) : 0;
+      const current = aggregates.get(productId) ?? { ratingSum: 0, reviewCount: 0 };
+      current.ratingSum += avgRating * reviewCount;
+      current.reviewCount += reviewCount;
+      aggregates.set(productId, current);
+    }
 
     const map = new Map<number, { rating: number; reviewCount: number }>();
-    for (const row of stats) {
-      map.set(parseInt(row.productId, 10), {
-        rating: row.avgRating ? parseFloat(parseFloat(row.avgRating).toFixed(1)) : 0,
-        reviewCount: parseInt(row.reviewCount, 10),
+    for (const [productId, stats] of aggregates) {
+      map.set(productId, {
+        rating: stats.reviewCount ? parseFloat((stats.ratingSum / stats.reviewCount).toFixed(1)) : 0,
+        reviewCount: stats.reviewCount,
       });
     }
     return map;

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -6,6 +6,7 @@ import { ProductOption } from './entities/product-option.entity';
 import { ProductImage } from './entities/product-image.entity';
 import { ProductDetailImage } from './entities/product-detail-image.entity';
 import { Review } from '../reviews/entities/review.entity';
+import { ExternalReview } from '../reviews/entities/external-review.entity';
 import { AttributeType } from './entities/attribute-type.entity';
 import { ProductAttribute } from './entities/product-attribute.entity';
 import { ProductsService } from './products.service';
@@ -36,6 +37,7 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
       ProductImage,
       ProductDetailImage,
       Review,
+      ExternalReview,
       AttributeType,
       ProductAttribute,
       RecentlyViewedProduct,

--- a/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
@@ -138,7 +138,12 @@ describe('ReviewsService', () => {
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
         addOrderBy: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
         getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+        getRawOne: jest.fn().mockResolvedValue({ avg: null, cnt: '0' }),
+        getRawMany: jest.fn().mockResolvedValue([]),
         getCount: jest.fn().mockResolvedValue(0),
       };
       mockRepo.createQueryBuilder.mockReturnValue(qb);
@@ -173,9 +178,15 @@ describe('ReviewsService', () => {
       };
       const externalQb = {
         where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
         addOrderBy: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
         getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+        getRawOne: jest.fn().mockResolvedValue({ avg: null, cnt: '0' }),
+        getRawMany: jest.fn().mockResolvedValue([]),
         getCount: jest.fn().mockResolvedValue(0),
       };
       mockRepo.createQueryBuilder.mockReturnValue(qb);
@@ -186,7 +197,7 @@ describe('ReviewsService', () => {
       expect(qb.orderBy).toHaveBeenCalledWith('review.rating', 'DESC');
     });
 
-    it('should merge SmartStore reviews into the product review list without internal average stats', async () => {
+    it('should include SmartStore reviews in product average stats and distribution', async () => {
       const internalReview = { ...mockReview, id: 1, rating: 4, createdAt: new Date('2026-03-01T12:00:00Z') };
       const externalReview = {
         id: 9,
@@ -220,7 +231,12 @@ describe('ReviewsService', () => {
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
         addOrderBy: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
         getManyAndCount: jest.fn().mockResolvedValue([[externalReview], 1]),
+        getRawOne: jest.fn().mockResolvedValue({ avg: '5.0', cnt: '1' }),
+        getRawMany: jest.fn().mockResolvedValue([{ rating: 5, count: '1' }]),
         getCount: jest.fn().mockResolvedValue(1),
       };
       mockRepo.createQueryBuilder.mockReturnValue(qb);
@@ -235,11 +251,12 @@ describe('ReviewsService', () => {
         userName: '네**',
         orderItemId: null,
       });
-      expect(result.stats.averageRating).toBe(4);
+      expect(result.stats.averageRating).toBe(4.5);
       expect(result.stats.totalCount).toBe(2);
       expect(result.stats.internalCount).toBe(1);
       expect(result.stats.externalCount).toBe(1);
-      expect(result.stats.distribution['5']).toBe(0);
+      expect(result.stats.distribution['5']).toBe(1);
+      expect(result.stats.distribution['4']).toBe(1);
       expect(result.pagination.total).toBe(2);
     });
   });
@@ -287,6 +304,10 @@ describe('ReviewsService', () => {
         externalReviewId: 'naver-2',
         isVisible: false,
       }));
+      expect(mockManager.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE products p'),
+        [5, 5, 5],
+      );
     });
   });
 

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -187,54 +187,73 @@ export class ReviewsService {
   }
 
   async getStats(productId?: number): Promise<ReviewStats> {
-    const qb = this.reviewRepo
+    const internalStatsQb = this.reviewRepo
       .createQueryBuilder('review')
       .where('review.is_visible = :visible', { visible: true });
+    const externalStatsQb = this.externalReviewRepo
+      .createQueryBuilder('externalReview')
+      .where('externalReview.is_visible = :visible', { visible: true });
 
     if (productId) {
-      qb.andWhere('review.product_id = :productId', { productId });
+      internalStatsQb.andWhere('review.product_id = :productId', { productId });
+      externalStatsQb.andWhere('externalReview.product_id = :productId', { productId });
     }
 
-    const result = await qb
-      .select('AVG(review.rating)', 'avg')
-      .addSelect('COUNT(*)', 'cnt')
-      .getRawOne<{ avg: string | null; cnt: string }>();
+    const [internalResult, externalResult] = await Promise.all([
+      internalStatsQb
+        .select('AVG(review.rating)', 'avg')
+        .addSelect('COUNT(*)', 'cnt')
+        .getRawOne<{ avg: string | null; cnt: string }>(),
+      externalStatsQb
+        .select('AVG(externalReview.rating)', 'avg')
+        .addSelect('COUNT(*)', 'cnt')
+        .getRawOne<{ avg: string | null; cnt: string }>(),
+    ]);
 
-    const avgRating = result?.avg ? parseFloat(parseFloat(result.avg).toFixed(1)) : 0;
-    const totalCount = result?.cnt ? parseInt(result.cnt, 10) : 0;
+    const internalCount = internalResult?.cnt ? parseInt(internalResult.cnt, 10) : 0;
+    const externalCount = externalResult?.cnt ? parseInt(externalResult.cnt, 10) : 0;
+    const totalCount = internalCount + externalCount;
+    const internalAvg = internalResult?.avg ? parseFloat(internalResult.avg) : 0;
+    const externalAvg = externalResult?.avg ? parseFloat(externalResult.avg) : 0;
+    const averageRating = totalCount
+      ? parseFloat(
+          (((internalAvg * internalCount) + (externalAvg * externalCount)) / totalCount).toFixed(1),
+        )
+      : 0;
 
-    const distQb = this.reviewRepo
+    const internalDistQb = this.reviewRepo
       .createQueryBuilder('review')
       .select('review.rating', 'rating')
       .addSelect('COUNT(*)', 'count')
       .where('review.is_visible = :visible', { visible: true })
       .groupBy('review.rating');
-
-    if (productId) {
-      distQb.andWhere('review.product_id = :productId', { productId });
-    }
-
-    const distRows = await distQb.getRawMany<{ rating: number; count: string }>();
-    const distribution: Record<string, number> = { '5': 0, '4': 0, '3': 0, '2': 0, '1': 0 };
-    for (const row of distRows) {
-      distribution[String(row.rating)] = parseInt(row.count, 10);
-    }
-
-    const externalQb = this.externalReviewRepo
+    const externalDistQb = this.externalReviewRepo
       .createQueryBuilder('externalReview')
-      .where('externalReview.is_visible = :visible', { visible: true });
+      .select('externalReview.rating', 'rating')
+      .addSelect('COUNT(*)', 'count')
+      .where('externalReview.is_visible = :visible', { visible: true })
+      .groupBy('externalReview.rating');
 
     if (productId) {
-      externalQb.andWhere('externalReview.product_id = :productId', { productId });
+      internalDistQb.andWhere('review.product_id = :productId', { productId });
+      externalDistQb.andWhere('externalReview.product_id = :productId', { productId });
     }
 
-    const externalCount = await externalQb.getCount();
+    const [internalDistRows, externalDistRows] = await Promise.all([
+      internalDistQb.getRawMany<{ rating: number; count: string }>(),
+      externalDistQb.getRawMany<{ rating: number; count: string }>(),
+    ]);
+    const distribution: Record<string, number> = { '5': 0, '4': 0, '3': 0, '2': 0, '1': 0 };
+    for (const row of [...internalDistRows, ...externalDistRows]) {
+      const key = String(row.rating);
+      distribution[key] = (distribution[key] ?? 0) + parseInt(row.count, 10);
+    }
 
     return {
-      averageRating: avgRating,
-      totalCount: totalCount + externalCount,
+      averageRating,
+      totalCount,
       distribution,
-      internalCount: totalCount,
+      internalCount,
       externalCount,
     };
   }
@@ -273,6 +292,10 @@ export class ReviewsService {
 
       if (patch.isVisible === false) hidden += 1;
     }
+
+    await this.dataSource.transaction((manager) =>
+      this.refreshProductReviewStats(manager, dto.productId),
+    );
 
     this.logger.log(
       `SmartStore reviews imported: productId=${dto.productId}, received=${dto.reviews.length}, created=${created}, updated=${updated}`,


### PR DESCRIPTION
## 요약\n- 스마트스토어 visible 리뷰를 리뷰 평균/분포 통계에 포함\n- 상품 목록/상세 평점 집계도 내부+외부 리뷰 기준으로 통일\n- 회귀 테스트를 외부 리뷰 평균/분포 포함 기준으로 갱신\n\nCloses #981\n\n## 검증\n- bash scripts/codex-project-guard.sh\n- npm run build\n- npm run test:run\n- cd backend && npm run build && npm run test\n\n## 미검증\n- cd backend && npm run test:e2e (스키마/마이그레이션 변경 없음)