### PR TITLE
fix: #995 React hydration 텍스트 불일치 수정

### DIFF
--- a/src/app/[locale]/my/orders/page.tsx
+++ b/src/app/[locale]/my/orders/page.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
 import { formatCurrency, type Locale } from '@/utils/currency';
+import { formatLongDate } from '@/utils/date';
 import { handleApiError } from '@/utils/error';
 import { useRequireAuth } from '@/components/shared/hooks/useRequireAuth';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
@@ -110,11 +111,7 @@ export default function OrdersPage() {
                           tMy('additionalItems', { count: order.items.length - 1 })}
                       </p>
                       <p className="text-xs text-muted-foreground mt-1">
-                        {new Date(order.createdAt).toLocaleDateString(locale === 'en' ? 'en-US' : 'ko-KR', {
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric',
-                        })}
+                        {formatLongDate(order.createdAt, locale)}
                       </p>
                     </div>
                     <div className="text-right shrink-0">

--- a/src/app/[locale]/my/page.tsx
+++ b/src/app/[locale]/my/page.tsx
@@ -10,6 +10,7 @@ import type { OrderResponse } from '@/lib/api';
 import { useRequireAuth } from '@/components/shared/hooks/useRequireAuth';
 import { SkeletonBox } from '@/components/ui/Skeleton';
 import { formatCurrency, type Locale } from '@/utils/currency';
