### PR TITLE
fix: #977 키워드 매핑 속성 타입과 단어 보강

### DIFF
--- a/backend/src/database/migrations/1785300000000-AddKeywordMappingAttributeTypes.ts
+++ b/backend/src/database/migrations/1785300000000-AddKeywordMappingAttributeTypes.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddKeywordMappingAttributeTypes1785300000000 implements MigrationInterface {
+  name = 'AddKeywordMappingAttributeTypes1785300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO \`attribute_types\` (\`code\`, \`name\`, \`name_ko\`, \`input_type\`, \`is_filterable\`, \`is_searchable\`, \`valid_values\`, \`sort_order\`, \`is_active\`)
+      VALUES
+        ('capacity', 'Capacity', '용량', 'text', TRUE, FALSE, NULL, 3, TRUE),
+        ('craft_method', 'Craft Method', '제작방식', 'select', TRUE, FALSE, '["handmade"]', 4, TRUE),
+        ('clay_origin', 'Clay Origin', '니료 산지', 'select', TRUE, FALSE, '["huanglongshan"]', 5, TRUE)
+      ON DUPLICATE KEY UPDATE
+        \`name\` = VALUES(\`name\`),
+        \`name_ko\` = VALUES(\`name_ko\`),
+        \`input_type\` = VALUES(\`input_type\`),
+        \`is_filterable\` = VALUES(\`is_filterable\`),
+        \`is_searchable\` = VALUES(\`is_searchable\`),
+        \`valid_values\` = VALUES(\`valid_values\`),
+        \`sort_order\` = VALUES(\`sort_order\`),
+        \`is_active\` = TRUE
+    `);
+
+    await queryRunner.query(`
+      UPDATE \`attribute_types\`
+      SET \`valid_values\` = '["junni","danji","jani","heugni","cheongsu","nokni","hongwei_zhuni","benshan_luni","old_qingshuini","old_duanni","tiechengzao_hongni","old_zini","dicaoqing","qinghuini","qingshuini","jiangponi","yubaini","duanni","zhuni","hongni","zini","heini","luni","wuni"]'
+      WHERE \`code\` = 'clay_type'
+    `);
+
+    await queryRunner.query(`
+      UPDATE \`attribute_types\`
+      SET \`valid_values\` = '["seoshi","seokpyo","juhu","bianping","inwang","deokjong","supeong","pinggai_lianzi","lianzi","xishi","shipiao","fanggu","shuiping","longdan","banyue","xubian","hanwa","tieqiu","banhu","julunzhu","yixing"]'
+      WHERE \`code\` = 'teapot_shape'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM \`attribute_types\` WHERE \`code\` IN ('capacity', 'craft_method', 'clay_origin')`);
+    await queryRunner.query(`
+      UPDATE \`attribute_types\`
+      SET \`valid_values\` = '["junni","danji","jani","heugni","cheongsu","nokni"]'
+      WHERE \`code\` = 'clay_type'
+    `);
+    await queryRunner.query(`
+      UPDATE \`attribute_types\`
+      SET \`valid_values\` = '["seoshi","seokpyo","juhu","bianping","inwang","deokjong","supeong"]'
+      WHERE \`code\` = 'teapot_shape'
+    `);
+  }
+}

--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -41,6 +41,7 @@ function createAttributeTypeRepositoryMock() {
     find: jest.fn().mockResolvedValue([
       { id: 10, code: 'clay_type', isActive: true },
       { id: 11, code: 'teapot_shape', isActive: true },
+      { id: 12, code: 'capacity', isActive: true },
       { id: 14, code: 'clay_origin', isActive: true },
     ]),
   };

