### PR TITLE
관리자 이미지 URL 입력을 직접 업로드로 통일 (#1024)

### DIFF
--- a/src/components/shared/admin/CategoryFormModal.tsx
+++ b/src/components/shared/admin/CategoryFormModal.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect, useMemo } from 'react';
 import { X } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import FormInput from '@/components/ui/FormInput';
+import ProductImageUploader from '@/components/shared/admin/ProductImageUploader';
 import type { AdminCategory, CreateCategoryData } from '@/lib/api';
 import { useFormModal } from '@/components/shared/hooks/useFormModal';
+import { localMessage } from '@/utils/localMessages';
 
 interface CategoryFormModalProps {
   open: boolean;
@@ -187,13 +189,14 @@ export default function CategoryFormModal({
             onChange={(e) => setForm({ ...form, sortOrder: Number(e.target.value) })}
           />
 
-          <FormInput
-            id="category-image-url"
-            label="이미지 URL"
-            value={form.imageUrl ?? ''}
-            onChange={(e) => setForm({ ...form, imageUrl: e.target.value })}
-            placeholder="https://example.com/image.jpg"
-          />
+          <div className="space-y-1">
+            <label className="text-sm font-medium">{localMessage('admin.imageUpload.label')}</label>
+            <ProductImageUploader
+              imageUrl={form.imageUrl ?? ''}
+              onChange={(url) => setForm({ ...form, imageUrl: url })}
+              altText={localMessage('admin.categories.imageAlt')}
+            />
+          </div>
 
           <div className="flex items-center gap-2">
             <input

--- a/src/components/shared/admin/ProductImageUploader.tsx
+++ b/src/components/shared/admin/ProductImageUploader.tsx
@@ -5,15 +5,22 @@ import { toast } from 'sonner';
 import { uploadApi } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
 import { toastMessage } from '@/utils/toastMessages';
+import { localMessage } from '@/utils/localMessages';
 
 interface ProductImageUploaderProps {
   imageUrl: string;
   onChange: (url: string) => void;
+  altText?: string;
+  emptyText?: string;
+  helperText?: string;
 }
 
 export default function ProductImageUploader({
   imageUrl,
   onChange,
+  altText = localMessage('admin.imageUpload.alt'),
+  emptyText = localMessage('admin.imageUpload.emptyText'),
+  helperText = localMessage('admin.imageUpload.helperText'),
 }: ProductImageUploaderProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -62,19 +69,19 @@ export default function ProductImageUploader({
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={imageUrl}
-            alt="상품 이미지"
+            alt={altText}
             className="h-full w-full rounded-lg object-cover"
           />
         ) : (
           <div className="flex flex-col items-center gap-2 text-muted-foreground">
             <span className="text-4xl">+</span>
-            <p className="text-sm">클릭하거나 드래그하여 이미지 업로드</p>
-            <p className="text-xs">JPEG, PNG, WebP · 20MB 초과 시 자동 리사이징</p>
+            <p className="text-sm">{emptyText}</p>
+            <p className="text-xs">{helperText}</p>
           </div>
         )}
         {uploading && (
           <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-background/70">
-            <span className="text-sm">업로드 중...</span>
+            <span className="text-sm">{localMessage('admin.imageUpload.uploading')}</span>
           </div>
         )}
       </div>

--- a/src/components/shared/admin/__tests__/CategoryFormModal.test.tsx
+++ b/src/components/shared/admin/__tests__/CategoryFormModal.test.tsx
@@ -126,6 +126,21 @@ describe('CategoryFormModal', () => {
     );
   });
 
+
+  it('이미지 URL 텍스트 입력 대신 직접 업로드 UI를 렌더링한다', () => {
+    render(
+      <CategoryFormModal
+        open={true}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        categories={[]}
+      />,
+    );
+
+    expect(screen.queryByLabelText('이미지 URL')).not.toBeInTheDocument();
+    expect(screen.getByText('클릭하거나 드래그하여 이미지 업로드')).toBeInTheDocument();
+  });
+
   it('상위 카테고리 목록 렌더링', () => {
     render(
       <CategoryFormModal

--- a/src/components/shared/admin/__tests__/ProductImageUploader.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductImageUploader.test.tsx
@@ -1,10 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import ProductImageUploader from '../ProductImageUploader';
 
+const { uploadImageMock } = vi.hoisted(() => ({ uploadImageMock: vi.fn() }));
+
 vi.mock('@/lib/api', () => ({
   uploadApi: {
-    uploadImage: vi.fn(),
+    uploadImage: uploadImageMock,
   },
 }));
 
@@ -16,6 +19,23 @@ vi.mock('sonner', () => ({
 }));
 
 describe('ProductImageUploader', () => {
+  it('uploads a selected image and returns the stored URL', async () => {
+    uploadImageMock.mockResolvedValueOnce({ url: '/uploads/admin-image.webp' });
+    const onChange = vi.fn();
+    render(<ProductImageUploader imageUrl="" onChange={onChange} />);
+
+    const input = document.querySelector('input[type=\"file\"]');
+    expect(input).toBeInstanceOf(HTMLInputElement);
+
+    const file = new File(['image'], 'admin-image.webp', { type: 'image/webp' });
+    await userEvent.upload(input as HTMLInputElement, file);
+
+    await waitFor(() => {
+      expect(uploadImageMock).toHaveBeenCalledWith(file);
+      expect(onChange).toHaveBeenCalledWith('/uploads/admin-image.webp');
+    });
+  });
+
   it('shows the 20MB image upload limit in the helper copy', () => {
     render(<ProductImageUploader imageUrl="" onChange={vi.fn()} />);
 

--- a/src/components/shared/admin/page-editor/__tests__/BlockPropertyPanel.test.tsx
+++ b/src/components/shared/admin/page-editor/__tests__/BlockPropertyPanel.test.tsx
@@ -43,6 +43,23 @@ describe('BlockPropertyPanel', () => {
     expect(onUpdateContent).toHaveBeenLastCalledWith(3, expect.objectContaining({ columns: 4 }));
   });
 
+
+  it('프로모션 배너 이미지는 URL 텍스트 입력 대신 직접 업로드 UI를 사용한다', () => {
+    const onUpdateContent = vi.fn();
+    const block: DraftBlock = {
+      id: 4,
+      type: 'promotion_banner',
+      content: { title: '프로모션', image_url: '' },
+      sort_order: 0,
+      is_visible: true,
+    };
+
+    render(<BlockPropertyPanel block={block} onUpdateContent={onUpdateContent} />);
+
+    expect(screen.queryByLabelText('이미지 URL')).not.toBeInTheDocument();
+    expect(screen.getByText('클릭하거나 드래그하여 이미지 업로드')).toBeInTheDocument();
+  });
+
   it('프로모션 배너 종료일은 렌더러 계약인 end_date로 저장한다', async () => {
     const onUpdateContent = vi.fn();
     const block: DraftBlock = {

--- a/src/components/shared/admin/page-editor/block-property-panel/blockConfig.ts
+++ b/src/components/shared/admin/page-editor/block-property-panel/blockConfig.ts
@@ -19,7 +19,7 @@ export const BLOCK_TYPE_LABELS: Record<PageBlock['type'], string> = {
 
 export const BLOCK_TYPE_DESCRIPTIONS: Record<PageBlock['type'], string> = {
   hero_banner:
-    '페이지 최상단에 크게 표시되는 배너입니다. 제목·이미지·버튼을 설정하세요. 이미지 URL을 비우면 배경색만 표시됩니다.',
+    '페이지 최상단에 크게 표시되는 배너입니다. 제목·이미지·버튼을 설정하세요. 이미지를 비우면 배경색만 표시됩니다.',
   product_grid:
     '상품을 격자 형태로 나열합니다. 카테고리를 선택하면 해당 카테고리 상품이 표시됩니다. [직접 선택]은 상품을 수동으로 고르고, [자동 불러오기]는 카테고리에서 자동으로 불러옵니다.',
   product_carousel:

--- a/src/components/shared/admin/page-editor/block-property-panel/blocks/GenericItemFields.tsx
+++ b/src/components/shared/admin/page-editor/block-property-panel/blocks/GenericItemFields.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import { useState, type ReactNode } from 'react';
-import { toast } from 'sonner';
-import { apiClient, type UploadedFile } from '@/lib/api';
-import { handleApiError } from '@/utils/error';
 import { NumberField, SelectField, StringField } from '../FormFields';
-import { toastMessage } from '@/utils/toastMessages';
+import ProductImageUploader from '@/components/shared/admin/ProductImageUploader';
 
 export interface EditableItem {
   id: string;
@@ -132,40 +129,18 @@ export function ImageUploadField({
   value: string;
   onChange: (value: string) => void;
 }) {
-  const [uploading, setUploading] = useState(false);
-
-  const upload = async (file: File) => {
-    setUploading(true);
-    try {
-      const uploaded = await apiClient.uploadFile<UploadedFile>('/upload/image', file);
-      onChange(uploaded.url);
-      toast.success(toastMessage('blockImageUploaded'));
-    } catch (error) {
-      toast.error(handleApiError(error));
-    } finally {
-      setUploading(false);
-    }
-  };
-
   return (
     <div className="space-y-2">
-      <StringField label={label} value={value} onChange={onChange} placeholder="https://..." />
-      <input
-        type="file"
-        accept="image/*"
-        disabled={uploading}
-        onChange={(event) => {
-          const file = event.target.files?.[0];
-          if (file) void upload(file);
-          event.target.value = '';
-        }}
-        className="w-full text-xs text-muted-foreground file:mr-2 file:rounded-md file:border file:border-input file:bg-background file:px-2 file:py-1 file:text-xs"
-        aria-label={`${label} 업로드`}
+      <label className="text-xs font-medium text-muted-foreground">{label}</label>
+      <ProductImageUploader
+        imageUrl={value}
+        onChange={onChange}
+        altText={label}
       />
-      {uploading && <p className="text-xs text-muted-foreground">업로드 중...</p>}
     </div>
   );
 }
+
 
 export { NumberField, SelectField, StringField };
 

--- a/src/components/shared/admin/page-editor/block-property-panel/blocks/HeroBannerFields.tsx
+++ b/src/components/shared/admin/page-editor/block-property-panel/blocks/HeroBannerFields.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { SelectField, StringField, createContentUpdater } from '../FormFields';
+import { ImageUploadField } from './GenericItemFields';
+import { localMessage } from '@/utils/localMessages';
 import { HERO_TEMPLATE_OPTIONS } from '../blockConfig';
 
 interface HeroBannerFieldsProps {
@@ -48,7 +50,7 @@ export default function HeroBannerFields({ content, onChange }: HeroBannerFields
       <StringField label="부제목 (EN)" value={(content.subtitle_en as string) ?? ''} onChange={(v) => update('subtitle_en', v)} placeholder="영문 부제목" />
       <StringField label="설명 (Markdown 지원)" value={(content.description as string) ?? ''} onChange={(v) => update('description', v)} multiline placeholder="**굵게**, *기울임*, **11** → 11 볼드 등 Markdown 포맷 사용 가능" />
       <StringField label="설명 (EN)" value={(content.description_en as string) ?? ''} onChange={(v) => update('description_en', v)} multiline placeholder="영문 설명" />
-      <StringField label="이미지 URL" value={(content.image_url as string) ?? ''} onChange={(v) => update('image_url', v)} placeholder="https://..." />
+      <ImageUploadField label={localMessage('admin.imageUpload.label')} value={(content.image_url as string) ?? ''} onChange={(v) => update('image_url', v)} />
       <StringField label="CTA 텍스트" value={(content.cta_text as string) ?? ''} onChange={(v) => update('cta_text', v)} />
       <StringField label="CTA 텍스트 (EN)" value={(content.cta_text_en as string) ?? ''} onChange={(v) => update('cta_text_en', v)} placeholder="영문 CTA" />
       <StringField label="CTA URL" value={(content.cta_url as string) ?? ''} onChange={(v) => update('cta_url', v)} />
@@ -89,7 +91,7 @@ export default function HeroBannerFields({ content, onChange }: HeroBannerFields
               <StringField label="제목 (EN)" value={slide.title_en ?? ''} onChange={(v) => updateSlide(index, 'title_en', v)} placeholder="영문 제목" />
               <StringField label="부제목" value={slide.subtitle ?? ''} onChange={(v) => updateSlide(index, 'subtitle', v)} />
               <StringField label="부제목 (EN)" value={slide.subtitle_en ?? ''} onChange={(v) => updateSlide(index, 'subtitle_en', v)} placeholder="영문 부제목" />
-              <StringField label="이미지 URL" value={slide.image_url ?? ''} onChange={(v) => updateSlide(index, 'image_url', v)} />
+              <ImageUploadField label={localMessage('admin.imageUpload.label')} value={slide.image_url ?? ''} onChange={(v) => updateSlide(index, 'image_url', v)} />
               <StringField label="배경색" value={slide.bg_color ?? '#1B3A4B'} onChange={(v) => updateSlide(index, 'bg_color', v)} />
               <StringField label="CTA 텍스트" value={slide.cta_text ?? ''} onChange={(v) => updateSlide(index, 'cta_text', v)} />
               <StringField label="CTA 텍스트 (EN)" value={slide.cta_text_en ?? ''} onChange={(v) => updateSlide(index, 'cta_text_en', v)} placeholder="영문 CTA" />

--- a/src/components/shared/admin/page-editor/block-property-panel/blocks/ImageCardGridFields.tsx
+++ b/src/components/shared/admin/page-editor/block-property-panel/blocks/ImageCardGridFields.tsx
@@ -3,6 +3,7 @@
 import SectionHeadingFields from './SectionHeadingFields';
 import { ImageUploadField, ItemListEditor, StringField, createEditorId } from './GenericItemFields';
 import { SelectField, createContentUpdater } from '../FormFields';
+import { localMessage } from '@/utils/localMessages';
 import type { ImageCardItem } from '@/lib/api';
 
 interface ImageCardGridFieldsProps {
@@ -35,7 +36,7 @@ export default function ImageCardGridFields({ content, onChange }: ImageCardGrid
         getTitle={(item, index) => item.name || `항목 ${index + 1}`}
         renderItem={(item, _index, updateItem) => (
           <div className="space-y-2">
-            <ImageUploadField label="이미지 URL" value={item.imageUrl} onChange={(value) => updateItem({ imageUrl: value })} />
+            <ImageUploadField label={localMessage('admin.imageUpload.label')} value={item.imageUrl} onChange={(value) => updateItem({ imageUrl: value })} />
             <StringField label="이름" value={item.name} onChange={(value) => updateItem({ name: value })} />
             <StringField label="설명 (HTML)" value={item.description} onChange={(value) => updateItem({ description: value })} multiline />
             <StringField label="링크 URL" value={item.href ?? ''} onChange={(value) => updateItem({ href: value })} />

--- a/src/components/shared/admin/page-editor/block-property-panel/blocks/PersonCardListFields.tsx
+++ b/src/components/shared/admin/page-editor/block-property-panel/blocks/PersonCardListFields.tsx
@@ -3,6 +3,7 @@
 import SectionHeadingFields from './SectionHeadingFields';
 import { ImageUploadField, ItemListEditor, StringField, createEditorId } from './GenericItemFields';
 import { createContentUpdater } from '../FormFields';
+import { localMessage } from '@/utils/localMessages';
 import type { PersonCardItem } from '@/lib/api';
 
 interface PersonCardListFieldsProps {
@@ -29,7 +30,7 @@ export default function PersonCardListFields({ content, onChange }: PersonCardLi
         getTitle={(item, index) => item.name || `항목 ${index + 1}`}
         renderItem={(item, _index, updateItem) => (
           <div className="space-y-2">
-            <ImageUploadField label="이미지 URL" value={item.imageUrl} onChange={(value) => updateItem({ imageUrl: value })} />
+            <ImageUploadField label={localMessage('admin.imageUpload.label')} value={item.imageUrl} onChange={(value) => updateItem({ imageUrl: value })} />
             <StringField label="직함" value={item.title ?? ''} onChange={(value) => updateItem({ title: value })} />
             <StringField label="이름" value={item.name} onChange={(value) => updateItem({ name: value })} />
             <StringField label="지역" value={item.region ?? ''} onChange={(value) => updateItem({ region: value })} />

--- a/src/components/shared/admin/page-editor/block-property-panel/blocks/PromotionBannerFields.tsx
+++ b/src/components/shared/admin/page-editor/block-property-panel/blocks/PromotionBannerFields.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { SelectField, StringField, createContentUpdater } from '../FormFields';
+import { ImageUploadField } from './GenericItemFields';
+import { localMessage } from '@/utils/localMessages';
 import { PROMOTION_TEMPLATE_OPTIONS } from '../blockConfig';
 
 interface PromotionBannerFieldsProps {
@@ -22,7 +24,7 @@ export default function PromotionBannerFields({ content, onChange }: PromotionBa
       <StringField label="제목 (EN)" value={(content.title_en as string) ?? ''} onChange={(v) => update('title_en', v)} placeholder="영문 제목" />
       <StringField label="부제목" value={(content.subtitle as string) ?? ''} onChange={(v) => update('subtitle', v)} />
       <StringField label="부제목 (EN)" value={(content.subtitle_en as string) ?? ''} onChange={(v) => update('subtitle_en', v)} placeholder="영문 부제목" />
-      <StringField label="이미지 URL" value={(content.image_url as string) ?? ''} onChange={(v) => update('image_url', v)} />
+      <ImageUploadField label={localMessage('admin.imageUpload.label')} value={(content.image_url as string) ?? ''} onChange={(v) => update('image_url', v)} />
       <StringField label="CTA 텍스트" value={(content.cta_text as string) ?? ''} onChange={(v) => update('cta_text', v)} />
       <StringField label="CTA 텍스트 (EN)" value={(content.cta_text_en as string) ?? ''} onChange={(v) => update('cta_text_en', v)} placeholder="영문 CTA" />
       <StringField label="CTA URL" value={(content.cta_url as string) ?? ''} onChange={(v) => update('cta_url', v)} />

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -967,7 +967,8 @@
       "title": "Navigation Management"
     },
     "categories": {
-      "title": "Category Management"
+      "title": "Category Management",
+      "imageAlt": "Category image"
     },
     "reviews": {
       "title": "Review Management",
@@ -1173,6 +1174,13 @@
       "deleteSuccess": "Attribute deleted.",
       "deleteError": "Failed to delete attribute.",
       "empty": "No attributes yet."
+    },
+    "imageUpload": {
+      "label": "Image",
+      "alt": "Uploaded image",
+      "emptyText": "Click or drag to upload an image",
+      "helperText": "JPEG, PNG, WebP · auto-resize above 20MB",
+      "uploading": "Uploading..."
     }
   },
   "search": {
@@ -1562,7 +1570,11 @@
     "title": "Shipping, Exchange & Refund Policy",
     "description": "Detailed shipping, exchange/return, and refund standards beyond the product-detail summary.",
     "effectiveDate": "Effective date: June 12, 2026",
-    "sectionKeys": ["shipping", "exchangeReturn", "refund"],
+    "sectionKeys": [
+      "shipping",
+      "exchangeReturn",
+      "refund"
+    ],
     "sections": {
       "shipping": {
         "title": "Shipping Policy",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -967,7 +967,8 @@
       "title": "네비게이션 관리"
     },
     "categories": {
-      "title": "카테고리 관리"
+      "title": "카테고리 관리",
+      "imageAlt": "카테고리 이미지"
     },
     "reviews": {
       "title": "리뷰 관리",
@@ -1173,6 +1174,13 @@
       "deleteSuccess": "속성을 삭제했습니다.",
       "deleteError": "속성을 삭제하지 못했습니다.",
       "empty": "등록된 속성이 없습니다."
+    },
+    "imageUpload": {
+      "label": "이미지",
+      "alt": "업로드 이미지",
+      "emptyText": "클릭하거나 드래그하여 이미지 업로드",
+      "helperText": "JPEG, PNG, WebP · 20MB 초과 시 자동 리사이징",
+      "uploading": "업로드 중..."
     }
   },
   "search": {
@@ -1562,7 +1570,11 @@
     "title": "배송/교환/환불 정책",
     "description": "상품 상세의 요약 안내보다 더 자세한 배송, 교환·반품, 환불 기준을 안내합니다.",
     "effectiveDate": "시행일: 2026년 6월 12일",
-    "sectionKeys": ["shipping", "exchangeReturn", "refund"],
+    "sectionKeys": [
+      "shipping",
+      "exchangeReturn",
+      "refund"
+    ],
     "sections": {
       "shipping": {
         "title": "배송 정책",


### PR DESCRIPTION
## Summary
- 카테고리 이미지 입력을 URL 텍스트 필드에서 직접 업로드 UI로 변경
- CMS 페이지 에디터의 hero/promotion/image-card/person-card 이미지 필드를 상품형 업로더 기반으로 통일
- 업로드 UI 문구를 locale 키로 분리하고 관련 회귀 테스트 추가

Closes #1024

## Verification
- bash scripts/codex-project-guard.sh
- npm run build
- npm run lint
- npx vitest run src/components/shared/admin/__tests__/ProductImageUploader.test.tsx src/components/shared/admin/__tests__/CategoryFormModal.test.tsx src/components/shared/admin/page-editor/__tests__/BlockPropertyPanel.test.tsx
- cd backend && npm run build && npm run test

## Notes
- `npm run test:run` 전체 프론트 스위트는 기존 테스트 진행 중 SIGTERM(143)으로 종료되어 요약을 생성하지 못했습니다. 단일 worker/verbose 재시도도 같은 방식으로 중단됐고, 변경 대상 테스트는 통과했습니다.
