### PR TITLE
fix: #1036 커머스 API 옵션관리 변경

### DIFF
--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -151,7 +151,9 @@ describe('NaverCommerceProductImportService', () => {
       identifier: 'SKU-1',
       action: 'update',
       productId: 7,
-      optionCount: 1,
+      optionCount: 0,
+      stock: 2,
+      stockSource: 'single_option_collapsed',
       galleryImageCount: 2,
       isFreeShipping: true,
       hasNoticeInfo: true,
@@ -197,7 +199,9 @@ describe('NaverCommerceProductImportService', () => {
         isVisibleEn: false,
         description: '<p>상세</p>',
         noticeInfo: expect.objectContaining({ manufacturer: '옥화당', countryOfOrigin: '중국' }),
-        options: [expect.objectContaining({ name: '용량', value: '100cc', stock: 2 })],
+        // 단일 원본 옵션(용량 100cc)은 상품 재고(2)로 흡수되어 제거되고,
+        // 상품명 키워드에서 파생된 용량 옵션(110cc)만 남는다. (issue #1036)
+        options: [expect.objectContaining({ name: '용량', value: '110cc' })],
         images: [
           expect.objectContaining({
             url: expect.stringContaining(encodeURIComponent('https://img.example.com/rep.jpg')),

--- a/backend/src/modules/products/__tests__/product-import-stock.util.spec.ts
+++ b/backend/src/modules/products/__tests__/product-import-stock.util.spec.ts
@@ -1,0 +1,50 @@
+import { ProductOptionInputDto } from '../dto/create-product.dto';
+import { resolveImportOptionsStock } from '../product-import-stock.util';
+
+function option(overrides: Partial<ProductOptionInputDto> = {}): ProductOptionInputDto {
+  return { name: '용량', value: '100cc', priceAdjustment: 0, stock: 0, sortOrder: 0, ...overrides };
+}
+
+describe('resolveImportOptionsStock', () => {
+  it('collapses a single option into base stock and drops the option (issue #1036)', () => {
+    const result = resolveImportOptionsStock(0, [option({ stock: 5 })]);
+
+    expect(result.options).toBeUndefined();
+    expect(result.stock).toBe(5);
+    expect(result.optionStockTotal).toBeNull();
+    expect(result.stockSource).toBe('single_option_collapsed');
+  });
+
+  it('keeps the larger of raw stock and single option stock when collapsing', () => {
+    expect(resolveImportOptionsStock(8, [option({ stock: 3 })]).stock).toBe(8);
+    expect(resolveImportOptionsStock(0, [option({ stock: 0 })]).stock).toBe(0);
+    expect(resolveImportOptionsStock(null, [option({ stock: 4 })]).stock).toBe(4);
+  });
+
+  it('sums option stock when there are multiple real options', () => {
+    const result = resolveImportOptionsStock(0, [
+      option({ value: '100cc', stock: 4 }),
+      option({ value: '200cc', stock: 6 }),
+    ]);
+
+    expect(result.options).toHaveLength(2);
+    expect(result.stock).toBe(10);
+    expect(result.optionStockTotal).toBe(10);
+    expect(result.stockSource).toBe('option_stock_total');
+  });
+
+  it('uses product stock when there are no options', () => {
+    const result = resolveImportOptionsStock(7, undefined);
+
+    expect(result.options).toBeUndefined();
+    expect(result.stock).toBe(7);
+    expect(result.stockSource).toBe('product_stock');
+  });
+
+  it('defaults to zero stock when neither options nor product stock exist', () => {
+    const result = resolveImportOptionsStock(null, undefined);
+
+    expect(result.stock).toBe(0);
+    expect(result.stockSource).toBe('default_zero');
+  });
+});

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -188,14 +188,17 @@ describe('SmartStoreProductImportService', () => {
     const service = createService(repository, commandService);
     const buffer = await createWorkbookBuffer([
       ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값'],
-      ['SKU-1', '옥화당 자사호 노단니 연자호 120cc', 10000, '단독형', '색상', '노단니'],
+      ['SKU-1', '옥화당 자사호 노단니 연자호 120cc', 10000, '단독형', '색상', '노단니,자니'],
     ]);
 
     const result = await service.commit(createFile(buffer));
 
     expect(result.rows[0].mappingWarnings.join(' ')).toContain('명시 옵션');
     expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
-      options: [expect.objectContaining({ name: '색상', value: '노단니' })],
+      options: [
+        expect.objectContaining({ name: '색상', value: '노단니' }),
+        expect.objectContaining({ name: '색상', value: '자니' }),
+      ],
     }));
   });
 
@@ -578,18 +581,46 @@ describe('SmartStoreProductImportService', () => {
       const service = createService(repository, commandService);
       const buffer = await createWorkbookBuffer([
         ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값', '옵션 사용여부'],
-        ['SKU-1', '옵션 상품', 10000, '단독형', '용량', '100cc,200cc', 'Y,N'],
+        ['SKU-1', '옵션 상품', 10000, '단독형', '용량', '100cc,200cc,300cc', 'Y,N,Y'],
         ['SKU-2', '단일 상품', 5000, '설정안함', '', '', ''],
       ]);
 
       await service.commit(createFile(buffer));
 
+      // 사용안함(N)으로 표시된 200cc는 제외되고 사용 가능한 100cc/300cc 두 옵션만 남는다.
       expect(commandService.create).toHaveBeenNthCalledWith(1, expect.objectContaining({
-        options: [expect.objectContaining({ value: '100cc' })],
+        options: [
+          expect.objectContaining({ value: '100cc' }),
+          expect.objectContaining({ value: '300cc' }),
+        ],
       }));
       expect(commandService.create).toHaveBeenNthCalledWith(2, expect.not.objectContaining({
         options: expect.anything(),
       }));
+    });
+
+    it('collapses a single usable option into product stock (issue #1036)', async () => {
+      const repository = createRepositoryMock([]);
+      const commandService = createCommandServiceMock();
+      const service = createService(repository, commandService);
+      const buffer = await createWorkbookBuffer([
+        ['판매자상품코드', '상품명', '판매가', '재고수량', '옵션형태', '옵션명', '옵션값', '옵션 재고수량'],
+        ['SKU-1', '단독 옵션 상품', 10000, 0, '단독형', '색상', '노단니', '4'],
+      ]);
+
+      const result = await service.commit(createFile(buffer));
+
+      expect(result.rows[0]).toMatchObject({
+        optionCount: 0,
+        stock: 4,
+        stockSource: 'single_option_collapsed',
+      });
+      expect(commandService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ stock: 4, status: ProductStatus.ACTIVE }),
+      );
+      expect(commandService.create).toHaveBeenCalledWith(
+        expect.not.objectContaining({ options: expect.anything() }),
+      );
     });
 
     it('reports option value count mismatch as a row error', async () => {
@@ -777,13 +808,16 @@ describe('SmartStoreProductImportService', () => {
       const service = createService(repository, commandService);
       const buffer = await createWorkbookBuffer([
         ['판매자상품코드', '상품명', '판매가', '옵션형태', '옵션명', '옵션값', '대표이미지'],
-        ['SKU-2', '기존 상품 갱신', 9000, '단독형', '용량', '100cc', 'https://img.example.com/rep.jpg'],
+        ['SKU-2', '기존 상품 갱신', 9000, '단독형', '용량', '100cc,200cc', 'https://img.example.com/rep.jpg'],
       ]);
 
       await service.commit(createFile(buffer));
 
       expect(commandService.update).toHaveBeenCalledWith(7, expect.objectContaining({
-        options: [expect.objectContaining({ name: '용량', value: '100cc' })],
+        options: [
+          expect.objectContaining({ name: '용량', value: '100cc' }),
+          expect.objectContaining({ name: '용량', value: '200cc' }),
+        ],
         images: [expect.objectContaining({ url: ingestedUrl('https://img.example.com/rep.jpg'), isThumbnail: true })],
       }));
     });

--- a/backend/src/modules/products/naver-commerce-product-import.service.ts
+++ b/backend/src/modules/products/naver-commerce-product-import.service.ts
@@ -8,10 +8,10 @@ import { ProductStatus } from './entities/product.entity';
 import { NaverCommerceApiClient, NaverCommerceFetchedProduct } from './naver-commerce-api.client';
 import {
   SmartStoreImportResult,
-  SmartStoreImportStockSource,
   SmartStoreParsedProductRow,
   SmartStoreProductImportService,
 } from './smartstore-product-import.service';
+import { resolveImportOptionsStock } from './product-import-stock.util';
 import { buildNaverExternalProductKey } from '../../common/imports/external-source.util';
 
 @Injectable()
@@ -117,9 +117,11 @@ export class NaverCommerceProductImportService {
       ]),
     );
     const noticeInfo = this.buildNoticeInfo(product, productName);
-    const options = this.buildOptions(product);
-    const optionStockTotal = this.sumOptionStock(options);
-    const { stock, stockSource } = this.resolveImportStock(rawStock, optionStockTotal);
+    const parsedOptions = this.buildOptions(product);
+    const { options, stock, optionStockTotal, stockSource } = resolveImportOptionsStock(
+      rawStock,
+      parsedOptions,
+    );
 
     if (!identifier) errors.push('네이버 상품번호 또는 판매자 상품코드가 필요합니다.');
     if (!productName) errors.push('네이버 상품명이 필요합니다.');
@@ -352,24 +354,6 @@ export class NaverCommerceProductImportService {
     if (value === false || value === 0) return true;
     if (typeof value !== 'string') return false;
     return ['N', 'NO', 'FALSE', '사용안함', 'X'].includes(value.toUpperCase());
-  }
-
-  private sumOptionStock(options: ProductOptionInputDto[] | undefined): number | null {
-    if (!options || options.length === 0) return null;
-    return options.reduce((sum, option) => sum + (option.stock ?? 0), 0);
-  }
-
-  private resolveImportStock(
-    rawStock: number | null,
-    optionStockTotal: number | null,
-  ): { stock: number; stockSource: SmartStoreImportStockSource } {
-    if (optionStockTotal !== null) {
-      return { stock: optionStockTotal, stockSource: 'option_stock_total' };
-    }
-    if (rawStock !== null) {
-      return { stock: rawStock, stockSource: 'product_stock' };
-    }
-    return { stock: 0, stockSource: 'default_zero' };
   }
 
   private mapStatus(status: string | null, stock: number): ProductStatus {

--- a/backend/src/modules/products/product-import-stock.util.ts
+++ b/backend/src/modules/products/product-import-stock.util.ts
@@ -1,0 +1,57 @@
+import { ProductOptionInputDto } from './dto/create-product.dto';
+
+export type SmartStoreImportStockSource =
+  | 'product_stock'
+  | 'option_stock_total'
+  | 'single_option_collapsed'
+  | 'default_zero';
+
+export interface ResolvedImportOptionsStock {
+  options: ProductOptionInputDto[] | undefined;
+  stock: number;
+  optionStockTotal: number | null;
+  stockSource: SmartStoreImportStockSource;
+}
+
+/**
+ * 커머스 임포트(네이버 커머스 API / 스마트스토어 엑셀)에서 옵션과 재고를 정규화한다. (issue #1036)
+ *
+ * 정책:
+ *   - 옵션이 2개 이상: 옵션 재고 합계를 상품 재고로 사용한다.
+ *   - 옵션이 정확히 1개: 고객이 선택할 수 있는 실제 옵션이 아니므로 옵션을 제거하고
+ *     상품 기본 재고로 흡수한다. 이때 재고는 원 재고와 단일 옵션 재고 중 큰 값으로 세팅해
+ *     원본이 옵션에만 재고를 넣고 상품 재고를 0으로 내려보내는 경우에도 품절로 오인되지 않게 한다.
+ *   - 옵션이 없음: 상품 기본 재고를 그대로 사용한다.
+ */
+export function resolveImportOptionsStock(
+  rawStock: number | null,
+  options: ProductOptionInputDto[] | undefined,
+): ResolvedImportOptionsStock {
+  const optionStockTotal = sumOptionStock(options);
+
+  if (options && options.length === 1) {
+    const singleOptionStock = options[0].stock ?? 0;
+    const stock = Math.max(rawStock ?? 0, singleOptionStock);
+    return {
+      options: undefined,
+      stock,
+      optionStockTotal: null,
+      stockSource: 'single_option_collapsed',
+    };
+  }
+
+  if (optionStockTotal !== null) {
+    return { options, stock: optionStockTotal, optionStockTotal, stockSource: 'option_stock_total' };
+  }
+
+  if (rawStock !== null) {
+    return { options, stock: rawStock, optionStockTotal: null, stockSource: 'product_stock' };
+  }
+
+  return { options, stock: 0, optionStockTotal: null, stockSource: 'default_zero' };
+}
+
+function sumOptionStock(options: ProductOptionInputDto[] | undefined): number | null {
+  if (!options || options.length === 0) return null;
+  return options.reduce((sum, option) => sum + (option.stock ?? 0), 0);
+}

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -19,9 +19,13 @@ import {
   ProductKeywordMappingService,
   ProductKeywordOptionMapping,
 } from './product-keyword-mapping.service';
+import {
+  resolveImportOptionsStock,
+  SmartStoreImportStockSource,
+} from './product-import-stock.util';
 
 export type SmartStoreImportAction = 'create' | 'update' | 'skip';
-export type SmartStoreImportStockSource = 'product_stock' | 'option_stock_total' | 'default_zero';
+export type { SmartStoreImportStockSource } from './product-import-stock.util';
 
 export interface SmartStoreImportRowResult {
   rowNumber: number;
@@ -373,9 +377,11 @@ export class SmartStoreProductImportService {
     const isFreeShipping = this.parseFreeShipping(row, headerMap);
     const noticeInfo = this.buildNoticeInfo(row, headerMap, productName);
 
-    const options = this.parseOptions(row, headerMap, errors);
-    const optionStockTotal = this.sumOptionStock(options);
-    const { stock, stockSource } = this.resolveImportStock(rawStock, optionStockTotal);
+    const parsedOptions = this.parseOptions(row, headerMap, errors);
+    const { options, stock, optionStockTotal, stockSource } = resolveImportOptionsStock(
+      rawStock,
+      parsedOptions,
+    );
     const representativeImage = this.getCell(row, headerMap.representativeImage);
     const additionalImages = this.splitImageUrls(this.getCell(row, headerMap.additionalImages));
     const galleryUrls = this.collectValidImageUrls(
@@ -683,24 +689,6 @@ export class SmartStoreProductImportService {
     });
 
     return options;
-  }
-
-  private sumOptionStock(options: ProductOptionInputDto[] | undefined): number | null {
-    if (!options || options.length === 0) return null;
-    return options.reduce((sum, option) => sum + (option.stock ?? 0), 0);
-  }
-
-  private resolveImportStock(
-    rawStock: number | null,
-    optionStockTotal: number | null,
-  ): { stock: number; stockSource: SmartStoreImportStockSource } {
-    if (optionStockTotal !== null) {
-      return { stock: optionStockTotal, stockSource: 'option_stock_total' };
-    }
-    if (rawStock !== null) {
-      return { stock: rawStock, stockSource: 'product_stock' };
-    }
-    return { stock: 0, stockSource: 'default_zero' };
   }
 
   private isOptionUsable(raw: string | undefined): boolean {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -851,6 +851,7 @@
         "stockSources": {
           "product_stock": "Product stock source",
           "option_stock_total": "Option stock total",
+          "single_option_collapsed": "Single option → product stock",
           "default_zero": "Default 0"
         }
       },

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -851,6 +851,7 @@
         "stockSources": {
           "product_stock": "상품 재고 원본",
           "option_stock_total": "옵션 재고 합계",
+          "single_option_collapsed": "단일 옵션 → 상품 재고",
           "default_zero": "기본값 0"
         }
       },

--- a/src/lib/api/admin/products.ts
+++ b/src/lib/api/admin/products.ts
@@ -69,7 +69,11 @@ export interface SmartStoreAutomaticMappingResult {
   noticeInfoType?: 'teaware' | 'tea';
 }
 
-export type SmartStoreImportStockSource = 'product_stock' | 'option_stock_total' | 'default_zero';
+export type SmartStoreImportStockSource =
+  | 'product_stock'
+  | 'option_stock_total'
+  | 'single_option_collapsed'
+  | 'default_zero';
 
 export interface SmartStoreProductImportRow {
   rowNumber: number;


### PR DESCRIPTION
## Summary
- Closes #1036
- 네이버 커머스 API / 스마트스토어 임포트에서 실제 옵션이 없는 상품에도 단일 placeholder 옵션이 재고 0으로 들어와 상품이 품절로 오인되던 버그 수정.
- **접근 (b) 채택**: 옵션이 정확히 1개면 옵션을 제거하고 상품 기본 재고로 흡수. 단일 옵션은 고객이 선택할 실제 항목이 아니며, cart/order 코드가 이미 옵션 없는 상품(`product.stock` 폴백)을 완전히 지원하므로 가장 비침습적.
- 재고는 원 재고와 단일 옵션 재고 중 **큰 값**으로 세팅해, 원본이 옵션에만 재고를 넣고 상품 재고를 0으로 내려보내도 품절 오염이 발생하지 않도록 함 (이슈의 "원 재고와 동일하게 세팅" + "옵션 미포함" 두 제안을 동시 충족).

## Changes
- `backend/src/modules/products/product-import-stock.util.ts` (신규): 옵션/재고 정규화 공용 유틸 `resolveImportOptionsStock`. 두 임포트 서비스의 중복 `sumOptionStock`/`resolveImportStock` 통합.
- `naver-commerce-product-import.service.ts`, `smartstore-product-import.service.ts`: 공용 유틸 사용으로 전환.
- `stockSource`에 `single_option_collapsed` 값 추가 (BE 타입 + FE `src/lib/api/admin/products.ts` 타입 + ko/en i18n).
- 옵션 ≥2개 상품은 기존 동작 유지 (옵션 재고 합산).

## Test plan
- [x] cd backend && npm run lint (0 errors)
- [x] cd backend && npm run build
- [x] cd backend && npm run test (123 suites / 1236 tests pass)
- [x] 신규 유틸 단위 테스트 `product-import-stock.util.spec.ts`
- [x] frontend tsc --noEmit (0 errors) + AdminProductsPage 테스트 pass
- 스키마 변경 없음 → 마이그레이션 불필요