--- a/backend/src/modules/products/__tests__/product-keyword-mapping.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-keyword-mapping.service.spec.ts
@@ -8,9 +8,10 @@ describe('ProductKeywordMappingService', () => {
     const result = service.analyzeProductName('옥화당 (老段泥) 120 mL');
 
     expect(result.normalizedName).toBe('옥화당 老段泥 120 ml');
-    expect(result.attributes).toEqual([
+    expect(result.attributes).toEqual(expect.arrayContaining([
       expect.objectContaining({ code: 'clay_type', value: 'old_duanni', displayValue: '노단니' }),
-    ]);
+      expect.objectContaining({ code: 'capacity', value: '120ml', displayValue: '120ml' }),
+    ]));
     expect(result.options).toEqual([
       expect.objectContaining({ name: '용량', value: '120ml' }),
     ]);
@@ -24,6 +25,7 @@ describe('ProductKeywordMappingService', () => {
       expect.objectContaining({ code: 'clay_type', value: 'old_duanni', displayValue: '노단니' }),
       expect.objectContaining({ code: 'teapot_shape', value: 'lianzi', displayValue: '연자호' }),
       expect.objectContaining({ code: 'clay_origin', value: 'huanglongshan', displayValue: '황룡산' }),
+      expect.objectContaining({ code: 'capacity', value: '110cc', displayValue: '110cc' }),
     ]));
     expect(result.attributes).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ code: 'clay_type', value: 'duanni' }),
@@ -44,8 +46,38 @@ describe('ProductKeywordMappingService', () => {
       expect.objectContaining({ code: 'clay_type', value: 'jiangponi' }),
       expect.objectContaining({ code: 'teapot_shape', value: 'fanggu' }),
       expect.objectContaining({ code: 'clay_origin', value: 'huanglongshan' }),
+      expect.objectContaining({ code: 'capacity', value: '130cc' }),
     ]));
     expect(result.options).toEqual([expect.objectContaining({ value: '130cc' })]);
