### PR TITLE
feat: #983 스토어 데이터 번역 상태 관리

### DIFF
--- a/backend/src/modules/admin/__tests__/admin-localization.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-localization.service.spec.ts
@@ -1,0 +1,138 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AdminLocalizationService } from '../admin-localization.service';
+import { Product } from '../../products/entities/product.entity';
+import { Category } from '../../products/entities/category.entity';
+import { ProductOption } from '../../products/entities/product-option.entity';
+import { Page } from '../../pages/entities/page.entity';
+import { PageBlock } from '../../pages/entities/page-block.entity';
+import { NavigationItem } from '../../navigation/entities/navigation-item.entity';
+import { ExternalReview } from '../../reviews/entities/external-review.entity';
+
+describe('AdminLocalizationService', () => {
+  let service: AdminLocalizationService;
+
+  const productRepo = { find: jest.fn() };
+  const categoryRepo = { find: jest.fn() };
+  const productOptionRepo = { find: jest.fn() };
+  const pageRepo = { find: jest.fn() };
+  const pageBlockRepo = { find: jest.fn() };
+  const navigationRepo = { find: jest.fn() };
+  const externalReviewRepo = { find: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminLocalizationService,
+        { provide: getRepositoryToken(Product), useValue: productRepo },
+        { provide: getRepositoryToken(Category), useValue: categoryRepo },
+        { provide: getRepositoryToken(ProductOption), useValue: productOptionRepo },
+        { provide: getRepositoryToken(Page), useValue: pageRepo },
+        { provide: getRepositoryToken(PageBlock), useValue: pageBlockRepo },
+        { provide: getRepositoryToken(NavigationItem), useValue: navigationRepo },
+        { provide: getRepositoryToken(ExternalReview), useValue: externalReviewRepo },
+      ],
+    }).compile();
+
+    service = module.get(AdminLocalizationService);
+    jest.clearAllMocks();
+  });
+
+  it('영문 번역 누락 리소스와 fallback 정책을 집계한다', async () => {
+    productRepo.find.mockResolvedValue([
+      {
+        id: 1,
+        name: '보이차',
+        nameEn: null,
+        description: '설명',
+        descriptionEn: 'Description',
+        shortDescription: '짧은 설명',
+        shortDescriptionEn: null,
+        status: 'active',
+      },
+      {
+        id: 2,
+        name: 'Tea',
+        nameEn: 'Tea',
+        description: null,
+        descriptionEn: null,
+        shortDescription: null,
+        shortDescriptionEn: null,
+        status: 'hidden',
+      },
+    ]);
+    categoryRepo.find.mockResolvedValue([
+      { id: 3, name: '다구', nameEn: '', description: '찻잔', descriptionEn: null, isActive: true },
+      { id: 11, name: '숨김', nameEn: null, description: null, descriptionEn: null, isActive: false },
+    ]);
+    productOptionRepo.find.mockResolvedValue([
+      { id: 10, productId: 1, name: '색상', nameEn: 'Color', value: '검정', valueEn: null },
+      { id: 12, productId: 2, name: '비공개', nameEn: null, value: '옵션', valueEn: null },
+    ]);
+    pageRepo.find.mockResolvedValue([
+      { id: 4, slug: 'home', title: '홈', titleEn: 'Home', is_published: true },
+      { id: 13, slug: 'draft', title: '초안', titleEn: null, is_published: false },
+    ]);
+    pageBlockRepo.find.mockResolvedValue([
+      {
+        id: 5,
+        page_id: 4,
+        type: 'hero_banner',
+        is_visible: true,
+        content: { title: '대표 문구', title_en: 'Hero', slides: [{ cta_text: '구매하기' }] },
+      },
+      {
+        id: 14,
+        page_id: 13,
+        type: 'text_content',
+        is_visible: true,
+        content: { title: '비공개 페이지 블록' },
+      },
+    ]);
+    navigationRepo.find.mockResolvedValue([
+      { id: 6, group: 'gnb', label: '상품', labelEn: null, is_active: true },
+      { id: 7, group: 'footer', label: 'Hidden', labelEn: null, is_active: false },
+    ]);
+    externalReviewRepo.find.mockResolvedValue([
+      { id: 8, externalReviewId: 'naver-1', content: '좋아요', isVisible: true },
+      { id: 9, externalReviewId: 'naver-2', content: '', isVisible: true },
+    ]);
+
+    const report = await service.getCoverage();
+
+    expect(report.locale).toBe('en');
+    expect(report.fallbackPolicy).toEqual({
+      default: 'koFallback',
+      smartStoreReviews: 'sourceTextFallback',
+    });
+    expect(report.summaries).toEqual(expect.arrayContaining([
+      { kind: 'product', total: 1, missing: 1, complete: 0 },
+      { kind: 'category', total: 1, missing: 1, complete: 0 },
+      { kind: 'productOption', total: 1, missing: 1, complete: 0 },
+      { kind: 'pageBlock', total: 1, missing: 1, complete: 0 },
+      { kind: 'navigation', total: 1, missing: 1, complete: 0 },
+      { kind: 'externalReview', total: 1, missing: 1, complete: 0 },
+    ]));
+    expect(report.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'product',
+        id: 1,
+        missingFields: ['name', 'shortDescription'],
+      }),
+      expect.objectContaining({ kind: 'productOption', id: 10, missingFields: ['value'] }),
+      expect.objectContaining({
+        kind: 'pageBlock',
+        id: 5,
+        missingFields: ['content.slides[0].cta_text'],
+      }),
+      expect.objectContaining({
+        kind: 'externalReview',
+        id: 8,
+        fallbackPolicy: 'sourceTextFallback',
+      }),
+    ]));
+    expect(report.items).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'pageBlock', id: 14 }),
+    ]));
+  });
+});

