### PR TITLE
fix: #999 영어 상품 목록 리스트뷰 locale 링크 수정

### DIFF
--- a/src/components/shared/products/ProductListItem.tsx
+++ b/src/components/shared/products/ProductListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Link from 'next/link';
+import { Link } from '@/i18n/navigation';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/components/ui/utils';
@@ -44,6 +44,7 @@ function ProductListItem({
   return (
     <Link
       href={`/products/${id}`}
+      locale={locale}
       className={cn(
         'group flex gap-4 overflow-hidden rounded-lg border border-border bg-card p-3 transition-shadow hover:shadow-md',
         isSoldout && 'opacity-75',

--- a/src/components/shared/products/__tests__/ProductListItem.test.tsx
+++ b/src/components/shared/products/__tests__/ProductListItem.test.tsx
@@ -10,6 +10,14 @@ vi.mock('next-intl', () => ({
     }[key] ?? key),
 }));
 
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, locale, children, ...props }: { href: string; locale?: string; children: React.ReactNode }) => (
+    <a href={locale ? `/${locale}${href}` : href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
 const images: ProductImage[] = [{ id: 1, url: 'https://example.com/a.jpg', sortOrder: 0 } as ProductImage];
 
 function renderItem(overrides: Partial<React.ComponentProps<typeof ProductListItem>> = {}) {
@@ -25,6 +33,20 @@ function renderItem(overrides: Partial<React.ComponentProps<typeof ProductListIt
     />,
   );
 }
+
+describe('ProductListItem locale-aware navigation', () => {
+  it('links to the English product detail route when locale is en', () => {
+    renderItem({ locale: 'en' });
+
+    expect(screen.getByRole('link', { name: /자사호/ })).toHaveAttribute('href', '/en/products/1');
+  });
+
+  it('links to the Korean product detail route when locale is ko', () => {
+    renderItem({ locale: 'ko' });
+
+    expect(screen.getByRole('link', { name: /자사호/ })).toHaveAttribute('href', '/ko/products/1');
+  });
+});
 
 describe('ProductListItem free-shipping badge', () => {
   it('renders the free-shipping badge when isFreeShipping is true', () => {


### PR DESCRIPTION
## Summary
- Closes #999
- `ProductListItem`이 `next/link` 대신 locale-aware `@/i18n/navigation` Link를 사용하도록 수정했습니다.
- 리스트뷰 상품 링크에 기존 `locale` prop을 전달해 `/en/products/{id}`와 `/ko/products/{id}`를 유지합니다.
- en/ko 리스트 아이템 상세 링크 회귀 테스트를 추가했습니다.

## Test plan
- [x] npm run test:run -- src/components/shared/products/__tests__/ProductListItem.test.tsx (RED 확인 후 GREEN)
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run