### PR TITLE
fix: #1010 리뷰 관리자 답글 컬럼 적용 보강

### DIFF
--- a/backend/src/database/__tests__/review-reply-migrations.spec.ts
+++ b/backend/src/database/__tests__/review-reply-migrations.spec.ts
@@ -1,0 +1,63 @@
+import { QueryRunner } from 'typeorm';
+import { AddReviewRepliesAndAttributeLinks1785500000000 } from '../migrations/1785500000000-AddReviewRepliesAndAttributeLinks';
+import { EnsureReviewReplyColumns1785500001000 } from '../migrations/1785500001000-EnsureReviewReplyColumns';
+
+describe('review reply migrations', () => {
+  function createQueryRunner(existingColumns = new Set<string>(), existingForeignKeys = new Set<string>()) {
+    const executed: string[] = [];
+    const query = jest.fn(async (sql: string, params?: unknown[]) => {
+      executed.push(sql);
+      if (sql.includes('INFORMATION_SCHEMA.COLUMNS')) {
+        const key = `${String(params?.[0])}.${String(params?.[1])}`;
+        return existingColumns.has(key) ? [{ COLUMN_NAME: String(params?.[1]) }] : [];
+      }
+      if (sql.includes('INFORMATION_SCHEMA.TABLE_CONSTRAINTS')) {
+        const key = `${String(params?.[0])}.${String(params?.[1])}`;
+        return existingForeignKeys.has(key) ? [{ CONSTRAINT_NAME: String(params?.[1]) }] : [];
+      }
+      return [];
+    });
+
+    return {
+      queryRunner: { query } as unknown as QueryRunner,
+      executed,
+    };
+  }
+
+  it('keeps the original mixed migration idempotent so review reply columns are not blocked', async () => {
+    const existingColumns = new Set(['attribute_types.parent_id', 'attribute_types.related_type_ids']);
+    const existingForeignKeys = new Set(['attribute_types.fk_attribute_types_parent']);
+    const { queryRunner, executed } = createQueryRunner(existingColumns, existingForeignKeys);
+
+    await new AddReviewRepliesAndAttributeLinks1785500000000().up(queryRunner);
+
+    expect(executed.some((sql) => sql.includes('ADD COLUMN `parent_id`'))).toBe(false);
+    expect(executed.some((sql) => sql.includes('ADD CONSTRAINT `fk_attribute_types_parent`'))).toBe(false);
+    expect(executed).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('ALTER TABLE `reviews` ADD COLUMN `admin_reply_content`'),
+        expect.stringContaining('ALTER TABLE `external_reviews` ADD COLUMN `admin_reply_content`'),
+      ]),
+    );
+  });
+
+  it('adds missing review reply columns as a forward-only safety net', async () => {
+    const existingColumns = new Set([
+      'reviews.admin_reply_content',
+      'reviews.admin_reply_author',
+      'reviews.admin_replied_at',
+    ]);
+    const { queryRunner, executed } = createQueryRunner(existingColumns);
+
+    await new EnsureReviewReplyColumns1785500001000().up(queryRunner);
+
+    expect(executed.some((sql) => sql.includes('ALTER TABLE `reviews` ADD COLUMN'))).toBe(false);
+    expect(executed).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('ALTER TABLE `external_reviews` ADD COLUMN `admin_reply_content`'),
+        expect.stringContaining('ALTER TABLE `external_reviews` ADD COLUMN `admin_reply_author`'),
+        expect.stringContaining('ALTER TABLE `external_reviews` ADD COLUMN `admin_replied_at`'),
+      ]),
+    );
+  });
+});

--- a/backend/src/database/migrations/1785500000000-AddReviewRepliesAndAttributeLinks.ts
+++ b/backend/src/database/migrations/1785500000000-AddReviewRepliesAndAttributeLinks.ts
@@ -4,35 +4,132 @@ export class AddReviewRepliesAndAttributeLinks1785500000000 implements Migration
   name = 'AddReviewRepliesAndAttributeLinks1785500000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`