--- a/backend/src/modules/admin/admin-localization.controller.ts
+++ b/backend/src/modules/admin/admin-localization.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { AdminLocalizationService } from './admin-localization.service';
+
+@ApiTags('관리자 - 번역 상태')
+@Controller('admin/localization')
+@Roles('admin', 'super_admin')
+export class AdminLocalizationController {
+  constructor(private readonly adminLocalizationService: AdminLocalizationService) {}
+
+  @Get('coverage')
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '스토어 데이터 번역 상태 조회',
+    description: '영문 스토어에서 한국어 fallback 또는 원문 fallback이 발생할 사용자 노출 데이터를 집계합니다.',
+  })
+  @ApiResponse({ status: 200, description: '번역 상태 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  getCoverage() {
+    return this.adminLocalizationService.getCoverage();
+  }
+}

--- a/backend/src/modules/admin/admin-localization.service.ts
+++ b/backend/src/modules/admin/admin-localization.service.ts
@@ -1,0 +1,331 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Product, ProductStatus } from '../products/entities/product.entity';
+import { Category } from '../products/entities/category.entity';
+import { ProductOption } from '../products/entities/product-option.entity';
+import { Page } from '../pages/entities/page.entity';
+import { PageBlock } from '../pages/entities/page-block.entity';
+import { NavigationItem } from '../navigation/entities/navigation-item.entity';
+import { ExternalReview } from '../reviews/entities/external-review.entity';
+
+const REPORT_LOCALE = 'en';
+const SAMPLE_LIMIT = 50;
+const CONTENT_TRANSLATION_KEYS = new Set([
+  'title',
+  'subtitle',
+  'description',
+  'eyebrow',
+  'cta_text',
+  'ctaText',
+  'hrefLabel',
+  'label',
+  'sectionLabel',
+  'sectionTitle',
+  'sectionDesc',
+  'html',
+  'name',
+  'nameKo',
+  'region',
+  'specialty',
+  'story',
+]);
+
+export type LocalizationResourceKind =
+  | 'product'
+  | 'category'
+  | 'productOption'
+  | 'page'
+  | 'pageBlock'
+  | 'navigation'
+  | 'externalReview';
+
+export interface LocalizationMissingItem {
+  kind: LocalizationResourceKind;
+  id: number;
+  label: string;
+  missingFields: string[];
+  editHref: string | null;
+  fallbackPolicy: 'koFallback' | 'sourceTextFallback';
+}
+
+export interface LocalizationCoverageSummary {
+  kind: LocalizationResourceKind;
+  total: number;
+  missing: number;
+  complete: number;
+}
+
+export interface LocalizationCoverageReport {
+  locale: typeof REPORT_LOCALE;
+  fallbackPolicy: {
+    default: 'koFallback';
+    smartStoreReviews: 'sourceTextFallback';
+  };
+  summaries: LocalizationCoverageSummary[];
+  items: LocalizationMissingItem[];
+}
+
+interface FieldPair {
+  base: string;
+  localized: string;
+  label: string;
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function missingEntityFields(entity: Record<string, unknown>, fields: FieldPair[]): string[] {
+  return fields
+    .filter(({ base, localized }) => hasText(entity[base]) && !hasText(entity[localized]))
+    .map(({ label }) => label);
+}
+
+function localizedKeyCandidates(key: string): string[] {
+  if (key === 'nameKo') return ['nameEn'];
+  return [`${key}_en`, `${key}En`];
+}
+
+function collectContentMissingFields(
+  content: unknown,
+  path = 'content',
+  seen = new WeakSet<object>(),
+): string[] {
+  if (content === null || typeof content !== 'object') return [];
+  if (seen.has(content)) return [];
+  seen.add(content);
+
+  if (Array.isArray(content)) {
+    return content.flatMap((item, index) => collectContentMissingFields(item, `${path}[${index}]`, seen));
+  }
+
+  const source = content as Record<string, unknown>;
+  const missing: string[] = [];
+
+  for (const [key, value] of Object.entries(source)) {
+    if (CONTENT_TRANSLATION_KEYS.has(key) && hasText(value)) {
+      const hasLocalizedValue = localizedKeyCandidates(key).some((candidate) => hasText(source[candidate]));
+      if (!hasLocalizedValue) {
+        missing.push(`${path}.${key}`);
+      }
+    }
+
+    if (value !== null && typeof value === 'object') {
+      missing.push(...collectContentMissingFields(value, `${path}.${key}`, seen));
+    }
+  }
+
+  return missing;
+}
+
+function pushSummary(
+  summaries: LocalizationCoverageSummary[],
+  kind: LocalizationResourceKind,
+  total: number,
+  missing: number,
+): void {
+  summaries.push({ kind, total, missing, complete: total - missing });
+}
+
+@Injectable()
+export class AdminLocalizationService {
+  constructor(
+    @InjectRepository(Product)
+    private readonly productRepository: Repository<Product>,
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+    @InjectRepository(ProductOption)
+    private readonly productOptionRepository: Repository<ProductOption>,
+    @InjectRepository(Page)
+    private readonly pageRepository: Repository<Page>,
+    @InjectRepository(PageBlock)
+    private readonly pageBlockRepository: Repository<PageBlock>,
+    @InjectRepository(NavigationItem)
+    private readonly navigationRepository: Repository<NavigationItem>,
+    @InjectRepository(ExternalReview)
+    private readonly externalReviewRepository: Repository<ExternalReview>,
+  ) {}
+
+  async getCoverage(): Promise<LocalizationCoverageReport> {
+    const [products, categories, productOptions, pages, pageBlocks, navigationItems, externalReviews] = await Promise.all([
+      this.productRepository.find({
+        select: [
+          'id',
+          'name',
+          'nameEn',
+          'description',
+          'descriptionEn',
+          'shortDescription',
+          'shortDescriptionEn',
+          'status',
+        ],
+      }),
+      this.categoryRepository.find({
+        select: ['id', 'name', 'nameEn', 'description', 'descriptionEn', 'isActive'],
+      }),
+      this.productOptionRepository.find({ select: ['id', 'productId', 'name', 'nameEn', 'value', 'valueEn'] }),
+      this.pageRepository.find({ select: ['id', 'slug', 'title', 'titleEn', 'is_published'] }),
+      this.pageBlockRepository.find({ select: ['id', 'page_id', 'type', 'content', 'is_visible'] }),
+      this.navigationRepository.find({ select: ['id', 'label', 'labelEn', 'group', 'is_active'] }),
+      this.externalReviewRepository.find({ select: ['id', 'content', 'externalReviewId', 'isVisible'] }),
+    ]);
+
+    const items: LocalizationMissingItem[] = [];
+    const summaries: LocalizationCoverageSummary[] = [];
+    const visibleProducts = products.filter((product) =>
+      product.status === ProductStatus.ACTIVE || product.status === ProductStatus.SOLDOUT,
+    );
+    const visibleProductIds = new Set(visibleProducts.map((product) => Number(product.id)));
+    const visibleCategories = categories.filter((category) => category.isActive);
+    const publishedPages = pages.filter((page) => page.is_published);
+    const publishedPageIds = new Set(publishedPages.map((page) => Number(page.id)));
+    const visiblePageBlocks = pageBlocks.filter((block) =>
+      block.is_visible && publishedPageIds.has(Number(block.page_id)),
+    );
+    const visibleProductOptions = productOptions.filter((option) =>
+      visibleProductIds.has(Number(option.productId)),
+    );
+
+    const productMissing = visibleProducts.flatMap((product) => {
+      const missingFields = missingEntityFields(product as unknown as Record<string, unknown>, [
+        { base: 'name', localized: 'nameEn', label: 'name' },
+        { base: 'description', localized: 'descriptionEn', label: 'description' },
+        { base: 'shortDescription', localized: 'shortDescriptionEn', label: 'shortDescription' },
+      ]);
+      return missingFields.length
+        ? [{
+            kind: 'product' as const,
+            id: Number(product.id),
+            label: product.name,
+            missingFields,
+            editHref: `/admin/products/${product.id}/edit`,
+            fallbackPolicy: 'koFallback' as const,
+          }]
+        : [];
+    });
+    items.push(...productMissing);
+    pushSummary(summaries, 'product', visibleProducts.length, productMissing.length);
+
+
+    const productOptionMissing = visibleProductOptions.flatMap((option) => {
+      const missingFields = missingEntityFields(option as unknown as Record<string, unknown>, [
+        { base: 'name', localized: 'nameEn', label: 'name' },
+        { base: 'value', localized: 'valueEn', label: 'value' },
+      ]);
+      return missingFields.length
+        ? [{
+            kind: 'productOption' as const,
+            id: Number(option.id),
+            label: `${option.name}: ${option.value}`,
+            missingFields,
+            editHref: `/admin/products/${option.productId}/edit`,
+            fallbackPolicy: 'koFallback' as const,
+          }]
+        : [];
+    });
+    items.push(...productOptionMissing);
+    pushSummary(summaries, 'productOption', visibleProductOptions.length, productOptionMissing.length);
+
+    const categoryMissing = visibleCategories.flatMap((category) => {
+      const missingFields = missingEntityFields(category as unknown as Record<string, unknown>, [
+        { base: 'name', localized: 'nameEn', label: 'name' },
+        { base: 'description', localized: 'descriptionEn', label: 'description' },
+      ]);
+      return missingFields.length
+        ? [{
+            kind: 'category' as const,
+            id: Number(category.id),
+            label: category.name,
+            missingFields,
+            editHref: '/admin/categories',
+            fallbackPolicy: 'koFallback' as const,
+          }]
+        : [];
+    });
+    items.push(...categoryMissing);
+    pushSummary(summaries, 'category', visibleCategories.length, categoryMissing.length);
+
+    const pageMissing = publishedPages.flatMap((page) => {
+      const missingFields = missingEntityFields(page as unknown as Record<string, unknown>, [
+        { base: 'title', localized: 'titleEn', label: 'title' },
+      ]);
+      return missingFields.length
+        ? [{
+            kind: 'page' as const,
+            id: Number(page.id),
+            label: `${page.slug} · ${page.title}`,
+            missingFields,
+            editHref: '/admin/pages',
+            fallbackPolicy: 'koFallback' as const,
+          }]
+        : [];
+    });
+    items.push(...pageMissing);
+    pushSummary(summaries, 'page', publishedPages.length, pageMissing.length);
+
+    const pageBlockMissing = visiblePageBlocks.flatMap((block) => {
+      const missingFields = collectContentMissingFields(block.content);
+      return missingFields.length
+        ? [{
+            kind: 'pageBlock' as const,
+            id: Number(block.id),
+            label: `${block.type} #${block.id}`,
+            missingFields,
+            editHref: '/admin/pages',
+            fallbackPolicy: 'koFallback' as const,
+          }]
+        : [];
+    });
+    items.push(...pageBlockMissing);
+    pushSummary(summaries, 'pageBlock', visiblePageBlocks.length, pageBlockMissing.length);
+
+    const navigationMissing = navigationItems.flatMap((item) => {
+      if (!item.is_active) return [];
+      const missingFields = missingEntityFields(item as unknown as Record<string, unknown>, [
+        { base: 'label', localized: 'labelEn', label: 'label' },
+      ]);
+      return missingFields.length
+        ? [{
+            kind: 'navigation' as const,
+            id: Number(item.id),
+            label: `${item.group} · ${item.label}`,
+            missingFields,
+            editHref: '/admin/navigation',
+            fallbackPolicy: 'koFallback' as const,
+          }]
+        : [];
+    });
+    items.push(...navigationMissing);
+    pushSummary(summaries, 'navigation', navigationItems.filter((item) => item.is_active).length, navigationMissing.length);
+
+    const externalReviewMissing = externalReviews.flatMap((review) => {
+      if (!review.isVisible || !hasText(review.content)) return [];
+      return [{
+        kind: 'externalReview' as const,
+        id: Number(review.id),
+        label: review.externalReviewId,
+        missingFields: ['content'],
+        editHref: '/admin/reviews',
+        fallbackPolicy: 'sourceTextFallback' as const,
+      }];
+    });
+    items.push(...externalReviewMissing);
+    pushSummary(
+      summaries,
+      'externalReview',
+      externalReviews.filter((review) => review.isVisible && hasText(review.content)).length,
+      externalReviewMissing.length,
+    );
+
+    return {
+      locale: REPORT_LOCALE,
+      fallbackPolicy: {
+        default: 'koFallback',
+        smartStoreReviews: 'sourceTextFallback',
+      },
+      summaries,
+      items: items.slice(0, SAMPLE_LIMIT),
+    };
+  }
+}

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -9,13 +9,21 @@ import { AdminOrdersService } from './admin-orders.service';
 import { AdminMembersController } from './admin-members.controller';
 import { AdminMembersService } from './admin-members.service';
 import { AdminExportController } from './admin-export.controller';
+import { AdminLocalizationController } from './admin-localization.controller';
 import { AdminExportService } from './admin-export.service';
+import { AdminLocalizationService } from './admin-localization.service';
 import { Order } from '../orders/entities/order.entity';
 import { OrderServiceRequest } from '../orders/entities/order-service-request.entity';
 import { Payment } from '../payments/entities/payment.entity';
 import { Shipping } from '../payments/entities/shipping.entity';
 import { User } from '../users/entities/user.entity';
 import { Product } from '../products/entities/product.entity';
+import { Category } from '../products/entities/category.entity';
+import { ProductOption } from '../products/entities/product-option.entity';
+import { Page } from '../pages/entities/page.entity';
+import { PageBlock } from '../pages/entities/page-block.entity';
+import { NavigationItem } from '../navigation/entities/navigation-item.entity';
+import { ExternalReview } from '../reviews/entities/external-review.entity';
 import { PaymentsModule } from '../payments/payments.module';
 import { AuditLogModule } from '../audit-logs/audit-log.module';
 import { MembershipModule } from '../membership/membership.module';
@@ -23,13 +31,40 @@ import { PointsModule } from '../points/points.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Order, OrderServiceRequest, Payment, Shipping, User, Product]),
+    TypeOrmModule.forFeature([
+      Order,
+      OrderServiceRequest,
+      Payment,
+      Shipping,
+      User,
+      Product,
+      Category,
+      ProductOption,
+      Page,
+      PageBlock,
+      NavigationItem,
+      ExternalReview,
+    ]),
     PaymentsModule,
     AuditLogModule,
     MembershipModule,
     PointsModule,
   ],
