### PR TITLE
feat: #1020 상품 속성값 한국어 병기

### DIFF
--- a/backend/src/modules/products/__tests__/attributes.service.spec.ts
+++ b/backend/src/modules/products/__tests__/attributes.service.spec.ts
@@ -5,9 +5,13 @@ import { ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm';
 import { AttributesService } from '../attributes.service';
 import { AttributeInputType, AttributeType } from '../entities/attribute-type.entity';
 import { ProductAttribute } from '../entities/product-attribute.entity';
+import { Collection } from '../../collections/entities/collection.entity';
 
 type RepoMock<T extends ObjectLiteral> = jest.Mocked<
-  Pick<Repository<T>, 'find' | 'findOne' | 'create' | 'save' | 'remove' | 'update' | 'delete' | 'createQueryBuilder'>
+  Pick<
+    Repository<T>,
+    'find' | 'findOne' | 'create' | 'save' | 'remove' | 'update' | 'delete' | 'createQueryBuilder'
+  >
 >;
 
 function createRepoMock<T extends ObjectLiteral>(): RepoMock<T> {
@@ -31,6 +35,7 @@ function createQueryBuilderMock(overrides: Record<string, unknown> = {}) {
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockResolvedValue([]),
     getRawMany: jest.fn().mockResolvedValue([]),
   };
@@ -42,16 +47,20 @@ describe('AttributesService', () => {
   let service: AttributesService;
   let typeRepo: RepoMock<AttributeType>;
   let attrRepo: RepoMock<ProductAttribute>;
+  let collectionRepo: RepoMock<Collection>;
 
   beforeEach(async () => {
     typeRepo = createRepoMock<AttributeType>();
     attrRepo = createRepoMock<ProductAttribute>();
+    collectionRepo = createRepoMock<Collection>();
+    collectionRepo.find.mockResolvedValue([]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AttributesService,
         { provide: getRepositoryToken(AttributeType), useValue: typeRepo },
         { provide: getRepositoryToken(ProductAttribute), useValue: attrRepo },
+        { provide: getRepositoryToken(Collection), useValue: collectionRepo },
       ],
     }).compile();
 
@@ -61,7 +70,12 @@ describe('AttributesService', () => {
   describe('createAttributeType', () => {
     it('기본값을 채워서 저장한다', async () => {
       typeRepo.findOne.mockResolvedValue(null as unknown as AttributeType);
-      const created = { id: 1, code: 'clay', name: '니료', inputType: AttributeInputType.TEXT } as unknown as AttributeType;
+      const created = {
+        id: 1,
+        code: 'clay',
+        name: '니료',
+        inputType: AttributeInputType.TEXT,
+      } as unknown as AttributeType;
       typeRepo.create.mockReturnValue(created);
       typeRepo.save.mockResolvedValue(created);
 
@@ -82,9 +96,9 @@ describe('AttributesService', () => {
     it('동일 code 가 이미 존재하면 ConflictException', async () => {
       typeRepo.findOne.mockResolvedValue({ id: 1, code: 'clay' } as AttributeType);
 
-      await expect(
-        service.createAttributeType({ code: 'clay', name: '니료' }),
-      ).rejects.toThrow(ConflictException);
+      await expect(service.createAttributeType({ code: 'clay', name: '니료' })).rejects.toThrow(
+        ConflictException,
+      );
     });
   });
 
@@ -92,7 +106,9 @@ describe('AttributesService', () => {
     it('없는 ID 수정 시 NotFoundException', async () => {
       typeRepo.findOne.mockResolvedValue(null as unknown as AttributeType);
 
-      await expect(service.updateAttributeType(999, { name: 'x' })).rejects.toThrow(NotFoundException);
+      await expect(service.updateAttributeType(999, { name: 'x' })).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('code 변경 시 다른 동일 code 가 있으면 ConflictException', async () => {
@@ -100,7 +116,9 @@ describe('AttributesService', () => {
         .mockResolvedValueOnce({ id: 1, code: 'old', name: 'a' } as AttributeType) // findAttributeTypeById
         .mockResolvedValueOnce({ id: 2, code: 'new' } as AttributeType); // 충돌 검사
 
-      await expect(service.updateAttributeType(1, { code: 'new' })).rejects.toThrow(ConflictException);
+      await expect(service.updateAttributeType(1, { code: 'new' })).rejects.toThrow(
+        ConflictException,
+      );
     });
 
     it('동일 code 변경 시도는 충돌 검사 스킵', async () => {
@@ -132,11 +150,13 @@ describe('AttributesService', () => {
 
     it('상품ID별로 그룹화한 Map을 반환한다', async () => {
       const qb = createQueryBuilderMock({
-        getMany: jest.fn().mockResolvedValue([
-          { id: 1, productId: 10, attributeTypeId: 1, value: 'a' } as ProductAttribute,
-          { id: 2, productId: 10, attributeTypeId: 2, value: 'b' } as ProductAttribute,
-          { id: 3, productId: 11, attributeTypeId: 1, value: 'c' } as ProductAttribute,
-        ]),
+        getMany: jest
+          .fn()
+          .mockResolvedValue([
+            { id: 1, productId: 10, attributeTypeId: 1, value: 'a' } as ProductAttribute,
+            { id: 2, productId: 10, attributeTypeId: 2, value: 'b' } as ProductAttribute,
+            { id: 3, productId: 11, attributeTypeId: 1, value: 'c' } as ProductAttribute,
+          ]),
       });
       attrRepo.createQueryBuilder.mockReturnValue(qb);
 
@@ -149,7 +169,13 @@ describe('AttributesService', () => {
 
   describe('createOrUpdateProductAttribute', () => {
     it('기존 값이 있으면 update', async () => {
-      const existing = { id: 1, productId: 1, attributeTypeId: 1, value: 'old', sortOrder: 0 } as ProductAttribute;
+      const existing = {
+        id: 1,
+        productId: 1,
+        attributeTypeId: 1,
+        value: 'old',
+        sortOrder: 0,
+      } as ProductAttribute;
       attrRepo.findOne.mockResolvedValue(existing);
       attrRepo.save.mockImplementation(async (entity: unknown) => entity as ProductAttribute);
 
@@ -182,17 +208,21 @@ describe('AttributesService', () => {
     it('없는 ID 수정 시 NotFoundException', async () => {
       attrRepo.findOne.mockResolvedValue(null as unknown as ProductAttribute);
 
-      await expect(
-        service.updateProductAttribute(999, { value: 'x' }),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.updateProductAttribute(999, { value: 'x' })).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
   describe('setProductAttributes', () => {
     it('기존 attributes 삭제 후 신규 일괄 저장', async () => {
-      attrRepo.delete.mockResolvedValue({ affected: 0 } as unknown as Awaited<ReturnType<Repository<ProductAttribute>['delete']>>);
+      attrRepo.delete.mockResolvedValue({ affected: 0 } as unknown as Awaited<
+        ReturnType<Repository<ProductAttribute>['delete']>
+      >);
       attrRepo.create.mockImplementation((dto: unknown) => dto as ProductAttribute);
-      (attrRepo.save as jest.Mock).mockImplementation(async (entities: unknown) => entities as ProductAttribute[]);
+      (attrRepo.save as jest.Mock).mockImplementation(
+        async (entities: unknown) => entities as ProductAttribute[],
+      );
 
       const result = await service.setProductAttributes(10, [
         { attributeTypeId: 1, value: 'a' },
@@ -204,7 +234,9 @@ describe('AttributesService', () => {
     });
 
     it('빈 배열이면 삭제만 수행하고 빈 배열 반환', async () => {
-      attrRepo.delete.mockResolvedValue({ affected: 0 } as unknown as Awaited<ReturnType<Repository<ProductAttribute>['delete']>>);
+      attrRepo.delete.mockResolvedValue({ affected: 0 } as unknown as Awaited<
+        ReturnType<Repository<ProductAttribute>['delete']>
+      >);
 
       const result = await service.setProductAttributes(10, []);
 
@@ -222,20 +254,36 @@ describe('AttributesService', () => {
       expect(result).toEqual([]);
     });
 
-    it('validValues 가 있으면 그것을 반환한다', async () => {
+    it('validValues 와 product_attributes 표시값을 병합해서 반환한다', async () => {
       typeRepo.findOne.mockResolvedValue({
         id: 1,
         code: 'clay',
         validValues: ['zhuni', 'duanni'],
       } as unknown as AttributeType);
 
+      const qb = createQueryBuilderMock({
+        getRawMany: jest.fn().mockResolvedValue([
+          { value: 'duanni', displayValue: 'duanni' },
+          { value: 'duanni', displayValue: '단니' },
+          { value: 'hongni', displayValue: '홍니' },
+        ]),
+      });
+      attrRepo.createQueryBuilder.mockReturnValue(qb);
+
+      collectionRepo.find.mockResolvedValue([
+        { name: 'Zhuni', nameKo: '주니', productUrl: '/products?attrs=clay:zhuni' } as Collection,
+      ]);
+
       const result = await service.getAttributeValuesByTypeCode('clay');
 
-      expect(result).toEqual(['zhuni', 'duanni']);
-      expect(attrRepo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        { value: 'zhuni', displayValue: '주니' },
+        { value: 'duanni', displayValue: '단니' },
+        { value: 'hongni', displayValue: '홍니' },
+      ]);
     });
 
-    it('validValues 가 없으면 product_attributes 에서 distinct 조회', async () => {
+    it('validValues 가 없으면 product_attributes 에서 value/displayValue 를 조회한다', async () => {
       typeRepo.findOne.mockResolvedValue({
         id: 1,
         code: 'clay',
@@ -243,13 +291,19 @@ describe('AttributesService', () => {
       } as unknown as AttributeType);
 
       const qb = createQueryBuilderMock({
-        getRawMany: jest.fn().mockResolvedValue([{ value: 'a' }, { value: 'b' }]),
+        getRawMany: jest.fn().mockResolvedValue([
+          { value: 'a', displayValue: '에이' },
+          { value: 'b', displayValue: null },
+        ]),
       });
       attrRepo.createQueryBuilder.mockReturnValue(qb);
 
       const result = await service.getAttributeValuesByTypeCode('clay');
 
-      expect(result).toEqual(['a', 'b']);
+      expect(result).toEqual([
+        { value: 'a', displayValue: '에이' },
+        { value: 'b', displayValue: null },
+      ]);
     });
   });
 

--- a/backend/src/modules/products/attributes.controller.ts
+++ b/backend/src/modules/products/attributes.controller.ts
@@ -12,17 +12,17 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { OptionalLocalePipe } from '../../common/pipes/optional-locale.pipe';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiCookieAuth,
-  ApiQuery,
-} from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiCookieAuth, ApiQuery } from '@nestjs/swagger';
 import { Public } from '../../common/decorators';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { AttributesService } from './attributes.service';
 import { CreateAttributeTypeDto, UpdateAttributeTypeDto } from './dto/attribute-type.dto';
-import { CreateProductAttributeDto, UpdateProductAttributeDto, SetProductAttributesDto } from './dto/product-attribute.dto';
+import {
+  AttributeValueOption,
+  CreateProductAttributeDto,
+  UpdateProductAttributeDto,
+  SetProductAttributesDto,
+} from './dto/product-attribute.dto';
 import { AttributeType } from './entities/attribute-type.entity';
 import { ProductAttribute } from './entities/product-attribute.entity';
 
@@ -37,7 +37,9 @@ export class AttributesController {
   @Public()
   @ApiOperation({ summary: '모든 속성 유형 조회' })
   @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en)' })
-  async findAllTypes(@Query('locale', OptionalLocalePipe) locale?: string): Promise<AttributeType[]> {
+  async findAllTypes(
+    @Query('locale', OptionalLocalePipe) locale?: string,
+  ): Promise<AttributeType[]> {
     return this.attributesService.findAllAttributeTypes(locale);
   }
 
@@ -45,7 +47,9 @@ export class AttributesController {
   @Public()
   @ApiOperation({ summary: '필터 가능한 속성 유형만 조회' })
   @ApiQuery({ name: 'locale', required: false, description: '언어 코드 (ko, en)' })
-  async findFilterableTypes(@Query('locale', OptionalLocalePipe) locale?: string): Promise<AttributeType[]> {
+  async findFilterableTypes(
+    @Query('locale', OptionalLocalePipe) locale?: string,
+  ): Promise<AttributeType[]> {
     return this.attributesService.getFilterableAttributes(locale);
   }
 
@@ -74,7 +78,7 @@ export class AttributesController {
   @Get('types/:code/values')
   @Public()
   @ApiOperation({ summary: '특정 타입의 가능한 값 목록 조회' })
-  async getTypeValues(@Param('code') code: string): Promise<string[]> {
+  async getTypeValues(@Param('code') code: string): Promise<AttributeValueOption[]> {
     return this.attributesService.getAttributeValuesByTypeCode(code);
   }
 
@@ -111,7 +115,9 @@ export class AttributesController {
   @Get('products/:productId')
   @Public()
   @ApiOperation({ summary: '상품 속성 조회' })
-  async findByProductId(@Param('productId', ParseIntPipe) productId: number): Promise<ProductAttribute[]> {
+  async findByProductId(
+    @Param('productId', ParseIntPipe) productId: number,
+  ): Promise<ProductAttribute[]> {
     return this.attributesService.findAttributesByProductId(productId);
   }
 

--- a/backend/src/modules/products/attributes.service.ts
+++ b/backend/src/modules/products/attributes.service.ts
@@ -1,11 +1,22 @@
-import { BadRequestException, Injectable, NotFoundException, ConflictException, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  Logger,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Like, Repository } from 'typeorm';
 import { AttributeType, AttributeInputType } from './entities/attribute-type.entity';
 import { ProductAttribute } from './entities/product-attribute.entity';
 import { CreateAttributeTypeDto, UpdateAttributeTypeDto } from './dto/attribute-type.dto';
-import { CreateProductAttributeDto, UpdateProductAttributeDto } from './dto/product-attribute.dto';
+import {
+  AttributeValueOption,
+  CreateProductAttributeDto,
+  UpdateProductAttributeDto,
+} from './dto/product-attribute.dto';
 import { applyLocale } from '../../common/utils/locale.util';
+import { Collection } from '../collections/entities/collection.entity';
 
 @Injectable()
 export class AttributesService {
@@ -16,7 +27,38 @@ export class AttributesService {
     private readonly attributeTypeRepository: Repository<AttributeType>,
     @InjectRepository(ProductAttribute)
     private readonly productAttributeRepository: Repository<ProductAttribute>,
+    @InjectRepository(Collection)
+    private readonly collectionRepository: Repository<Collection>,
   ) {}
+
+  private getAttributeValueFromProductUrl(productUrl: string, code: string): string | null {
+    const [, query = ''] = productUrl.split('?');
+    if (!query) return null;
+    const params = new URLSearchParams(query);
+    const attrs = params.get('attrs');
+    if (!attrs) return null;
+
+    for (const pair of attrs.split(',')) {
+      const [attrCode, value] = pair.split(':');
+      if (attrCode === code && value) return decodeURIComponent(value);
+    }
+    return null;
+  }
+
+  private async getCollectionDisplayValuesByAttributeValue(
+    code: string,
+  ): Promise<Map<string, string>> {
+    const collections = await this.collectionRepository.find({
+      where: { productUrl: Like(`%attrs=${code}:%`) },
+    });
+    const displayValueByValue = new Map<string, string>();
+    for (const collection of collections) {
+      const value = this.getAttributeValueFromProductUrl(collection.productUrl, code);
+      const displayValue = collection.nameKo?.trim() || collection.name.trim();
+      if (value && displayValue) displayValueByValue.set(value, displayValue);
+    }
+    return displayValueByValue;
+  }
 
   private applyLocaleToAttributeType(entity: AttributeType, locale?: string): AttributeType {
     // ko 로케일: name 컬럼이 영문일 수 있으므로 nameKo 우선 적용
@@ -217,7 +259,10 @@ export class AttributesService {
     return this.createProductAttribute({ ...dto, productId });
   }
 
-  async updateProductAttribute(id: number, dto: UpdateProductAttributeDto): Promise<ProductAttribute> {
+  async updateProductAttribute(
+    id: number,
+    dto: UpdateProductAttributeDto,
+  ): Promise<ProductAttribute> {
     const attr = await this.productAttributeRepository.findOne({ where: { id } });
     if (!attr) {
       throw new NotFoundException(`ProductAttribute ID ${id} not found`);
@@ -246,7 +291,12 @@ export class AttributesService {
 
   async setProductAttributes(
     productId: number,
-    attributes: Array<{ attributeTypeId: number; value: string; displayValue?: string; sortOrder?: number }>,
+    attributes: Array<{
+      attributeTypeId: number;
+      value: string;
+      displayValue?: string;
+      sortOrder?: number;
+    }>,
   ): Promise<ProductAttribute[]> {
     // Delete existing
     await this.deleteAttributesByProductId(productId);
@@ -277,23 +327,40 @@ export class AttributesService {
     return types.map((t) => this.applyLocaleToAttributeType(t, locale));
   }
 
-  async getAttributeValuesByTypeCode(code: string): Promise<string[]> {
+  async getAttributeValuesByTypeCode(code: string): Promise<AttributeValueOption[]> {
     const type = await this.findAttributeTypeByCode(code);
     if (!type) {
       return [];
     }
-    if (type.validValues && type.validValues.length > 0) {
-      return type.validValues;
-    }
 
-    // Fetch unique values from product_attributes
     const result = await this.productAttributeRepository
       .createQueryBuilder('pa')
       .innerJoin('pa.attributeType', 'at', 'at.code = :code', { code })
-      .select('DISTINCT pa.value', 'value')
+      .select('pa.value', 'value')
+      .addSelect('pa.display_value', 'displayValue')
       .orderBy('pa.value', 'ASC')
-      .getRawMany();
+      .getRawMany<{ value: string; displayValue: string | null }>();
 
-    return result.map((r) => r.value);
+    const collectionDisplayValueByValue =
+      await this.getCollectionDisplayValuesByAttributeValue(code);
+    const displayValueByValue = new Map<string, string | null>();
+    for (const row of result) {
+      const displayValue = row.displayValue?.trim() || null;
+      const existing = displayValueByValue.get(row.value);
+      if (!existing || (displayValue && displayValue !== row.value)) {
+        displayValueByValue.set(row.value, displayValue);
+      }
+    }
+    for (const [value, displayValue] of collectionDisplayValueByValue) {
+      if (!displayValueByValue.get(value)) displayValueByValue.set(value, displayValue);
+    }
+    const values = [...(type.validValues ?? []), ...result.map((row) => row.value)];
+
+    return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).map(
+      (value) => ({
+        value,
+        displayValue: displayValueByValue.get(value) ?? null,
+      }),
+    );
   }
 }

--- a/backend/src/modules/products/dto/product-attribute.dto.ts
+++ b/backend/src/modules/products/dto/product-attribute.dto.ts
@@ -1,6 +1,11 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, IsNumber, IsArray, Min, MaxLength } from 'class-validator';
 
+export interface AttributeValueOption {
+  value: string;
+  displayValue: string | null;
+}
+
 export class CreateProductAttributeDto {
   @ApiProperty({ example: 1 })
   @IsNumber()

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -20,6 +20,7 @@ import { NaverCommerceApiClient } from './naver-commerce-api.client';
 import { NaverCommerceProductImportService } from './naver-commerce-product-import.service';
 import { NaverCommerceImportJobService } from './naver-commerce-import-job.service';
 import { ProductKeywordMappingService } from './product-keyword-mapping.service';
+import { Collection } from '../collections/entities/collection.entity';
 import { ProductsController } from './products.controller';
 import { AdminProductsController } from './admin-products.controller';
 import { CategoriesController } from './categories.controller';
@@ -43,6 +44,7 @@ import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guar
       AttributeType,
       ProductAttribute,
       RecentlyViewedProduct,
+      Collection,
     ]),
     CacheModule,
     RestockAlertsModule,

--- a/backend/test/suites/attributes.e2e-spec.ts
+++ b/backend/test/suites/attributes.e2e-spec.ts
@@ -139,8 +139,12 @@ export function registerAttributesSuite(getApp: () => INestApplication) {
           .expect(200)
           .expect((res) => {
             expect(Array.isArray(res.body)).toBe(true);
-            expect(res.body).toContain('val1');
-            expect(res.body).toContain('val2');
+            expect(res.body).toEqual(
+              expect.arrayContaining([
+                { value: 'val1', displayValue: null },
+                { value: 'val2', displayValue: null },
+              ]),
+            );
           });
       });
     });

--- a/src/components/shared/admin/ProductFormPage.tsx
+++ b/src/components/shared/admin/ProductFormPage.tsx
@@ -6,7 +6,13 @@ import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
 import { adminCategoriesApi, adminProductsApi, attributesApi } from '@/lib/api';
-import type { AdminCategory, AttributeType, ProductDetail, ProductNoticeInfo } from '@/lib/api';
+import type {
+  AdminCategory,
+  AttributeType,
+  AttributeValueOption,
+  ProductDetail,
+  ProductNoticeInfo,
+} from '@/lib/api';
 import MultiImageUploader from './MultiImageUploader';
 import ProductOptionsEditor, { type ProductOptionDraft } from './ProductOptionsEditor';
 import { CheckboxField, SelectField, TextAreaField, TextField } from './FormField';
@@ -119,15 +125,46 @@ function buildNoticeInfoPayload(
   ) as ProductNoticeInfo;
 }
 
-function uniqueAttributeValues(values: Array<string | null | undefined>): string[] {
-  return Array.from(
-    new Set(values.map((value) => value?.trim() ?? '').filter((value) => value.length > 0)),
-  );
+interface ProductAttributeValueOption {
+  value: string;
+  displayValue: string | null;
+}
+
+function normalizeAttributeValueOption(
+  option: string | AttributeValueOption,
+): ProductAttributeValueOption {
+  if (typeof option === 'string') {
+    return { value: option.trim(), displayValue: null };
+  }
+  return {
+    value: option.value.trim(),
+    displayValue: option.displayValue?.trim() || null,
+  };
+}
+
+function uniqueAttributeValueOptions(
+  options: Array<string | AttributeValueOption>,
+): ProductAttributeValueOption[] {
+  const byValue = new Map<string, ProductAttributeValueOption>();
+  for (const option of options) {
+    const normalized = normalizeAttributeValueOption(option);
+    if (!normalized.value) continue;
+    const existing = byValue.get(normalized.value);
+    if (!existing || (!existing.displayValue && normalized.displayValue)) {
+      byValue.set(normalized.value, normalized);
+    }
+  }
+  return Array.from(byValue.values());
+}
+
+function formatAttributeValueLabel(option: ProductAttributeValueOption): string {
+  if (!option.displayValue || option.displayValue === option.value) return option.value;
+  return `${option.displayValue} (${option.value})`;
 }
 
 async function loadAttributeValueOptions(
   attributeTypes: AttributeType[],
-): Promise<Record<string, string[]>> {
+): Promise<Record<string, ProductAttributeValueOption[]>> {
   const settledValues = await Promise.allSettled(
     attributeTypes.map((type) => attributesApi.getTypeValues(type.code)),
   );
@@ -138,7 +175,7 @@ async function loadAttributeValueOptions(
       const existingValues = remoteValues?.status === 'fulfilled' ? remoteValues.value : [];
       return [
         String(type.id),
-        uniqueAttributeValues([...(type.validValues ?? []), ...existingValues]),
+        uniqueAttributeValueOptions([...(type.validValues ?? []), ...existingValues]),
       ] as const;
     }),
   );
@@ -423,7 +460,7 @@ function ProductAttributesSection({
 }: {
   attributes: ProductAttributeDraft[];
   attributeTypes: AttributeType[];
-  attributeValueOptions: Record<string, string[]>;
+  attributeValueOptions: Record<string, ProductAttributeValueOption[]>;
   set: Setter;
 }) {
   const t = useTranslations('admin.productForm');
@@ -439,15 +476,15 @@ function ProductAttributesSection({
     );
   };
 
-  const selectExistingValue = (index: number, value: string) => {
+  const selectExistingValue = (index: number, option: ProductAttributeValueOption) => {
     set(
       'attributes',
       attributes.map((attr, i) => {
         if (i !== index) return attr;
         return {
           ...attr,
-          value,
-          displayValue: value,
+          value: option.value,
+          displayValue: option.displayValue ?? option.value,
         };
       }),
     );
@@ -513,13 +550,14 @@ function ProductAttributesSection({
                   {t('existingAttributeValues')}
                 </p>
                 <div className="flex flex-wrap gap-2">
-                  {existingValues.map((value) => {
-                    const selected = attribute.value === value;
+                  {existingValues.map((option) => {
+                    const selected = attribute.value === option.value;
+                    const label = formatAttributeValueLabel(option);
                     return (
                       <button
-                        key={value}
+                        key={option.value}
                         type="button"
-                        onClick={() => selectExistingValue(index, value)}
+                        onClick={() => selectExistingValue(index, option)}
                         className={
                           selected
                             ? 'rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground'
@@ -527,7 +565,7 @@ function ProductAttributesSection({
                         }
                         aria-pressed={selected}
                       >
-                        {value}
+                        {label}
                       </button>
                     );
                   })}
@@ -546,7 +584,9 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
   const [submitting, setSubmitting] = useState(false);
   const [categories, setCategories] = useState<AdminCategory[]>([]);
   const [attributeTypes, setAttributeTypes] = useState<AttributeType[]>([]);
-  const [attributeValueOptions, setAttributeValueOptions] = useState<Record<string, string[]>>({});
+  const [attributeValueOptions, setAttributeValueOptions] = useState<
+    Record<string, ProductAttributeValueOption[]>
+  >({});
   const hadNoticeInfo = product?.noticeInfo != null;
   const [form, setForm] = useState<ProductFormData>({
     categoryId: product?.category?.id != null ? String(product.category.id) : '',

--- a/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
@@ -141,7 +141,10 @@ describe('ProductFormPage', () => {
           isActive: true,
         },
       ]);
-      vi.mocked(attributesApi.getTypeValues).mockResolvedValue(['zhuni', 'duanni']);
+      vi.mocked(attributesApi.getTypeValues).mockResolvedValue([
+        { value: 'zhuni', displayValue: '주니' },
+        { value: 'duanni', displayValue: '단니' },
+      ]);
       vi.mocked(adminProductsApi.create).mockResolvedValue({
         id: 1,
         name: '테스트 상품',
@@ -169,7 +172,8 @@ describe('ProductFormPage', () => {
       await waitFor(() => expect(attributesApi.getTypeValues).toHaveBeenCalledWith('clay_type'));
       fireEvent.click(screen.getByText('+ 속성 추가'));
       fireEvent.change(screen.getByDisplayValue('선택'), { target: { value: '1' } });
-      fireEvent.click(screen.getByText('duanni'));
+      expect(screen.getByText('주니 (zhuni)')).toBeInTheDocument();
+      fireEvent.click(screen.getByText('단니 (duanni)'));
 
       fireEvent.change(screen.getByPlaceholderText('상품명을 입력하세요'), {
         target: { value: '테스트 상품' },
@@ -187,7 +191,7 @@ describe('ProductFormPage', () => {
             {
               attributeTypeId: 1,
               value: 'duanni',
-              displayValue: 'duanni',
+              displayValue: '단니',
               sortOrder: 0,
             },
           ],

--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -56,6 +56,11 @@ export interface ProductAttribute {
   attributeType?: AttributeType;
 }
 
+export interface AttributeValueOption {
+  value: string;
+  displayValue: string | null;
+}
+
 export interface AttributeType {
   id: number;
   code: string;
@@ -114,7 +119,8 @@ export interface ProductDetail extends Product {
 
 export type ProductListResponse = PaginatedResponse<Product>;
 
-export type ProductSort = 'latest' | 'price_asc' | 'price_desc' | 'popular' | 'review_count' | 'rating';
+export type ProductSort =
+  'latest' | 'price_asc' | 'price_desc' | 'popular' | 'review_count' | 'rating';
 
 export interface AutocompleteItem {
   id: number;
@@ -123,12 +129,28 @@ export interface AutocompleteItem {
 }
 
 export const productsApi = {
-  getList: (params?: { page?: number; limit?: number; sort?: ProductSort; categoryId?: number; q?: string; price_min?: number; price_max?: number; locale?: string; attrs?: string }) =>
-    apiClient.get<ProductListResponse>('/products', { params: params as Record<string, string | number | undefined> }),
+  getList: (params?: {
+    page?: number;
+    limit?: number;
+    sort?: ProductSort;
+    categoryId?: number;
+    q?: string;
+    price_min?: number;
+    price_max?: number;
+    locale?: string;
+    attrs?: string;
+  }) =>
+    apiClient.get<ProductListResponse>('/products', {
+      params: params as Record<string, string | number | undefined>,
+    }),
   getById: (id: number, locale?: string) =>
     apiClient.get<ProductDetail>(`/products/${id}`, { params: locale ? { locale } : undefined }),
   getBulk: (ids: number[], locale?: string) =>
-    apiClient.post<Product[]>('/products/bulk', { ids }, { params: locale ? { locale } : undefined }),
+    apiClient.post<Product[]>(
+      '/products/bulk',
+      { ids },
+      { params: locale ? { locale } : undefined },
+    ),
   autocomplete: (q: string) =>
     apiClient.get<AutocompleteItem[]>('/products/autocomplete', { params: { q } }),
 };
@@ -146,9 +168,12 @@ export const attributesApi = {
   getTypes: () => apiClient.get<AttributeType[]>('/attributes/types'),
   getFilterableTypes: () => apiClient.get<AttributeType[]>('/attributes/types/filterable'),
   getTypeById: (id: number) => apiClient.get<AttributeType>(`/attributes/types/${id}`),
-  getTypeByCode: (code: string) => apiClient.get<AttributeType | null>(`/attributes/types/code/${code}`),
-  getTypeValues: (code: string) => apiClient.get<string[]>(`/attributes/types/${code}/values`),
-  getProductAttributes: (productId: number) => apiClient.get<ProductAttribute[]>(`/attributes/products/${productId}`),
+  getTypeByCode: (code: string) =>
+    apiClient.get<AttributeType | null>(`/attributes/types/code/${code}`),
+  getTypeValues: (code: string) =>
+    apiClient.get<Array<string | AttributeValueOption>>(`/attributes/types/${code}/values`),
+  getProductAttributes: (productId: number) =>
+    apiClient.get<ProductAttribute[]>(`/attributes/products/${productId}`),
   createType: (data: Partial<AttributeType> & { code: string; name: string }) =>
     apiClient.post<AttributeType>('/attributes/types', data),
   updateType: (id: number, data: Partial<AttributeType>) =>
@@ -159,11 +184,17 @@ export const attributesApi = {
 export const homeApi = {
   getFeaturedProducts: () =>
     apiClient.get<ProductListResponse>('/products', {
-      params: { isFeatured: 'true', limit: 8, status: 'active' } as Record<string, string | number | undefined>,
+      params: { isFeatured: 'true', limit: 8, status: 'active' } as Record<
+        string,
+        string | number | undefined
+      >,
     }),
   getPopularProducts: () =>
     apiClient.get<ProductListResponse>('/products', {
-      params: { sort: 'popular', limit: 8, status: 'active' } as Record<string, string | number | undefined>,
+      params: { sort: 'popular', limit: 8, status: 'active' } as Record<
+        string,
+        string | number | undefined
+      >,
     }),
 };
 


### PR DESCRIPTION
## Summary
- `/attributes/types/:code/values` 응답을 원본 `value` + 표시용 `displayValue` 객체로 확장
- 상품 속성값 선택 칩을 `한국어 표시값 (원본값)` 형태로 병기
- `value`는 기존 코드값으로 저장하고, `displayValue`는 한국어 표시값으로 저장되도록 유지
- `product_attributes.display_value`가 비어 있는 값은 `collections.productUrl`/`nameKo`로 표시명을 보강

Closes #1020

## Verification
- `npx vitest run src/components/shared/admin/__tests__/ProductFormPage.test.tsx`
- `cd backend && npm run test -- --runTestsByPath src/modules/products/__tests__/attributes.service.spec.ts`
- `bash scripts/codex-project-guard.sh && npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- Direct backend start + `curl http://localhost:3000/api/attributes/types/clay_type/values` returned displayValue entries
- `curl -I http://localhost:5173/ko`
- `curl -I http://localhost:5173/ko/admin/products/new` (auth redirect 확인)

## Notes
- DB schema/migration 변경 없음. backend e2e는 생략했습니다.
- 인증된 관리자 브라우저 세션에서의 수동 클릭 검증은 수행하지 않았습니다.