-      ALTER TABLE attribute_types
-      ADD COLUMN parent_id int NULL,
-      ADD COLUMN related_type_ids json NULL
-    `);
-    await queryRunner.query(`
-      ALTER TABLE attribute_types
-      ADD CONSTRAINT fk_attribute_types_parent
-      FOREIGN KEY (parent_id) REFERENCES attribute_types(id)
-      ON DELETE SET NULL
-    `);
-    await queryRunner.query(`
-      ALTER TABLE reviews
-      ADD COLUMN admin_reply_content text NULL,
-      ADD COLUMN admin_reply_author varchar(100) NULL,
-      ADD COLUMN admin_replied_at datetime NULL
-    `);
-    await queryRunner.query(`
-      ALTER TABLE external_reviews
-      ADD COLUMN admin_reply_content text NULL,
-      ADD COLUMN admin_reply_author varchar(100) NULL,
-      ADD COLUMN admin_replied_at datetime NULL
-    `);
+    await this.addColumnIfMissing(queryRunner, 'attribute_types', 'parent_id', '`parent_id` int NULL');
+    await this.addColumnIfMissing(
+      queryRunner,
+      'attribute_types',
+      'related_type_ids',
+      '`related_type_ids` json NULL',
+    );
+    await this.addForeignKeyIfMissing(
+      queryRunner,
+      'attribute_types',
+      'fk_attribute_types_parent',
+      `ALTER TABLE \`attribute_types\`
+       ADD CONSTRAINT \`fk_attribute_types_parent\`
+       FOREIGN KEY (\`parent_id\`) REFERENCES \`attribute_types\`(\`id\`)
+       ON DELETE SET NULL`,
+    );
+
+    await this.addReviewReplyColumns(queryRunner, 'reviews');
+    await this.addReviewReplyColumns(queryRunner, 'external_reviews');
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query('ALTER TABLE external_reviews DROP COLUMN admin_replied_at, DROP COLUMN admin_reply_author, DROP COLUMN admin_reply_content');
-    await queryRunner.query('ALTER TABLE reviews DROP COLUMN admin_replied_at, DROP COLUMN admin_reply_author, DROP COLUMN admin_reply_content');
-    await queryRunner.query('ALTER TABLE attribute_types DROP FOREIGN KEY fk_attribute_types_parent');
-    await queryRunner.query('ALTER TABLE attribute_types DROP COLUMN related_type_ids, DROP COLUMN parent_id');
+    await this.dropColumnIfExists(queryRunner, 'external_reviews', 'admin_replied_at');
+    await this.dropColumnIfExists(queryRunner, 'external_reviews', 'admin_reply_author');
+    await this.dropColumnIfExists(queryRunner, 'external_reviews', 'admin_reply_content');
+    await this.dropColumnIfExists(queryRunner, 'reviews', 'admin_replied_at');
+    await this.dropColumnIfExists(queryRunner, 'reviews', 'admin_reply_author');
+    await this.dropColumnIfExists(queryRunner, 'reviews', 'admin_reply_content');
+    await this.dropForeignKeyIfExists(queryRunner, 'attribute_types', 'fk_attribute_types_parent');
+    await this.dropColumnIfExists(queryRunner, 'attribute_types', 'related_type_ids');
+    await this.dropColumnIfExists(queryRunner, 'attribute_types', 'parent_id');
+  }
+
+  private async addReviewReplyColumns(queryRunner: QueryRunner, tableName: string): Promise<void> {
+    await this.addColumnIfMissing(
+      queryRunner,
+      tableName,
+      'admin_reply_content',
+      '`admin_reply_content` text NULL',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      tableName,
+      'admin_reply_author',
+      '`admin_reply_author` varchar(100) NULL',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      tableName,
+      'admin_replied_at',
+      '`admin_replied_at` datetime NULL',
+    );
+  }
+
+  private async addColumnIfMissing(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+    definition: string,
+  ): Promise<void> {
+    if (!(await this.columnExists(queryRunner, tableName, columnName))) {
+      await queryRunner.query(`ALTER TABLE \`${tableName}\` ADD COLUMN ${definition}`);
+    }
+  }
+
+  private async dropColumnIfExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+  ): Promise<void> {
+    if (await this.columnExists(queryRunner, tableName, columnName)) {
+      await queryRunner.query(`ALTER TABLE \`${tableName}\` DROP COLUMN \`${columnName}\``);
+    }
+  }
+
+  private async addForeignKeyIfMissing(
+    queryRunner: QueryRunner,
+    tableName: string,
+    constraintName: string,
+    statement: string,
+  ): Promise<void> {
+    if (!(await this.foreignKeyExists(queryRunner, tableName, constraintName))) {
+      await queryRunner.query(statement);
+    }
+  }
+
+  private async dropForeignKeyIfExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    constraintName: string,
+  ): Promise<void> {
+    if (await this.foreignKeyExists(queryRunner, tableName, constraintName)) {
+      await queryRunner.query(`ALTER TABLE \`${tableName}\` DROP FOREIGN KEY \`${constraintName}\``);
+    }
+  }
+
+  private async columnExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+  ): Promise<boolean> {
+    const [row] = (await queryRunner.query(
+      `SELECT COLUMN_NAME
+       FROM INFORMATION_SCHEMA.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_NAME = ?
+         AND COLUMN_NAME = ?`,
+      [tableName, columnName],
+    )) as Array<{ COLUMN_NAME: string }>;
+    return Boolean(row);
+  }
+
+  private async foreignKeyExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    constraintName: string,
+  ): Promise<boolean> {
+    const [row] = (await queryRunner.query(
+      `SELECT CONSTRAINT_NAME
+       FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_NAME = ?
+         AND CONSTRAINT_NAME = ?
+         AND CONSTRAINT_TYPE = 'FOREIGN KEY'`,
+      [tableName, constraintName],
+    )) as Array<{ CONSTRAINT_NAME: string }>;
+    return Boolean(row);
   }
 }