-  controllers: [AdminController, AdminDashboardController, AdminOrdersController, AdminMembersController, AdminExportController],
-  providers: [AdminService, AdminDashboardService, AdminOrdersService, AdminMembersService, AdminExportService],
+  controllers: [
+    AdminController,
+    AdminDashboardController,
+    AdminOrdersController,
+    AdminMembersController,
+    AdminExportController,
+    AdminLocalizationController,
+  ],
+  providers: [
+    AdminService,
+    AdminDashboardService,
+    AdminOrdersService,
+    AdminMembersService,
+    AdminExportService,
+    AdminLocalizationService,
+  ],
 })
 export class AdminModule {}

--- a/src/app/[locale]/admin/localization/page.tsx
+++ b/src/app/[locale]/admin/localization/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
+import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
+import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
+import { adminLocalizationApi } from '@/lib/api';
+import type {
+  LocalizationCoverageReport,
+  LocalizationMissingItem,
+  LocalizationResourceKind,
+} from '@/lib/api';
+
+const KIND_ORDER: LocalizationResourceKind[] = [
+  'product',
+  'category',
+  'productOption',
+  'page',
+  'pageBlock',
+  'navigation',
+  'externalReview',
+];
+
+export default function AdminLocalizationPage() {
+  const t = useTranslations('admin.localization');
+  const { isAdmin } = useAdminGuard();
+  const [report, setReport] = useState<LocalizationCoverageReport | null>(null);
+
+  const { execute: loadCoverage, isLoading } = useAsyncAction(
+    async () => {
+      const data = await adminLocalizationApi.getCoverage();
+      setReport(data);
+    },
+    { errorMessage: t('loadError') },
+  );
+
+  useEffect(() => {
+    if (isAdmin) void loadCoverage();
+  }, [isAdmin, loadCoverage]);
+
+  const sortedItems = useMemo(() => {
+    if (!report) return [];
+    return [...report.items].sort((a, b) => KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind));
+  }, [report]);
+
+  if (!isAdmin) return null;
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title={t('title')}
+        meta={<p className="typo-body-sm text-muted-foreground">{t('description')}</p>}
+        className="items-start"
+      />
+
+      <section className="rounded-lg border bg-card p-5">
+        <h2 className="typo-h3 mb-3">{t('fallbackTitle')}</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          <PolicyCard label={t('defaultPolicy')} value={t('koFallback')} />
+          <PolicyCard label={t('smartStorePolicy')} value={t('sourceTextFallback')} />
+        </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {(report?.summaries ?? []).map((summary) => (
+          <div key={summary.kind} className="rounded-lg border bg-card p-5">
+            <p className="typo-body-sm text-muted-foreground">{t(`kinds.${summary.kind}`)}</p>
+            <div className="mt-3 flex items-end justify-between">
+              <p className="typo-h2">{summary.missing}</p>
+              <p className="typo-body-sm text-muted-foreground">
+                {t('summaryRatio', { complete: summary.complete, total: summary.total })}
+              </p>
+            </div>
+          </div>
+        ))}
+      </section>
+
+      <section className="rounded-lg border bg-card">
+        <div className="border-b p-5">
+          <h2 className="typo-h3">{t('missingTitle')}</h2>
+          <p className="typo-body-sm mt-1 text-muted-foreground">{t('missingDescription')}</p>
+        </div>
+        {isLoading && !report ? (
+          <p className="typo-body-sm p-5 text-muted-foreground">{t('loading')}</p>
+        ) : sortedItems.length === 0 ? (
+          <p className="typo-body-sm p-5 text-muted-foreground">{t('empty')}</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr className="border-b bg-muted/40 text-left">
+                  <th className="px-4 py-3 typo-label">{t('table.kind')}</th>
+                  <th className="px-4 py-3 typo-label">{t('table.item')}</th>
+                  <th className="px-4 py-3 typo-label">{t('table.fields')}</th>
+                  <th className="px-4 py-3 typo-label">{t('table.policy')}</th>
+                  <th className="px-4 py-3 typo-label">{t('table.action')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedItems.map((item) => (
+                  <MissingRow key={`${item.kind}-${item.id}`} item={item} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function PolicyCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-muted p-4">
+      <p className="typo-label text-muted-foreground">{label}</p>
+      <p className="typo-body-sm mt-2 text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function MissingRow({ item }: { item: LocalizationMissingItem }) {
+  const t = useTranslations('admin.localization');
+  return (
+    <tr className="border-b last:border-0">
+      <td className="px-4 py-3 typo-body-sm">{t(`kinds.${item.kind}`)}</td>
+      <td className="px-4 py-3 typo-body-sm">{item.label}</td>
+      <td className="px-4 py-3 typo-body-sm text-muted-foreground">{item.missingFields.join(', ')}</td>
+      <td className="px-4 py-3 typo-body-sm text-muted-foreground">{t(item.fallbackPolicy)}</td>
+      <td className="px-4 py-3 typo-body-sm">
+        {item.editHref ? (
+          <Link href={item.editHref} className="font-medium text-primary hover:underline">
+            {t('edit')}
+          </Link>
+        ) : (
+          <span className="text-muted-foreground">{t('notAvailable')}</span>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -10,6 +10,7 @@ import {
   ShoppingBag,
   FileText,
   Settings,
+  Languages,
   ChevronDown,
   Home,
   X,
@@ -39,6 +40,7 @@ type NavItem = NavLeafItem | NavGroup;
 
 const NAV_ITEMS: NavItem[] = [
   { labelKey: 'dashboard', href: '/admin/dashboard', icon: LayoutDashboard },
+  { labelKey: 'localization', href: '/admin/localization', icon: Languages },
   {
     labelKey: 'productsGroup',
     icon: Package,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -942,7 +942,8 @@
       "business": "Business Info",
       "close": "Close sidebar",
       "cmsGroup": "CMS",
-      "reviews": "Reviews"
+      "reviews": "Reviews",
+      "localization": "Localization"
     },
     "navigation": {
       "title": "Navigation Management"
@@ -1087,6 +1088,41 @@
         "title": "Could not load review management.",
         "description": "Please try again shortly.",
         "retry": "Retry"
+      }
+    },
+    "localization": {
+      "title": "Localization Coverage",
+      "description": "Review customer-facing data that falls back to Korean or imported source text in the English storefront.",
+      "fallbackTitle": "Fallback policy",
+      "defaultPolicy": "General store data",
+      "smartStorePolicy": "SmartStore reviews",
+      "koFallback": "Show Korean source text when no English translation is available.",
+      "sourceTextFallback": "Show imported source text and manage it as translation-review work.",
+      "summaryRatio": "{complete}/{total} complete",
+      "missingTitle": "Translation work queue",
+      "missingDescription": "Shows up to 50 items. Add English values from each edit screen.",
+      "loading": "Loading localization coverage.",
+      "empty": "No missing English translations found.",
+      "loadError": "Could not load localization coverage.",
+      "edit": "Edit",
+      "notAvailable": "Review policy",
+      "koFallbackPolicy": "Korean fallback",
+      "sourceTextFallbackPolicy": "Source-text fallback",
+      "kinds": {
+        "product": "Products",
+        "category": "Categories",
+        "page": "Pages",
+        "pageBlock": "CMS blocks",
+        "navigation": "Navigation",
+        "externalReview": "SmartStore reviews",
+        "productOption": "Product options"
+      },
+      "table": {
+        "kind": "Type",
+        "item": "Item",
+        "fields": "Missing fields",
+        "policy": "Policy",
+        "action": "Action"
       }
     }
   },

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -942,7 +942,8 @@
       "business": "사업자 정보",
       "close": "사이드바 닫기",
       "cmsGroup": "CMS",
-      "reviews": "리뷰관리"
+      "reviews": "리뷰관리",
+      "localization": "번역 상태"
     },
     "navigation": {
       "title": "네비게이션 관리"
@@ -1087,6 +1088,41 @@
         "title": "리뷰 관리 화면을 불러오지 못했습니다.",
         "description": "잠시 후 다시 시도해 주세요.",
         "retry": "다시 시도"
+      }
+    },
+    "localization": {
+      "title": "번역 상태",
+      "description": "영문 스토어에서 한국어 또는 원문 fallback이 발생할 사용자 노출 데이터를 확인합니다.",
+      "fallbackTitle": "Fallback 정책",
+      "defaultPolicy": "일반 스토어 데이터",
+      "smartStorePolicy": "스마트스토어 리뷰",
+      "koFallback": "영문 번역값이 없으면 한국어 원문을 표시합니다.",
+      "sourceTextFallback": "가져온 원문을 표시하고 번역 검수 대상으로 관리합니다.",
+      "summaryRatio": "{complete}/{total} 완료",
+      "missingTitle": "번역 필요 항목",
+      "missingDescription": "최대 50개 항목을 표시합니다. 각 항목의 편집 화면에서 영문 값을 입력하세요.",
+      "loading": "번역 상태를 불러오는 중입니다.",
+      "empty": "누락된 영문 번역이 없습니다.",
+      "loadError": "번역 상태를 불러오지 못했습니다.",
+      "edit": "수정",
+      "notAvailable": "관리 정책 확인",
+      "koFallbackPolicy": "한국어 fallback",
+      "sourceTextFallbackPolicy": "원문 fallback",
+      "kinds": {
+        "product": "상품",
+        "category": "카테고리",
+        "page": "페이지",
+        "pageBlock": "CMS 블록",
+        "navigation": "네비게이션",
+        "externalReview": "스마트스토어 리뷰",
+        "productOption": "상품 옵션"
+      },
+      "table": {
+        "kind": "유형",
+        "item": "항목",
+        "fields": "누락 필드",
+        "policy": "정책",
+        "action": "작업"
       }
     }
   },

--- a/src/lib/api/admin/localization.ts
+++ b/src/lib/api/admin/localization.ts
@@ -1,0 +1,40 @@
+import { apiClient } from '../core';
+
+export type LocalizationResourceKind =
+  | 'product'
+  | 'category'
+  | 'productOption'
+  | 'page'
+  | 'pageBlock'
+  | 'navigation'
+  | 'externalReview';
+
+export interface LocalizationCoverageSummary {
+  kind: LocalizationResourceKind;
+  total: number;
+  missing: number;
+  complete: number;
+}
+
+export interface LocalizationMissingItem {
+  kind: LocalizationResourceKind;
+  id: number;
+  label: string;
+  missingFields: string[];
+  editHref: string | null;
+  fallbackPolicy: 'koFallback' | 'sourceTextFallback';
+}
+
+export interface LocalizationCoverageReport {
+  locale: 'en';
+  fallbackPolicy: {
+    default: 'koFallback';
+    smartStoreReviews: 'sourceTextFallback';
+  };
+  summaries: LocalizationCoverageSummary[];
+  items: LocalizationMissingItem[];
+}
+
+export const adminLocalizationApi = {
+  getCoverage: () => apiClient.get<LocalizationCoverageReport>('/admin/localization/coverage'),
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -47,3 +47,4 @@ export * from './admin/settings';
 export * from './admin/collections';
 export * from './admin/archives';
 export * from './admin/journals';
+export * from './admin/localization';


### PR DESCRIPTION
## 요약
- 관리자 전용 번역 커버리지 API 추가 (`/admin/localization/coverage`)
- `/admin/localization` 화면에서 상품/카테고리/페이지/CMS 블록/네비게이션/스마트스토어 리뷰의 영문 누락 상태 표시
- 스마트스토어 리뷰는 현재 번역 컬럼이 없어 원문 fallback 정책으로 명시
- 관리자 상품 수정 화면이 route locale을 상품 상세 조회에 전달하도록 수정

Closes #983

## 검증
- bash scripts/codex-project-guard.sh
- npm run build
- npm run test:run
- cd backend && npm run build && npm run test
- cd backend && npm run test -- admin-localization.service.spec.ts
- npx vitest run src/app/[locale]/admin/products/[id]/edit/__tests__/AdminProductEditPage.test.tsx

## 미검증
- cd backend && npm run test:e2e (스키마/마이그레이션 변경 없음)
