### PR TITLE
feat: #1011 기존 상품 속성값 선택 UI 추가

### DIFF
--- a/src/components/shared/admin/ProductFormPage.tsx
+++ b/src/components/shared/admin/ProductFormPage.tsx
@@ -119,6 +119,31 @@ function buildNoticeInfoPayload(
   ) as ProductNoticeInfo;
 }
 
+function uniqueAttributeValues(values: Array<string | null | undefined>): string[] {
+  return Array.from(
+    new Set(values.map((value) => value?.trim() ?? '').filter((value) => value.length > 0)),
+  );
+}
+
+async function loadAttributeValueOptions(
+  attributeTypes: AttributeType[],
+): Promise<Record<string, string[]>> {
+  const settledValues = await Promise.allSettled(
+    attributeTypes.map((type) => attributesApi.getTypeValues(type.code)),
+  );
+
+  return Object.fromEntries(
+    attributeTypes.map((type, index) => {
+      const remoteValues = settledValues[index];
+      const existingValues = remoteValues?.status === 'fulfilled' ? remoteValues.value : [];
+      return [
+        String(type.id),
+        uniqueAttributeValues([...(type.validValues ?? []), ...existingValues]),
+      ] as const;
+    }),
+  );
+}
+
 function NoticeInfoSection({ noticeInfo, set }: { noticeInfo: ProductNoticeInfo; set: Setter }) {
   const updateNoticeInfo = (key: NoticeInfoKey, value: string) => {
     if (key === 'type') {
@@ -393,12 +418,15 @@ function VisibilitySection({
 function ProductAttributesSection({
   attributes,
   attributeTypes,
+  attributeValueOptions,
   set,
 }: {
   attributes: ProductAttributeDraft[];
   attributeTypes: AttributeType[];
+  attributeValueOptions: Record<string, string[]>;
   set: Setter;
 }) {
+  const t = useTranslations('admin.productForm');
   const typeOptions = attributeTypes.map((type) => ({
     value: String(type.id),
     label: `${type.name} (${type.code})`,
@@ -411,10 +439,27 @@ function ProductAttributesSection({
     );
   };
 
+  const selectExistingValue = (index: number, value: string) => {
+    set(
+      'attributes',
+      attributes.map((attr, i) => {
+        if (i !== index) return attr;
+        return {
+          ...attr,
+          value,
+          displayValue: value,
+        };
+      }),
+    );
+  };
+
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold">상품 속성</h2>
+        <div>
+          <h2 className="text-sm font-semibold">상품 속성</h2>
+          <p className="mt-1 text-xs text-muted-foreground">{t('attributePickerHelp')}</p>
+        </div>
         <button
           type="button"
           onClick={() =>
@@ -426,43 +471,72 @@ function ProductAttributesSection({
         </button>
       </div>
       {attributes.length === 0 && <p className="text-sm text-muted-foreground">속성이 없습니다.</p>}
-      {attributes.map((attribute, index) => (
-        <div
-          key={index}
-          className="grid gap-2 rounded-lg border p-3 md:grid-cols-[1fr_1fr_1fr_auto]"
-        >
-          <SelectField
-            label="속성"
-            value={attribute.attributeTypeId}
-            onChange={(value) => update(index, 'attributeTypeId', value)}
-            options={[{ value: '', label: '선택' }, ...typeOptions]}
-          />
-          <TextField
-            label="값"
-            value={attribute.value}
-            onChange={(value) => update(index, 'value', value)}
-            placeholder="zhuni"
-          />
-          <TextField
-            label="표시값"
-            value={attribute.displayValue}
-            onChange={(value) => update(index, 'displayValue', value)}
-            placeholder="주니"
-          />
-          <button
-            type="button"
-            onClick={() =>
-              set(
-                'attributes',
-                attributes.filter((_, i) => i !== index),
-              )
-            }
-            className="self-end rounded px-3 py-2 text-sm text-destructive hover:bg-destructive/10"
-          >
-            삭제
-          </button>
-        </div>
-      ))}
+      {attributes.map((attribute, index) => {
+        const existingValues = attributeValueOptions[attribute.attributeTypeId] ?? [];
+        return (
+          <div key={index} className="space-y-3 rounded-lg border p-3">
+            <div className="grid gap-2 md:grid-cols-[1fr_1fr_1fr_auto]">
+              <SelectField
+                label="속성"
+                value={attribute.attributeTypeId}
+                onChange={(value) => update(index, 'attributeTypeId', value)}
+                options={[{ value: '', label: '선택' }, ...typeOptions]}
+              />
+              <TextField
+                label="값"
+                value={attribute.value}
+                onChange={(value) => update(index, 'value', value)}
+                placeholder="zhuni"
+              />
+              <TextField
+                label="표시값"
+                value={attribute.displayValue}
+                onChange={(value) => update(index, 'displayValue', value)}
+                placeholder="주니"
+              />
+              <button
+                type="button"
+                onClick={() =>
+                  set(
+                    'attributes',
+                    attributes.filter((_, i) => i !== index),
+                  )
+                }
+                className="self-end rounded px-3 py-2 text-sm text-destructive hover:bg-destructive/10"
+              >
+                삭제
+              </button>
+            </div>
+            {attribute.attributeTypeId && existingValues.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-muted-foreground">
+                  {t('existingAttributeValues')}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {existingValues.map((value) => {
+                    const selected = attribute.value === value;
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => selectExistingValue(index, value)}
+                        className={
+                          selected
+                            ? 'rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground'
+                            : 'rounded-full border px-3 py-1 text-xs hover:bg-secondary'
+                        }
+                        aria-pressed={selected}
+                      >
+                        {value}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </section>
   );
 }
@@ -472,6 +546,7 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
   const [submitting, setSubmitting] = useState(false);
   const [categories, setCategories] = useState<AdminCategory[]>([]);
   const [attributeTypes, setAttributeTypes] = useState<AttributeType[]>([]);
+  const [attributeValueOptions, setAttributeValueOptions] = useState<Record<string, string[]>>({});
   const hadNoticeInfo = product?.noticeInfo != null;
   const [form, setForm] = useState<ProductFormData>({
     categoryId: product?.category?.id != null ? String(product.category.id) : '',
@@ -513,10 +588,12 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
   useEffect(() => {
     let cancelled = false;
     Promise.all([adminCategoriesApi.getAll(), attributesApi.getTypes()])
-      .then(([categoryItems, attributeItems]) => {
+      .then(async ([categoryItems, attributeItems]) => {
+        const valueOptions = await loadAttributeValueOptions(attributeItems);
         if (cancelled) return;
         setCategories(categoryItems);
         setAttributeTypes(attributeItems);
+        setAttributeValueOptions(valueOptions);
       })
       .catch((err: unknown) => {
         toast.error(handleApiError(err, toastMessage('productMetaLoadError')));
@@ -625,6 +702,7 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
         <ProductAttributesSection
           attributes={form.attributes}
           attributeTypes={attributeTypes}
+          attributeValueOptions={attributeValueOptions}
           set={set}
         />
 

--- a/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/lib/api', () => ({
   },
   attributesApi: {
     getTypes: vi.fn().mockResolvedValue([]),
+    getTypeValues: vi.fn().mockResolvedValue([]),
   },
   uploadApi: {
     uploadImage: vi.fn(),
@@ -119,6 +120,79 @@ describe('ProductFormPage', () => {
           }),
         );
       });
+    });
+
+    it('기존 속성 값을 태그처럼 선택해서 상품 속성 payload에 포함한다', async () => {
+      const { adminProductsApi, attributesApi } = await import('@/lib/api');
+      vi.mocked(attributesApi.getTypes).mockResolvedValue([
+        {
+          id: 1,
+          code: 'clay_type',
+          name: '니료',
+          nameKo: '니료',
+          nameEn: 'Clay type',
+          inputType: 'select',
+          isFilterable: true,
+          isSearchable: true,
+          validValues: ['hongni', 'zhuni'],
+          parentId: null,
+          relatedTypeIds: null,
+          sortOrder: 0,
+          isActive: true,
+        },
+      ]);
+      vi.mocked(attributesApi.getTypeValues).mockResolvedValue(['zhuni', 'duanni']);
+      vi.mocked(adminProductsApi.create).mockResolvedValue({
+        id: 1,
+        name: '테스트 상품',
+        slug: 'test-product',
+        price: 10000,
+        salePrice: null,
+        status: 'draft',
+        isFeatured: false,
+        viewCount: 0,
+        category: null,
+        images: [],
+        description: null,
+        shortDescription: null,
+        rating: 0,
+        reviewCount: 0,
+        stock: 0,
+        sku: null,
+        options: [],
+        detailImages: [],
+        noticeInfo: null,
+      });
+
+      render(<ProductFormPage mode="create" />);
+
+      await waitFor(() => expect(attributesApi.getTypeValues).toHaveBeenCalledWith('clay_type'));
+      fireEvent.click(screen.getByText('+ 속성 추가'));
+      fireEvent.change(screen.getByDisplayValue('선택'), { target: { value: '1' } });
+      fireEvent.click(screen.getByText('duanni'));
+
+      fireEvent.change(screen.getByPlaceholderText('상품명을 입력하세요'), {
+        target: { value: '테스트 상품' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('url-friendly-slug'), {
+        target: { value: 'test-product' },
+      });
+      fireEvent.change(screen.getAllByRole('spinbutton')[0], { target: { value: '10000' } });
+      fireEvent.click(screen.getByText('등록하기'));
+
+      await waitFor(() => expect(adminProductsApi.create).toHaveBeenCalled());
+      expect(adminProductsApi.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: [
+            {
+              attributeTypeId: 1,
+              value: 'duanni',
+              displayValue: 'duanni',
+              sortOrder: 0,
+            },
+          ],
+        }),
+      );
     });
 
     it('무료배송 상품 체크 시 create payload에 isFreeShipping=true를 포함한다', async () => {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -882,7 +882,9 @@
         "slugRequired": "Please enter a slug.",
         "priceRequired": "Please enter a valid price."
       },
-      "freeShippingProduct": "Free-shipping product"
+      "freeShippingProduct": "Free-shipping product",
+      "attributePickerHelp": "Choose an existing value like a tag, or type a new value to save it.",
+      "existingAttributeValues": "Existing attribute values"
     },
     "members": {
       "title": "Member Management",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -882,7 +882,9 @@
         "slugRequired": "슬러그를 입력해주세요.",
         "priceRequired": "가격을 올바르게 입력해주세요."
       },
-      "freeShippingProduct": "무료배송 상품"
+      "freeShippingProduct": "무료배송 상품",
+      "attributePickerHelp": "기존 값은 태그처럼 선택하고, 없으면 직접 입력해 새 값으로 저장하세요.",
+      "existingAttributeValues": "기존 속성 값"
     },
     "members": {
       "title": "회원 관리",


### PR DESCRIPTION
## Summary
- 상품 등록/수정 폼에서 속성 타입별 기존 값(validValues + 실제 사용 값)을 불러와 태그형 선택지로 노출
- 기존 값을 클릭하면 값/표시값이 채워지고, 목록에 없는 값은 기존 입력 필드로 직접 추가 가능
- 상품 속성 선택 흐름 테스트 및 ko/en locale 문구 추가

Closes #1011

## Verification
- `npx vitest run src/components/shared/admin/__tests__/ProductFormPage.test.tsx`
- `bash scripts/codex-project-guard.sh && npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `bash scripts/start-local.sh`
- `curl -fsS http://localhost:3000/api/health`
- `curl -fsSI http://localhost:5173/ko`
- `curl -fsSI http://localhost:5173/ko/admin/products/new` (auth redirect 확인)

## Notes
- DB/entity 변경 없음. backend e2e는 생략했습니다.
- 관리자 인증 세션으로 브라우저 수동 클릭 검증은 수행하지 않았습니다.
