### PR TITLE
fix: #1015 상품상세 관리자 리뷰 답글 UX 개선

### DIFF
--- a/src/app/[locale]/admin/reviews/__tests__/AdminReviewsPage.test.tsx
+++ b/src/app/[locale]/admin/reviews/__tests__/AdminReviewsPage.test.tsx
@@ -284,6 +284,19 @@ describe('AdminReviewsPage', () => {
     expect(screen.getAllByText('table.noContent')).toHaveLength(2);
   });
 
+  it('shows selected review details above the review table', async () => {
+    render(<AdminReviewsPage />);
+    await screen.findByText('아주 좋아요');
+
+    fireEvent.click(screen.getByRole('button', { name: 'actions.detail' }));
+
+    const detailTitle = await screen.findByText('detail.title:{\"id\":\"5008298806\"}');
+    const tableHeader = screen.getByText('table.product');
+    expect(
+      Boolean(detailTitle.compareDocumentPosition(tableHeader) & Node.DOCUMENT_POSITION_FOLLOWING),
+    ).toBe(true);
+  });
+
   it('bulk hides selected reviews through the admin API', async () => {
     render(<AdminReviewsPage />);
     await screen.findByText('아주 좋아요');

--- a/src/app/[locale]/admin/reviews/page.tsx
+++ b/src/app/[locale]/admin/reviews/page.tsx
@@ -470,6 +470,100 @@ export default function AdminReviewsPage() {
         </div>
       </section>
 
+      {selectedReview && (
+        <section className="rounded-lg border bg-card p-4 shadow-sm">
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <h2 className="typo-body font-semibold">
+              {t('detail.title', { id: selectedReview.externalReviewId })}
+            </h2>
+            <button
+              type="button"
+              onClick={() => setSelectedReview(null)}
+              className="rounded border px-3 py-1 typo-body-sm hover:bg-secondary"
+            >
+              {t('detail.close')}
+            </button>
+          </div>
+          <dl className="grid gap-3 typo-body-sm md:grid-cols-2">
+            <DetailItem
+              label={t('detail.product')}
+              value={selectedReview.product?.name ?? t('table.unmatchedProduct')}
+            />
+            <DetailItem
+              label={t('detail.orderNo')}
+              value={selectedReview.orderNo ?? t('emptyValue')}
+            />
+            <DetailItem
+              label={t('detail.reviewType')}
+              value={selectedReview.reviewType ?? t('emptyValue')}
+            />
+            <DetailItem
+              label={t('detail.helpfulCount')}
+              value={String(selectedReview.helpfulCount)}
+            />
+            <DetailItem
+              label={t('detail.sourceDisplayStatus')}
+              value={selectedReview.sourceDisplayStatus ?? t('emptyValue')}
+            />
+            <DetailItem
+              label={t('detail.importBatchId')}
+              value={selectedReview.importBatchId ?? t('emptyValue')}
+            />
+          </dl>
+          <div className="mt-4 space-y-2">
+            <h3 className="typo-label text-muted-foreground">{t('detail.content')}</h3>
+            <p className="whitespace-pre-wrap rounded border bg-background p-3 typo-body-sm">
+              {selectedReview.content ?? t('table.noContent')}
+            </p>
+          </div>
+          {selectedReview.relatedReviewContent && (
+            <div className="mt-4 space-y-2">
+              <h3 className="typo-label text-muted-foreground">{t('detail.relatedContent')}</h3>
+              <p className="whitespace-pre-wrap rounded border bg-background p-3 typo-body-sm">
+                {selectedReview.relatedReviewContent}
+              </p>
+            </div>
+          )}
+          <div className="mt-4 space-y-2">
+            <h3 className="typo-label text-muted-foreground">{t('reply.title')}</h3>
+            <textarea
+              value={replyContent}
+              onChange={(event) => setReplyContent(event.target.value)}
+              rows={4}
+              className="w-full rounded border bg-background p-3 typo-body-sm"
+              placeholder={t('reply.placeholder')}
+            />
+            <button
+              type="button"
+              onClick={() => void saveReply()}
+              disabled={savingReply}
+              className="rounded bg-primary px-4 py-2 typo-body-sm text-primary-foreground disabled:opacity-50"
+            >
+              {t('reply.save')}
+            </button>
+          </div>
+          {selectedReview.imageUrls && selectedReview.imageUrls.length > 0 && (
+            <div className="mt-4 space-y-2">
+              <h3 className="typo-label text-muted-foreground">{t('detail.media')}</h3>
+              <ul className="space-y-1 typo-body-sm">
+                {selectedReview.imageUrls.map((url) => (
+                  <li key={url}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary underline-offset-2 hover:underline"
+                    >
+                      {url}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+      )}
+
       <PaginatedAdminTableShell
         loading={loading}
         loadingMessage={t('loading')}
@@ -594,99 +688,7 @@ export default function AdminReviewsPage() {
         </div>
       </PaginatedAdminTableShell>
 
-      {selectedReview && (
-        <section className="rounded-lg border bg-card p-4 shadow-sm">
-          <div className="mb-3 flex items-center justify-between gap-2">
-            <h2 className="typo-body font-semibold">
-              {t('detail.title', { id: selectedReview.externalReviewId })}
-            </h2>
-            <button
-              type="button"
-              onClick={() => setSelectedReview(null)}
-              className="rounded border px-3 py-1 typo-body-sm hover:bg-secondary"
-            >
-              {t('detail.close')}
-            </button>
-          </div>
-          <dl className="grid gap-3 typo-body-sm md:grid-cols-2">
-            <DetailItem
-              label={t('detail.product')}
-              value={selectedReview.product?.name ?? t('table.unmatchedProduct')}
-            />
-            <DetailItem
-              label={t('detail.orderNo')}
-              value={selectedReview.orderNo ?? t('emptyValue')}
-            />
-            <DetailItem
-              label={t('detail.reviewType')}
-              value={selectedReview.reviewType ?? t('emptyValue')}
-            />
-            <DetailItem
-              label={t('detail.helpfulCount')}
-              value={String(selectedReview.helpfulCount)}
-            />
-            <DetailItem
-              label={t('detail.sourceDisplayStatus')}
-              value={selectedReview.sourceDisplayStatus ?? t('emptyValue')}
-            />
-            <DetailItem
-              label={t('detail.importBatchId')}
-              value={selectedReview.importBatchId ?? t('emptyValue')}
-            />
-          </dl>
-          <div className="mt-4 space-y-2">
-            <h3 className="typo-label text-muted-foreground">{t('detail.content')}</h3>
-            <p className="whitespace-pre-wrap rounded border bg-background p-3 typo-body-sm">
-              {selectedReview.content ?? t('table.noContent')}
-            </p>
-          </div>
-          {selectedReview.relatedReviewContent && (
-            <div className="mt-4 space-y-2">
-              <h3 className="typo-label text-muted-foreground">{t('detail.relatedContent')}</h3>
-              <p className="whitespace-pre-wrap rounded border bg-background p-3 typo-body-sm">
-                {selectedReview.relatedReviewContent}
-              </p>
-            </div>
-          )}
-          <div className="mt-4 space-y-2">
-            <h3 className="typo-label text-muted-foreground">{t('reply.title')}</h3>
-            <textarea
-              value={replyContent}
-              onChange={(event) => setReplyContent(event.target.value)}
-              rows={4}
-              className="w-full rounded border bg-background p-3 typo-body-sm"
-              placeholder={t('reply.placeholder')}
-            />
-            <button
-              type="button"
-              onClick={() => void saveReply()}
-              disabled={savingReply}
-              className="rounded bg-primary px-4 py-2 typo-body-sm text-primary-foreground disabled:opacity-50"
-            >
-              {t('reply.save')}
-            </button>
-          </div>
-          {selectedReview.imageUrls && selectedReview.imageUrls.length > 0 && (
-            <div className="mt-4 space-y-2">
-              <h3 className="typo-label text-muted-foreground">{t('detail.media')}</h3>
-              <ul className="space-y-1 typo-body-sm">
-                {selectedReview.imageUrls.map((url) => (
-                  <li key={url}>
-                    <a
-                      href={url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-primary underline-offset-2 hover:underline"
-                    >
-                      {url}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </section>
-      )}
+
     </div>
   );
 }

--- a/src/components/shared/reviews/ReviewCard.tsx
+++ b/src/components/shared/reviews/ReviewCard.tsx
@@ -2,27 +2,37 @@
 
 import { useState, memo } from 'react';
 import Image from 'next/image';
-import { reviewsApi } from '@/lib/api';
+import { adminReviewsApi, reviewsApi } from '@/lib/api';
 import type { ReviewItem } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
 import StarRating from './StarRating';
 import { getClientLocale } from '@/utils/clientLocale';
 import { localMessage } from '@/utils/localMessages';
+import { handleApiError } from '@/utils/error';
+import { toast } from 'sonner';
 
 interface ReviewCardProps {
   review: ReviewItem;
+  onReplySaved?: (review: ReviewItem) => void;
 }
 
 function detectReviewSourceLocale(content: string): 'ko' | 'en' {
   return /[\u3131-\u318E\uAC00-\uD7A3]/.test(content) ? 'ko' : 'en';
 }
 
-const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps) {
+const ADMIN_ROLES = new Set(['admin', 'super_admin']);
+
+const ReviewCardComponent = memo(function ReviewCard({ review, onReplySaved }: ReviewCardProps) {
   const locale = getClientLocale();
+  const { user } = useAuth();
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
   const [translatedContent, setTranslatedContent] = useState<string | null>(null);
   const [showTranslation, setShowTranslation] = useState(false);
   const [isTranslating, setIsTranslating] = useState(false);
   const [translationError, setTranslationError] = useState<string | null>(null);
+  const [isReplyEditorOpen, setIsReplyEditorOpen] = useState(false);
+  const [replyContent, setReplyContent] = useState(review.adminReplyContent ?? '');
+  const [isSavingReply, setIsSavingReply] = useState(false);
 
   const formattedDate = new Date(review.createdAt).toLocaleDateString(
     locale === 'en' ? 'en-US' : 'ko-KR',
@@ -34,6 +44,7 @@ const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps
   );
 
   const isSmartStoreReview = review.source === 'smartstore';
+  const canManageReply = Boolean(user && ADMIN_ROLES.has(user.role));
   const content = review.content?.trim() ?? '';
   const sourceLocale = content ? detectReviewSourceLocale(content) : locale;
   const canTranslate = Boolean(content) && sourceLocale !== locale;
@@ -62,6 +73,32 @@ const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps
       setTranslationError(localMessage('review.translateError'));
     } finally {
       setIsTranslating(false);
+    }
+  };
+
+  const handleSaveReply = async () => {
+    setIsSavingReply(true);
+    try {
+      const updated = await adminReviewsApi.setReply(
+        review.id,
+        replyContent,
+        undefined,
+        review.source ?? 'internal',
+      );
+      const nextReview: ReviewItem = {
+        ...review,
+        adminReplyContent: updated.adminReplyContent,
+        adminReplyAuthor: updated.adminReplyAuthor,
+        adminRepliedAt: updated.adminRepliedAt,
+      };
+      onReplySaved?.(nextReview);
+      setReplyContent(updated.adminReplyContent ?? '');
+      setIsReplyEditorOpen(false);
+      toast.success(localMessage('review.adminReplySaveSuccess'));
+    } catch (err) {
+      toast.error(handleApiError(err, localMessage('review.adminReplySaveError')));
+    } finally {
+      setIsSavingReply(false);
     }
   };
 
@@ -114,6 +151,67 @@ const ReviewCardComponent = memo(function ReviewCard({ review }: ReviewCardProps
           <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed text-foreground">
             {review.adminReplyContent}
           </p>
+        </div>
+      )}
+
+      {canManageReply && (
+        <div className="mt-3 rounded-md border border-dashed bg-background p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="typo-label text-muted-foreground">
+                {localMessage('review.adminReplyManageTitle')}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {localMessage('review.adminReplyManageDescription')}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setReplyContent(review.adminReplyContent ?? '');
+                setIsReplyEditorOpen((value) => !value);
+              }}
+              className="rounded border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-muted"
+            >
+              {review.adminReplyContent
+                ? localMessage('review.adminReplyEdit')
+                : localMessage('review.adminReplyWrite')}
+            </button>
+          </div>
+          {isReplyEditorOpen && (
+            <div className="mt-3 space-y-2">
+              <textarea
+                value={replyContent}
+                onChange={(event) => setReplyContent(event.target.value)}
+                rows={3}
+                className="w-full rounded border bg-background p-3 text-sm"
+                placeholder={localMessage('review.adminReplyPlaceholder')}
+              />
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleSaveReply()}
+                  disabled={isSavingReply}
+                  className="rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-50"
+                >
+                  {isSavingReply
+                    ? localMessage('review.adminReplySaving')
+                    : localMessage('review.adminReplySave')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setReplyContent(review.adminReplyContent ?? '');
+                    setIsReplyEditorOpen(false);
+                  }}
+                  disabled={isSavingReply}
+                  className="rounded border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                >
+                  {localMessage('review.adminReplyCancel')}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/shared/reviews/ReviewList.tsx
+++ b/src/components/shared/reviews/ReviewList.tsx
@@ -46,6 +46,15 @@ export default function ReviewList({ productId }: ReviewListProps) {
   }, [productId, sort, page]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const totalPages = Math.ceil(total / limit)
+  const updateReviewReply = (updatedReview: ReviewItem) => {
+    setReviews((items) =>
+      items.map((item) => {
+        const itemSource = item.source ?? 'internal'
+        const updatedSource = updatedReview.source ?? 'internal'
+        return item.id === updatedReview.id && itemSource === updatedSource ? updatedReview : item
+      }),
+    )
+  }
 
   return (
     <div className="space-y-6">
@@ -84,7 +93,11 @@ export default function ReviewList({ productId }: ReviewListProps) {
       ) : (
         <div>
           {reviews.map((review) => (
-            <ReviewCard key={`${review.source ?? 'internal'}-${review.id}`} review={review} />
+            <ReviewCard
+              key={`${review.source ?? 'internal'}-${review.id}`}
+              review={review}
+              onReplySaved={updateReviewReply}
+            />
           ))}
         </div>
       )}
@@ -98,7 +111,7 @@ export default function ReviewList({ productId }: ReviewListProps) {
             onClick={() => setPage((p) => p - 1)}
             className="rounded px-3 py-1 text-sm text-muted-foreground hover:bg-muted disabled:opacity-50"
           >
-            이전
+            {localMessage('review.previous')}
           </button>
           <span className="text-sm text-muted-foreground">
             {page} / {totalPages}
@@ -109,7 +122,7 @@ export default function ReviewList({ productId }: ReviewListProps) {
             onClick={() => setPage((p) => p + 1)}
             className="rounded px-3 py-1 text-sm text-muted-foreground hover:bg-muted disabled:opacity-50"
           >
-            다음
+            {localMessage('review.next')}
           </button>
         </div>
       )}

--- a/src/components/shared/reviews/__tests__/ReviewList.test.tsx
+++ b/src/components/shared/reviews/__tests__/ReviewList.test.tsx
@@ -4,12 +4,29 @@ import ReviewList from '../ReviewList'
 
 const mockGetByProduct = vi.fn()
 const mockTranslateContent = vi.fn()
+const mockSetReply = vi.fn()
+let mockUser: { id: number; role: string } | null = null
 
 vi.mock('@/lib/api', () => ({
   reviewsApi: {
     getByProduct: (...args: unknown[]) => mockGetByProduct(...args),
     translateContent: (...args: unknown[]) => mockTranslateContent(...args),
   },
+  adminReviewsApi: {
+    setReply: (...args: unknown[]) => mockSetReply(...args),
+  },
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    isAuthenticated: Boolean(mockUser),
+    isLoading: false,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }))
 
 vi.mock('next-intl', () => ({
@@ -38,6 +55,9 @@ describe('ReviewList', () => {
         content: '정말 좋아요',
         imageUrls: null,
         isVisible: true,
+        adminReplyContent: null,
+        adminReplyAuthor: null,
+        adminRepliedAt: null,
         createdAt: '2026-03-01T12:00:00Z',
       },
     ],
@@ -51,8 +71,10 @@ describe('ReviewList', () => {
 
   beforeEach(() => {
     document.documentElement.lang = 'ko'
+    mockUser = null
     mockGetByProduct.mockResolvedValue(mockResponse)
     mockTranslateContent.mockResolvedValue({ translatedText: 'Really good', sourceLocale: 'ko', targetLocale: 'en' })
+    mockSetReply.mockReset()
   })
 
   it('renders reviews after loading', async () => {
@@ -150,5 +172,44 @@ describe('ReviewList', () => {
     await waitFor(() => {
       expect(mockGetByProduct).toHaveBeenCalledWith(5, expect.objectContaining({ sort: 'rating_high' }))
     })
+  })
+
+  it('lets admins write a product-review reply inline and updates the card', async () => {
+    mockUser = { id: 1, role: 'admin' }
+    mockSetReply.mockResolvedValue({
+      id: 1,
+      source: 'internal',
+      adminReplyContent: '소중한 후기 감사합니다.',
+      adminReplyAuthor: '옥화당',
+      adminRepliedAt: '2026-07-05T00:00:00.000Z',
+    })
+
+    render(<ReviewList productId={5} />)
+
+    expect(await screen.findByText('정말 좋아요')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '답글 달기' }))
+    fireEvent.change(screen.getByPlaceholderText('고객에게 표시할 답글을 입력하세요.'), {
+      target: { value: '소중한 후기 감사합니다.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '답글 저장' }))
+
+    await waitFor(() => {
+      expect(mockSetReply).toHaveBeenCalledWith(
+        1,
+        '소중한 후기 감사합니다.',
+        undefined,
+        'internal',
+      )
+    })
+    expect(await screen.findByText('소중한 후기 감사합니다.')).toBeInTheDocument()
+  })
+
+  it('does not show admin reply controls to non-admin users', async () => {
+    mockUser = { id: 2, role: 'user' }
+
+    render(<ReviewList productId={5} />)
+
+    expect(await screen.findByText('정말 좋아요')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '답글 달기' })).not.toBeInTheDocument()
   })
 })

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -615,7 +615,17 @@
     "showOriginal": "Show original",
     "machineTranslated": "Machine-translated review.",
     "translateError": "Failed to translate this review.",
-    "adminReply": "Ockhwadang reply"
+    "adminReply": "Ockhwadang reply",
+    "adminReplyManageTitle": "Manage admin reply",
+    "adminReplyManageDescription": "This reply is shown to customers on the product review.",
+    "adminReplyWrite": "Write reply",
+    "adminReplyEdit": "Edit reply",
+    "adminReplyPlaceholder": "Write the reply shown to customers.",
+    "adminReplySave": "Save reply",
+    "adminReplySaving": "Saving...",
+    "adminReplyCancel": "Cancel",
+    "adminReplySaveSuccess": "Reply saved.",
+    "adminReplySaveError": "Failed to save reply."
   },
   "shipping": {
     "title": "Register Tracking Number",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -615,7 +615,17 @@
     "showOriginal": "원문 보기",
     "machineTranslated": "자동 번역된 리뷰입니다.",
     "translateError": "리뷰 번역에 실패했습니다.",
-    "adminReply": "옥화당 답글"
+    "adminReply": "옥화당 답글",
+    "adminReplyManageTitle": "관리자 답글 관리",
+    "adminReplyManageDescription": "이 답글은 상품상세 리뷰에 고객에게 표시됩니다.",
+    "adminReplyWrite": "답글 달기",
+    "adminReplyEdit": "답글 수정",
+    "adminReplyPlaceholder": "고객에게 표시할 답글을 입력하세요.",
+    "adminReplySave": "답글 저장",
+    "adminReplySaving": "저장 중...",
+    "adminReplyCancel": "취소",
+    "adminReplySaveSuccess": "답글을 저장했습니다.",
+    "adminReplySaveError": "답글을 저장하지 못했습니다."
   },
   "shipping": {
     "title": "운송장 등록",


### PR DESCRIPTION
## Summary
- 상품상세 리뷰 카드에 관리자 전용 답글 작성/수정 패널을 추가했습니다.
- 저장은 기존 `adminReviewsApi.setReply` 계약을 사용하고, 성공 시 리뷰 카드의 관리자 답글 표시를 즉시 갱신합니다.
- 일반 사용자/비로그인 사용자는 상품상세 리뷰 카드의 답글 관리 UI를 볼 수 없습니다.
- `/admin/reviews`의 선택 리뷰 상세/답글 패널을 테이블 아래에서 필터 영역 아래/테이블 위로 이동했습니다.
- 신규 문구는 `ko/en` locale 메시지로 추가했습니다.

Closes #1015

## Verification
- `npm run build && npm run test:run && npm run lint`
- `cd backend && npm run build && npm run test && npm run lint`
- `bash scripts/codex-project-guard.sh`
- `make up`
- `curl http://localhost:3000/api/health`
- `curl -I http://localhost:5173/ko`
- `curl -I http://localhost:5173/ko/products/1`
- `curl -I http://localhost:5173/ko/admin/reviews`
- listening ports `3000`/`5173`

## Notes
- UI runtime was verified by local HTTP/port checks. Manual browser click with an admin account was not performed in this pass.
