### PR TITLE
fix: #1017 네이버 자동 매핑 속성 누락 방지

### DIFF
--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -83,6 +83,7 @@ function createService(
     repository,
     commandService,
     ingestService,
+    attributesService,
   };
 }
 
@@ -170,7 +171,10 @@ describe('NaverCommerceProductImportService', () => {
 
   it('commits only SKU-matched Naver products and never creates unmatched API rows', async () => {
     const existing = { id: 7, sku: 'SKU-1', slug: 'old-product' } as Product;
-    const { service, commandService, ingestService } = createService(NAVER_PRODUCTS, [existing]);
+    const { service, commandService, ingestService, attributesService } = createService(
+      NAVER_PRODUCTS,
+      [existing],
+    );
 
     const result = await service.commit();
 
@@ -205,6 +209,21 @@ describe('NaverCommerceProductImportService', () => {
       }),
     );
     expect(commandService.create).not.toHaveBeenCalled();
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(
+      7,
+      10,
+      expect.objectContaining({ value: 'old_duanni', displayValue: '노단니' }),
+    );
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(
+      7,
+      11,
+      expect.objectContaining({ value: 'lianzi', displayValue: '연자호' }),
+    );
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(
+      7,
+      12,
+      expect.objectContaining({ value: '110cc', displayValue: '110cc' }),
+    );
     expect(ingestService.ingest).toHaveBeenCalledTimes(2);
   });
 
@@ -238,6 +257,56 @@ describe('NaverCommerceProductImportService', () => {
       expect.objectContaining({ sku: 'naver-2001' }),
     );
     expect(commandService.create).not.toHaveBeenCalled();
+  });
+
+  it('uses seller management code from Naver origin detail attributes so keyword attributes apply to matched products', async () => {
+    const existing = {
+      id: 9,
+      sku: 'SELLER-DETAIL-1',
+      slug: 'detail-seller-code-product',
+    } as Product;
+    const fetchedProducts: NaverCommerceFetchedProduct[] = [
+      {
+        rowNumber: 1,
+        listProduct: { originProductNo: 3001 },
+        detailProduct: {
+          originProduct: {
+            name: '옥화당 자사호 노단니 연자호 120cc',
+            salePrice: 88000,
+            stockQuantity: 2,
+            detailAttribute: {
+              sellerCodeInfo: { sellerManagementCode: 'SELLER-DETAIL-1' },
+            },
+          },
+        },
+      },
+    ];
+    const { service, commandService, attributesService } = createService(fetchedProducts, [
+      existing,
+    ]);
+
+    const result = await service.commit();
+
+    expect(result.rows[0]).toMatchObject({
+      identifier: 'SELLER-DETAIL-1',
+      action: 'update',
+      productId: 9,
+      status: 'success',
+    });
+    expect(commandService.update).toHaveBeenCalledWith(
+      9,
+      expect.objectContaining({ sku: 'SELLER-DETAIL-1' }),
+    );
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(
+      9,
+      10,
+      expect.objectContaining({ value: 'old_duanni', displayValue: '노단니' }),
+    );
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(
+      9,
+      11,
+      expect.objectContaining({ value: 'lianzi', displayValue: '연자호' }),
+    );
   });
 
   it('marks product detail failures as row-level failures while keeping other rows processable', async () => {

--- a/backend/src/modules/products/naver-commerce-product-import.service.ts
+++ b/backend/src/modules/products/naver-commerce-product-import.service.ts
@@ -63,6 +63,10 @@ export class NaverCommerceProductImportService {
     const sellerCode = this.firstString(product, [
       'sellerManagementCode',
       'originProduct.sellerManagementCode',
+      'originProduct.detailAttribute.sellerCodeInfo.sellerManagementCode',
+      'originProduct.detailAttribute.sellerManagementCode',
+      'detailAttribute.sellerCodeInfo.sellerManagementCode',
+      'detailAttribute.sellerManagementCode',
       'channelProducts.0.sellerManagementCode',
       'channelProducts.0.sellerManagementCodeNo',
     ]);


### PR DESCRIPTION
## Summary
- 네이버 커머스API 원상품 상세 응답의 판매자상품코드 경로를 추가 인식합니다.
- 상세 응답의 `sellerCodeInfo.sellerManagementCode` 기반 SKU 매칭과 자동 상품속성 저장을 회귀 테스트로 고정했습니다.

Closes #1017

## Verification
- `cd backend && npx jest src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts src/modules/products/__tests__/smartstore-product-import.service.spec.ts --runInBand`
- `bash scripts/codex-project-guard.sh`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`

## Notes
- DB/entity 변경 없음: backend e2e는 생략했습니다.
