### PR TITLE
hotfix: force product detail content centered

### DIFF
--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -216,11 +216,11 @@ export default function ProductTabs({ description, descriptionImages, productId,
         {activeTab === 'details' && (
           <div className="flex flex-col gap-6">
             {descriptionImages.length > 0 && !descriptionContainsEmbeddedMedia && (
-              <div className="flex flex-col gap-0">
+              <div className="flex flex-col items-center gap-0">
                 {descriptionImages.map((image, index) => (
                   <div
                     key={image.id}
-                    className="relative w-full overflow-hidden bg-muted"
+                    className="relative w-full max-w-4xl overflow-hidden bg-muted"
                     style={{ aspectRatio: '3/2' }}
                   >
                     <Image

--- a/src/components/shared/products/__tests__/ProductTabs.test.tsx
+++ b/src/components/shared/products/__tests__/ProductTabs.test.tsx
@@ -77,6 +77,7 @@ describe('ProductTabs SmartEditor detail HTML', () => {
 
     await screen.findByText('연자호');
 
+    expect(document.querySelector('.product-detail-html')).toBeTruthy();
     const paragraph = document.querySelector('.se-text-paragraph-align-center');
     expect(paragraph).toBeTruthy();
     expect(paragraph?.getAttribute('style')).toContain('line-height: 1.8');
@@ -107,5 +108,7 @@ describe('ProductTabs SmartEditor detail HTML', () => {
       expect(screen.getByText('텍스트 설명')).toBeInTheDocument();
     });
     expect(screen.getByAltText('separate detail image')).toBeInTheDocument();
+    expect(screen.getByAltText('separate detail image').closest('.relative')).toHaveClass('max-w-4xl');
+    expect(screen.getByAltText('separate detail image').closest('.flex')).toHaveClass('items-center');
   });
 });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -624,6 +624,7 @@ h3 {
   font-size: var(--font-size-body-sm);
   line-height: var(--line-height-body);
   color: var(--color-foreground);
+  text-align: center;
 }
 
 .product-detail-html .se-main-container,
@@ -632,6 +633,8 @@ h3 {
 .product-detail-html .se-section,
 .product-detail-html .se-module {
   max-width: 100%;
+  margin-inline: auto;
+  text-align: center;
 }
 
 .product-detail-html .se-component {
@@ -650,13 +653,10 @@ h3 {
 }
 
 .product-detail-html .se-text-paragraph-align-left,
-.product-detail-html .se-section-align-left {
-  text-align: left;
-}
-
+.product-detail-html .se-section-align-left,
 .product-detail-html .se-text-paragraph-align-right,
 .product-detail-html .se-section-align-right {
-  text-align: right;
+  text-align: center;
 }
 
 .product-detail-html .se-fs-fs11 { font-size: 0.6875rem; }
@@ -707,4 +707,6 @@ h3 {
 .product-detail-html .se-module-image-link {
   display: inline-block;
   max-width: 100%;
+  margin-inline: auto;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- Force product detail SmartEditor HTML scope to center text/media by default.
- Override SmartEditor left/right alignment classes to center in product detail rendering.
- Center fallback extracted detail images and constrain them to the same visual column.

## Verification
- npm run test:run -- src/components/shared/products/__tests__/ProductTabs.test.tsx src/components/__tests__/ProductTabs.test.tsx
- npm run typecheck
- npm run lint
- npm run build
- bash scripts/codex-project-guard.sh