### PR TITLE
#987 S3 상품 이미지 장기 캐싱 정책 적용

### DIFF
--- a/backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts
+++ b/backend/src/modules/upload/adapters/__tests__/s3.adapter.spec.ts
@@ -73,6 +73,7 @@ describe('S3StorageAdapter', () => {
         Key: 'products/photo.jpg',
         Body: buffer,
         ContentType: 'image/jpeg',
+        CacheControl: 'public, max-age=31536000, immutable',
       });
       expect(s3Module.__mockSend).toHaveBeenCalledTimes(1);
       expect(result.filename).toBe('products/photo.jpg');
@@ -122,6 +123,7 @@ describe('S3StorageAdapter', () => {
           Key: 'categories/cat.png',
           Bucket: 'test-bucket',
           ContentType: 'image/png',
+          CacheControl: 'public, max-age=31536000, immutable',
         }),
       );
       expect(result.filename).toBe('categories/cat.png');

--- a/backend/src/modules/upload/adapters/s3.adapter.ts
+++ b/backend/src/modules/upload/adapters/s3.adapter.ts
@@ -8,6 +8,8 @@ import {
 import { StorageAdapter, UploadedFile } from '../interfaces/storage.interface';
 import { STORAGE_CONFIG, StorageConfig } from '../../../config/storage.config';
 
+const IMAGE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
 @Injectable()
 export class S3StorageAdapter implements StorageAdapter {
   private readonly logger = new Logger(S3StorageAdapter.name);
@@ -54,6 +56,7 @@ export class S3StorageAdapter implements StorageAdapter {
         Key: key,
         Body: buffer,
         ContentType: mimetype,
+        CacheControl: IMAGE_CACHE_CONTROL,
       }),
     );
 

--- a/docs/infrastructure/DEPLOYMENT.md
+++ b/docs/infrastructure/DEPLOYMENT.md
@@ -6,6 +6,15 @@
 - **API 경로**: 브라우저는 `ockhwadang.com/api/*`만 호출. Next.js middleware(`src/middleware.ts`)가 Vercel Edge에서 `BACKEND_URL`로 런타임 프록시. Vercel Edge는 IP 직접 fetch를 금지하므로 반드시 도메인(`api.ockhwadang.com`) 경유.
 - **CDN 서브도메인**: `https://cdn.ockhwadang.com` → CloudFront → S3 `okhwadang-assets`
 
+## 상품 이미지 캐시 정책
+
+- 신규 업로드 S3 객체는 `Cache-Control: public, max-age=31536000, immutable` 메타데이터를 붙인다.
+- 업로드 파일명은 UUID 기반이므로 이미지를 교체할 때 기존 key를 덮어쓰지 말고 새 URL을 발급한다.
+- 운영 `AWS_CDN_URL`은 CloudFront 도메인 또는 `https://cdn.ockhwadang.com`을 가리켜야 한다.
+- CloudFront 캐시 정책은 S3 origin의 `Cache-Control` 헤더를 존중해야 한다. 장애 대응 외에는 무효화보다 새 URL 발급을 우선한다.
+- 기존 S3 객체에는 신규 코드가 소급 적용되지 않는다. 기존 상품 이미지까지 같은 정책을 적용해야 하면 AWS 콘솔/CLI로 객체 메타데이터를 일괄 교체하거나 관리자에서 이미지를 재업로드한다.
+- 프론트 `next/image` 최적화 캐시는 `next.config.ts`의 `images.minimumCacheTTL`로 최소 1일을 유지한다. 신규 S3 이미지처럼 origin `Cache-Control`이 더 길면 최적화 이미지 변형도 더 긴 upstream TTL을 따를 수 있으므로, 변경된 이미지는 반드시 새 URL로 교체한다.
+
 ### Vercel 환경변수
 - `BACKEND_URL=http://api.ockhwadang.com` (Cloudflare Proxied → EC2 Nginx :80 → NestJS :3000, HTTP)
 - `SITE_URL=https://ockhwadang.com`

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const withBundleAnalyzer = createBundleAnalyzer({
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: false,
   images: {
+    minimumCacheTTL: 86400,
     remotePatterns: [
       { protocol: 'https', hostname: '*.amazonaws.com' },
       { protocol: 'https', hostname: 'cdn.ockhwadang.com' },

--- a/src/__tests__/next-config-csp.test.ts
+++ b/src/__tests__/next-config-csp.test.ts
@@ -75,3 +75,11 @@ describe('Next.js CSP headers', () => {
     expect(frameSrc).toContain('https://hooks.stripe.com');
   });
 });
+
+describe('Next.js image cache policy', () => {
+  it('keeps optimized remote product images cached beyond the default TTL', () => {
+    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
+
+    expect(source).toContain('minimumCacheTTL: 86400');
+  });
+});


### PR DESCRIPTION
## 요약

- S3 업로드 객체에 `Cache-Control: public, max-age=31536000, immutable` 추가
- Next Image 최적화 캐시 최소 TTL을 1일(`minimumCacheTTL: 86400`)로 설정
- 기존 S3 객체 운영 처리 기준과 CloudFront/cache 정책을 배포 문서에 기록
- S3 adapter/Next config 테스트로 캐시 정책 고정

Closes #987

## 검증

- `bash scripts/codex-project-guard.sh`
- `npm run lint`
- `npm run build`
- `npx vitest run src/__tests__/next-config-csp.test.ts --maxWorkers=1 --no-file-parallelism`
- `npx vitest run --maxWorkers=1 --no-file-parallelism --reporter=dot` (rebase 전 전체 FE tests: 142 files / 818 tests passed)
- `cd backend && npm run build && npm run test`
- `cd backend && npm run build && npm run test -- src/modules/upload/adapters/__tests__/s3.adapter.spec.ts --runInBand`

## 운영 메모

- 기존 S3 객체에는 신규 `Cache-Control`이 소급 적용되지 않으므로 운영에서 기존 이미지까지 적용하려면 S3 메타데이터 일괄 교체 또는 관리자 재업로드가 필요합니다.
- 동일 S3 key overwrite 방식을 도입하면 `immutable` 캐시 정책을 재검토해야 합니다.