+import { formatDate } from '@/utils/date';
 import { handleApiError } from '@/utils/error';
 import {
   Package,
@@ -138,7 +139,7 @@ export default function MyPage() {
                       {order.items.length > 1 &&
                         t('additionalItems', { count: order.items.length - 1 })}
                       {' · '}
-                      {new Date(order.createdAt).toLocaleDateString(locale === 'en' ? 'en-US' : 'ko-KR')}
+                      {formatDate(order.createdAt, locale)}
                     </p>
                   </div>
                   <div className="text-right shrink-0 ml-4">

--- a/src/components/__tests__/ThemeContext.test.tsx
+++ b/src/components/__tests__/ThemeContext.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
-import { ThemeProvider, useTheme, THEME_STORAGE_KEY } from '@/contexts/ThemeContext';
+import { ThemeProvider, useTheme, THEME_STORAGE_KEY, getInitialTheme } from '@/contexts/ThemeContext';
 
 function ThemeDisplay() {
   const { theme, setTheme, toggleTheme } = useTheme();
@@ -45,14 +45,21 @@ describe('ThemeContext', () => {
     expect(document.documentElement.dataset.theme).toBe('light');
   });
 
-  it('ko 로케일은 localStorage 값을 반영한다', () => {
+  it('첫 렌더에서는 localStorage 값보다 로케일 기본값을 사용한다', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'light');
+
+    expect(getInitialTheme('ko')).toBe('dark');
+  });
+
+  it('ko 로케일은 hydration 이후 localStorage 값을 반영한다', async () => {
     localStorage.setItem(THEME_STORAGE_KEY, 'light');
     render(
       <ThemeProvider locale="ko">
         <ThemeDisplay />
       </ThemeProvider>,
     );
-    expect(screen.getByTestId('theme').textContent).toBe('light');
+
+    expect(await screen.findByText('light')).toBeInTheDocument();
   });
 
   it('en 로케일은 localStorage에 dark가 있어도 light로 고정된다', () => {

--- a/src/components/shared/blocks/PromotionBannerBlock.tsx
+++ b/src/components/shared/blocks/PromotionBannerBlock.tsx
@@ -139,9 +139,10 @@ export default function PromotionBannerBlock({ content }: Props) {
 
 function CountdownTimer({ endDate }: { endDate: string }) {
   const t = useTranslations('promotion');
-  const [remaining, setRemaining] = useState(calcRemaining(endDate));
+  const [remaining, setRemaining] = useState(createInitialRemaining);
 
   useEffect(() => {
+    setRemaining(calcRemaining(endDate));
     const interval = setInterval(() => {
       setRemaining(calcRemaining(endDate));
     }, 1000);
@@ -169,6 +170,10 @@ function TimeUnit({ value, label }: { value: number; label: string }) {
       <span className="text-xs text-muted-foreground">{label}</span>
     </div>
   );
+}
+
+function createInitialRemaining() {
+  return { total: 1, days: 0, hours: 0, minutes: 0, seconds: 0 };
 }
 
 function calcRemaining(endDate: string) {

--- a/src/components/shared/blocks/__tests__/PromotionBannerBlock.test.tsx
+++ b/src/components/shared/blocks/__tests__/PromotionBannerBlock.test.tsx
@@ -1,0 +1,55 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import PromotionBannerBlock from '@/components/shared/blocks/PromotionBannerBlock';
+import type { PromotionBannerContent } from '@/lib/api';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) =>
+    ({
+      limitedTime: 'Limited time',
+      days: 'Days',
+      hours: 'Hours',
+      minutes: 'Minutes',
+      seconds: 'Seconds',
+      eventEnded: 'Event ended',
+      specialOffer: 'Special offer',
+    }[key] ?? key),
+}));
+
+vi.mock('@/components/shared/hooks/useScrollAnimation', () => ({
+  useScrollAnimation: () => ({ ref: { current: null }, visible: true }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ alt }: { alt: string }) => <span aria-label={alt} />,
+}));
+
+const timerContent: PromotionBannerContent = {
+  type: 'promotion_banner',
+  title: 'Timer promotion',
+  template: 'timer',
+  end_date: '2030-01-02T03:04:05.000Z',
+};
+
+describe('PromotionBannerBlock hydration safety', () => {
+  it('renders stable timer text on the server regardless of current time', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    const firstRender = renderToString(<PromotionBannerBlock content={timerContent} />);
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:05.000Z'));
+    const secondRender = renderToString(<PromotionBannerBlock content={timerContent} />);
+
+    vi.useRealTimers();
+
+    expect(secondRender).toBe(firstRender);
+  });
+});

--- a/src/components/shared/blocks/__tests__/PromotionBannerBlock.test.tsx
+++ b/src/components/shared/blocks/__tests__/PromotionBannerBlock.test.tsx
@@ -33,7 +33,6 @@ vi.mock('next/image', () => ({
 }));
 
 const timerContent: PromotionBannerContent = {
-  type: 'promotion_banner',
   title: 'Timer promotion',
   template: 'timer',
   end_date: '2030-01-02T03:04:05.000Z',

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -28,12 +28,13 @@ export function getDefaultThemeForLocale(locale: string): Theme {
 }
 
 export function getInitialTheme(locale: string): Theme {
+  return getDefaultThemeForLocale(locale);
+}
+
+function getSavedThemeAfterHydration(locale: string): Theme {
   const defaultTheme = getDefaultThemeForLocale(locale);
-  if (typeof window === 'undefined') {
+  if (defaultTheme === 'light' || typeof window === 'undefined') {
     return defaultTheme;
-  }
-  if (defaultTheme === 'light') {
-    return 'light';
   }
   try {
     const saved = window.localStorage.getItem(THEME_STORAGE_KEY);
@@ -53,7 +54,7 @@ export function ThemeProvider({ children, locale }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(() => getInitialTheme(locale));
 
   useEffect(() => {
-    setThemeState(getInitialTheme(locale));
+    setThemeState(getSavedThemeAfterHydration(locale));
   }, [locale]);
 
   // Sync dataset on mount and whenever theme changes

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { formatDate, formatLongDate } from '@/utils/date';
+
+describe('date formatting', () => {
+  it('formats short dates with an explicit UTC timezone for hydration stability', () => {
+    expect(formatDate('2026-01-02T23:30:00.000Z', 'ko')).toBe('2026. 1. 2.');
+    expect(formatDate('2026-01-02T23:30:00.000Z', 'en')).toBe('1/2/2026');
+  });
+
+  it('formats long dates with an explicit UTC timezone for hydration stability', () => {
+    expect(formatLongDate('2026-01-02T23:30:00.000Z', 'ko')).toBe('2026년 1월 2일');
+    expect(formatLongDate('2026-01-02T23:30:00.000Z', 'en')).toBe('January 2, 2026');
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,23 @@
+import type { Locale } from '@/utils/currency';
+
+const DATE_LOCALE_BY_LOCALE: Record<Locale, string> = {
+  ko: 'ko-KR',
+  en: 'en-US',
+};
+
+const TIME_ZONE = 'UTC';
+
+export function formatDate(value: string | Date, locale: Locale): string {
+  return new Intl.DateTimeFormat(DATE_LOCALE_BY_LOCALE[locale], {
+    timeZone: TIME_ZONE,
+  }).format(new Date(value));
+}
+
+export function formatLongDate(value: string | Date, locale: Locale): string {
+  return new Intl.DateTimeFormat(DATE_LOCALE_BY_LOCALE[locale], {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: TIME_ZONE,
+  }).format(new Date(value));
+}


### PR DESCRIPTION
## Summary
- Closes #995
- 카운트다운이 서버/클라이언트 첫 렌더에서 현재 시간을 직접 계산하지 않도록 안정적인 초기값을 사용하고, 실제 남은 시간은 mount 이후 계산하도록 변경했습니다.
- 테마 초기값은 첫 렌더에서 로케일 기본값만 사용하고, 저장된 localStorage 선호는 hydration 이후 반영하도록 분리했습니다.
- 주문 날짜 렌더링은 UTC timezone을 명시한 formatter를 통해 서버/브라우저 timezone 차이를 제거했습니다.
- hydration-sensitive 회귀 테스트를 추가했습니다.

## Test plan
- [x] npm run test:run -- src/components/__tests__/ThemeContext.test.tsx src/components/shared/blocks/__tests__/PromotionBannerBlock.test.tsx src/utils/__tests__/date.test.ts (RED 확인 후 GREEN)
- [x] npm run lint
- [x] npm run build
- [x] npm run test:run