### PR TITLE
fix: #1026 상품 가져오기 재고 반영 보정

### DIFF
--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -95,7 +95,7 @@ const NAVER_PRODUCTS: NaverCommerceFetchedProduct[] = [
       originProduct: {
         name: '옥화당 자사호 황룡산 노단니 연자호 110cc',
         salePrice: 50000,
-        stockQuantity: 3,
+        stockQuantity: 0,
         statusType: 'SALE',
         detailContent: '<p>상세</p>',
         images: {
@@ -191,7 +191,7 @@ describe('NaverCommerceProductImportService', () => {
         name: '옥화당 자사호 황룡산 노단니 연자호 110cc',
         sku: 'SKU-1',
         price: 50000,
-        stock: 3,
+        stock: 2,
         isFreeShipping: true,
         description: '<p>상세</p>',
         noticeInfo: expect.objectContaining({ manufacturer: '옥화당', countryOfOrigin: '중국' }),
@@ -225,6 +225,57 @@ describe('NaverCommerceProductImportService', () => {
       expect.objectContaining({ value: '110cc', displayValue: '110cc' }),
     );
     expect(ingestService.ingest).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps Naver Commerce detailAttribute option combinations and derives product stock when stockQuantity is omitted', async () => {
+    const existing = { id: 8, sku: 'SKU-OPTION', slug: 'option-product' } as Product;
+    const fetchedProducts: NaverCommerceFetchedProduct[] = [
+      {
+        rowNumber: 1,
+        listProduct: { originProductNo: 2001, channelProducts: [{ sellerManagementCode: 'SKU-OPTION' }] },
+        detailProduct: {
+          originProduct: {
+            name: '옵션 재고 상품',
+            salePrice: 10000,
+            statusType: 'SALE',
+            detailAttribute: {
+              optionInfo: {
+                optionCombinationGroupNames: {
+                  optionGroupName1: '색상',
+                  optionGroupName2: '용량',
+                },
+                optionCombinations: [
+                  { optionName1: '홍니', optionName2: '100cc', stockQuantity: 4, price: 0, usable: true },
+                  { optionName1: '자니', optionName2: '120cc', stockQuantity: 6, price: 2000, usable: true },
+                  { optionName1: '흑니', optionName2: '150cc', stockQuantity: 9, price: 3000, isUsable: false },
+                ],
+              },
+            },
+          },
+        },
+      },
+    ];
+    const { service, commandService } = createService(fetchedProducts, [existing]);
+
+    const result = await service.commit();
+
+    expect(result.rows[0]).toMatchObject({
+      stock: 10,
+      optionStockTotal: 10,
+      stockSource: 'option_stock_total',
+      optionCount: 2,
+    });
+    expect(commandService.update).toHaveBeenCalledWith(
+      8,
+      expect.objectContaining({
+        stock: 10,
+        status: 'active',
+        options: [
+          expect.objectContaining({ name: '색상/용량', value: '홍니/100cc', stock: 4 }),
+          expect.objectContaining({ name: '색상/용량', value: '자니/120cc', stock: 6, priceAdjustment: 2000 }),
+        ],
+      }),
+    );
   });
 
   it('uses the SmartStore channel product number as the fallback SKU-compatible identifier', async () => {

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -481,6 +481,55 @@ describe('SmartStoreProductImportService', () => {
       }));
     });
 
+    it('derives product stock from option stocks when the SmartStore product stock cell is blank', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '재고수량', '옵션형태', '옵션명', '옵션값', '옵션 재고수량'],
+        ['SKU-1', '옵션 재고 합산 상품', 10000, '', '단독형', '용량', '100cc,200cc', '5,7'],
+      ]);
+
+      const result = await service.commit(createFile(buffer));
+
+      expect(result.rows[0]).toMatchObject({
+        stock: 12,
+        optionStockTotal: 12,
+        stockSource: 'option_stock_total',
+      });
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        stock: 12,
+        status: ProductStatus.ACTIVE,
+        options: [
+          expect.objectContaining({ value: '100cc', stock: 5 }),
+          expect.objectContaining({ value: '200cc', stock: 7 }),
+        ],
+      }));
+    });
+
+
+    it('uses option stock total for option products even when SmartStore product stock is zero', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '재고수량', '옵션형태', '옵션명', '옵션값', '옵션 재고수량'],
+        ['SKU-1', '옵션 재고 우선 상품', 10000, 0, '단독형', '용량', '100cc,200cc', '5,7'],
+      ]);
+
+      const result = await service.commit(createFile(buffer));
+
+      expect(result.rows[0]).toMatchObject({
+        stock: 12,
+        optionStockTotal: 12,
+        stockSource: 'option_stock_total',
+      });
+      expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+        stock: 12,
+        status: ProductStatus.ACTIVE,
+      }));
+    });
+
     it('keeps option price and stock alignment when optional cells contain blanks', async () => {
       const repository = createRepositoryMock([]);
       const commandService = createCommandServiceMock();

--- a/backend/src/modules/products/naver-commerce-product-import.service.ts
+++ b/backend/src/modules/products/naver-commerce-product-import.service.ts
@@ -8,6 +8,7 @@ import { ProductStatus } from './entities/product.entity';
 import { NaverCommerceApiClient, NaverCommerceFetchedProduct } from './naver-commerce-api.client';
 import {
   SmartStoreImportResult,
+  SmartStoreImportStockSource,
   SmartStoreParsedProductRow,
   SmartStoreProductImportService,
 } from './smartstore-product-import.service';
@@ -77,10 +78,12 @@ export class NaverCommerceProductImportService {
       'channelProducts.0.salePrice',
       'channelProducts.0.price',
     ]);
-    const stock = this.firstNumber(product, [
+    const rawStock = this.firstNumber(product, [
       'originProduct.stockQuantity',
       'stockQuantity',
       'originProduct.optionInfo.stockQuantity',
+      'originProduct.detailAttribute.optionInfo.stockQuantity',
+      'detailAttribute.optionInfo.stockQuantity',
       'channelProducts.0.stockQuantity',
     ]);
     const salePrice = this.resolveSalePrice(product, price);
@@ -115,6 +118,8 @@ export class NaverCommerceProductImportService {
     );
     const noticeInfo = this.buildNoticeInfo(product, productName);
     const options = this.buildOptions(product);
+    const optionStockTotal = this.sumOptionStock(options);
+    const { stock, stockSource } = this.resolveImportStock(rawStock, optionStockTotal);
 
     if (!identifier) errors.push('네이버 상품번호 또는 판매자 상품코드가 필요합니다.');
     if (!productName) errors.push('네이버 상품명이 필요합니다.');
@@ -166,6 +171,9 @@ export class NaverCommerceProductImportService {
       hasDiscount: salePrice !== undefined && price !== null && salePrice < price,
       isFreeShipping: this.resolveFreeShipping(product) ?? null,
       hasNoticeInfo: Boolean(noticeInfo),
+      stock,
+      optionStockTotal,
+      stockSource,
       errors,
     };
   }
@@ -284,24 +292,26 @@ export class NaverCommerceProductImportService {
   private buildOptions(product: Record<string, unknown>): ProductOptionInputDto[] | undefined {
     const combinations = this.firstArray(product, [
       'originProduct.optionInfo.optionCombinations',
+      'originProduct.detailAttribute.optionInfo.optionCombinations',
       'optionInfo.optionCombinations',
+      'detailAttribute.optionInfo.optionCombinations',
       'optionCombinations',
     ]);
     if (!combinations || combinations.length === 0) return undefined;
 
+    const groupNames = this.resolveOptionGroupNames(product);
     const options: ProductOptionInputDto[] = [];
     for (const item of combinations) {
       if (!this.isRecord(item)) continue;
-      const usable = this.firstString(item, ['usable', 'isUsable', 'useYn']);
-      if (usable && ['N', 'NO', 'FALSE', '사용안함'].includes(usable.toUpperCase())) continue;
-      const optionName = this.firstString(item, ['optionName', 'name']) ?? '옵션';
-      const optionValue = this.firstString(item, [
-        'optionValue',
-        'value',
-        'optionValue1',
-        'optionName1',
-      ]);
+      const usable = this.firstExistingValue(item, ['usable', 'isUsable', 'useYn']);
+      if (this.isNaverOptionDisabled(usable)) continue;
+      const optionParts = this.resolveOptionValueParts(item);
+      const optionValue = optionParts.join('/');
       if (!optionValue) continue;
+      const optionName =
+        groupNames.slice(0, optionParts.length).join('/') ||
+        this.firstString(item, ['optionName', 'name']) ||
+        '옵션';
       options.push({
         name: optionName,
         value: optionValue,
@@ -312,6 +322,52 @@ export class NaverCommerceProductImportService {
     }
 
     return options.length > 0 ? options : undefined;
+  }
+
+  private resolveOptionGroupNames(product: Record<string, unknown>): string[] {
+    const groupRecord = this.firstRecord(product, [
+      'originProduct.detailAttribute.optionInfo.optionCombinationGroupNames',
+      'originProduct.optionInfo.optionCombinationGroupNames',
+      'detailAttribute.optionInfo.optionCombinationGroupNames',
+      'optionInfo.optionCombinationGroupNames',
+      'optionCombinationGroupNames',
+    ]);
+    if (!groupRecord) return [];
+    return [1, 2, 3, 4]
+      .map((index) => this.firstString(groupRecord, [`optionGroupName${index}`]))
+      .filter((value): value is string => Boolean(value));
+  }
+
+  private resolveOptionValueParts(item: Record<string, unknown>): string[] {
+    const explicit = this.firstString(item, ['optionValue', 'value']);
+    if (explicit) return [explicit];
+    return [1, 2, 3, 4]
+      .map((index) => this.firstString(item, [`optionName${index}`, `optionValue${index}`]))
+      .filter((value): value is string => Boolean(value));
+  }
+
+  private isNaverOptionDisabled(value: unknown): boolean {
+    if (value === false || value === 0) return true;
+    if (typeof value !== 'string') return false;
+    return ['N', 'NO', 'FALSE', '사용안함', 'X'].includes(value.toUpperCase());
+  }
+
+  private sumOptionStock(options: ProductOptionInputDto[] | undefined): number | null {
+    if (!options || options.length === 0) return null;
+    return options.reduce((sum, option) => sum + (option.stock ?? 0), 0);
+  }
+
+  private resolveImportStock(
+    rawStock: number | null,
+    optionStockTotal: number | null,
+  ): { stock: number; stockSource: SmartStoreImportStockSource } {
+    if (optionStockTotal !== null) {
+      return { stock: optionStockTotal, stockSource: 'option_stock_total' };
+    }
+    if (rawStock !== null) {
+      return { stock: rawStock, stockSource: 'product_stock' };
+    }
+    return { stock: 0, stockSource: 'default_zero' };
   }
 
   private mapStatus(status: string | null, stock: number): ProductStatus {
@@ -364,10 +420,26 @@ export class NaverCommerceProductImportService {
     return this.firstString(record, paths);
   }
 
+  private firstExistingValue(record: Record<string, unknown>, paths: string[]): unknown {
+    for (const path of paths) {
+      const value = this.readPath(record, path);
+      if (value !== undefined && value !== null) return value;
+    }
+    return undefined;
+  }
+
   private firstArray(record: Record<string, unknown>, paths: string[]): unknown[] | null {
     for (const path of paths) {
       const value = this.readPath(record, path);
       if (Array.isArray(value)) return value;
+    }
+    return null;
+  }
+
+  private firstRecord(record: Record<string, unknown>, paths: string[]): Record<string, unknown> | null {
+    for (const path of paths) {
+      const value = this.readPath(record, path);
+      if (this.isRecord(value)) return value;
     }
     return null;
   }

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -21,6 +21,7 @@ import {
 } from './product-keyword-mapping.service';
 
 export type SmartStoreImportAction = 'create' | 'update' | 'skip';
+export type SmartStoreImportStockSource = 'product_stock' | 'option_stock_total' | 'default_zero';
 
 export interface SmartStoreImportRowResult {
   rowNumber: number;
@@ -37,6 +38,9 @@ export interface SmartStoreImportRowResult {
   hasDiscount: boolean;
   isFreeShipping: boolean | null;
   hasNoticeInfo: boolean;
+  stock: number | null;
+  optionStockTotal: number | null;
+  stockSource: SmartStoreImportStockSource;
   automaticMapping: SmartStoreAutomaticMappingResult;
   mappingWarnings: string[];
   errors: string[];
@@ -67,6 +71,9 @@ export interface SmartStoreParsedProductRow {
   hasDiscount: boolean;
   isFreeShipping: boolean | null;
   hasNoticeInfo: boolean;
+  stock: number | null;
+  optionStockTotal: number | null;
+  stockSource: SmartStoreImportStockSource;
   errors: string[];
 }
 
@@ -233,6 +240,9 @@ export class SmartStoreProductImportService {
         hasDiscount: parsed.hasDiscount,
         isFreeShipping: parsed.isFreeShipping,
         hasNoticeInfo: parsed.hasNoticeInfo,
+        stock: parsed.stock,
+        optionStockTotal: parsed.optionStockTotal,
+        stockSource: parsed.stockSource,
         automaticMapping: this.toRowAutomaticMapping(keywordMapping),
         mappingWarnings: keywordMapping.warnings,
         errors,
@@ -357,13 +367,15 @@ export class SmartStoreProductImportService {
     const price = this.parseMoney(this.getCell(row, headerMap.price));
     if (price === null || price < 1) errors.push('판매가는 1원 이상이어야 합니다.');
 
-    const stock = this.parseInteger(this.getCell(row, headerMap.stock));
+    const rawStock = this.parseInteger(this.getCell(row, headerMap.stock));
     const salePrice = this.resolveSalePrice(row, headerMap, price);
     const description = this.getCell(row, headerMap.description);
     const isFreeShipping = this.parseFreeShipping(row, headerMap);
     const noticeInfo = this.buildNoticeInfo(row, headerMap, productName);
 
     const options = this.parseOptions(row, headerMap, errors);
+    const optionStockTotal = this.sumOptionStock(options);
+    const { stock, stockSource } = this.resolveImportStock(rawStock, optionStockTotal);
     const representativeImage = this.getCell(row, headerMap.representativeImage);
     const additionalImages = this.splitImageUrls(this.getCell(row, headerMap.additionalImages));
     const galleryUrls = this.collectValidImageUrls(
@@ -416,6 +428,9 @@ export class SmartStoreProductImportService {
       hasDiscount: salePrice !== undefined && price !== null && salePrice < price,
       isFreeShipping: isFreeShipping ?? null,
       hasNoticeInfo: Boolean(noticeInfo),
+      stock,
+      optionStockTotal,
+      stockSource,
       errors,
     };
   }
@@ -666,6 +681,24 @@ export class SmartStoreProductImportService {
     });
 
     return options;
+  }
+
+  private sumOptionStock(options: ProductOptionInputDto[] | undefined): number | null {
+    if (!options || options.length === 0) return null;
+    return options.reduce((sum, option) => sum + (option.stock ?? 0), 0);
+  }
+
+  private resolveImportStock(
+    rawStock: number | null,
+    optionStockTotal: number | null,
+  ): { stock: number; stockSource: SmartStoreImportStockSource } {
+    if (optionStockTotal !== null) {
+      return { stock: optionStockTotal, stockSource: 'option_stock_total' };
+    }
+    if (rawStock !== null) {
+      return { stock: rawStock, stockSource: 'product_stock' };
+    }
+    return { stock: 0, stockSource: 'default_zero' };
   }
 
   private isOptionUsable(raw: string | undefined): boolean {

--- a/src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx
+++ b/src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx
@@ -93,6 +93,9 @@ const naverResult: SmartStoreProductImportResult = {
       hasDiscount: false,
       isFreeShipping: true,
       hasNoticeInfo: true,
+      stock: 10,
+      optionStockTotal: 10,
+      stockSource: 'option_stock_total',
       automaticMapping: { status: 'none', attributes: [], options: [] },
       mappingWarnings: [],
       errors: [],
@@ -137,6 +140,11 @@ describe('AdminProductsPage', () => {
     });
     expect(await screen.findByText('SKU-1')).toBeInTheDocument();
     expect(screen.getByText('네이버 상품')).toBeInTheDocument();
+    expect(screen.getByText('import.previewColumns.stock')).toBeInTheDocument();
+    expect(screen.getByText('import.previewColumns.optionStockTotal')).toBeInTheDocument();
+    expect(screen.getByText('import.previewColumns.stockSource')).toBeInTheDocument();
+    expect(screen.getByText('import.stockSources.option_stock_total')).toBeInTheDocument();
+    expect(screen.getAllByText('10')).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('button', { name: 'naverCommerce.commitButton' }));
 

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -377,6 +377,15 @@ export default function AdminProductsPage() {
                         <th className="px-3 py-2 text-left">
                           {t('import.previewColumns.noticeInfo')}
                         </th>
+                        <th className="px-3 py-2 text-right">
+                          {t('import.previewColumns.stock')}
+                        </th>
+                        <th className="px-3 py-2 text-right">
+                          {t('import.previewColumns.optionStockTotal')}
+                        </th>
+                        <th className="px-3 py-2 text-left">
+                          {t('import.previewColumns.stockSource')}
+                        </th>
                         <th className="px-3 py-2 text-left">
                           {t('import.previewColumns.automaticMapping')}
                         </th>
@@ -434,6 +443,15 @@ export default function AdminProductsPage() {
                             {row.hasNoticeInfo
                               ? t('import.previewValues.yes')
                               : t('import.previewValues.no')}
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            {row.stock == null ? '-' : row.stock}
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            {row.optionStockTotal == null ? '-' : row.optionStockTotal}
+                          </td>
+                          <td className="px-3 py-2">
+                            {t(`import.stockSources.${row.stockSource}`)}
                           </td>
                           <td className="min-w-56 px-3 py-2">
                             <ImportMappingSummary row={row} t={t} />

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -799,6 +799,9 @@
           "discount": "Discount",
           "freeShipping": "Free shipping",
           "noticeInfo": "Notice info",
+          "stock": "Product stock",
+          "optionStockTotal": "Option stock total",
+          "stockSource": "Stock source",
           "matchedProduct": "Matched product",
           "automaticMapping": "Auto mapping"
         },
@@ -843,6 +846,11 @@
         "noticeInfoTypes": {
           "teaware": "Teaware",
           "tea": "Tea"
+        },
+        "stockSources": {
+          "product_stock": "Product stock source",
+          "option_stock_total": "Option stock total",
+          "default_zero": "Default 0"
         }
       },
       "naverCommerce": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -799,6 +799,9 @@
           "discount": "할인 반영",
           "freeShipping": "무료배송",
           "noticeInfo": "고시정보",
+          "stock": "상품 재고",
+          "optionStockTotal": "옵션 재고 합계",
+          "stockSource": "재고 출처",
           "matchedProduct": "연결 상품",
           "automaticMapping": "자동 매핑"
         },
@@ -843,6 +846,11 @@
         "noticeInfoTypes": {
           "teaware": "다구",
           "tea": "차류"
+        },
+        "stockSources": {
+          "product_stock": "상품 재고 원본",
+          "option_stock_total": "옵션 재고 합계",
+          "default_zero": "기본값 0"
         }
       },
       "naverCommerce": {

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -67,6 +67,8 @@ export interface SmartStoreAutomaticMappingResult {
   noticeInfoType?: 'teaware' | 'tea';
 }
 
+export type SmartStoreImportStockSource = 'product_stock' | 'option_stock_total' | 'default_zero';
+
 export interface SmartStoreProductImportRow {
   rowNumber: number;
   identifier: string | null;
@@ -82,6 +84,9 @@ export interface SmartStoreProductImportRow {
   hasDiscount: boolean;
   isFreeShipping: boolean | null;
   hasNoticeInfo: boolean;
+  stock: number | null;
+  optionStockTotal: number | null;
+  stockSource: SmartStoreImportStockSource;
   automaticMapping: SmartStoreAutomaticMappingResult;
   mappingWarnings: string[];
   errors: string[];


### PR DESCRIPTION
## Summary
- Fix SmartStore Excel imports so blank product stock falls back to summed option stock instead of saving product stock as 0
- Map Naver Commerce API option combinations from `detailAttribute.optionInfo`, including `optionName1~4`, option group names, boolean usable flags, and option stock totals
- Show product stock and option stock total in the admin import preview table

Closes #1026

## Verification
- `bash scripts/codex-project-guard.sh`
- `cd backend && npm run test -- --runInBand src/modules/products/__tests__/smartstore-product-import.service.spec.ts src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts`
- `npx vitest run 'src/app/[locale]/admin/products/__tests__/AdminProductsPage.test.tsx'`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `curl -fsS http://localhost:3000/api/health`
- `curl -fsSI http://localhost:5173/ko`
