### PR TITLE
상품별 한글/영어 페이지 노출 설정 지원 (#1021)

### DIFF
--- a/backend/src/database/migrations/1785600000000-AddProductLocaleVisibility.ts
+++ b/backend/src/database/migrations/1785600000000-AddProductLocaleVisibility.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductLocaleVisibility1785600000000 implements MigrationInterface {
+  name = 'AddProductLocaleVisibility1785600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE products ADD COLUMN is_visible_ko tinyint NOT NULL DEFAULT 1`);
+    await queryRunner.query(`ALTER TABLE products ADD COLUMN is_visible_en tinyint NOT NULL DEFAULT 1`);
+    await queryRunner.query(`ALTER TABLE products ALTER COLUMN is_visible_en SET DEFAULT 0`);
+    await queryRunner.query(`CREATE INDEX IDX_products_is_visible_ko ON products (is_visible_ko)`);
+    await queryRunner.query(`CREATE INDEX IDX_products_is_visible_en ON products (is_visible_en)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IDX_products_is_visible_en ON products`);
+    await queryRunner.query(`DROP INDEX IDX_products_is_visible_ko ON products`);
+    await queryRunner.query(`ALTER TABLE products DROP COLUMN is_visible_en`);
+    await queryRunner.query(`ALTER TABLE products DROP COLUMN is_visible_ko`);
+  }
+}

--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -193,6 +193,8 @@ describe('NaverCommerceProductImportService', () => {
         price: 50000,
         stock: 3,
         isFreeShipping: true,
+        isVisibleKo: true,
+        isVisibleEn: false,
         description: '<p>상세</p>',
         noticeInfo: expect.objectContaining({ manufacturer: '옥화당', countryOfOrigin: '중국' }),
         options: [expect.objectContaining({ name: '용량', value: '100cc', stock: 2 })],

--- a/backend/src/modules/products/__tests__/product-command.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-command.service.spec.ts
@@ -98,6 +98,8 @@ describe('ProductCommandService', () => {
           categoryId: null,
           salePrice: null,
           sku: null,
+          isVisibleKo: true,
+          isVisibleEn: false,
         }),
       );
     });
@@ -192,8 +194,9 @@ describe('ProductCommandService', () => {
 
       await service.update(1, { name: 'new' });
 
-      expect(cacheService.del).toHaveBeenCalled();
-      expect(cacheService.delPattern).toHaveBeenCalled();
+      expect(cacheService.delPattern).toHaveBeenCalledWith('products:detail:*');
+      expect(cacheService.delPattern).toHaveBeenCalledWith('products:list:*');
+      expect(cacheService.delPattern).toHaveBeenCalledWith('products:bulk:*');
     });
 
     it('stock 변경 시 RestockAlertsService.processProductRestock 호출', async () => {
@@ -279,8 +282,9 @@ describe('ProductCommandService', () => {
       const result = await service.remove(1);
 
       expect(result).toEqual({ message: '삭제되었습니다.' });
-      expect(cacheService.del).toHaveBeenCalled();
-      expect(cacheService.delPattern).toHaveBeenCalled();
+      expect(cacheService.delPattern).toHaveBeenCalledWith('products:detail:*');
+      expect(cacheService.delPattern).toHaveBeenCalledWith('products:list:*');
+      expect(cacheService.delPattern).toHaveBeenCalledWith('products:bulk:*');
     });
   });
 });

--- a/backend/src/modules/products/__tests__/product-query.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-query.service.spec.ts
@@ -331,6 +331,14 @@ describe('ProductQueryService', () => {
       await expect(service.findOne(2, false)).rejects.toThrow(NotFoundException);
     });
 
