### PR TITLE
fix: #985 관리자 리뷰 목록 500 오류 방지

### DIFF
--- a/backend/src/modules/reviews/__tests__/admin-reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/admin-reviews.service.spec.ts
@@ -1,7 +1,45 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { Column, DataSource, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { AdminReviewsService } from '../admin-reviews.service';
 import { ExternalReview } from '../entities/external-review.entity';
+
+@Entity('test_products')
+class TestProduct {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  name!: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  sku!: string | null;
+}
+
+@Entity('test_external_reviews')
+class TestExternalReview {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({ name: 'product_id', type: 'bigint' })
+  productId!: number;
+
+  @Column({ name: 'reviewed_at', type: 'datetime' })
+  reviewedAt!: Date;
+
+  @Column({ name: 'last_synced_at', type: 'datetime' })
+  lastSyncedAt!: Date;
+
+  @Column({ name: 'helpful_count', type: 'int', unsigned: true, default: 0 })
+  helpfulCount!: number;
+
+  @Column({ name: 'is_visible', type: 'boolean', default: true })
+  isVisible!: boolean;
+
+  @ManyToOne(() => TestProduct)
+  @JoinColumn({ name: 'product_id' })
+  product!: TestProduct;
+}
 
 describe('AdminReviewsService', () => {
   let service: AdminReviewsService;
@@ -51,10 +89,36 @@ describe('AdminReviewsService', () => {
     expect(result).toEqual({ items: [], total: 0, page: 1, limit: 20 });
     expect(externalReviewRepository.createQueryBuilder).toHaveBeenCalledWith('review');
     expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('review.product', 'product');
-    expect(qb.andWhere).not.toHaveBeenCalledWith('review.is_visible = :visible', expect.anything());
+    expect(qb.andWhere.mock.calls).toEqual([]);
     expect(qb.orderBy).toHaveBeenCalledWith('review.reviewedAt', 'DESC');
     expect(qb.skip).toHaveBeenCalledWith(0);
     expect(qb.take).toHaveBeenCalledWith(20);
+  });
+
+
+  it('keeps joined pagination order paths resolvable by TypeORM metadata', async () => {
+    const dataSource = new DataSource({
+      type: 'mysql',
+      database: 'metadata_only',
+      entities: [TestProduct, TestExternalReview],
+    });
+    await (dataSource as unknown as { buildMetadatas: () => Promise<void> }).buildMetadatas();
+
+    const qb = dataSource
+      .getRepository(TestExternalReview)
+      .createQueryBuilder('review')
+      .leftJoinAndSelect('review.product', 'product')
+      .orderBy('review.reviewedAt', 'DESC')
+      .skip(0)
+      .take(20);
+
+    expect(() =>
+      (
+        qb as unknown as {
+          createOrderByCombinedWithSelectExpression: (parentAlias: string) => unknown;
+        }
+      ).createOrderByCombinedWithSelectExpression('distinctAlias'),
+    ).not.toThrow();
   });
 
   it('applies visibility and secondary sort filters with entity property paths', async () => {

--- a/backend/src/modules/reviews/__tests__/admin-reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/admin-reviews.service.spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AdminReviewsService } from '../admin-reviews.service';
+import { ExternalReview } from '../entities/external-review.entity';
+
+describe('AdminReviewsService', () => {
+  let service: AdminReviewsService;
+
+  const qb = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+  };
+
+  const externalReviewRepository = {
+    createQueryBuilder: jest.fn(() => qb),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+    save: jest.fn(),
+    manager: { query: jest.fn() },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminReviewsService,
+        { provide: getRepositoryToken(ExternalReview), useValue: externalReviewRepository },
+      ],
+    }).compile();
+
+    service = module.get(AdminReviewsService);
+    jest.clearAllMocks();
+    qb.leftJoinAndSelect.mockReturnThis();
+    qb.andWhere.mockReturnThis();
+    qb.orderBy.mockReturnThis();
+    qb.addOrderBy.mockReturnThis();
+    qb.skip.mockReturnThis();
+    qb.take.mockReturnThis();
+    qb.getManyAndCount.mockResolvedValue([[], 0]);
+    externalReviewRepository.createQueryBuilder.mockReturnValue(qb);
+  });
+
+  it('lists all visibility reviews using entity property paths for paginated sorting', async () => {
+    const result = await service.findAll({ page: 1, limit: 20, visibility: 'all' });
+
+    expect(result).toEqual({ items: [], total: 0, page: 1, limit: 20 });
+    expect(externalReviewRepository.createQueryBuilder).toHaveBeenCalledWith('review');
+    expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('review.product', 'product');
+    expect(qb.andWhere).not.toHaveBeenCalledWith('review.is_visible = :visible', expect.anything());
+    expect(qb.orderBy).toHaveBeenCalledWith('review.reviewedAt', 'DESC');
+    expect(qb.skip).toHaveBeenCalledWith(0);
+    expect(qb.take).toHaveBeenCalledWith(20);
+  });
+
+  it('applies visibility and secondary sort filters with entity property paths', async () => {
+    await service.findAll({
+      page: 2,
+      limit: 10,
+      visibility: 'hidden',
+      sort: 'helpful',
+      order: 'ASC',
+    });
+
+    expect(qb.andWhere).toHaveBeenCalledWith('review.isVisible = :visible', { visible: false });
+    expect(qb.orderBy).toHaveBeenCalledWith('review.helpfulCount', 'ASC');
+    expect(qb.addOrderBy).toHaveBeenCalledWith('review.reviewedAt', 'DESC');
+    expect(qb.skip).toHaveBeenCalledWith(10);
+    expect(qb.take).toHaveBeenCalledWith(10);
+  });
+});

