### PR TITLE
feat: 리뷰 번역 기능 추가

### DIFF
--- a/.claude/rules/backend-patterns.md
+++ b/.claude/rules/backend-patterns.md
@@ -8,6 +8,7 @@ NestJS-specific patterns and utilities. Complements `backend/CLAUDE.md`.
 - **Shipping**: `ShippingProvider` interface → `MockShippingAdapter` and `CjShippingAdapter`; `hanjin`/`lotte` currently fall back to mock. CarrierCode type supports `'mock' | 'cj' | 'hanjin' | 'lotte'`.
 - **Storage**: `local` / `s3`. Selected by `STORAGE_PROVIDER` env.
 - **Notification/Email**: `EmailProvider` adapters → mock, Resend, SES stub. Selected by `NOTIFICATION_PROVIDER`; `mock` is blocked in production.
+- **리뷰 번역 (예외 — adapter 없음)**: `ReviewsService.translateReviewContent`가 keyless Google Translate 비공식 endpoint(`translate.googleapis.com/translate_a/single?client=gtx`)를 직접 호출. env/API key 불필요, 5초 타임아웃, `@Throttle` 30/min, 실패는 502(BadGatewayException)로 매핑. 무SLA 엔드포인트임을 인지한 의도적 KISS 선택 — 유료 API 어댑터화는 실제 장애가 반복될 때만 검토.
 
 ## Payment Gateway Selection
 

--- a/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/reviews.service.spec.ts
@@ -261,6 +261,45 @@ describe('ReviewsService', () => {
     });
   });
 