+  });
+
+
+  it('deduplicates nested shape aliases and keeps only one lower-priority warning', () => {
+    const result = service.analyzeProductName('옥화당 자사호 옥백니 평개연자호 135cc');
+
+    expect(result.attributes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'clay_type', value: 'yubaini', displayValue: '옥백니' }),
+      expect.objectContaining({ code: 'teapot_shape', value: 'pinggai_lianzi', displayValue: '평개연자호' }),
+      expect.objectContaining({ code: 'capacity', value: '135cc', displayValue: '135cc' }),
+    ]));
+    expect(result.warnings.filter((warning) => warning.includes("후보 '연자호'"))).toHaveLength(1);
+  });
+
+  it('maps follow-up SmartStore words from the remote preview sample', () => {
+    const cases = [
+      ['옥화당 자사호 홍위주니 전수공 반호 90cc', 'hongwei_zhuni', 'banhu'],
+      ['옥화당 자사호 황룡산 철성조홍니 거륜주 110cc', 'tiechengzao_hongni', 'julunzhu'],
+      ['옥화당 자사호 황룡산 노자니 이형호 120cc', 'old_zini', 'yixing'],
+    ] as const;
+
+    cases.forEach(([name, clayValue, shapeValue]) => {
+      const result = service.analyzeProductName(name);
+      expect(result.attributes).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: 'clay_type', value: clayValue }),
+        expect.objectContaining({ code: 'teapot_shape', value: shapeValue }),
+        expect.objectContaining({ code: 'capacity' }),
+      ]));
+    });
   });
 
   it('maps tea names to tea notice information', () => {

--- a/backend/src/modules/products/product-keyword-mapping.service.ts
+++ b/backend/src/modules/products/product-keyword-mapping.service.ts
@@ -76,6 +76,8 @@ const STATIC_RULES: StaticKeywordRule[] = [
   attribute('clay_type', 'benshan_luni', '본산녹니', ['본산녹니'], 230),
   attribute('clay_type', 'old_qingshuini', '노청수니', ['노청수니'], 230),
   attribute('clay_type', 'old_duanni', '노단니', ['노단니', '老段泥', 'old duanni'], 230),
+  attribute('clay_type', 'tiechengzao_hongni', '철성조홍니', ['철성조홍니'], 230),
+  attribute('clay_type', 'old_zini', '노자니', ['노자니'], 230),
   attribute('clay_type', 'dicaoqing', '저조청', ['저조청', '底槽青'], 220),
   attribute('clay_type', 'qinghuini', '청회니', ['청회니', '青灰泥'], 220),
   attribute('clay_type', 'qingshuini', '청수니', ['청수니'], 210),
@@ -100,6 +102,9 @@ const STATIC_RULES: StaticKeywordRule[] = [
   attribute('teapot_shape', 'xubian', '허편', ['허편', '虛扁'], 200),
   attribute('teapot_shape', 'hanwa', '한와호', ['한와호'], 200),
   attribute('teapot_shape', 'tieqiu', '철구호', ['철구호'], 200),
+  attribute('teapot_shape', 'banhu', '반호', ['반호'], 200),
+  attribute('teapot_shape', 'julunzhu', '거륜주', ['거륜주'], 200),
+  attribute('teapot_shape', 'yixing', '이형호', ['이형호'], 200),
 
   attribute('craft_method', 'handmade', '전수공', ['전수공'], 150),
   attribute('clay_origin', 'huanglongshan', '황룡산', ['황룡산'], 150),
@@ -158,7 +163,7 @@ export class ProductKeywordMappingService {
   }
 
   private selectAttributes(normalizedName: string, warnings: string[]): ProductKeywordAttributeMapping[] {
-    const matches = this.findMatches<AttributeKeywordRule>(normalizedName, 'attribute');
+    const matches = this.dedupeAttributeMatches(this.findMatches<AttributeKeywordRule>(normalizedName, 'attribute'));
     const byCode = new Map<string, Array<MatchedRule<AttributeKeywordRule>>>();
     matches.forEach((match) => {
       const items = byCode.get(match.rule.code) ?? [];
@@ -166,7 +171,7 @@ export class ProductKeywordMappingService {
       byCode.set(match.rule.code, items);
     });
 
-    return [...byCode.entries()].map(([code, items]) => {
+    const attributes = [...byCode.entries()].map(([code, items]) => {
       const selected = this.selectBest(items);
       items
         .filter((match) => match.rule.value !== selected.rule.value)
@@ -180,6 +185,35 @@ export class ProductKeywordMappingService {
         keyword: selected.keyword,
       };
     });
+
+    const capacity = this.extractCapacityAttribute(normalizedName);
+    if (capacity && !attributes.some((attribute) => attribute.code === 'capacity')) {
+      attributes.push(capacity);
+    }
+    return attributes;
+  }
+
+  private dedupeAttributeMatches(matches: Array<MatchedRule<AttributeKeywordRule>>): Array<MatchedRule<AttributeKeywordRule>> {
+    const byValue = new Map<string, Array<MatchedRule<AttributeKeywordRule>>>();
+    matches.forEach((match) => {
+      const key = `${match.rule.code}\u0000${match.rule.value}`;
+      const items = byValue.get(key) ?? [];
+      items.push(match);
+      byValue.set(key, items);
+    });
+    return [...byValue.values()].map((items) => this.selectBest(items));
+  }
+
+  private extractCapacityAttribute(normalizedName: string): ProductKeywordAttributeMapping | null {
+    const capacityMatch = /\b(\d{2,4})\s?(cc|ml)\b/i.exec(normalizedName);
+    if (!capacityMatch) return null;
+    const value = `${capacityMatch[1]}${capacityMatch[2].toLowerCase()}`;
+    return {
+      code: 'capacity',
+      value,
+      displayValue: value,
+      keyword: capacityMatch[0],
+    };
   }
 
   private selectNoticeInfoType(normalizedName: string): ProductNoticeInfoType | undefined {


### PR DESCRIPTION
## 요약
- 원격/운영 DB에 누락된 자동 매핑 속성 타입(capacity, craft_method, clay_origin)을 배포 마이그레이션으로 추가합니다.
- 사용자 제공 미리보기 샘플 기준 단어(반호, 거륜주, 이형호, 철성조홍니, 노자니)를 자사호 키워드 매핑에 추가합니다.
- 용량(cc/ml)을 옵션뿐 아니라 product_attributes에도 저장하고, 평개연자호 안의 연자호 중복 경고를 1회로 정리합니다.

## 검증
- cd backend && npx jest src/modules/products/__tests__/product-keyword-mapping.service.spec.ts src/modules/products/__tests__/smartstore-product-import.service.spec.ts src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts --runInBand
- cd backend && npm run build
- bash scripts/codex-project-guard.sh
- LOCAL_DATABASE_URL=... cd backend && npm run migration:run && npm run migration:show
- TEST_DATABASE_URL=... cd backend && npm run test:e2e
- cd backend && npm run lint
- cd backend && npm run test -- --runInBand

## 배포 메모
- main 병합 시 deploy.yml이 backend 마이그레이션을 실행하여 원격 서버 attribute_types/valid_values를 갱신합니다.

Related #977