+
+
+    it('비관리자는 현재 locale에서 숨김 처리된 상품 상세를 조회할 수 없다', async () => {
+      qb.getOne.mockResolvedValue({ id: 1, status: ProductStatus.ACTIVE, isVisibleEn: false } as Product);
+
+      await expect(service.findOne(1, false, 'en')).rejects.toThrow(NotFoundException);
+    });
+
     it('정상 조회 후 viewCount 증가는 fire-and-forget', async () => {
       qb.getOne.mockResolvedValue({ id: 1, status: ProductStatus.ACTIVE } as Product);
       reviewQb.getRawMany.mockResolvedValue([]);
@@ -415,6 +423,19 @@ describe('ProductQueryService', () => {
         'attribute.attributeType',
         'attributeType',
       );
+    });
+
+    it('비관리자 bulk 조회는 현재 locale에서 숨김 처리된 상품을 제외한다', async () => {
+      qb.getMany.mockResolvedValue([
+        { id: 1, status: ProductStatus.ACTIVE, isVisibleEn: true } as Product,
+        { id: 2, status: ProductStatus.ACTIVE, isVisibleEn: false } as Product,
+      ]);
+      reviewQb.getRawMany.mockResolvedValue([]);
+
+      const result = await service.findBulk([1, 2], false, 'en');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(1);
     });
 
     it('비관리자 bulk cache hit 에도 hidden 상품을 반환하지 않는다', async () => {

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -239,6 +239,8 @@ describe('SmartStoreProductImportService', () => {
       price: 12000,
       stock: 3,
       status: ProductStatus.ACTIVE,
+      isVisibleKo: true,
+      isVisibleEn: false,
       description: '<p>상세</p>',
       images: [expect.objectContaining({ url: ingestedUrl('https://cdn.example.com/1.jpg'), isThumbnail: true })],
     }));
@@ -271,6 +273,8 @@ describe('SmartStoreProductImportService', () => {
       price: 500000,
       salePrice: 400000,
       isFreeShipping: true,
+      isVisibleKo: true,
+      isVisibleEn: false,
       noticeInfo: expect.objectContaining({
         type: 'teaware',
         productName: '옥화당 자사호 홍위주니 연자호 100cc',

--- a/backend/src/modules/products/dto/create-product.dto.ts
+++ b/backend/src/modules/products/dto/create-product.dto.ts
@@ -233,6 +233,16 @@ export class CreateProductDto {
   @IsBoolean({ message: '무료배송 상품 여부는 불리언이어야 합니다.' })
   isFreeShipping?: boolean;
 
+  @ApiPropertyOptional({ example: true, description: '한국어 페이지 노출 여부' })
+  @IsOptional()
+  @IsBoolean({ message: '한국어 페이지 노출 여부는 불리언이어야 합니다.' })
+  isVisibleKo?: boolean;
+
+  @ApiPropertyOptional({ example: false, description: '영어 페이지 노출 여부' })
+  @IsOptional()
+  @IsBoolean({ message: '영어 페이지 노출 여부는 불리언이어야 합니다.' })
+  isVisibleEn?: boolean;
+
   @ApiPropertyOptional({ example: 'Ockhwadang Pu-erh Tea', description: '상품명 (영문)' })
   @IsOptional()
   @IsString({ message: '영문 상품명은 문자열이어야 합니다.' })

--- a/backend/src/modules/products/dto/update-product.dto.ts
+++ b/backend/src/modules/products/dto/update-product.dto.ts
@@ -73,6 +73,16 @@ export class UpdateProductDto {
   @IsBoolean()
   isFreeShipping?: boolean;
 
+  @ApiPropertyOptional({ example: true, description: '한국어 페이지 노출 여부' })
+  @IsOptional()
+  @IsBoolean()
+  isVisibleKo?: boolean;
+
+  @ApiPropertyOptional({ example: false, description: '영어 페이지 노출 여부' })
+  @IsOptional()
+  @IsBoolean()
+  isVisibleEn?: boolean;
+
   @ApiPropertyOptional({ example: 'Ockhwadang Pu-erh Tea', description: '상품명 (영문)' })
   @IsOptional()
   @IsString()

--- a/backend/src/modules/products/entities/product.entity.ts
+++ b/backend/src/modules/products/entities/product.entity.ts
@@ -49,6 +49,8 @@ export interface ProductNoticeInfo {
 @Index(['status'])
 @Index(['isFeatured'])
 @Index(['isFreeShipping'])
+@Index(['isVisibleKo'])
+@Index(['isVisibleEn'])
 @Index(['reviewCount'])
 @Index(['avgRating'])
 export class Product {
@@ -127,6 +129,12 @@ export class Product {
 
   @Column({ name: 'is_free_shipping', default: false })
   isFreeShipping!: boolean;
+
+  @Column({ name: 'is_visible_ko', default: true })
+  isVisibleKo!: boolean;
+
+  @Column({ name: 'is_visible_en', default: false })
+  isVisibleEn!: boolean;
 
   @Column({ name: 'view_count', default: 0 })
   viewCount!: number;

--- a/backend/src/modules/products/naver-commerce-product-import.service.ts
+++ b/backend/src/modules/products/naver-commerce-product-import.service.ts
@@ -141,6 +141,8 @@ export class NaverCommerceProductImportService {
             ),
             description: description || undefined,
             isFreeShipping: this.resolveFreeShipping(product),
+            isVisibleKo: true,
+            isVisibleEn: false,
             noticeInfo,
             images: this.buildImages(productName, galleryUrls),
             detailImages: detailUrls.map((url, index) => ({

--- a/backend/src/modules/products/product-cache.util.ts
+++ b/backend/src/modules/products/product-cache.util.ts
@@ -1,5 +1,6 @@
 export const PRODUCT_LIST_CACHE_PATTERN = 'products:list:*';
 export const PRODUCT_BULK_CACHE_PATTERN = 'products:bulk:*';
+export const PRODUCT_DETAIL_CACHE_PATTERN = 'products:detail:*';
 
 export function getProductListCacheKey(query: unknown, isAdmin: boolean): string {
   const hash = Buffer.from(JSON.stringify({ ...asRecord(query), isAdmin })).toString(
@@ -8,12 +9,12 @@ export function getProductListCacheKey(query: unknown, isAdmin: boolean): string
   return `products:list:${hash}`;
 }
 
-export function getProductDetailCacheKey(id: number): string {
-  return `products:detail:${id}`;
+export function getProductDetailCacheKey(id: number, isAdmin: boolean, locale?: string): string {
+  return `products:detail:${isAdmin ? 'admin' : 'public'}:${locale ?? 'ko'}:${id}`;
 }
 
-export function getProductBulkCacheKey(ids: number[], isAdmin: boolean): string {
-  return `products:bulk:${isAdmin ? 'admin' : 'public'}:${[...ids].sort().join(',')}`;
+export function getProductBulkCacheKey(ids: number[], isAdmin: boolean, locale?: string): string {
+  return `products:bulk:${isAdmin ? 'admin' : 'public'}:${locale ?? 'ko'}:${[...ids].sort().join(',')}`;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/backend/src/modules/products/product-command.service.ts
+++ b/backend/src/modules/products/product-command.service.ts
@@ -16,8 +16,8 @@ import { RestockAlertsService } from '../restock-alerts/restock-alerts.service';
 import { CacheService } from '../cache/cache.service';
 import { findOrThrow } from '../../common/utils/repository.util';
 import {
-  getProductDetailCacheKey,
   PRODUCT_BULK_CACHE_PATTERN,
+  PRODUCT_DETAIL_CACHE_PATTERN,
   PRODUCT_LIST_CACHE_PATTERN,
 } from './product-cache.util';
 
@@ -42,6 +42,8 @@ export class ProductCommandService {
           categoryId: dto.categoryId ?? null,
           salePrice: dto.salePrice ?? null,
           sku: dto.sku ?? null,
+          isVisibleKo: dto.isVisibleKo ?? true,
+          isVisibleEn: dto.isVisibleEn ?? false,
         });
         const saved = await manager.save(product);
 
@@ -152,7 +154,7 @@ export class ProductCommandService {
         return updatedProduct;
       });
 
-      await this.invalidateProductCache(id);
+      await this.invalidateProductCache();
 
       if (dto.stock !== undefined) {
         await this.restockAlertsService.processProductRestock(
@@ -172,7 +174,7 @@ export class ProductCommandService {
   async remove(id: number): Promise<{ message: string }> {
     const product = await this.findById(id);
     await this.productRepository.remove(product);
-    await this.invalidateProductCache(id);
+    await this.invalidateProductCache();
     return { message: '삭제되었습니다.' };
   }
 
@@ -180,9 +182,9 @@ export class ProductCommandService {
     return findOrThrow(this.productRepository, { id }, '상품을 찾을 수 없습니다.');
   }
 
-  private async invalidateProductCache(productId: number): Promise<void> {
+  private async invalidateProductCache(): Promise<void> {
     await Promise.all([
-      this.cacheService.del(getProductDetailCacheKey(productId)),
+      this.cacheService.delPattern(PRODUCT_DETAIL_CACHE_PATTERN),
       this.cacheService.delPattern(PRODUCT_LIST_CACHE_PATTERN),
       this.cacheService.delPattern(PRODUCT_BULK_CACHE_PATTERN),
     ]);

--- a/backend/src/modules/products/product-query.service.ts
+++ b/backend/src/modules/products/product-query.service.ts
@@ -152,6 +152,7 @@ export class ProductQueryService {
     const qb = this.buildBaseQueryBuilder(
       isAdmin,
       status as ProductStatus | undefined,
+      locale,
     );
 
     if (q) {
@@ -191,7 +192,8 @@ export class ProductQueryService {
   }
 
   async findOne(id: number, isAdmin = false, locale?: string): Promise<Product & { rating: number; reviewCount: number }> {
-    const cacheKey = getProductDetailCacheKey(id);
+    const normalizedLocale = this.normalizeLocale(locale);
+    const cacheKey = getProductDetailCacheKey(id, isAdmin, normalizedLocale);
     const cached = await this.cacheService.get<Product & { rating: number; reviewCount: number }>(cacheKey);
 
     if (cached) {
@@ -199,11 +201,12 @@ export class ProductQueryService {
         !isAdmin &&
         (cached.status === ProductStatus.DRAFT ||
           cached.status === ProductStatus.HIDDEN ||
-          cached.category?.isActive === false)
+          cached.category?.isActive === false ||
+          !this.isVisibleInLocale(cached, normalizedLocale))
       ) {
         throw new NotFoundException('상품을 찾을 수 없습니다.');
       }
-      return this.applyLocale(cached, locale) as Product & { rating: number; reviewCount: number };
+      return this.applyLocale(cached, normalizedLocale) as Product & { rating: number; reviewCount: number };
     }
 
     const product = await this.productRepository
@@ -225,7 +228,8 @@ export class ProductQueryService {
       !isAdmin &&
       (product.status === ProductStatus.DRAFT ||
         product.status === ProductStatus.HIDDEN ||
-        product.category?.isActive === false)
+        product.category?.isActive === false ||
+        !this.isVisibleInLocale(product, normalizedLocale))
     ) {
       throw new NotFoundException('상품을 찾을 수 없습니다.');
     }
@@ -234,7 +238,7 @@ export class ProductQueryService {
       this.logger.warn(`view_count increment failed: ${err.message}`),
     );
 
-    const localized = this.applyLocale(product, locale);
+    const localized = this.applyLocale(product, normalizedLocale);
     const statsMap = await this.getReviewStats([id]);
     const itemsWithStats = this.applyReviewStats([localized], statsMap);
     await this.cacheService.set(cacheKey, itemsWithStats[0], CACHE_TTL_DETAIL);
@@ -250,14 +254,15 @@ export class ProductQueryService {
       return [];
     }
 
-    const cacheKey = getProductBulkCacheKey(ids, isAdmin);
+    const normalizedLocale = this.normalizeLocale(locale);
+    const cacheKey = getProductBulkCacheKey(ids, isAdmin, normalizedLocale);
     const cached = await this.cacheService.get<
       (Product & { rating: number; reviewCount: number })[]
     >(cacheKey);
 
     if (cached) {
-      const visible = this.filterVisibleForPublic(cached, isAdmin);
-      const localized = visible.map((product) => this.applyLocale(product, locale));
+      const visible = this.filterVisibleForPublic(cached, isAdmin, normalizedLocale);
+      const localized = visible.map((product) => this.applyLocale(product, normalizedLocale));
       return localized as (Product & { rating: number; reviewCount: number })[];
     }
 
@@ -281,10 +286,11 @@ export class ProductQueryService {
       ? products
       : products.filter((product) =>
           product.status === ProductStatus.ACTIVE &&
-          (product.category == null || product.category.isActive),
+          (product.category == null || product.category.isActive) &&
+          this.isVisibleInLocale(product, normalizedLocale),
         );
 
-    const localizedItems = filtered.map((product) => this.applyLocale(product, locale));
+    const localizedItems = filtered.map((product) => this.applyLocale(product, normalizedLocale));
     const statsMap = await this.getReviewStats(
       localizedItems.map((product) => Number(product.id)),
     );
@@ -294,7 +300,8 @@ export class ProductQueryService {
     return itemsWithStats;
   }
 
-  async autocomplete(q: string): Promise<{ id: number; name: string; slug: string }[]> {
+  async autocomplete(q: string, locale?: string): Promise<{ id: number; name: string; slug: string }[]> {
+    const normalizedLocale = this.normalizeLocale(locale);
     if (!q || q.length < 2) {
       return [];
     }
@@ -308,6 +315,10 @@ export class ProductQueryService {
       .andWhere('(p.category_id IS NULL OR category.is_active = :categoryActive)', {
         categoryActive: true,
       })
+      .andWhere(
+        normalizedLocale === 'en' ? 'p.is_visible_en = :localeVisible' : 'p.is_visible_ko = :localeVisible',
+        { localeVisible: true },
+      )
       .limit(10)
       .getMany();
 
@@ -370,6 +381,7 @@ export class ProductQueryService {
   private filterVisibleForPublic<T extends { status: ProductStatus }>(
     items: T[],
     isAdmin: boolean,
+    locale?: string,
   ): T[] {
     return isAdmin
       ? items
@@ -377,7 +389,8 @@ export class ProductQueryService {
           product.status === ProductStatus.ACTIVE &&
           (!('category' in product) ||
             product.category == null ||
-            (product.category as Category).isActive),
+            (product.category as Category).isActive) &&
+          this.isVisibleInLocale(product, locale),
         );
   }
 
@@ -403,6 +416,24 @@ export class ProductQueryService {
     return localized;
   }
 
+  private normalizeLocale(locale?: string): 'ko' | 'en' {
+    return locale === 'en' ? 'en' : 'ko';
+  }
+
+  private isVisibleInLocale(product: Partial<Product>, locale?: string): boolean {
+    return this.normalizeLocale(locale) === 'en'
+      ? product.isVisibleEn !== false
+      : product.isVisibleKo !== false;
+  }
+
+  private applyLocaleVisibilityFilter(qb: SelectQueryBuilder<Product>, locale?: string): void {
+    if (this.normalizeLocale(locale) === 'en') {
+      qb.andWhere('product.isVisibleEn = :localeVisible', { localeVisible: true });
+      return;
+    }
+    qb.andWhere('product.isVisibleKo = :localeVisible', { localeVisible: true });
+  }
+
   private async preResolveFilterData(query: QueryProductsDto): Promise<{
     categoryIds: number[] | undefined;
     attrTypeIdMap: Map<string, number>;
@@ -426,6 +457,7 @@ export class ProductQueryService {
   private buildBaseQueryBuilder(
     isAdmin: boolean,
     status?: ProductStatus,
+    locale?: string,
   ): SelectQueryBuilder<Product> {
     const qb = this.productRepository
       .createQueryBuilder('product')
@@ -440,13 +472,15 @@ export class ProductQueryService {
       .leftJoinAndSelect('attribute.attributeType', 'attributeType');
 
     if (!isAdmin) {
-      return qb
+      qb
         .andWhere('product.status = :status', {
           status: ProductStatus.ACTIVE,
         })
         .andWhere('(product.category_id IS NULL OR category.is_active = :categoryActive)', {
           categoryActive: true,
         });
+      this.applyLocaleVisibilityFilter(qb, locale);
+      return qb;
     }
 
     if (status) {
@@ -575,6 +609,7 @@ export class ProductQueryService {
     const likeQb = this.buildBaseQueryBuilder(
       isAdmin,
       status as ProductStatus | undefined,
+      locale,
     );
 
     if (q) {

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -79,8 +79,11 @@ export class ProductsController {
   })
   @ApiResponse({ status: 200, description: '자동완성 결과 반환 성공' })
   @ApiQuery({ name: 'q', required: true, type: String, description: '검색어' })
-  autocomplete(@Query('q') q: string) {
-    return this.productsService.autocomplete(q);
+  autocomplete(
+    @Query('q') q: string,
+    @Query('locale', OptionalLocalePipe) locale: string | undefined,
+  ) {
+    return this.productsService.autocomplete(q, locale);
   }
 
   @Post('bulk')
@@ -92,9 +95,13 @@ export class ProductsController {
   })
   @ApiResponse({ status: 200, description: '상품 목록 조회 성공' })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
-  bulkLookup(@Body() dto: BulkProductsDto, @Request() req: RequestWithAuthUser) {
+  bulkLookup(
+    @Body() dto: BulkProductsDto,
+    @Query('locale', OptionalLocalePipe) locale: string | undefined,
+    @Request() req: RequestWithAuthUser,
+  ) {
     const isAdmin = req.user?.role === 'admin';
-    return this.productsService.findBulk(dto.ids, isAdmin);
+    return this.productsService.findBulk(dto.ids, isAdmin, locale);
   }
 
   @Get(':id')

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -49,7 +49,7 @@ export class ProductsService {
     return this.productQueryService.findBulk(ids, isAdmin, locale);
   }
 
-  autocomplete(q: string): Promise<{ id: number; name: string; slug: string }[]> {
-    return this.productQueryService.autocomplete(q);
+  autocomplete(q: string, locale?: string): Promise<{ id: number; name: string; slug: string }[]> {
+    return this.productQueryService.autocomplete(q, locale);
   }
 }

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -395,6 +395,8 @@ export class SmartStoreProductImportService {
           shortDescription: this.getCell(row, headerMap.shortDescription) || undefined,
           description: description || undefined,
           isFreeShipping,
+          isVisibleKo: true,
+          isVisibleEn: false,
           noticeInfo,
           images: this.buildImages(productName, galleryUrls),
           detailImages: detailUrls.length > 0

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -134,6 +134,18 @@ export default function AdminProductsPage() {
     { errorMessage: t('statusChangeError') },
   );
 
+  const { execute: toggleLocaleVisibility } = useAsyncAction(
+    async ({ product, locale }: { product: Product; locale: 'ko' | 'en' }) => {
+      const field = locale === 'ko' ? 'isVisibleKo' : 'isVisibleEn';
+      const current = field === 'isVisibleKo' ? product.isVisibleKo ?? true : product.isVisibleEn ?? false;
+      const next = !current;
+      await adminProductsApi.update(product.id, { [field]: next });
+      toast.success(t('localeVisibilityChanged', { locale: locale.toUpperCase(), status: next ? t('visible') : t('hidden') }));
+      void fetchProducts();
+    },
+    { errorMessage: t('localeVisibilityChangeError') },
+  );
+
   const { execute: deleteProduct } = useAsyncAction(
     async (product: Product) => {
       await adminProductsApi.remove(product.id);
@@ -177,6 +189,9 @@ export default function AdminProductsPage() {
   };
 
   const handleToggleStatus = (product: Product) => void toggleStatus(product);
+
+  const handleToggleLocaleVisibility = (product: Product, locale: 'ko' | 'en') =>
+    void toggleLocaleVisibility({ product, locale });
 
   const handleDelete = (product: Product) => {
     if (!window.confirm(t('deleteConfirm', { name: product.name }))) return;
@@ -482,6 +497,7 @@ export default function AdminProductsPage() {
                 <th className="px-4 py-3 text-left">{t('columns.name')}</th>
                 <th className="px-4 py-3 text-left">{t('columns.price')}</th>
                 <th className="px-4 py-3 text-left">{t('columns.status')}</th>
+                <th className="px-4 py-3 text-left">{t('columns.localeVisibility')}</th>
                 <th className="px-4 py-3 text-left">{t('columns.featured')}</th>
                 <th className="px-4 py-3 text-left">{t('columns.freeShipping')}</th>
                 <th className="px-4 py-3 text-right">{t('columns.action')}</th>
@@ -495,6 +511,20 @@ export default function AdminProductsPage() {
                   <td className="px-4 py-3">{formatCurrency(product.price)}</td>
                   <td className="px-4 py-3">
                     <ProductStatusBadge status={product.status as ProductStatus} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-1" aria-label={t('localeVisibilityAria', { name: product.name })}>
+                      <LocaleVisibilityButton
+                        label={t('localeKoShort')}
+                        visible={product.isVisibleKo ?? true}
+                        onClick={() => handleToggleLocaleVisibility(product, 'ko')}
+                      />
+                      <LocaleVisibilityButton
+                        label={t('localeEnShort')}
+                        visible={product.isVisibleEn ?? false}
+                        onClick={() => handleToggleLocaleVisibility(product, 'en')}
+                      />
+                    </div>
                   </td>
                   <td className="px-4 py-3">{product.isFeatured ? '✓' : '-'}</td>
                   <td className="px-4 py-3">
@@ -535,6 +565,32 @@ export default function AdminProductsPage() {
         </div>
       </PaginatedAdminTableShell>
     </div>
+  );
+}
+
+
+function LocaleVisibilityButton({
+  label,
+  visible,
+  onClick,
+}: {
+  label: string;
+  visible: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={visible}
+      className={
+        visible
+          ? 'rounded border border-tea bg-tea px-2 py-1 typo-label font-medium text-white'
+          : 'rounded border px-2 py-1 typo-label font-medium text-muted-foreground hover:bg-secondary'
+      }
+    >
+      {label}
+    </button>
   );
 }
 

--- a/src/components/shared/admin/ProductFormPage.tsx
+++ b/src/components/shared/admin/ProductFormPage.tsx
@@ -35,6 +35,8 @@ interface ProductFormData {
   status: 'draft' | 'active' | 'soldout' | 'hidden';
   isFeatured: boolean;
   isFreeShipping: boolean;
+  isVisibleKo: boolean;
+  isVisibleEn: boolean;
   images: GalleryImage[];
   detailImages: DetailImage[];
   options: ProductOptionDraft[];
@@ -384,7 +386,7 @@ function VisibilitySection({
   form,
   set,
 }: {
-  form: Pick<ProductFormData, 'status' | 'isFeatured' | 'isFreeShipping'>;
+  form: Pick<ProductFormData, 'status' | 'isFeatured' | 'isFreeShipping' | 'isVisibleKo' | 'isVisibleEn'>;
   set: Setter;
 }) {
   const t = useTranslations('admin.productForm');
@@ -405,6 +407,22 @@ function VisibilitySection({
         checked={form.isFeatured}
         onChange={(v) => set('isFeatured', v)}
       />
+
+      <div className="rounded-md border bg-secondary/30 p-3">
+        <p className="mb-2 text-xs text-muted-foreground">{t('localeVisibilityHelp')}</p>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <CheckboxField
+            label={t('visibleKo')}
+            checked={form.isVisibleKo}
+            onChange={(v) => set('isVisibleKo', v)}
+          />
+          <CheckboxField
+            label={t('visibleEn')}
+            checked={form.isVisibleEn}
+            onChange={(v) => set('isVisibleEn', v)}
+          />
+        </div>
+      </div>
 
       <CheckboxField
         label={t('freeShippingProduct')}
@@ -561,6 +579,8 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
     status: (product?.status as ProductFormData['status']) ?? 'draft',
     isFeatured: product?.isFeatured ?? false,
     isFreeShipping: product?.isFreeShipping ?? false,
+    isVisibleKo: product?.isVisibleKo ?? true,
+    isVisibleEn: product?.isVisibleEn ?? false,
     images: product?.images?.map((img) => ({ url: img.url, alt: img.alt ?? undefined })) ?? [],
     detailImages:
       product?.detailImages?.map((img) => ({ url: img.url, alt: img.alt ?? undefined })) ?? [],
@@ -577,8 +597,8 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
         value: attr.value,
         displayValue: attr.displayValue ?? '',
       })) ?? [],
-    nameEn: '',
-    descriptionEn: '',
+    nameEn: product?.nameEn ?? '',
+    descriptionEn: product?.descriptionEn ?? '',
     noticeInfo: { ...EMPTY_NOTICE_INFO, ...(product?.noticeInfo ?? {}) },
   });
 
@@ -636,6 +656,8 @@ export default function ProductFormPage({ mode, product }: ProductFormPageProps)
         status: form.status,
         isFeatured: form.isFeatured,
         isFreeShipping: form.isFreeShipping,
+        isVisibleKo: form.isVisibleKo,
+        isVisibleEn: form.isVisibleEn,
         nameEn: form.nameEn.trim() || undefined,
         descriptionEn: form.descriptionEn.trim() || undefined,
         noticeInfo: buildNoticeInfoPayload(form.noticeInfo, hadNoticeInfo),

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -736,7 +736,8 @@
         "status": "Status",
         "featured": "Featured",
         "freeShipping": "Free Shipping",
-        "action": "Action"
+        "action": "Action",
+        "localeVisibility": "Locale"
       },
       "actions": {
         "hide": "Hide",
@@ -856,7 +857,14 @@
         "previewError": "Failed to validate Naver Commerce API products.",
         "commitSuccess": "Naver Commerce API products applied to the store.",
         "commitError": "Failed to apply Naver Commerce API products."
-      }
+      },
+      "localeKoShort": "KO",
+      "localeEnShort": "EN",
+      "visible": "visible",
+      "hidden": "hidden",
+      "localeVisibilityChanged": "{locale} page is now {status}.",
+      "localeVisibilityChangeError": "Failed to change locale visibility.",
+      "localeVisibilityAria": "Manage locale visibility for {name}"
     },
     "productForm": {
       "createTitle": "Add Product",
@@ -894,7 +902,10 @@
       },
       "freeShippingProduct": "Free-shipping product",
       "attributePickerHelp": "Choose an existing value like a tag, or type a new value to save it.",
-      "existingAttributeValues": "Existing attribute values"
+      "existingAttributeValues": "Existing attribute values",
+      "visibleKo": "Visible on Korean page",
+      "visibleEn": "Visible on English page",
+      "localeVisibilityHelp": "Choose whether this product appears on each locale page. Imported products are Korean-only by default."
     },
     "members": {
       "title": "Member Management",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -736,7 +736,8 @@
         "status": "상태",
         "featured": "추천",
         "freeShipping": "무료배송",
-        "action": "액션"
+        "action": "액션",
+        "localeVisibility": "언어노출"
       },
       "actions": {
         "hide": "숨기기",
@@ -856,7 +857,14 @@
         "previewError": "네이버 커머스API 상품 검증에 실패했습니다.",
         "commitSuccess": "네이버 커머스API 상품을 자사몰에 반영했습니다.",
         "commitError": "네이버 커머스API 상품 반영에 실패했습니다."
-      }
+      },
+      "localeKoShort": "한",
+      "localeEnShort": "EN",
+      "visible": "노출",
+      "hidden": "숨김",
+      "localeVisibilityChanged": "{locale} 페이지가 {status} 상태로 변경되었습니다.",
+      "localeVisibilityChangeError": "언어별 노출 상태 변경에 실패했습니다.",
+      "localeVisibilityAria": "{name} 언어별 노출 관리"
     },
     "productForm": {
       "createTitle": "상품 등록",
@@ -894,7 +902,10 @@
       },
       "freeShippingProduct": "무료배송 상품",
       "attributePickerHelp": "기존 값은 태그처럼 선택하고, 없으면 직접 입력해 새 값으로 저장하세요.",
-      "existingAttributeValues": "기존 속성 값"
+      "existingAttributeValues": "기존 속성 값",
+      "visibleKo": "한국어 페이지 노출",
+      "visibleEn": "영어 페이지 노출",
+      "localeVisibilityHelp": "언어별 공개 페이지에서 이 상품을 보여줄지 선택합니다. 가져온 상품은 기본적으로 한국어만 노출됩니다."
     },
     "members": {
       "title": "회원 관리",

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -19,6 +19,8 @@ export interface CreateProductData {
   status?: string;
   isFeatured?: boolean;
   isFreeShipping?: boolean;
+  isVisibleKo?: boolean;
+  isVisibleEn?: boolean;
   categoryId?: number | null;
   nameEn?: string;
   descriptionEn?: string;

--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -41,6 +41,8 @@ export interface Product {
   status: 'active' | 'soldout' | 'inactive' | 'draft' | 'hidden';
   isFeatured: boolean;
   isFreeShipping?: boolean;
+  isVisibleKo?: boolean;
+  isVisibleEn?: boolean;
   viewCount: number;
   category: Category | null;
   images: ProductImage[];
@@ -108,6 +110,8 @@ export interface ProductDetail extends Product {
   stock: number;
   sku: string | null;
   noticeInfo: ProductNoticeInfo | null;
+  nameEn?: string | null;
+  descriptionEn?: string | null;
   options: ProductOption[];
   detailImages: ProductDetailImage[];
 }


### PR DESCRIPTION
## Summary
- Add product-level Korean/English page visibility flags with migration defaults that keep existing products visible in both locales.
- Apply locale visibility filtering to public product list/detail/bulk/autocomplete queries while keeping admin queries unrestricted.
- Default SmartStore Excel and Naver Commerce API imported products to Korean-only visibility.
- Add admin product list KO/EN visibility badges with one-click toggles and product form controls.

Closes #1021

## Verification
- `npm run build`
- `npm run test:run`
- `cd backend && npm run build`
- `cd backend && npm run test`
- `cd backend && set -a && source .env && set +a && npm run test:e2e`
- `bash scripts/codex-project-guard.sh`
- `bash scripts/start-local.sh` + smoke: `/api/health`, `/ko`, `/en/products`, `/api/products?locale=en&limit=1`
