### PR TITLE
fix: #1023 상품상세 리뷰 답글 삭제 및 UI 개선

### DIFF
--- a/src/components/shared/reviews/ReviewCard.tsx
+++ b/src/components/shared/reviews/ReviewCard.tsx
@@ -76,12 +76,12 @@ const ReviewCardComponent = memo(function ReviewCard({ review, onReplySaved }: R
     }
   };
 
-  const handleSaveReply = async () => {
+  const updateReply = async (contentToSave: string | null, successMessageKey: string) => {
     setIsSavingReply(true);
     try {
       const updated = await adminReviewsApi.setReply(
         review.id,
-        replyContent,
+        contentToSave,
         undefined,
         review.source ?? 'internal',
       );
@@ -94,13 +94,17 @@ const ReviewCardComponent = memo(function ReviewCard({ review, onReplySaved }: R
       onReplySaved?.(nextReview);
       setReplyContent(updated.adminReplyContent ?? '');
       setIsReplyEditorOpen(false);
-      toast.success(localMessage('review.adminReplySaveSuccess'));
+      toast.success(localMessage(successMessageKey));
     } catch (err) {
       toast.error(handleApiError(err, localMessage('review.adminReplySaveError')));
     } finally {
       setIsSavingReply(false);
     }
   };
+
+  const handleSaveReply = () => updateReply(replyContent, 'review.adminReplySaveSuccess');
+
+  const handleDeleteReply = () => updateReply(null, 'review.adminReplyDeleteSuccess');
 
   return (
     <div className="border-b border-border py-4 last:border-b-0">
@@ -146,8 +150,8 @@ const ReviewCardComponent = memo(function ReviewCard({ review, onReplySaved }: R
       )}
 
       {review.adminReplyContent && (
-        <div className="mt-3 rounded-md border bg-muted/30 p-3">
-          <p className="typo-label text-muted-foreground">{localMessage('review.adminReply')}</p>
+        <div className="mt-3 pl-3">
+          <p className="text-xs font-medium text-muted-foreground">{localMessage('review.adminReply')}</p>
           <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed text-foreground">
             {review.adminReplyContent}
           </p>
@@ -155,36 +159,38 @@ const ReviewCardComponent = memo(function ReviewCard({ review, onReplySaved }: R
       )}
 
       {canManageReply && (
-        <div className="mt-3 rounded-md border border-dashed bg-background p-3">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <p className="typo-label text-muted-foreground">
-                {localMessage('review.adminReplyManageTitle')}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {localMessage('review.adminReplyManageDescription')}
-              </p>
-            </div>
+        <div className="mt-3 space-y-2">
+          <div className="flex flex-wrap items-center gap-3 text-xs">
             <button
               type="button"
               onClick={() => {
                 setReplyContent(review.adminReplyContent ?? '');
                 setIsReplyEditorOpen((value) => !value);
               }}
-              className="rounded border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-muted"
+              className="font-medium text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
             >
-              {review.adminReplyContent
-                ? localMessage('review.adminReplyEdit')
-                : localMessage('review.adminReplyWrite')}
+              {localMessage('review.adminReplyWrite')}
             </button>
+            {review.adminReplyContent && (
+              <button
+                type="button"
+                onClick={() => void handleDeleteReply()}
+                disabled={isSavingReply}
+                className="font-medium text-muted-foreground underline-offset-2 hover:text-destructive hover:underline disabled:opacity-50"
+              >
+                {isSavingReply
+                  ? localMessage('review.adminReplyDeleting')
+                  : localMessage('review.adminReplyDelete')}
+              </button>
+            )}
           </div>
           {isReplyEditorOpen && (
-            <div className="mt-3 space-y-2">
+            <div className="space-y-2">
               <textarea
                 value={replyContent}
                 onChange={(event) => setReplyContent(event.target.value)}
                 rows={3}
-                className="w-full rounded border bg-background p-3 text-sm"
+                className="w-full rounded-md border border-border/70 bg-background p-3 text-sm outline-none transition-colors focus:border-foreground/40"
                 placeholder={localMessage('review.adminReplyPlaceholder')}
               />
               <div className="flex gap-2">
@@ -192,7 +198,7 @@ const ReviewCardComponent = memo(function ReviewCard({ review, onReplySaved }: R
                   type="button"
                   onClick={() => void handleSaveReply()}
                   disabled={isSavingReply}
-                  className="rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-50"
+                  className="rounded bg-foreground px-3 py-1.5 text-xs font-medium text-background disabled:opacity-50"
                 >
                   {isSavingReply
                     ? localMessage('review.adminReplySaving')
@@ -205,7 +211,7 @@ const ReviewCardComponent = memo(function ReviewCard({ review, onReplySaved }: R
                     setIsReplyEditorOpen(false);
                   }}
                   disabled={isSavingReply}
-                  className="rounded border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                  className="px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
                 >
                   {localMessage('review.adminReplyCancel')}
                 </button>

--- a/src/components/shared/reviews/__tests__/ReviewList.test.tsx
+++ b/src/components/shared/reviews/__tests__/ReviewList.test.tsx
@@ -187,7 +187,8 @@ describe('ReviewList', () => {
     render(<ReviewList productId={5} />)
 
     expect(await screen.findByText('정말 좋아요')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: '답글 달기' }))
+    expect(screen.queryByText('관리자 답글 관리')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '답글달기' }))
     fireEvent.change(screen.getByPlaceholderText('고객에게 표시할 답글을 입력하세요.'), {
       target: { value: '소중한 후기 감사합니다.' },
     })
@@ -204,12 +205,47 @@ describe('ReviewList', () => {
     expect(await screen.findByText('소중한 후기 감사합니다.')).toBeInTheDocument()
   })
 
+  it('lets admins delete an existing product-review reply inline', async () => {
+    mockUser = { id: 1, role: 'admin' }
+    mockGetByProduct.mockResolvedValue({
+      ...mockResponse,
+      data: [
+        {
+          ...mockResponse.data[0],
+          adminReplyContent: '기존 답글입니다.',
+          adminReplyAuthor: '옥화당',
+          adminRepliedAt: '2026-07-05T00:00:00.000Z',
+        },
+      ],
+    })
+    mockSetReply.mockResolvedValue({
+      id: 1,
+      source: 'internal',
+      adminReplyContent: null,
+      adminReplyAuthor: null,
+      adminRepliedAt: null,
+    })
+
+    render(<ReviewList productId={5} />)
+
+    expect(await screen.findByText('기존 답글입니다.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }))
+
+    await waitFor(() => {
+      expect(mockSetReply).toHaveBeenCalledWith(1, null, undefined, 'internal')
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('기존 답글입니다.')).not.toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: '삭제' })).not.toBeInTheDocument()
+  })
+
   it('does not show admin reply controls to non-admin users', async () => {
     mockUser = { id: 2, role: 'user' }
 
     render(<ReviewList productId={5} />)
 
     expect(await screen.findByText('정말 좋아요')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: '답글 달기' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '답글달기' })).not.toBeInTheDocument()
   })
 })

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -616,16 +616,16 @@
     "machineTranslated": "Machine-translated review.",
     "translateError": "Failed to translate this review.",
     "adminReply": "Ockhwadang reply",
-    "adminReplyManageTitle": "Manage admin reply",
-    "adminReplyManageDescription": "This reply is shown to customers on the product review.",
     "adminReplyWrite": "Write reply",
-    "adminReplyEdit": "Edit reply",
     "adminReplyPlaceholder": "Write the reply shown to customers.",
     "adminReplySave": "Save reply",
     "adminReplySaving": "Saving...",
     "adminReplyCancel": "Cancel",
     "adminReplySaveSuccess": "Reply saved.",
-    "adminReplySaveError": "Failed to save reply."
+    "adminReplySaveError": "Failed to save reply.",
+    "adminReplyDelete": "Delete",
+    "adminReplyDeleting": "Deleting...",
+    "adminReplyDeleteSuccess": "Reply deleted."
   },
   "shipping": {
     "title": "Register Tracking Number",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -616,16 +616,16 @@
     "machineTranslated": "자동 번역된 리뷰입니다.",
     "translateError": "리뷰 번역에 실패했습니다.",
     "adminReply": "옥화당 답글",
-    "adminReplyManageTitle": "관리자 답글 관리",
-    "adminReplyManageDescription": "이 답글은 상품상세 리뷰에 고객에게 표시됩니다.",
-    "adminReplyWrite": "답글 달기",
-    "adminReplyEdit": "답글 수정",
+    "adminReplyWrite": "답글달기",
     "adminReplyPlaceholder": "고객에게 표시할 답글을 입력하세요.",
     "adminReplySave": "답글 저장",
     "adminReplySaving": "저장 중...",
     "adminReplyCancel": "취소",
     "adminReplySaveSuccess": "답글을 저장했습니다.",
-    "adminReplySaveError": "답글을 저장하지 못했습니다."
+    "adminReplySaveError": "답글을 저장하지 못했습니다.",
+    "adminReplyDelete": "삭제",
+    "adminReplyDeleting": "삭제 중...",
+    "adminReplyDeleteSuccess": "답글을 삭제했습니다."
   },
   "shipping": {
     "title": "운송장 등록",


### PR DESCRIPTION
## Summary
- 상품상세 리뷰의 관리자 답글 UI를 박스형 패널에서 스마트스토어형 가벼운 텍스트 액션으로 정리했습니다.
- 관리자 답글 삭제를 추가했습니다. 기존 `adminReviewsApi.setReply(..., null, ...)` 계약을 사용해 답글을 제거합니다.
- 기존 고객-facing 답글 표시는 유지하되 외곽선/박스/배경을 제거해 인라인에 가깝게 낮췄습니다.
- 관리자만 `답글달기`/`삭제` 액션을 보고, 비관리자는 답글 관리 UI를 볼 수 없도록 회귀 테스트를 보강했습니다.

Closes #1023

## Verification
- `npm run build`
- `npm run test:run`
- `npm run lint`
- `bash scripts/codex-project-guard.sh`
- `cd backend && npm run build && npm run test && npm run lint`
- `make up`
- `curl http://localhost:3000/api/health`
- `curl -I http://localhost:5173/ko`
- `curl -I http://localhost:5173/ko/products/1`
- `lsof` ports `3000` / `5173`

## Notes
- 실제 브라우저 관리자 계정으로 답글 삭제를 수동 클릭하는 QA는 수행하지 않았습니다.
- 스키마/마이그레이션 변경은 없어 backend e2e는 생략했습니다.
