### PR TITLE
fix: preserve SmartStore detail HTML fidelity

### DIFF
--- a/src/components/__tests__/ProductTabs.test.tsx
+++ b/src/components/__tests__/ProductTabs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import ProductTabs from '@/components/shared/products/ProductTabs'
@@ -74,10 +74,13 @@ describe('ProductTabs', () => {
     mockCreate.mockResolvedValue({ id: 1 })
   })
 
-  it('default tab shows description content', () => {
+  it('default tab shows description content', async () => {
     render(<ProductTabs description="<p>상품 상세 내용입니다.</p>" descriptionImages={[]} />)
     expect(screen.getByText('상세정보')).toBeInTheDocument()
-    const detailContent = document.querySelector('.prose')
+    await waitFor(() => {
+      expect(screen.getByText('상품 상세 내용입니다.')).toBeInTheDocument()
+    })
+    const detailContent = document.querySelector('.product-detail-html')
     expect(detailContent).toBeInTheDocument()
   })
 

--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/contexts/AuthContext'
 import { cn } from '@/components/ui/utils'
 import ReviewsTab from '@/components/shared/reviews/ReviewsTab'
 import { localMessage } from '@/utils/localMessages'
+import { hasEmbeddedDetailMedia, sanitizeProductDetailHtml } from '@/lib/product-detail-html'
 
 interface ProductTabsProps {
   description: string | null
@@ -162,12 +163,12 @@ export default function ProductTabs({ description, descriptionImages, productId,
 
   useEffect(() => {
     import('dompurify').then((mod) => {
-      setSanitized(mod.default.sanitize(description ?? '', {
-        ALLOWED_TAGS: ['p','br','strong','em','ul','ol','li','h2','h3','h4','a','img'],
-        ALLOWED_ATTR: ['href','src','alt','target','rel'],
-      }))
+      const DOMPurify = mod.default ?? mod
+      setSanitized(sanitizeProductDetailHtml(DOMPurify, description))
     })
   }, [description])
+
+  const descriptionContainsEmbeddedMedia = hasEmbeddedDetailMedia(description)
 
   // 한 세션 동안 같은 (사용자, 탭 진입) 조건에서 중복 호출을 막는 가드.
   // GlobalLoadingContext / useAsyncAction 의 reference 안정화로도 방어되지만,
@@ -214,7 +215,7 @@ export default function ProductTabs({ description, descriptionImages, productId,
       <div className="py-6">
         {activeTab === 'details' && (
           <div className="flex flex-col gap-6">
-            {descriptionImages.length > 0 && (
+            {descriptionImages.length > 0 && !descriptionContainsEmbeddedMedia && (
               <div className="flex flex-col gap-0">
                 {descriptionImages.map((image, index) => (
                   <div
@@ -235,7 +236,7 @@ export default function ProductTabs({ description, descriptionImages, productId,
               </div>
             )}
             <div
-              className="prose prose-sm max-w-none"
+              className="product-detail-html max-w-none"
               dangerouslySetInnerHTML={{ __html: sanitized }}
             />
             <ProductNoticeInfoGuide noticeInfo={noticeInfo} />

--- a/src/components/shared/products/__tests__/ProductTabs.test.tsx
+++ b/src/components/shared/products/__tests__/ProductTabs.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ProductTabs from '@/components/shared/products/ProductTabs';
+import type { ProductDetailImage } from '@/lib/api';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/ko/products/1',
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, number>) => {
+    if (key === 'tabs.detailsImageAlt') return `상세 이미지 ${params?.index ?? ''}`;
+    return key;
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: false }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  inquiriesApi: {
+    getList: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/shared/reviews/ReviewsTab', () => ({
+  default: () => <div>reviews-tab</div>,
+}));
+
+const separateDetailImages: ProductDetailImage[] = [
+  {
+    id: 1,
+    url: '/separate-detail.jpg',
+    alt: 'separate detail image',
+    sortOrder: 0,
+    isActive: true,
+  },
+];
+
+describe('ProductTabs SmartEditor detail HTML', () => {
+  it('renders SmartStore SmartEditor HTML with alignment, font classes, images, and embedded video preserved', async () => {
+    render(
+      <ProductTabs
+        description={`
+          <div class="se-viewer se-theme-default" lang="ko-KR">
+            <div class="se-main-container">
+              <div class="se-component se-horizontalLine"><hr class="se-hr"></div>
+              <p class="se-text-paragraph se-text-paragraph-align-center" style="line-height:1.8; color:#823f00" id="SE-text">
+                <span class="se-fs-fs19 se-ff-system" style="color:#823f00"><b>연자호</b></span>
+              </p>
+              <div class="se-component se-image">
+                <img src="https://shop-phinf.pstatic.net/example.jpg" alt="detail" class="se-image-resource">
+              </div>
+              <iframe src="https://www.youtube.com/embed/example" title="video"></iframe>
+              <script>window.bad=true</script>
+            </div>
+          </div>
+        `}
+        descriptionImages={separateDetailImages}
+        productId={1}
+      />,
+    );
+
+    await screen.findByText('연자호');
+
+    const paragraph = document.querySelector('.se-text-paragraph-align-center');
+    expect(paragraph).toBeTruthy();
+    expect(paragraph?.getAttribute('style')).toContain('line-height: 1.8');
+    expect(paragraph?.getAttribute('style')).toContain('color: #823f00');
+    expect(document.querySelector('.se-fs-fs19')).toBeTruthy();
+    expect(document.querySelector('.se-hr')).toBeTruthy();
+    expect(document.querySelector('.se-image-resource')?.getAttribute('src')).toBe(
+      'https://shop-phinf.pstatic.net/example.jpg',
+    );
+    expect(document.querySelector('iframe')?.getAttribute('src')).toBe(
+      'https://www.youtube.com/embed/example',
+    );
+    expect(document.querySelector('iframe')?.getAttribute('loading')).toBe('lazy');
+    expect(document.querySelector('script')).toBeNull();
+    expect(screen.queryByAltText('separate detail image')).not.toBeInTheDocument();
+  });
+
+  it('falls back to separate detail images when description has no embedded media', async () => {
+    render(
+      <ProductTabs
+        description="<p>텍스트 설명</p>"
+        descriptionImages={separateDetailImages}
+        productId={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('텍스트 설명')).toBeInTheDocument();
+    });
+    expect(screen.getByAltText('separate detail image')).toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/product-detail-html.test.ts
+++ b/src/lib/__tests__/product-detail-html.test.ts
@@ -1,0 +1,76 @@
+import DOMPurify from 'dompurify';
+import { describe, expect, it } from 'vitest';
+import { hasEmbeddedDetailMedia, sanitizeProductDetailHtml } from '@/lib/product-detail-html';
+
+describe('sanitizeProductDetailHtml', () => {
+  it('preserves SmartEditor structure, alignment, font classes, styles, images, and video embeds', () => {
+    const sanitized = sanitizeProductDetailHtml(
+      DOMPurify,
+      `
+        <div class="se-viewer se-theme-default" lang="ko-KR">
+          <div class="se-main-container">
+            <div class="se-section se-section-align-center"><hr class="se-hr"></div>
+            <p class="se-text-paragraph se-text-paragraph-align-center" style="line-height:1.8; color:#823f00" id="SE-text">
+              <span class="se-fs-fs19 se-ff-system" style="color:#823f00"><b>연자호</b></span>
+            </p>
+            <img src="https://shop-phinf.pstatic.net/example.jpg" alt="detail" class="se-image-resource">
+            <iframe src="https://www.youtube.com/embed/example" title="video"></iframe>
+          </div>
+        </div>
+      `,
+    );
+
+    const template = document.createElement('template');
+    template.innerHTML = sanitized;
+
+    expect(template.content.querySelector('.se-viewer')).toBeTruthy();
+    expect(template.content.querySelector('.se-text-paragraph-align-center')).toBeTruthy();
+    expect(template.content.querySelector('.se-fs-fs19')).toBeTruthy();
+    expect(template.content.querySelector('.se-hr')).toBeTruthy();
+    expect(template.content.querySelector('img')?.getAttribute('src')).toBe(
+      'https://shop-phinf.pstatic.net/example.jpg',
+    );
+    expect(template.content.querySelector('iframe')?.getAttribute('src')).toBe(
+      'https://www.youtube.com/embed/example',
+    );
+    expect(template.content.querySelector('iframe')?.getAttribute('loading')).toBe('lazy');
+    expect(template.content.querySelector('p')?.getAttribute('style')).toContain(
+      'line-height: 1.8',
+    );
+    expect(template.content.querySelector('span')?.getAttribute('style')).toContain(
+      'color: #823f00',
+    );
+  });
+
+  it('strips scripts, unsafe URLs, and URL-based inline CSS while retaining safe text styling', () => {
+    const sanitized = sanitizeProductDetailHtml(
+      DOMPurify,
+      `
+        <script>window.bad = true</script>
+        <img src="javascript:alert(1)" alt="bad">
+        <p style="background-image:url(javascript:alert(1)); color:#000000; line-height:1.8">safe</p>
+      `,
+    );
+
+    const template = document.createElement('template');
+    template.innerHTML = sanitized;
+
+    expect(template.content.querySelector('script')).toBeNull();
+    expect(template.content.querySelector('img')?.hasAttribute('src')).toBe(false);
+    const style = template.content.querySelector('p')?.getAttribute('style') ?? '';
+    expect(style).toContain('color: #000000');
+    expect(style).toContain('line-height: 1.8');
+    expect(style).not.toContain('background-image');
+    expect(style).not.toContain('javascript');
+  });
+});
+
+describe('hasEmbeddedDetailMedia', () => {
+  it('detects media embedded in SmartEditor HTML', () => {
+    expect(hasEmbeddedDetailMedia('<div><img src="/detail.jpg"></div>')).toBe(true);
+    expect(hasEmbeddedDetailMedia('<div><iframe src="https://example.com"></iframe></div>')).toBe(
+      true,
+    );
+    expect(hasEmbeddedDetailMedia('<p>텍스트만</p>')).toBe(false);
+  });
+});

--- a/src/lib/product-detail-html.ts
+++ b/src/lib/product-detail-html.ts
@@ -1,0 +1,190 @@
+type DomPurifyLike = {
+  sanitize: (html: string, options?: Record<string, unknown>) => string;
+};
+
+const ALLOWED_TAGS = [
+  'a',
+  'b',
+  'blockquote',
+  'br',
+  'caption',
+  'div',
+  'em',
+  'figcaption',
+  'figure',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'i',
+  'iframe',
+  'img',
+  'li',
+  'ol',
+  'p',
+  'source',
+  'span',
+  'strong',
+  'table',
+  'tbody',
+  'td',
+  'tfoot',
+  'th',
+  'thead',
+  'tr',
+  'u',
+  'ul',
+  'video',
+];
+
+const ALLOWED_ATTR = [
+  'allow',
+  'allowfullscreen',
+  'alt',
+  'class',
+  'colspan',
+  'controls',
+  'data-linkdata',
+  'data-linktype',
+  'frameborder',
+  'height',
+  'href',
+  'id',
+  'lang',
+  'loading',
+  'loop',
+  'muted',
+  'playsinline',
+  'poster',
+  'rel',
+  'rowspan',
+  'src',
+  'style',
+  'target',
+  'title',
+  'type',
+  'width',
+];
+
+const ALLOWED_STYLE_PROPERTIES = new Set([
+  'background-color',
+  'border',
+  'border-bottom',
+  'border-color',
+  'border-left',
+  'border-right',
+  'border-top',
+  'border-width',
+  'color',
+  'display',
+  'font-size',
+  'font-style',
+  'font-weight',
+  'height',
+  'letter-spacing',
+  'line-height',
+  'margin',
+  'margin-bottom',
+  'margin-left',
+  'margin-right',
+  'margin-top',
+  'max-width',
+  'min-height',
+  'padding',
+  'padding-bottom',
+  'padding-left',
+  'padding-right',
+  'padding-top',
+  'text-align',
+  'text-decoration',
+  'vertical-align',
+  'white-space',
+  'width',
+]);
+
+const URL_STYLE_PATTERN = /url\s*\(|expression\s*\(|javascript:|data:/i;
+const MEDIA_TAG_PATTERN = /<(img|iframe|video|source)\b/i;
+
+function sanitizeInlineStyle(style: string): string {
+  return style
+    .split(';')
+    .map((declaration) => declaration.trim())
+    .filter(Boolean)
+    .map((declaration) => {
+      const separator = declaration.indexOf(':');
+      if (separator === -1) return null;
+      const property = declaration.slice(0, separator).trim().toLowerCase();
+      const value = declaration.slice(separator + 1).trim();
+      if (!ALLOWED_STYLE_PROPERTIES.has(property)) return null;
+      if (!value || URL_STYLE_PATTERN.test(value)) return null;
+      return `${property}: ${value}`;
+    })
+    .filter((declaration): declaration is string => Boolean(declaration))
+    .join('; ');
+}
+
+function isSafeUrl(value: string | null): boolean {
+  if (!value) return true;
+  try {
+    const parsed = new URL(value, window.location.origin);
+    return (
+      parsed.protocol === 'http:' ||
+      parsed.protocol === 'https:' ||
+      (parsed.protocol === 'data:' && parsed.pathname.startsWith('image/'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function normalizeAfterSanitize(html: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+
+  template.content.querySelectorAll<HTMLElement>('[style]').forEach((element) => {
+    const sanitized = sanitizeInlineStyle(element.getAttribute('style') ?? '');
+    if (sanitized) element.setAttribute('style', sanitized);
+    else element.removeAttribute('style');
+  });
+
+  template.content.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((anchor) => {
+    if (!isSafeUrl(anchor.getAttribute('href'))) anchor.removeAttribute('href');
+    if (anchor.target === '_blank') anchor.rel = 'noopener noreferrer';
+  });
+
+  template.content
+    .querySelectorAll<HTMLImageElement | HTMLIFrameElement | HTMLVideoElement | HTMLSourceElement>(
+      'img[src], iframe[src], video[src], source[src]',
+    )
+    .forEach((element) => {
+      if (!isSafeUrl(element.getAttribute('src'))) element.removeAttribute('src');
+    });
+
+  template.content.querySelectorAll<HTMLIFrameElement>('iframe').forEach((iframe) => {
+    iframe.setAttribute('loading', iframe.getAttribute('loading') || 'lazy');
+    iframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
+  });
+
+  return template.innerHTML;
+}
+
+export function sanitizeProductDetailHtml(
+  DOMPurify: DomPurifyLike,
+  html: string | null | undefined,
+): string {
+  if (!html) return '';
+  const sanitized = DOMPurify.sanitize(html, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    ALLOW_DATA_ATTR: true,
+    ADD_ATTR: ['referrerpolicy'],
+  });
+  return normalizeAfterSanitize(sanitized);
+}
+
+export function hasEmbeddedDetailMedia(html: string | null | undefined): boolean {
+  return Boolean(html && MEDIA_TAG_PATTERN.test(html));
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -615,3 +615,96 @@ h3 {
 [data-sonner-progress-bar] {
   background-color: var(--color-primary) !important;
 }
+
+/* ── SmartStore/Naver SmartEditor detail HTML compatibility ─────── */
+.product-detail-html {
+  width: 100%;
+  overflow-wrap: anywhere;
+  font-family: var(--font-body);
+  font-size: var(--font-size-body-sm);
+  line-height: var(--line-height-body);
+  color: var(--color-foreground);
+}
+
+.product-detail-html .se-main-container,
+.product-detail-html .se-component,
+.product-detail-html .se-component-content,
+.product-detail-html .se-section,
+.product-detail-html .se-module {
+  max-width: 100%;
+}
+
+.product-detail-html .se-component {
+  margin-block: 0.75rem;
+}
+
+.product-detail-html p,
+.product-detail-html .se-text-paragraph {
+  margin: 0;
+  min-height: 1em;
+}
+
+.product-detail-html .se-text-paragraph-align-center,
+.product-detail-html .se-section-align-center {
+  text-align: center;
+}
+
+.product-detail-html .se-text-paragraph-align-left,
+.product-detail-html .se-section-align-left {
+  text-align: left;
+}
+
+.product-detail-html .se-text-paragraph-align-right,
+.product-detail-html .se-section-align-right {
+  text-align: right;
+}
+
+.product-detail-html .se-fs-fs11 { font-size: 0.6875rem; }
+.product-detail-html .se-fs-fs13 { font-size: 0.8125rem; }
+.product-detail-html .se-fs-fs15 { font-size: 0.9375rem; }
+.product-detail-html .se-fs-fs16 { font-size: 1rem; }
+.product-detail-html .se-fs-fs19 { font-size: 1.1875rem; }
+.product-detail-html .se-fs-fs24 { font-size: 1.5rem; }
+.product-detail-html .se-fs-fs28 { font-size: 1.75rem; }
+.product-detail-html .se-fs-fs30 { font-size: 1.875rem; }
+.product-detail-html .se-fs-fs34 { font-size: 2.125rem; }
+.product-detail-html .se-fs-fs38 { font-size: 2.375rem; }
+
+.product-detail-html .se-ff-system {
+  font-family: var(--font-body);
+}
+
+.product-detail-html b,
+.product-detail-html strong {
+  font-weight: 700;
+}
+
+.product-detail-html hr,
+.product-detail-html .se-hr {
+  width: min(100%, 42rem);
+  margin: 1.25rem auto;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.product-detail-html img,
+.product-detail-html video,
+.product-detail-html iframe,
+.product-detail-html .se-image-resource {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-inline: auto;
+}
+
+.product-detail-html iframe,
+.product-detail-html video {
+  width: min(100%, 56rem);
+  aspect-ratio: 16 / 9;
+  background: var(--color-muted);
+}
+
+.product-detail-html .se-module-image-link {
+  display: inline-block;
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary
- Closes #1001
- Preserve Naver SmartEditor/SmartStore detail HTML wrappers, se-* classes, safe inline styles, hr, images, iframe/video/source embeds.
- Render SmartEditor detail HTML in a scoped .product-detail-html container instead of Tailwind prose.
- Avoid duplicate/cropped extracted detail images when the description already embeds detail media.

## Verification
- npm run test:run
- npm run typecheck
- npm run lint
- npm run build
- bash scripts/codex-project-guard.sh