--- a/backend/src/database/migrations/1785500001000-EnsureReviewReplyColumns.ts
+++ b/backend/src/database/migrations/1785500001000-EnsureReviewReplyColumns.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EnsureReviewReplyColumns1785500001000 implements MigrationInterface {
+  name = 'EnsureReviewReplyColumns1785500001000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.addReplyColumns(queryRunner, 'reviews');
+    await this.addReplyColumns(queryRunner, 'external_reviews');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Forward-only safety net. The original 1785500000000 migration owns these columns;
+    // this migration only guarantees their existence when older environments missed them.
+    void queryRunner;
+  }
+
+  private async addReplyColumns(queryRunner: QueryRunner, tableName: string): Promise<void> {
+    await this.addColumnIfMissing(
+      queryRunner,
+      tableName,
+      'admin_reply_content',
+      '`admin_reply_content` text NULL',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      tableName,
+      'admin_reply_author',
+      '`admin_reply_author` varchar(100) NULL',
+    );
+    await this.addColumnIfMissing(
+      queryRunner,
+      tableName,
+      'admin_replied_at',
+      '`admin_replied_at` datetime NULL',
+    );
+  }
+
+  private async addColumnIfMissing(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+    definition: string,
+  ): Promise<void> {
+    if (!(await this.columnExists(queryRunner, tableName, columnName))) {
+      await queryRunner.query(`ALTER TABLE \`${tableName}\` ADD COLUMN ${definition}`);
+    }
+  }
+
+  private async columnExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+  ): Promise<boolean> {
+    const [row] = (await queryRunner.query(
+      `SELECT COLUMN_NAME
+       FROM INFORMATION_SCHEMA.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_NAME = ?
+         AND COLUMN_NAME = ?`,
+      [tableName, columnName],
+    )) as Array<{ COLUMN_NAME: string }>;
+    return Boolean(row);
+  }
+}

--- a/backend/src/modules/reviews/__tests__/admin-reviews.service.spec.ts
+++ b/backend/src/modules/reviews/__tests__/admin-reviews.service.spec.ts
@@ -174,4 +174,63 @@ describe('AdminReviewsService', () => {
     expect(result.adminReplyContent).toBe('감사합니다');
   });
 
+  it('saves and clears replies for external reviews by default', async () => {
+    const review = {
+      id: 5,
+      source: 'smartstore',
+      externalReviewId: '5008298806',
+      externalProductId: '13629303355',
+      productId: 9,
+      product: { id: 9, name: '상품', sku: 'SKU-9' },
+      reviewType: '일반',
+      rating: 5,
+      content: '좋아요',
+      reviewerNameMasked: 'da**',
+      helpfulCount: 0,
+      imageUrls: null,
+      mediaAssets: [],
+      sourceDisplayStatus: null,
+      isVisible: true,
+      isBest: false,
+      reviewedAt: new Date('2026-01-01T00:00:00.000Z'),
+      sourceUpdatedAt: null,
+      lastSyncedAt: new Date('2026-01-02T00:00:00.000Z'),
+      importBatchId: null,
+      orderNo: null,
+      relatedReviewExternalId: null,
+      relatedReviewContent: null,
+      adminReplyContent: null,
+      adminReplyAuthor: null,
+      adminRepliedAt: null,
+    } as unknown as ExternalReview;
+    externalReviewRepository.findOne.mockResolvedValue(review);
+    externalReviewRepository.save.mockImplementation(async (entity: unknown) => entity as ExternalReview);
+
+    const saved = await service.setReply(5, ' 답글입니다 ', '관리자', 'smartstore');
+
+    expect(externalReviewRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 5 },
+      relations: ['product'],
+    });
+    expect(externalReviewRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adminReplyContent: '답글입니다',
+        adminReplyAuthor: '관리자',
+        adminRepliedAt: expect.any(Date),
+      }),
+    );
+    expect(saved.adminReplyContent).toBe('답글입니다');
+
+    const cleared = await service.setReply(5, '   ', '관리자', 'smartstore');
+
+    expect(externalReviewRepository.save).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        adminReplyContent: null,
+        adminReplyAuthor: null,
+        adminRepliedAt: null,
+      }),
+    );
+    expect(cleared.adminReplyContent).toBeNull();
+  });
+
 });

