### PR TITLE
네이버 커머스API 반영 타임아웃 방지

### DIFF
--- a/backend/src/modules/products/__tests__/naver-commerce-import-job.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-import-job.service.spec.ts
@@ -1,0 +1,69 @@
+import { NotFoundException } from '@nestjs/common';
+import { NaverCommerceImportJobService } from '../naver-commerce-import-job.service';
+import { NaverCommerceProductImportService } from '../naver-commerce-product-import.service';
+import { SmartStoreImportResult } from '../smartstore-product-import.service';
+
+const result: SmartStoreImportResult = {
+  summary: {
+    totalRows: 1,
+    createCount: 0,
+    updateCount: 1,
+    skipCount: 0,
+    successCount: 1,
+    failureCount: 0,
+  },
+  rows: [],
+};
+
+function flushPromises() {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+describe('NaverCommerceImportJobService', () => {
+  it('starts a preview job immediately and exposes the completed result later', async () => {
+    const importService = { preview: jest.fn().mockResolvedValue(result) };
+    const jobService = new NaverCommerceImportJobService(
+      importService as unknown as NaverCommerceProductImportService,
+    );
+
+    const started = jobService.start('preview');
+
+    expect(started).toMatchObject({ type: 'preview' });
+    expect(['pending', 'running']).toContain(started.status);
+    expect(started.id).toBeTruthy();
+
+    await flushPromises();
+
+    expect(importService.preview).toHaveBeenCalledTimes(1);
+    expect(jobService.get(started.id)).toMatchObject({
+      id: started.id,
+      type: 'preview',
+      status: 'completed',
+      result,
+    });
+  });
+
+  it('records failed jobs without throwing from start', async () => {
+    const importService = { commit: jest.fn().mockRejectedValue(new Error('네이버 제한')) };
+    const jobService = new NaverCommerceImportJobService(
+      importService as unknown as NaverCommerceProductImportService,
+    );
+
+    const started = jobService.start('commit');
+    await flushPromises();
+
+    expect(jobService.get(started.id)).toMatchObject({
+      type: 'commit',
+      status: 'failed',
+      error: '네이버 제한',
+    });
+  });
+
+  it('throws not found for unknown or expired job ids', () => {
+    const jobService = new NaverCommerceImportJobService({} as NaverCommerceProductImportService);
+
+    expect(() => jobService.get('missing')).toThrow(NotFoundException);
+  });
+});

--- a/backend/src/modules/products/naver-commerce-import-job.service.ts
+++ b/backend/src/modules/products/naver-commerce-import-job.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { NaverCommerceProductImportService } from './naver-commerce-product-import.service';
+import { SmartStoreImportResult } from './smartstore-product-import.service';
+
+type NaverCommerceImportJobType = 'preview' | 'commit';
+type NaverCommerceImportJobStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface NaverCommerceImportJobSnapshot {
+  id: string;
+  type: NaverCommerceImportJobType;
+  status: NaverCommerceImportJobStatus;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  result?: SmartStoreImportResult;
+  error?: string;
+}
+
+interface NaverCommerceImportJobRecord extends NaverCommerceImportJobSnapshot {
+  createdAtMs: number;
+}
+
+const JOB_TTL_MS = 30 * 60 * 1000;
+
+@Injectable()
+export class NaverCommerceImportJobService {
+  private readonly jobs = new Map<string, NaverCommerceImportJobRecord>();
+
+  constructor(
+    private readonly naverCommerceProductImportService: NaverCommerceProductImportService,
+  ) {}
+
+  start(type: NaverCommerceImportJobType): NaverCommerceImportJobSnapshot {
+    this.pruneExpiredJobs();
+    const now = new Date();
+    const job: NaverCommerceImportJobRecord = {
+      id: randomUUID(),
+      type,
+      status: 'pending',
+      createdAt: now.toISOString(),
+      createdAtMs: now.getTime(),
+    };
+    this.jobs.set(job.id, job);
+
+    void this.run(job.id);
+    return this.toSnapshot(job);
+  }
+
+  get(id: string): NaverCommerceImportJobSnapshot {
+    this.pruneExpiredJobs();
+    const job = this.jobs.get(id);
+    if (!job) {
+      throw new NotFoundException('네이버 커머스API 작업을 찾을 수 없습니다.');
+    }
+    return this.toSnapshot(job);
+  }
+
+  private async run(id: string): Promise<void> {
+    const job = this.jobs.get(id);
+    if (!job) return;
+
+    job.status = 'running';
+    job.startedAt = new Date().toISOString();
+
+    try {
+      job.result =
+        job.type === 'commit'
+          ? await this.naverCommerceProductImportService.commit()
+          : await this.naverCommerceProductImportService.preview();
+      job.status = 'completed';
+    } catch (err) {
+      job.status = 'failed';
+      job.error = err instanceof Error ? err.message : '네이버 커머스API 작업에 실패했습니다.';
+    } finally {
+      job.completedAt = new Date().toISOString();
+    }
+  }
+
+  private pruneExpiredJobs(): void {
+    const minCreatedAtMs = Date.now() - JOB_TTL_MS;
+    for (const [id, job] of this.jobs.entries()) {
+      if (job.createdAtMs < minCreatedAtMs) {
+        this.jobs.delete(id);
+      }
+    }
+  }
+
+  private toSnapshot(job: NaverCommerceImportJobRecord): NaverCommerceImportJobSnapshot {
+    return {
+      id: job.id,
+      type: job.type,
+      status: job.status,
+      createdAt: job.createdAt,
+      startedAt: job.startedAt,
+      completedAt: job.completedAt,
+      result: job.result,
+      error: job.error,
+    };
+  }
+}

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -39,7 +39,7 @@ import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
 import { CreateRestockAlertDto } from '../restock-alerts/dto/create-restock-alert.dto';
 import { RecentlyViewedService } from './recently-viewed.service';
 import { SmartStoreProductImportService } from './smartstore-product-import.service';
-import { NaverCommerceProductImportService } from './naver-commerce-product-import.service';
+import { NaverCommerceImportJobService } from './naver-commerce-import-job.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { createSingleFileMemoryUploadOptions } from '../../common/multer/single-file-upload.options';
 import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guard';
@@ -52,12 +52,15 @@ export class ProductsController {
     private readonly restockAlertsService: RestockAlertsService,
     private readonly recentlyViewedService: RecentlyViewedService,
     private readonly smartStoreProductImportService: SmartStoreProductImportService,
-    private readonly naverCommerceProductImportService: NaverCommerceProductImportService,
+    private readonly naverCommerceImportJobService: NaverCommerceImportJobService,
   ) {}
 
   @Get()
   @Public()
-  @ApiOperation({ summary: '상품 목록 조회', description: '상품 목록을 페이지네이션 및 필터링하여 조회합니다.' })
+  @ApiOperation({
+    summary: '상품 목록 조회',
+    description: '상품 목록을 페이지네이션 및 필터링하여 조회합니다.',
+  })
   @ApiResponse({ status: 200, description: '상품 목록 조회 성공' })
   @ApiQuery({ name: 'page', required: false, type: Number, description: '페이지 번호' })
   @ApiQuery({ name: 'limit', required: false, type: Number, description: '페이지당 개수' })
@@ -70,7 +73,10 @@ export class ProductsController {
 
   @Get('autocomplete')
   @Public()
-  @ApiOperation({ summary: '상품 자동완성', description: '검색어 기반 상품 자동완성 제안어를 반환합니다.' })
+  @ApiOperation({
+    summary: '상품 자동완성',
+    description: '검색어 기반 상품 자동완성 제안어를 반환합니다.',
+  })
   @ApiResponse({ status: 200, description: '자동완성 결과 반환 성공' })
   @ApiQuery({ name: 'q', required: true, type: String, description: '검색어' })
   autocomplete(@Query('q') q: string) {
@@ -80,7 +86,10 @@ export class ProductsController {
   @Post('bulk')
   @HttpCode(HttpStatus.OK)
   @Public()
-  @ApiOperation({ summary: '상품 벌크 조회', description: '여러 상품 ID로 상품 목록을 한 번에 조회합니다.' })
+  @ApiOperation({
+    summary: '상품 벌크 조회',
+    description: '여러 상품 ID로 상품 목록을 한 번에 조회합니다.',
+  })
   @ApiResponse({ status: 200, description: '상품 목록 조회 성공' })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   bulkLookup(@Body() dto: BulkProductsDto, @Request() req: RequestWithAuthUser) {
@@ -92,7 +101,10 @@ export class ProductsController {
   @Public()
   @UseGuards(OptionalJwtAuthGuard)
   @ApiCookieAuth()
-  @ApiOperation({ summary: '상품 상세 조회', description: '상품 ID로 상품 상세 정보를 조회합니다.' })
+  @ApiOperation({
+    summary: '상품 상세 조회',
+    description: '상품 ID로 상품 상세 정보를 조회합니다.',
+  })
   @ApiResponse({ status: 200, description: '상품 상세 조회 성공' })
   @ApiResponse({ status: 404, description: '상품을 찾을 수 없음' })
   @ApiParam({ name: 'id', type: Number, description: '상품 ID' })
@@ -106,29 +118,34 @@ export class ProductsController {
     const result = await this.productsService.findOne(id, isAdmin, locale);
 
     if (req.user?.id) {
-      this.recentlyViewedService
-        .upsert(req.user.id, id)
-        .catch(() => undefined);
+      this.recentlyViewedService.upsert(req.user.id, id).catch(() => undefined);
     }
 
     return result;
   }
 
-
   @Post('imports/smartstore/preview')
   @Roles('admin')
   @ApiCookieAuth()
-  @ApiOperation({ summary: '스마트스토어 상품 엑셀 미리보기', description: '스마트스토어 상품 엑셀 파일을 검증하고 생성/수정 예정 내역을 반환합니다.' })
+  @ApiOperation({
+    summary: '스마트스토어 상품 엑셀 미리보기',
+    description: '스마트스토어 상품 엑셀 파일을 검증하고 생성/수정 예정 내역을 반환합니다.',
+  })
   @ApiResponse({ status: 201, description: '상품 가져오기 미리보기 성공' })
   @ApiResponse({ status: 400, description: '잘못된 파일 또는 상품 데이터' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
   @ApiConsumes('multipart/form-data')
-  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: ['file'] } })
-  @UseInterceptors(FileInterceptor(
-    'file',
-    createSingleFileMemoryUploadOptions({ fileSize: 10 * 1024 * 1024 }),
-  ))
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  @UseInterceptors(
+    FileInterceptor('file', createSingleFileMemoryUploadOptions({ fileSize: 10 * 1024 * 1024 })),
+  )
   previewSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
     return this.smartStoreProductImportService.preview(file);
   }
@@ -136,44 +153,74 @@ export class ProductsController {
   @Post('imports/smartstore/commit')
   @Roles('admin')
   @ApiCookieAuth()
-  @ApiOperation({ summary: '스마트스토어 상품 엑셀 반영', description: '검증된 스마트스토어 상품 엑셀 파일로 자사몰 상품을 생성하거나 수정합니다.' })
+  @ApiOperation({
+    summary: '스마트스토어 상품 엑셀 반영',
+    description: '검증된 스마트스토어 상품 엑셀 파일로 자사몰 상품을 생성하거나 수정합니다.',
+  })
   @ApiResponse({ status: 201, description: '상품 가져오기 반영 성공' })
   @ApiResponse({ status: 400, description: '잘못된 파일 또는 상품 데이터' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
   @ApiConsumes('multipart/form-data')
-  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: ['file'] } })
-  @UseInterceptors(FileInterceptor(
-    'file',
-    createSingleFileMemoryUploadOptions({ fileSize: 10 * 1024 * 1024 }),
-  ))
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  @UseInterceptors(
+    FileInterceptor('file', createSingleFileMemoryUploadOptions({ fileSize: 10 * 1024 * 1024 })),
+  )
   commitSmartStoreImport(@UploadedFile() file: Express.Multer.File) {
     return this.smartStoreProductImportService.commit(file);
   }
 
-
   @Post('imports/naver-commerce/preview')
   @Roles('admin')
   @ApiCookieAuth()
-  @ApiOperation({ summary: '네이버 커머스API 상품 업데이트 미리보기', description: '네이버 커머스API로 스마트스토어 상품을 조회하고 SKU가 일치하는 자사몰 상품 업데이트 예정 내역을 반환합니다.' })
-  @ApiResponse({ status: 201, description: '네이버 커머스API 가져오기 미리보기 성공' })
-  @ApiResponse({ status: 400, description: '네이버 커머스API 자격증명 누락 또는 잘못된 요청' })
+  @ApiOperation({
+    summary: '네이버 커머스API 상품 업데이트 미리보기',
+    description:
+      '네이버 커머스API로 스마트스토어 상품을 조회하고 SKU가 일치하는 자사몰 상품 업데이트 예정 내역을 반환합니다.',
+  })
+  @ApiResponse({ status: 201, description: '네이버 커머스API 미리보기 작업 시작' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
   previewNaverCommerceImport() {
-    return this.naverCommerceProductImportService.preview();
+    return this.naverCommerceImportJobService.start('preview');
   }
 
   @Post('imports/naver-commerce/commit')
   @Roles('admin')
   @ApiCookieAuth()
-  @ApiOperation({ summary: '네이버 커머스API 상품 업데이트 반영', description: '네이버 커머스API 미리보기와 동일한 매칭/매핑 기준으로 SKU가 일치하는 자사몰 상품을 업데이트합니다.' })
-  @ApiResponse({ status: 201, description: '네이버 커머스API 가져오기 반영 성공' })
-  @ApiResponse({ status: 400, description: '네이버 커머스API 자격증명 누락 또는 잘못된 요청' })
+  @ApiOperation({
+    summary: '네이버 커머스API 상품 업데이트 반영',
+    description:
+      '네이버 커머스API 미리보기와 동일한 매칭/매핑 기준으로 SKU가 일치하는 자사몰 상품을 업데이트합니다.',
+  })
+  @ApiResponse({ status: 201, description: '네이버 커머스API 반영 작업 시작' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({ status: 403, description: '권한 없음' })
   commitNaverCommerceImport() {
-    return this.naverCommerceProductImportService.commit();
+    return this.naverCommerceImportJobService.start('commit');
+  }
+
+  @Get('imports/naver-commerce/jobs/:id')
+  @Roles('admin')
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '네이버 커머스API 작업 상태 조회',
+    description:
+      '비동기로 시작한 네이버 커머스API 미리보기/반영 작업 상태와 완료 결과를 반환합니다.',
+  })
+  @ApiParam({ name: 'id', type: String, description: '작업 ID' })
+  @ApiResponse({ status: 200, description: '네이버 커머스API 작업 상태 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 404, description: '작업 없음 또는 만료됨' })
+  getNaverCommerceImportJob(@Param('id') id: string) {
+    return this.naverCommerceImportJobService.get(id);
   }
 
   @Post()
@@ -189,7 +236,10 @@ export class ProductsController {
 
   @Post(':id/restock-alert')
   @ApiCookieAuth()
-  @ApiOperation({ summary: '재입고 알림 신청', description: '품절된 상품 또는 옵션의 재입고 알림을 신청합니다.' })
+  @ApiOperation({
+    summary: '재입고 알림 신청',
+    description: '품절된 상품 또는 옵션의 재입고 알림을 신청합니다.',
+  })
   @ApiResponse({ status: 201, description: '재입고 알림 신청 성공' })
   @ApiResponse({ status: 400, description: '이미 재고가 있거나 잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 필요' })

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -18,6 +18,7 @@ import { RecentlyViewedService } from './recently-viewed.service';
 import { SmartStoreProductImportService } from './smartstore-product-import.service';
 import { NaverCommerceApiClient } from './naver-commerce-api.client';
 import { NaverCommerceProductImportService } from './naver-commerce-product-import.service';
+import { NaverCommerceImportJobService } from './naver-commerce-import-job.service';
 import { ProductKeywordMappingService } from './product-keyword-mapping.service';
 import { ProductsController } from './products.controller';
 import { AdminProductsController } from './admin-products.controller';
@@ -57,10 +58,16 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
     SmartStoreProductImportService,
     NaverCommerceApiClient,
     NaverCommerceProductImportService,
+    NaverCommerceImportJobService,
     ProductKeywordMappingService,
     OptionalJwtAuthGuard,
   ],
-  controllers: [ProductsController, AdminProductsController, CategoriesController, AttributesController],
+  controllers: [
+    ProductsController,
+    AdminProductsController,
+    CategoriesController,
+    AttributesController,
+  ],
   exports: [
     ProductsService,
     ProductQueryService,
@@ -71,6 +78,7 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
     SmartStoreProductImportService,
     NaverCommerceApiClient,
     NaverCommerceProductImportService,
+    NaverCommerceImportJobService,
     ProductKeywordMappingService,
     OptionalJwtAuthGuard,
   ],

--- a/src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx
+++ b/src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx
@@ -20,8 +20,14 @@ vi.mock('next-intl', () => ({
 }));
 
 vi.mock('next/link', () => ({
-  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
-    <a href={href} {...props}>{children}</a>
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
   ),
 }));
 
@@ -123,6 +129,7 @@ describe('AdminProductsPage', () => {
     render(<AdminProductsPage />);
 
     expect(await screen.findByText('옥화당 자사호')).toBeInTheDocument();
+    expect(screen.queryByText('naverCommerce.credentialsHint')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'naverCommerce.previewButton' }));
 
     await waitFor(() => {

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -27,7 +27,9 @@ export default function AdminProductsPage() {
   const [smartStoreFile, setSmartStoreFile] = useState<File | null>(null);
   const [importPreview, setImportPreview] = useState<SmartStoreProductImportResult | null>(null);
   const [importResult, setImportResult] = useState<SmartStoreProductImportResult | null>(null);
-  const [activeImportSource, setActiveImportSource] = useState<'smartstore-excel' | 'naver-commerce' | null>(null);
+  const [activeImportSource, setActiveImportSource] = useState<
+    'smartstore-excel' | 'naver-commerce' | null
+  >(null);
   const [showAllImportRows, setShowAllImportRows] = useState(false);
   const [showFailedImportRowsOnly, setShowFailedImportRowsOnly] = useState(false);
   const { page, setPage, filters, setFilter } = useAdminListPage({
@@ -92,17 +94,21 @@ export default function AdminProductsPage() {
     { successMessage: t('import.commitSuccess'), errorMessage: t('import.commitError') },
   );
 
-  const { execute: previewNaverCommerceImport, isLoading: previewingNaverCommerce } = useAsyncAction(
-    async () => {
-      const result = await adminProductsApi.previewNaverCommerceImport();
-      setImportPreview(result);
-      setImportResult(null);
-      setActiveImportSource('naver-commerce');
-      setShowAllImportRows(false);
-      setShowFailedImportRowsOnly(false);
-    },
-    { successMessage: t('naverCommerce.previewSuccess'), errorMessage: t('naverCommerce.previewError') },
-  );
+  const { execute: previewNaverCommerceImport, isLoading: previewingNaverCommerce } =
+    useAsyncAction(
+      async () => {
+        const result = await adminProductsApi.previewNaverCommerceImport();
+        setImportPreview(result);
+        setImportResult(null);
+        setActiveImportSource('naver-commerce');
+        setShowAllImportRows(false);
+        setShowFailedImportRowsOnly(false);
+      },
+      {
+        successMessage: t('naverCommerce.previewSuccess'),
+        errorMessage: t('naverCommerce.previewError'),
+      },
+    );
 
   const { execute: commitNaverCommerceImport, isLoading: committingNaverCommerce } = useAsyncAction(
     async () => {
@@ -112,7 +118,10 @@ export default function AdminProductsPage() {
       setActiveImportSource('naver-commerce');
       void fetchProducts();
     },
-    { successMessage: t('naverCommerce.commitSuccess'), errorMessage: t('naverCommerce.commitError') },
+    {
+      successMessage: t('naverCommerce.commitSuccess'),
+      errorMessage: t('naverCommerce.commitError'),
+    },
   );
 
   const { execute: toggleStatus } = useAsyncAction(
@@ -181,20 +190,21 @@ export default function AdminProductsPage() {
     ? allImportRows.filter((row) => row.status === 'failed')
     : allImportRows;
   const importRows = showAllImportRows ? visibleImportRows : visibleImportRows.slice(0, 5);
-  const isImporting = previewingImport || committingImport || previewingNaverCommerce || committingNaverCommerce;
+  const isImporting =
+    previewingImport || committingImport || previewingNaverCommerce || committingNaverCommerce;
 
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
       <AdminPageHeader
         title={t('title')}
-        action={(
+        action={
           <Link
             href="/admin/products/new"
             className="rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
           >
             {t('addProduct')}
           </Link>
-        )}
+        }
       />
 
       <section className="rounded-lg border bg-card p-4 shadow-sm">
@@ -216,7 +226,10 @@ export default function AdminProductsPage() {
                 'limits',
               ].map((key) => (
                 <li key={key} className="flex gap-2">
-                  <span aria-hidden="true" className="mt-1 size-1.5 flex-shrink-0 rounded-full bg-foreground/40" />
+                  <span
+                    aria-hidden="true"
+                    className="mt-1 size-1.5 flex-shrink-0 rounded-full bg-foreground/40"
+                  />
                   <span>{t(`import.scopeDetails.${key}`)}</span>
                 </li>
               ))}
@@ -241,7 +254,12 @@ export default function AdminProductsPage() {
             <button
               type="button"
               onClick={handleCommitImport}
-              disabled={!smartStoreFile || isImporting || !importPreview || activeImportSource !== 'smartstore-excel'}
+              disabled={
+                !smartStoreFile ||
+                isImporting ||
+                !importPreview ||
+                activeImportSource !== 'smartstore-excel'
+              }
               className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {committingImport ? t('import.committing') : t('import.commitButton')}
@@ -254,7 +272,6 @@ export default function AdminProductsPage() {
             <div className="space-y-1">
               <h3 className="font-semibold typo-body-sm">{t('naverCommerce.title')}</h3>
               <p className="text-sm text-muted-foreground">{t('naverCommerce.description')}</p>
-              <p className="text-sm text-muted-foreground">{t('naverCommerce.credentialsHint')}</p>
             </div>
             <div className="flex flex-wrap gap-2">
               <button
@@ -263,7 +280,9 @@ export default function AdminProductsPage() {
                 disabled={isImporting}
                 className="rounded border px-4 py-2 text-sm hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {previewingNaverCommerce ? t('naverCommerce.previewing') : t('naverCommerce.previewButton')}
+                {previewingNaverCommerce
+                  ? t('naverCommerce.previewing')
+                  : t('naverCommerce.previewButton')}
               </button>
               <button
                 type="button"
@@ -271,7 +290,9 @@ export default function AdminProductsPage() {
                 disabled={isImporting || !importPreview || activeImportSource !== 'naver-commerce'}
                 className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {committingNaverCommerce ? t('naverCommerce.committing') : t('naverCommerce.commitButton')}
+                {committingNaverCommerce
+                  ? t('naverCommerce.committing')
+                  : t('naverCommerce.commitButton')}
               </button>
             </div>
           </div>
@@ -280,12 +301,27 @@ export default function AdminProductsPage() {
         {importSummary && (
           <div className="mt-4 space-y-3 rounded-lg bg-secondary/40 p-4 text-sm">
             <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-6">
-              <ImportSummaryItem label={t('import.summary.total')} value={importSummary.totalRows} />
-              <ImportSummaryItem label={t('import.summary.create')} value={importSummary.createCount} />
-              <ImportSummaryItem label={t('import.summary.update')} value={importSummary.updateCount} />
+              <ImportSummaryItem
+                label={t('import.summary.total')}
+                value={importSummary.totalRows}
+              />
+              <ImportSummaryItem
+                label={t('import.summary.create')}
+                value={importSummary.createCount}
+              />
+              <ImportSummaryItem
+                label={t('import.summary.update')}
+                value={importSummary.updateCount}
+              />
               <ImportSummaryItem label={t('import.summary.skip')} value={importSummary.skipCount} />
-              <ImportSummaryItem label={t('import.summary.success')} value={importSummary.successCount} />
-              <ImportSummaryItem label={t('import.summary.failure')} value={importSummary.failureCount} />
+              <ImportSummaryItem
+                label={t('import.summary.success')}
+                value={importSummary.successCount}
+              />
+              <ImportSummaryItem
+                label={t('import.summary.failure')}
+                value={importSummary.failureCount}
+              />
             </div>
             {importRows.length > 0 && (
               <div className="space-y-2">
@@ -296,7 +332,9 @@ export default function AdminProductsPage() {
                       onClick={() => setShowAllImportRows((value) => !value)}
                       className="rounded border px-3 py-1 text-xs hover:bg-secondary"
                     >
-                      {showAllImportRows ? t('import.showTopRows') : t('import.showAllRows', { count: visibleImportRows.length })}
+                      {showAllImportRows
+                        ? t('import.showTopRows')
+                        : t('import.showAllRows', { count: visibleImportRows.length })}
                     </button>
                   )}
                   {allImportRows.some((row) => row.status === 'failed') && (
@@ -308,75 +346,109 @@ export default function AdminProductsPage() {
                       }}
                       className="rounded border px-3 py-1 text-xs hover:bg-secondary"
                     >
-                      {showFailedImportRowsOnly ? t('import.showAllResults') : t('import.showFailedRows')}
+                      {showFailedImportRowsOnly
+                        ? t('import.showAllResults')
+                        : t('import.showFailedRows')}
                     </button>
                   )}
                 </div>
                 <div className="overflow-x-auto rounded border bg-background">
                   <table className="w-full text-xs">
-                  <thead className="bg-secondary">
-                    <tr>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.row')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.identifier')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.productName')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.action')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.matchedProduct')}</th>
-                      <th className="px-3 py-2 text-right">{t('import.previewColumns.price')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.discount')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.freeShipping')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.noticeInfo')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.automaticMapping')}</th>
-                      <th className="px-3 py-2 text-right">{t('import.previewColumns.options')}</th>
-                      <th className="px-3 py-2 text-right">{t('import.previewColumns.galleryImages')}</th>
-                      <th className="px-3 py-2 text-right">{t('import.previewColumns.detailImages')}</th>
-                      <th className="px-3 py-2 text-left">{t('import.previewColumns.result')}</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y">
-                    {importRows.map((row) => (
-                      <tr key={`${row.rowNumber}-${row.identifier ?? 'empty'}`}>
-                        <td className="px-3 py-2">{row.rowNumber}</td>
-                        <td className="px-3 py-2">{row.identifier ?? '-'}</td>
-                        <td className="px-3 py-2">{row.productName ?? '-'}</td>
-                        <td className="px-3 py-2">{t(`import.actions.${row.action}`)}</td>
-                        <td className="px-3 py-2">
-                          {row.productId ? (
-                            <Link
-                              href={`/admin/products/${row.productId}/edit`}
-                              className="font-medium text-primary underline-offset-2 hover:underline"
-                            >
-                              {t('import.previewValues.productLink', { id: row.productId })}
-                            </Link>
-                          ) : (
-                            <span className="text-muted-foreground">{t('import.previewValues.notLinked')}</span>
-                          )}
-                        </td>
-                        <td className="px-3 py-2 text-right">{row.price != null ? formatCurrency(row.price) : '-'}</td>
-                        <td className="px-3 py-2">
-                          {row.hasDiscount && row.salePrice != null
-                            ? t('import.previewValues.discountApplied', { salePrice: formatCurrency(row.salePrice) })
-                            : t('import.previewValues.discountNone')}
-                        </td>
-                        <td className="px-3 py-2">
-                          {row.isFreeShipping == null
-                            ? t('import.previewValues.unknown')
-                            : row.isFreeShipping
+                    <thead className="bg-secondary">
+                      <tr>
+                        <th className="px-3 py-2 text-left">{t('import.previewColumns.row')}</th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.previewColumns.identifier')}
+                        </th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.previewColumns.productName')}
+                        </th>
+                        <th className="px-3 py-2 text-left">{t('import.previewColumns.action')}</th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.previewColumns.matchedProduct')}
+                        </th>
+                        <th className="px-3 py-2 text-right">{t('import.previewColumns.price')}</th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.previewColumns.discount')}
+                        </th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.previewColumns.freeShipping')}
+                        </th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.previewColumns.noticeInfo')}
+                        </th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.previewColumns.automaticMapping')}
+                        </th>
+                        <th className="px-3 py-2 text-right">
+                          {t('import.previewColumns.options')}
+                        </th>
+                        <th className="px-3 py-2 text-right">
+                          {t('import.previewColumns.galleryImages')}
+                        </th>
+                        <th className="px-3 py-2 text-right">
+                          {t('import.previewColumns.detailImages')}
+                        </th>
+                        <th className="px-3 py-2 text-left">{t('import.previewColumns.result')}</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                      {importRows.map((row) => (
+                        <tr key={`${row.rowNumber}-${row.identifier ?? 'empty'}`}>
+                          <td className="px-3 py-2">{row.rowNumber}</td>
+                          <td className="px-3 py-2">{row.identifier ?? '-'}</td>
+                          <td className="px-3 py-2">{row.productName ?? '-'}</td>
+                          <td className="px-3 py-2">{t(`import.actions.${row.action}`)}</td>
+                          <td className="px-3 py-2">
+                            {row.productId ? (
+                              <Link
+                                href={`/admin/products/${row.productId}/edit`}
+                                className="font-medium text-primary underline-offset-2 hover:underline"
+                              >
+                                {t('import.previewValues.productLink', { id: row.productId })}
+                              </Link>
+                            ) : (
+                              <span className="text-muted-foreground">
+                                {t('import.previewValues.notLinked')}
+                              </span>
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            {row.price != null ? formatCurrency(row.price) : '-'}
+                          </td>
+                          <td className="px-3 py-2">
+                            {row.hasDiscount && row.salePrice != null
+                              ? t('import.previewValues.discountApplied', {
+                                  salePrice: formatCurrency(row.salePrice),
+                                })
+                              : t('import.previewValues.discountNone')}
+                          </td>
+                          <td className="px-3 py-2">
+                            {row.isFreeShipping == null
+                              ? t('import.previewValues.unknown')
+                              : row.isFreeShipping
+                                ? t('import.previewValues.yes')
+                                : t('import.previewValues.no')}
+                          </td>
+                          <td className="px-3 py-2">
+                            {row.hasNoticeInfo
                               ? t('import.previewValues.yes')
                               : t('import.previewValues.no')}
-                        </td>
-                        <td className="px-3 py-2">{row.hasNoticeInfo ? t('import.previewValues.yes') : t('import.previewValues.no')}</td>
-                        <td className="min-w-56 px-3 py-2">
-                          <ImportMappingSummary row={row} t={t} />
-                        </td>
-                        <td className="px-3 py-2 text-right">{row.optionCount ?? 0}</td>
-                        <td className="px-3 py-2 text-right">{row.galleryImageCount ?? 0}</td>
-                        <td className="px-3 py-2 text-right">{row.detailImageCount ?? 0}</td>
-                        <td className="px-3 py-2">
-                          {row.errors.length > 0 ? row.errors.join(', ') : t(`import.status.${row.status}`)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
+                          </td>
+                          <td className="min-w-56 px-3 py-2">
+                            <ImportMappingSummary row={row} t={t} />
+                          </td>
+                          <td className="px-3 py-2 text-right">{row.optionCount ?? 0}</td>
+                          <td className="px-3 py-2 text-right">{row.galleryImageCount ?? 0}</td>
+                          <td className="px-3 py-2 text-right">{row.detailImageCount ?? 0}</td>
+                          <td className="px-3 py-2">
+                            {row.errors.length > 0
+                              ? row.errors.join(', ')
+                              : t(`import.status.${row.status}`)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
                   </table>
                 </div>
               </div>
@@ -488,15 +560,25 @@ function ImportMappingSummary({
   }
 
   const parts = [
-    mapping.category ? t('import.mappingValues.category', { value: mapping.category.displayName }) : null,
+    mapping.category
+      ? t('import.mappingValues.category', { value: mapping.category.displayName })
+      : null,
     ...mapping.attributes.map((attribute) => `${attribute.code}: ${attribute.displayValue}`),
     ...mapping.options.map((option) => `${option.name}: ${option.value}`),
-    mapping.noticeInfoType ? t('import.mappingValues.noticeInfo', { value: t(`import.noticeInfoTypes.${mapping.noticeInfoType}`) }) : null,
+    mapping.noticeInfoType
+      ? t('import.mappingValues.noticeInfo', {
+          value: t(`import.noticeInfoTypes.${mapping.noticeInfoType}`),
+        })
+      : null,
   ].filter((value): value is string => Boolean(value));
 
   return (
     <div className="space-y-1">
-      <span className={mapping.status === 'needs_review' ? 'font-medium text-amber-700' : 'font-medium text-tea'}>
+      <span
+        className={
+          mapping.status === 'needs_review' ? 'font-medium text-amber-700' : 'font-medium text-tea'
+        }
+      >
         {t(`import.mappingStatus.${mapping.status}`)}
       </span>
       <p className="text-muted-foreground">{parts.join(' · ')}</p>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -832,7 +832,6 @@
       "naverCommerce": {
         "title": "Naver Commerce API product update",
         "description": "Fetch SmartStore products from the Naver Commerce API without Excel and preview updates only for existing store products with matching SKUs.",
-        "credentialsHint": "Required environment variables: NAVER_COMMERCE_APP_ID and NAVER_COMMERCE_APP_SECRET. Secret values are never shown in responses or logs.",
         "previewButton": "Preview API sync",
         "previewing": "Fetching...",
         "commitButton": "Apply API result",
@@ -1513,11 +1512,7 @@
     "title": "Shipping, Exchange & Refund Policy",
     "description": "Detailed shipping, exchange/return, and refund standards beyond the product-detail summary.",
     "effectiveDate": "Effective date: June 12, 2026",
-    "sectionKeys": [
-      "shipping",
-      "exchangeReturn",
-      "refund"
-    ],
+    "sectionKeys": ["shipping", "exchangeReturn", "refund"],
     "sections": {
       "shipping": {
         "title": "Shipping Policy",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -832,7 +832,6 @@
       "naverCommerce": {
         "title": "네이버 커머스API 상품 업데이트",
         "description": "엑셀 파일 없이 네이버 커머스API에서 스마트스토어 상품을 조회해 SKU가 일치하는 기존 자사몰 상품만 업데이트 후보로 미리보기합니다.",
-        "credentialsHint": "필요 환경변수: NAVER_COMMERCE_APP_ID, NAVER_COMMERCE_APP_SECRET. 실제 시크릿 값은 응답과 로그에 표시하지 않습니다.",
         "previewButton": "API 미리보기",
         "previewing": "조회 중...",
         "commitButton": "API 결과 반영",
@@ -1513,11 +1512,7 @@
     "title": "배송/교환/환불 정책",
     "description": "상품 상세의 요약 안내보다 더 자세한 배송, 교환·반품, 환불 기준을 안내합니다.",
     "effectiveDate": "시행일: 2026년 6월 12일",
-    "sectionKeys": [
-      "shipping",
-      "exchangeReturn",
-      "refund"
-    ],
+    "sectionKeys": ["shipping", "exchangeReturn", "refund"],
     "sections": {
       "shipping": {
         "title": "배송 정책",

--- a/src/lib/__tests__/products-api.test.ts
+++ b/src/lib/__tests__/products-api.test.ts
@@ -9,7 +9,9 @@ afterEach(() => {
 
 describe('productsApi', () => {
   it('passes attrs to the product list request params', async () => {
-    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 });
+    const getSpy = vi
+      .spyOn(apiClient, 'get')
+      .mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 });
 
     await productsApi.getList({ attrs: 'clay_type:junni', price_min: 10000 });
 
@@ -30,17 +32,64 @@ describe('adminProductsApi', () => {
     });
   });
 
-  it('calls Naver Commerce preview and commit endpoints without raw fetches', async () => {
+  it('starts Naver Commerce jobs and returns completed results without raw fetches', async () => {
     const response = {
-      summary: { totalRows: 0, createCount: 0, updateCount: 0, skipCount: 0, successCount: 0, failureCount: 0 },
+      summary: {
+        totalRows: 0,
+        createCount: 0,
+        updateCount: 0,
+        skipCount: 0,
+        successCount: 0,
+        failureCount: 0,
+      },
       rows: [],
     };
-    const postSpy = vi.spyOn(apiClient, 'post').mockResolvedValue(response);
+    const postSpy = vi.spyOn(apiClient, 'post').mockResolvedValue({
+      id: 'job-1',
+      type: 'preview',
+      status: 'completed',
+      createdAt: '2026-07-03T00:00:00.000Z',
+      result: response,
+    });
 
-    await adminProductsApi.previewNaverCommerceImport();
-    await adminProductsApi.commitNaverCommerceImport();
+    await expect(adminProductsApi.previewNaverCommerceImport()).resolves.toBe(response);
 
-    expect(postSpy).toHaveBeenNthCalledWith(1, '/products/imports/naver-commerce/preview');
-    expect(postSpy).toHaveBeenNthCalledWith(2, '/products/imports/naver-commerce/commit');
+    expect(postSpy).toHaveBeenCalledWith('/products/imports/naver-commerce/preview');
+  });
+
+  it('polls a pending Naver Commerce job until it completes', async () => {
+    vi.useFakeTimers();
+    const response = {
+      summary: {
+        totalRows: 1,
+        createCount: 0,
+        updateCount: 1,
+        skipCount: 0,
+        successCount: 1,
+        failureCount: 0,
+      },
+      rows: [],
+    };
+    const postSpy = vi.spyOn(apiClient, 'post').mockResolvedValue({
+      id: 'job-2',
+      type: 'commit',
+      status: 'running',
+      createdAt: '2026-07-03T00:00:00.000Z',
+    });
+    const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue({
+      id: 'job-2',
+      type: 'commit',
+      status: 'completed',
+      createdAt: '2026-07-03T00:00:00.000Z',
+      result: response,
+    });
+
+    const promise = adminProductsApi.commitNaverCommerceImport();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(promise).resolves.toBe(response);
+    expect(postSpy).toHaveBeenCalledWith('/products/imports/naver-commerce/commit');
+    expect(getSpy).toHaveBeenCalledWith('/products/imports/naver-commerce/jobs/job-2');
+    vi.useRealTimers();
   });
 });

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -43,7 +43,12 @@ export type SmartStoreImportStatus = 'valid' | 'failed' | 'success';
 export interface SmartStoreAutomaticMappingResult {
   status: 'none' | 'mapped' | 'needs_review';
   category?: { slug: string; displayName: string; categoryId?: number };
-  attributes: Array<{ code: string; value: string; displayValue: string; attributeTypeId?: number }>;
+  attributes: Array<{
+    code: string;
+    value: string;
+    displayValue: string;
+    attributeTypeId?: number;
+  }>;
   options: Array<{ name: string; value: string }>;
   noticeInfoType?: 'teaware' | 'tea';
 }
@@ -80,6 +85,55 @@ export interface SmartStoreProductImportResult {
   rows: SmartStoreProductImportRow[];
 }
 
+export interface NaverCommerceImportJob {
+  id: string;
+  type: 'preview' | 'commit';
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  result?: SmartStoreProductImportResult;
+  error?: string;
+}
+
+const NAVER_COMMERCE_IMPORT_POLL_INTERVAL_MS = 2_000;
+const NAVER_COMMERCE_IMPORT_MAX_POLLS = 900;
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function pollNaverCommerceImportJob(
+  job: NaverCommerceImportJob,
+): Promise<SmartStoreProductImportResult> {
+  let currentJob = job;
+
+  for (let attempt = 0; attempt < NAVER_COMMERCE_IMPORT_MAX_POLLS; attempt += 1) {
+    if (currentJob.status === 'completed' && currentJob.result) {
+      return currentJob.result;
+    }
+    if (currentJob.status === 'failed') {
+      throw new Error(currentJob.error || '네이버 커머스API 작업에 실패했습니다.');
+    }
+
+    await wait(NAVER_COMMERCE_IMPORT_POLL_INTERVAL_MS);
+    currentJob = await apiClient.get<NaverCommerceImportJob>(
+      `/products/imports/naver-commerce/jobs/${currentJob.id}`,
+    );
+  }
+
+  throw new Error('네이버 커머스API 작업 시간이 길어지고 있습니다. 잠시 후 다시 확인해 주세요.');
+}
+
+async function startNaverCommerceImportJob(
+  endpoint: string,
+): Promise<SmartStoreProductImportResult> {
+  const job = await apiClient.post<NaverCommerceImportJob>(endpoint);
+  return pollNaverCommerceImportJob(job);
+}
+
 export const adminProductsApi = {
   getList: (params?: AdminProductsParams) =>
     apiClient.get<ProductListResponse>('/admin/products', {
@@ -89,18 +143,22 @@ export const adminProductsApi = {
     apiClient.get<ProductDetail>(`/admin/products/${id}`, {
       params: locale ? { locale } : undefined,
     }),
-  create: (data: CreateProductData) =>
-    apiClient.post<ProductDetail>('/products', data),
+  create: (data: CreateProductData) => apiClient.post<ProductDetail>('/products', data),
   update: (id: number, data: UpdateProductData) =>
     apiClient.patch<ProductDetail>(`/products/${id}`, data),
-  remove: (id: number) =>
-    apiClient.delete<{ message: string }>(`/products/${id}`),
+  remove: (id: number) => apiClient.delete<{ message: string }>(`/products/${id}`),
   previewSmartStoreImport: (file: File) =>
-    apiClient.uploadFile<SmartStoreProductImportResult>('/products/imports/smartstore/preview', file),
+    apiClient.uploadFile<SmartStoreProductImportResult>(
+      '/products/imports/smartstore/preview',
+      file,
+    ),
   commitSmartStoreImport: (file: File) =>
-    apiClient.uploadFile<SmartStoreProductImportResult>('/products/imports/smartstore/commit', file),
+    apiClient.uploadFile<SmartStoreProductImportResult>(
+      '/products/imports/smartstore/commit',
+      file,
+    ),
   previewNaverCommerceImport: () =>
-    apiClient.post<SmartStoreProductImportResult>('/products/imports/naver-commerce/preview'),
+    startNaverCommerceImportJob('/products/imports/naver-commerce/preview'),
   commitNaverCommerceImport: () =>
-    apiClient.post<SmartStoreProductImportResult>('/products/imports/naver-commerce/commit'),
+    startNaverCommerceImportJob('/products/imports/naver-commerce/commit'),
 };


### PR DESCRIPTION
## Summary
- remove the Naver Commerce environment-variable hint from the admin products UI
- change Naver Commerce preview/commit endpoints to start async backend jobs immediately
- add frontend polling for Naver Commerce job status so long-running apply operations do not depend on one long POST response
- add backend and frontend tests for job completion/failure/polling behavior

## Verification
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `npm run lint`
- `cd backend && npm run lint`
- `bash scripts/codex-project-guard.sh`
- post-rebase targeted: `npm run test:run -- src/lib/__tests__/products-api.test.ts src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx`
- post-rebase targeted: `cd backend && npm run build && npm test -- --runInBand src/modules/products/__tests__/naver-commerce-import-job.service.spec.ts src/modules/products/__tests__/naver-commerce-api.client.spec.ts src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts`

Closes #994