--- a/backend/src/modules/reviews/admin-reviews.service.ts
+++ b/backend/src/modules/reviews/admin-reviews.service.ts
@@ -135,9 +135,9 @@ export class AdminReviewsService {
       qb.andWhere(
         new Brackets((sub) => {
           sub
-            .where('review.external_review_id LIKE :search', { search: `%${search}%` })
-            .orWhere('review.external_product_id LIKE :search', { search: `%${search}%` })
-            .orWhere('review.reviewer_name_masked LIKE :search', { search: `%${search}%` })
+            .where('review.externalReviewId LIKE :search', { search: `%${search}%` })
+            .orWhere('review.externalProductId LIKE :search', { search: `%${search}%` })
+            .orWhere('review.reviewerNameMasked LIKE :search', { search: `%${search}%` })
             .orWhere('review.content LIKE :search', { search: `%${search}%` })
             .orWhere('product.name LIKE :search', { search: `%${search}%` })
             .orWhere('product.sku LIKE :search', { search: `%${search}%` });
@@ -146,27 +146,27 @@ export class AdminReviewsService {
     }
 
     if (query.visibility === 'visible') {
-      qb.andWhere('review.is_visible = :visible', { visible: true });
+      qb.andWhere('review.isVisible = :visible', { visible: true });
     }
     if (query.visibility === 'hidden') {
-      qb.andWhere('review.is_visible = :visible', { visible: false });
+      qb.andWhere('review.isVisible = :visible', { visible: false });
     }
     if (query.rating) {
       qb.andWhere('review.rating = :rating', { rating: query.rating });
     }
     if (query.reviewType?.trim()) {
-      qb.andWhere('review.review_type = :reviewType', { reviewType: query.reviewType.trim() });
+      qb.andWhere('review.reviewType = :reviewType', { reviewType: query.reviewType.trim() });
     }
     if (query.importBatchId?.trim()) {
-      qb.andWhere('review.import_batch_id = :importBatchId', {
+      qb.andWhere('review.importBatchId = :importBatchId', {
         importBatchId: query.importBatchId.trim(),
       });
     }
     if (query.hasMedia === 'true') {
-      qb.andWhere('review.image_urls IS NOT NULL AND JSON_LENGTH(review.image_urls) > 0');
+      qb.andWhere('review.imageUrls IS NOT NULL AND JSON_LENGTH(review.imageUrls) > 0');
     }
     if (query.hasMedia === 'false') {
-      qb.andWhere('(review.image_urls IS NULL OR JSON_LENGTH(review.image_urls) = 0)');
+      qb.andWhere('(review.imageUrls IS NULL OR JSON_LENGTH(review.imageUrls) = 0)');
     }
   }
 
@@ -174,16 +174,16 @@ export class AdminReviewsService {
     const order = String(query.order ?? 'DESC').toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
     switch (query.sort ?? 'reviewedAt') {
       case 'rating':
-        qb.orderBy('review.rating', order).addOrderBy('review.reviewed_at', 'DESC');
+        qb.orderBy('review.rating', order).addOrderBy('review.reviewedAt', 'DESC');
         break;
       case 'helpful':
-        qb.orderBy('review.helpful_count', order).addOrderBy('review.reviewed_at', 'DESC');
+        qb.orderBy('review.helpfulCount', order).addOrderBy('review.reviewedAt', 'DESC');
         break;
       case 'importedAt':
-        qb.orderBy('review.last_synced_at', order).addOrderBy('review.reviewed_at', 'DESC');
+        qb.orderBy('review.lastSyncedAt', order).addOrderBy('review.reviewedAt', 'DESC');
         break;
       default:
-        qb.orderBy('review.reviewed_at', order);
+        qb.orderBy('review.reviewedAt', order);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix admin reviews query-builder filters/sorts to use TypeORM entity property paths instead of raw snake_case DB column names
- Add regression coverage for `visibility=all` and hidden/helpful sorted admin review list queries

Closes #985

## Verification
- `cd backend && npm test -- admin-reviews.service.spec.ts --runInBand`
- `cd backend && npm run build && npm run test`
- `npm run build && npm run test:run`
- `bash scripts/codex-project-guard.sh`
- `curl http://localhost:3000/api/health` → 200
- `curl -I http://localhost:5173/ko` → 200
- Authenticated `GET /api/admin/reviews?page=1&limit=20&visibility=all` → 200