--- a/src/app/[locale]/admin/reviews/__tests__/AdminReviewsPage.test.tsx
+++ b/src/app/[locale]/admin/reviews/__tests__/AdminReviewsPage.test.tsx
@@ -6,6 +6,7 @@ import type { AdminReviewItem } from '@/lib/api';
 const mockUseAdminGuard = vi.fn();
 const mockGetList = vi.fn();
 const mockSetVisibility = vi.fn();
+const mockSetReply = vi.fn();
 const mockBulkSetVisibility = vi.fn();
 const mockPreviewSmartStoreImport = vi.fn();
 const mockCommitSmartStoreImport = vi.fn();
@@ -38,6 +39,7 @@ vi.mock('@/lib/api', () => ({
   adminReviewsApi: {
     getList: (...args: unknown[]) => mockGetList(...args),
     setVisibility: (...args: unknown[]) => mockSetVisibility(...args),
+    setReply: (...args: unknown[]) => mockSetReply(...args),
     bulkSetVisibility: (...args: unknown[]) => mockBulkSetVisibility(...args),
     previewSmartStoreImport: (...args: unknown[]) => mockPreviewSmartStoreImport(...args),
     commitSmartStoreImport: (...args: unknown[]) => mockCommitSmartStoreImport(...args),
@@ -88,6 +90,13 @@ describe('AdminReviewsPage', () => {
     });
     mockGetList.mockResolvedValue({ items: [makeReview()], total: 1, page: 1, limit: 20 });
     mockSetVisibility.mockResolvedValue(makeReview({ isVisible: false }));
+    mockSetReply.mockResolvedValue(
+      makeReview({
+        adminReplyContent: '소중한 후기 감사합니다.',
+        adminReplyAuthor: '옥화당',
+        adminRepliedAt: '2026-07-05T00:00:00.000Z',
+      }),
+    );
     mockBulkSetVisibility.mockResolvedValue({ updated: 1 });
     mockPreviewSmartStoreImport.mockResolvedValue({
       importBatchId: null,
@@ -286,6 +295,26 @@ describe('AdminReviewsPage', () => {
       expect(mockBulkSetVisibility).toHaveBeenCalledWith(
         [{ id: 1, source: 'naver-smartstore' }],
         false,
+      );
+    });
+  });
+
+  it('saves an admin reply for the selected review with its source', async () => {
+    render(<AdminReviewsPage />);
+    await screen.findByText('아주 좋아요');
+
+    fireEvent.click(screen.getByRole('button', { name: 'actions.detail' }));
+    fireEvent.change(screen.getByPlaceholderText('reply.placeholder'), {
+      target: { value: '소중한 후기 감사합니다.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'reply.save' }));
+
+    await waitFor(() => {
+      expect(mockSetReply).toHaveBeenCalledWith(
+        1,
+        '소중한 후기 감사합니다.',
+        undefined,
+        'naver-smartstore',
       );
     });
   });


### PR DESCRIPTION
## Summary
- 관리자 리뷰 답글 기능의 미적용 원인을 확인했습니다: API/UI는 존재했지만 댓글 컬럼 추가 migration이 attribute_types 변경과 비멱등으로 묶여, 일부 환경에서 선행 컬럼/FK가 있으면 migration이 중단되어 reply 컬럼이 적용되지 않을 수 있었습니다.
- 기존 `1785500000000` migration을 idempotent하게 보강했습니다.
- 이미 지나간 환경에서도 `reviews`/`external_reviews` 답글 컬럼 존재를 보장하는 forward-only 안전망 migration을 추가했습니다.
- 관리자 답글 저장 UI 호출, 내부/외부 리뷰 답글 저장·삭제, migration 멱등성을 회귀 테스트로 고정했습니다.

Closes #1010

## Verification
- `bash scripts/codex-project-guard.sh`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `bash scripts/test.sh e2e`
- `npm run lint && cd backend && npm run lint`

## Notes
- `cd backend && npm run test:e2e`는 직접 실행 시 `TEST_DATABASE_URL or DATABASE_URL is required`로 실패하므로, 프로젝트 테스트 스크립트인 `bash scripts/test.sh e2e`로 테스트 MySQL을 기동해 통과 확인했습니다.
- 운영 DB에는 PR 병합 후 backend migration 실행이 필요합니다.