+
+
+  describe('translateReviewContent', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('translates review content through the translation service', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue([[["Really good", "정말 좋아요", null, null]]]),
+      } as unknown as Response);
+
+      const result = await service.translateReviewContent({
+        text: '정말 좋아요',
+        sourceLocale: 'ko',
+        targetLocale: 'en',
+      });
+
+      expect(result).toEqual({
+        translatedText: 'Really good',
+        sourceLocale: 'ko',
+        targetLocale: 'en',
+      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('translate.googleapis.com/translate_a/single'),
+        expect.objectContaining({ headers: { accept: 'application/json' } }),
+      );
+    });
+
+    it('rejects blank review translation requests', async () => {
+      await expect(
+        service.translateReviewContent({ text: '   ', sourceLocale: 'ko', targetLocale: 'en' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
   describe('importSmartStoreReviews', () => {
     it('should upsert SmartStore reviews by external review id', async () => {
       mockExternalRepo.findOne

--- a/backend/src/modules/reviews/dto/translate-review.dto.ts
+++ b/backend/src/modules/reviews/dto/translate-review.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class TranslateReviewDto {
+  @ApiProperty({ example: '정말 좋아요', description: '번역할 리뷰 원문' })
+  @IsString({ message: '번역할 리뷰 원문은 문자열이어야 합니다.' })
+  @MinLength(1, { message: '번역할 리뷰 원문이 필요합니다.' })
+  @MaxLength(2000, { message: '리뷰 번역은 2000자 이하만 지원합니다.' })
+  text!: string;
+
+  @ApiProperty({ example: 'ko', enum: ['ko', 'en'], description: '원문 언어' })
+  @IsIn(['ko', 'en'], { message: '원문 언어는 ko 또는 en이어야 합니다.' })
+  sourceLocale!: 'ko' | 'en';
+
+  @ApiProperty({ example: 'en', enum: ['ko', 'en'], description: '번역 대상 언어' })
+  @IsIn(['ko', 'en'], { message: '번역 대상 언어는 ko 또는 en이어야 합니다.' })
+  targetLocale!: 'ko' | 'en';
+}

--- a/backend/src/modules/reviews/reviews.controller.ts
+++ b/backend/src/modules/reviews/reviews.controller.ts
@@ -30,6 +30,7 @@ import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { ReviewQueryDto } from './dto/review-query.dto';
+import { TranslateReviewDto } from './dto/translate-review.dto';
 import { ImportSmartStoreReviewsDto } from './dto/import-smartstore-reviews.dto';
 import { Public } from '../../common/decorators/public.decorator';
 import { Roles } from '../../common/decorators/roles.decorator';
@@ -81,6 +82,17 @@ export class ReviewsController {
   @ApiResponse({ status: 403, description: '관리자 권한 필요' })
   importSmartStoreReviews(@Body() dto: ImportSmartStoreReviewsDto) {
     return this.reviewsService.importSmartStoreReviews(dto);
+  }
+
+  @Public()
+  @Post('translate')
+  @Throttle({ global: { limit: 30, ttl: 60000 } })
+  @ApiOperation({ summary: '리뷰 원문 번역', description: '리뷰 원문을 현재 상점 언어에 맞게 번역합니다.' })
+  @ApiResponse({ status: 201, description: '리뷰 번역 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 번역 요청' })
+  @ApiResponse({ status: 502, description: '번역 서비스 오류' })
+  translate(@Body() dto: TranslateReviewDto) {
+    return this.reviewsService.translateReviewContent(dto);
   }
 
   @Post()

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  BadGatewayException,
   BadRequestException,
   ConflictException,
   ForbiddenException,
@@ -25,6 +26,17 @@ const REVIEW_POINT_REWARD_KEY = 'review_point_reward';
 const PHOTO_REVIEW_BONUS_KEY = 'photo_review_bonus';
 const DEFAULT_REVIEW_POINT_REWARD = 100;
 const DEFAULT_PHOTO_REVIEW_BONUS = 0;
+const REVIEW_TRANSLATION_TIMEOUT_MS = 5000;
+
+function extractGoogleTranslateText(payload: unknown): string | null {
+  if (!Array.isArray(payload) || !Array.isArray(payload[0])) return null;
+
+  const translatedParts = payload[0]
+    .map((part) => (Array.isArray(part) && typeof part[0] === 'string' ? part[0] : ''))
+    .filter((part) => part.length > 0);
+
+  return translatedParts.length > 0 ? translatedParts.join('') : null;
+}
 
 export interface ReviewResponse {
   id: number;
@@ -256,6 +268,56 @@ export class ReviewsService {
       internalCount,
       externalCount,
     };
+  }
+
+
+  async translateReviewContent(dto: {
+    text: string;
+    sourceLocale: 'ko' | 'en';
+    targetLocale: 'ko' | 'en';
+  }): Promise<{ translatedText: string; sourceLocale: 'ko' | 'en'; targetLocale: 'ko' | 'en' }> {
+    const text = dto.text.trim();
+    if (!text) {
+      throw new BadRequestException('번역할 리뷰 원문이 필요합니다.');
+    }
+
+    if (dto.sourceLocale === dto.targetLocale) {
+      return { translatedText: text, sourceLocale: dto.sourceLocale, targetLocale: dto.targetLocale };
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REVIEW_TRANSLATION_TIMEOUT_MS);
+    const params = new URLSearchParams({
+      client: 'gtx',
+      sl: dto.sourceLocale,
+      tl: dto.targetLocale,
+      dt: 't',
+      q: text,
+    });
+
+    try {
+      const response = await fetch(`https://translate.googleapis.com/translate_a/single?${params.toString()}`, {
+        signal: controller.signal,
+        headers: { accept: 'application/json' },
+      });
+
+      if (!response.ok) {
+        throw new BadGatewayException('리뷰 번역 서비스 응답이 올바르지 않습니다.');
+      }
+
+      const translatedText = extractGoogleTranslateText(await response.json());
+      if (!translatedText) {
+        throw new BadGatewayException('리뷰 번역 결과를 읽지 못했습니다.');
+      }
+
+      return { translatedText, sourceLocale: dto.sourceLocale, targetLocale: dto.targetLocale };
+    } catch (error) {
+      if (error instanceof BadGatewayException) throw error;
+      this.logger.warn(`Review translation failed: ${(error as Error).message}`);
+      throw new BadGatewayException('리뷰 번역에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   async importSmartStoreReviews(dto: ImportSmartStoreReviewsDto): Promise<SmartStoreImportResult> {

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -18,7 +18,7 @@ Next.js 15 (App Router) + React 19 + TS + TailwindCSS v4. Inherits root CLAUDE.m
 - Error extraction: `handleApiError(err)` from `@/utils/error` — no inline instanceof checks
 - Price formatting: `formatCurrency()` from `@/utils/currency` — no inline `.toLocaleString() + '원'`
 - Data fetching: `useAsyncAction` hook — no manual useState(loading) + try/catch/finally
-- i18n: use `next-intl` (`useTranslations('ns')`) for locale-backed user-facing strings and reusable shared UI. Locale files: `src/i18n/messages/{ko,en}.json`. When values come from enums/keys, map them to translation keys (see `JournalPreviewBlock` `CATEGORY_KEY_MAP`). When adding a locale-backed key, update both locale files.
+- i18n: use `next-intl` (`useTranslations('ns')`) for route/component translation contexts; use `localMessage()` from `@/utils/localMessages` for client-only shared utilities/components where hooks are unavailable. Locale files: `src/i18n/messages/{ko,en}.json`. When values come from enums/keys, map them to translation keys (see `JournalPreviewBlock` `CATEGORY_KEY_MAP`). When adding a locale-backed key, update both locale files.
 
 ## Responsive & Accessibility
 - Responsive: flex/grid based, component-level mobile branching

--- a/src/components/shared/reviews/ReviewCard.tsx
+++ b/src/components/shared/reviews/ReviewCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, memo } from 'react'
 import Image from 'next/image'
+import { reviewsApi } from '@/lib/api'
 import type { ReviewItem } from '@/lib/api'
 import StarRating from './StarRating'
 import { getClientLocale } from '@/utils/clientLocale'
@@ -11,9 +12,17 @@ interface ReviewCardProps {
   review: ReviewItem
 }
 
+function detectReviewSourceLocale(content: string): 'ko' | 'en' {
+  return /[\u3131-\u318E\uAC00-\uD7A3]/.test(content) ? 'ko' : 'en'
+}
+
 const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps) {
   const locale = getClientLocale()
   const [expandedImage, setExpandedImage] = useState<string | null>(null)
+  const [translatedContent, setTranslatedContent] = useState<string | null>(null)
+  const [showTranslation, setShowTranslation] = useState(false)
+  const [isTranslating, setIsTranslating] = useState(false)
+  const [translationError, setTranslationError] = useState<string | null>(null)
 
   const formattedDate = new Date(review.createdAt).toLocaleDateString(locale === 'en' ? 'en-US' : 'ko-KR', {
     year: 'numeric',
@@ -22,6 +31,36 @@ const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps
   })
 
   const isSmartStoreReview = review.source === 'smartstore'
+  const content = review.content?.trim() ?? ''
+  const sourceLocale = content ? detectReviewSourceLocale(content) : locale
+  const canTranslate = Boolean(content) && sourceLocale !== locale
+  const visibleContent = showTranslation && translatedContent ? translatedContent : review.content
+
+  const handleTranslate = async () => {
+    if (!content || !canTranslate) return
+
+    if (translatedContent) {
+      setShowTranslation((value) => !value)
+      setTranslationError(null)
+      return
+    }
+
+    setIsTranslating(true)
+    setTranslationError(null)
+    try {
+      const result = await reviewsApi.translateContent({
+        text: content,
+        sourceLocale,
+        targetLocale: locale,
+      })
+      setTranslatedContent(result.translatedText)
+      setShowTranslation(true)
+    } catch {
+      setTranslationError(localMessage('review.translateError'))
+    } finally {
+      setIsTranslating(false)
+    }
+  }
 
   return (
     <div className="border-b border-border py-4 last:border-b-0">
@@ -39,7 +78,31 @@ const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps
       </div>
 
       {review.content && (
-        <p className="mt-2 text-sm text-foreground leading-relaxed">{review.content}</p>
+        <div className="mt-2 space-y-1">
+          <div className="flex flex-wrap items-start gap-x-2 gap-y-1">
+            <p className="text-sm text-foreground leading-relaxed">{visibleContent}</p>
+            {canTranslate && (
+              <button
+                type="button"
+                onClick={handleTranslate}
+                disabled={isTranslating}
+                className="text-xs font-medium text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+              >
+                {isTranslating
+                  ? localMessage('review.translating')
+                  : showTranslation
+                    ? localMessage('review.showOriginal')
+                    : localMessage('review.translate')}
+              </button>
+            )}
+          </div>
+          {showTranslation && translatedContent && (
+            <p className="text-[11px] text-muted-foreground">{localMessage('review.machineTranslated')}</p>
+          )}
+          {translationError && (
+            <p className="text-xs text-destructive">{translationError}</p>
+          )}
+        </div>
       )}
 
       {review.imageUrls && review.imageUrls.length > 0 && (

--- a/src/components/shared/reviews/__tests__/ReviewList.test.tsx
+++ b/src/components/shared/reviews/__tests__/ReviewList.test.tsx
@@ -3,10 +3,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import ReviewList from '../ReviewList'
 
 const mockGetByProduct = vi.fn()
+const mockTranslateContent = vi.fn()
 
 vi.mock('@/lib/api', () => ({
   reviewsApi: {
     getByProduct: (...args: unknown[]) => mockGetByProduct(...args),
+    translateContent: (...args: unknown[]) => mockTranslateContent(...args),
   },
 }))
 
@@ -48,7 +50,9 @@ describe('ReviewList', () => {
   }
 
   beforeEach(() => {
+    document.documentElement.lang = 'ko'
     mockGetByProduct.mockResolvedValue(mockResponse)
+    mockTranslateContent.mockResolvedValue({ translatedText: 'Really good', sourceLocale: 'ko', targetLocale: 'en' })
   })
 
   it('renders reviews after loading', async () => {
@@ -85,6 +89,29 @@ describe('ReviewList', () => {
     })
     expect(screen.getByText('네이버 스마트스토어')).toBeInTheDocument()
     expect(screen.getByText('네이버 스마트스토어 1개 포함')).toBeInTheDocument()
+  })
+
+
+
+  it('translates Korean review content inline on English storefront', async () => {
+    document.documentElement.lang = 'en'
+    render(<ReviewList productId={5} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('정말 좋아요')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Translate' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Really good')).toBeInTheDocument()
+    })
+    expect(mockTranslateContent).toHaveBeenCalledWith({
+      text: '정말 좋아요',
+      sourceLocale: 'ko',
+      targetLocale: 'en',
+    })
+    expect(screen.getByText('Machine-translated review.')).toBeInTheDocument()
   })
 
   it('shows empty state when no reviews', async () => {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -609,7 +609,12 @@
     "expandImage": "Enlarge image",
     "expandedImageAlt": "Enlarged image",
     "previous": "Previous",
-    "next": "Next"
+    "next": "Next",
+    "translate": "Translate",
+    "translating": "Translating...",
+    "showOriginal": "Show original",
+    "machineTranslated": "Machine-translated review.",
+    "translateError": "Failed to translate this review."
   },
   "shipping": {
     "title": "Register Tracking Number",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -609,7 +609,12 @@
     "expandImage": "이미지 확대",
     "expandedImageAlt": "확대 이미지",
     "previous": "이전",
-    "next": "다음"
+    "next": "다음",
+    "translate": "번역하기",
+    "translating": "번역 중...",
+    "showOriginal": "원문 보기",
+    "machineTranslated": "자동 번역된 리뷰입니다.",
+    "translateError": "리뷰 번역에 실패했습니다."
   },
   "shipping": {
     "title": "운송장 등록",

--- a/src/lib/api/reviews.ts
+++ b/src/lib/api/reviews.ts
@@ -30,6 +30,18 @@ export interface ReviewListResponse {
   pagination: { page: number; limit: number; total: number };
 }
 
+export interface TranslateReviewRequest {
+  text: string;
+  sourceLocale: 'ko' | 'en';
+  targetLocale: 'ko' | 'en';
+}
+
+export interface TranslateReviewResponse {
+  translatedText: string;
+  sourceLocale: 'ko' | 'en';
+  targetLocale: 'ko' | 'en';
+}
+
 export type ReviewSort = 'recent' | 'rating_high' | 'rating_low';
 
 export interface ReviewQueryParams {
@@ -58,6 +70,8 @@ export const reviewsApi = {
     apiClient.get<ReviewListResponse>('/reviews', {
       params: { productId, ...params } as Record<string, string | number | undefined>,
     }),
+  translateContent: (data: TranslateReviewRequest) =>
+    apiClient.post<TranslateReviewResponse>('/reviews/translate', data),
   create: (data: CreateReviewData) =>
     apiClient.post<ReviewItem>('/reviews', data),
   update: (id: number, data: UpdateReviewData) =>


### PR DESCRIPTION
## Summary
- 리뷰 언어가 현재 상점 언어와 다를 때 `번역하기` 버튼을 노출하고, 클릭 시 인라인 번역을 표시합니다 (원문 보기 토글 지원)
- 백엔드에 `POST /api/reviews/translate` 엔드포인트 추가 (5초 타임아웃, 30/min rate limit, 실패 시 502)

## Changes
- `src/components/shared/reviews/ReviewCard.tsx` — 번역 버튼/토글 UI
- `src/lib/api/reviews.ts` — 번역 API 클라이언트 메서드
- `backend/src/modules/reviews/` — translate 엔드포인트 + DTO + 서비스 로직
- `src/i18n/messages/{ko,en}.json` — 번역 관련 i18n 키
- 문서: `.claude/rules/backend-patterns.md`, `src/CLAUDE.md`

## Test plan
- [x] npm run build
- [x] npm run test:run (143 files / 823 tests)
- [x] cd backend && npm run build && npm run test (121 suites / 1217 tests)
- [x] 실제 번역 API 동작 확인 ("정말 좋아요" → "I really like it")

🤖 Generated with [Claude Code](https://claude.com/claude-code)