### PR TITLE
fix: #1025 상품속성 조회 응답 누락 수정

### DIFF
--- a/backend/src/modules/products/__tests__/product-query.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-query.service.spec.ts
@@ -208,6 +208,20 @@ describe('ProductQueryService', () => {
     });
   });
 
+  describe('findAll - 속성 relation', () => {
+    it('상품 목록 응답에 product_attributes 와 attributeType 을 포함한다', async () => {
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({});
+
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('product.attributes', 'attribute');
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(
+        'attribute.attributeType',
+        'attributeType',
+      );
+    });
+  });
+
   describe('findAll - 카테고리 트리', () => {
     it('categoryId 지정 시 자식 카테고리 ID 까지 조건에 포함', async () => {
       categoryRepo.find.mockResolvedValue([
@@ -327,6 +341,19 @@ describe('ProductQueryService', () => {
       expect(productRepo.increment).toHaveBeenCalledWith({ id: 1 }, 'viewCount', 1);
     });
 
+    it('상품 상세 응답에 product_attributes 와 attributeType 을 포함한다', async () => {
+      qb.getOne.mockResolvedValue({ id: 1, status: ProductStatus.ACTIVE } as Product);
+      reviewQb.getRawMany.mockResolvedValue([]);
+
+      await service.findOne(1);
+
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('product.attributes', 'attribute');
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(
+        'attribute.attributeType',
+        'attributeType',
+      );
+    });
+
     it('cache 에 저장되는지 확인', async () => {
       qb.getOne.mockResolvedValue({ id: 1, status: ProductStatus.ACTIVE } as Product);
       reviewQb.getRawMany.mockResolvedValue([]);
@@ -375,6 +402,19 @@ describe('ProductQueryService', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe(1);
+    });
+
+    it('bulk 상품 응답에 product_attributes 와 attributeType 을 포함한다', async () => {
+      qb.getMany.mockResolvedValue([{ id: 1, status: ProductStatus.ACTIVE } as Product]);
+      reviewQb.getRawMany.mockResolvedValue([]);
+
+      await service.findBulk([1], false);
+
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('product.attributes', 'attribute');
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(
+        'attribute.attributeType',
+        'attributeType',
+      );
     });
 
     it('비관리자 bulk cache hit 에도 hidden 상품을 반환하지 않는다', async () => {

--- a/backend/src/modules/products/product-query.service.ts
+++ b/backend/src/modules/products/product-query.service.ts
@@ -212,6 +212,8 @@ export class ProductQueryService {
       .leftJoinAndSelect('product.images', 'image')
       .leftJoinAndSelect('product.detailImages', 'detailImage')
       .leftJoinAndSelect('product.category', 'category')
+      .leftJoinAndSelect('product.attributes', 'attribute')
+      .leftJoinAndSelect('attribute.attributeType', 'attributeType')
       .where('product.id = :id', { id })
       .getOne();
 
@@ -270,6 +272,8 @@ export class ProductQueryService {
           isThumbnail: true,
         },
       )
+      .leftJoinAndSelect('product.attributes', 'attribute')
+      .leftJoinAndSelect('attribute.attributeType', 'attributeType')
       .where('product.id IN (:...ids)', { ids })
       .getMany();
 
@@ -431,7 +435,9 @@ export class ProductQueryService {
         'image',
         'image.is_thumbnail = :isThumbnail',
         { isThumbnail: true },
-      );
+      )
+      .leftJoinAndSelect('product.attributes', 'attribute')
+      .leftJoinAndSelect('attribute.attributeType', 'attributeType');
 
     if (!isAdmin) {
       return qb

--- a/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
+++ b/src/components/shared/admin/__tests__/ProductFormPage.test.tsx
@@ -346,6 +346,66 @@ describe('ProductFormPage', () => {
       expect(payload).not.toHaveProperty('descriptionJa');
       expect(payload).not.toHaveProperty('descriptionZh');
     });
+
+    it('수정 모드에서 기존 상품속성을 입력값으로 표시한다', async () => {
+      const { attributesApi } = await import('@/lib/api');
+      vi.mocked(attributesApi.getTypes).mockResolvedValue([
+        {
+          id: 1,
+          code: 'clay_type',
+          name: '니료',
+          nameKo: '니료',
+          nameEn: 'Clay type',
+          inputType: 'select',
+          isFilterable: true,
+          isSearchable: true,
+          validValues: ['old_duanni'],
+          parentId: null,
+          relatedTypeIds: null,
+          sortOrder: 0,
+          isActive: true,
+        },
+      ]);
+
+      render(
+        <ProductFormPage
+          mode="edit"
+          product={{
+            id: 1,
+            name: '테스트 상품',
+            slug: 'test-product',
+            price: 10000,
+            salePrice: null,
+            status: 'draft',
+            isFeatured: false,
+            viewCount: 0,
+            category: null,
+            images: [],
+            description: null,
+            shortDescription: null,
+            rating: 0,
+            reviewCount: 0,
+            stock: 0,
+            sku: null,
+            options: [],
+            detailImages: [],
+            noticeInfo: null,
+            attributes: [
+              {
+                id: 11,
+                attributeTypeId: 1,
+                value: 'old_duanni',
+                displayValue: '노단니',
+                sortOrder: 0,
+              },
+            ],
+          }}
+        />,
+      );
+
+      expect(await screen.findByDisplayValue('old_duanni')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('노단니')).toBeInTheDocument();
+    });
     it('수정 모드에서 기존 상품고시정보를 모두 비우면 noticeInfo=null을 전송한다', async () => {
       const { adminProductsApi } = await import('@/lib/api');
       vi.mocked(adminProductsApi.update).mockResolvedValue({

--- a/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
+++ b/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
@@ -297,6 +297,64 @@ describe('ProductDetailClient', () => {
     expect(screen.getByText('품절')).toBeInTheDocument();
   });
 
+  it('상품속성 배지를 표시하고 속성 필터 링크로 연결한다', () => {
+    render(
+      <ProductDetailClient
+        product={{
+          ...productWithoutOptions,
+          attributes: [
+            {
+              id: 101,
+              attributeTypeId: 1,
+              value: 'old_duanni',
+              displayValue: '노단니',
+              sortOrder: 0,
+              attributeType: {
+                id: 1,
+                code: 'clay_type',
+                name: 'Clay Type',
+                nameKo: '니료',
+                inputType: 'select',
+                isFilterable: true,
+                isSearchable: false,
+                validValues: null,
+                sortOrder: 1,
+              },
+            },
+            {
+              id: 102,
+              attributeTypeId: 2,
+              value: 'lianzi',
+              displayValue: '연자호',
+              sortOrder: 1,
+              attributeType: {
+                id: 2,
+                code: 'teapot_shape',
+                name: 'Shape',
+                nameKo: '모양',
+                inputType: 'select',
+                isFilterable: true,
+                isSearchable: false,
+                validValues: null,
+                sortOrder: 2,
+              },
+            },
+          ],
+        }}
+        locale="ko"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: '진흙: old_duanni' })).toHaveAttribute(
+      'href',
+      '/ko/products?attrs=clay_type:old_duanni',
+    );
+    expect(screen.getByRole('link', { name: '모양: lianzi' })).toHaveAttribute(
+      'href',
+      '/ko/products?attrs=teapot_shape:lianzi',
+    );
+  });
+
   it('찜 추가 → wishlistApi.add 호출 + 성공 토스트', async () => {
     render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
     // wishlist check 결과 처리 대기


### PR DESCRIPTION
## 요약
- `ProductQueryService`의 목록/상세/bulk 조회에 `product.attributes`와 `attribute.attributeType` relation을 포함했습니다.
- 상품상세 속성 배지/필터 링크와 어드민 상품수정 속성 prefill 회귀 테스트를 추가했습니다.
- DB 저장/자동매핑 문제와 별개로, 조회 응답에서 relation을 빠뜨려 원격 프론트가 속성을 받지 못하던 문제를 수정합니다.

Closes #1025

## 검증
- `bash scripts/codex-project-guard.sh`
- `cd backend && npx jest src/modules/products/__tests__/product-query.service.spec.ts --runInBand`
- `npx vitest run src/components/shared/products/__tests__/ProductDetailClient.test.tsx src/components/shared/admin/__tests__/ProductFormPage.test.tsx`
- `cd backend && npm run build && npm run test`
- `rm -rf .next && npm run build && npm run test:run`

## 비고
- 로컬 DB에는 상품 데이터가 없어 실데이터 속성 응답은 로컬에서 확인하지 못했습니다. 대신 원격 DB/API 조사에서 저장 데이터는 존재하고 응답만 누락됨을 확인했고, relation 조회 계약을 단위 테스트로 고정했습니다.
- DB/schema 변경 없음: backend e2e는 생략했습니다.
