### PR TITLE
어드민 UX 공통 흐름 표준화 (#1040-#1049)

### DIFF
--- a/src/app/[locale]/admin/members/page.tsx
+++ b/src/app/[locale]/admin/members/page.tsx
@@ -11,6 +11,7 @@ import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
 import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
 import { AdminSearchForm } from '@/components/shared/admin/AdminSearchForm';
 import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
+import { localMessage } from '@/utils/localMessages';
 
 const ROLE_FILTERS = [
   { label: '전체', value: '' },
@@ -40,6 +41,8 @@ export default function AdminMembersPage() {
     filters,
     setFilter,
     submitSearch,
+    resetFilters,
+    hasActiveFilters,
   } = useAdminListPage({
     initialFilters: {
       role: '',
@@ -76,13 +79,20 @@ export default function AdminMembersPage() {
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
       <AdminPageHeader title="회원 관리" />
 
-      <AdminFilterChips
-        items={ROLE_FILTERS}
-        value={filters.role}
-        onToggle={(value) => setFilter('role', value)}
-        ariaLabel="회원 역할 필터"
-        size="sm"
-      />
+      <div className="flex flex-wrap items-center gap-2">
+        <AdminFilterChips
+          items={ROLE_FILTERS}
+          value={filters.role}
+          onToggle={(value) => setFilter('role', value)}
+          ariaLabel="회원 역할 필터"
+          size="sm"
+        />
+        {hasActiveFilters && (
+          <button type="button" onClick={resetFilters} className="rounded-md border px-3 py-1 typo-button text-muted-foreground hover:bg-muted">
+            {localMessage('admin.common.resetFilters')}
+          </button>
+        )}
+      </div>
 
       <div className="flex flex-wrap items-end gap-4">
         <AdminSearchForm

--- a/src/app/[locale]/admin/orders/page.tsx
+++ b/src/app/[locale]/admin/orders/page.tsx
@@ -12,6 +12,7 @@ import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
 import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
 import { AdminSearchForm } from '@/components/shared/admin/AdminSearchForm';
 import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
+import { localMessage } from '@/utils/localMessages';
 
 const STATUS_FILTERS = [
   { label: '전체', value: '' },
@@ -43,6 +44,8 @@ export default function AdminOrdersPage() {
     filters,
     setFilter,
     submitSearch,
+    resetFilters,
+    hasActiveFilters,
   } = useAdminListPage({
     initialFilters: {
       status: '',
@@ -96,13 +99,20 @@ export default function AdminOrdersPage() {
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-8">
       <AdminPageHeader title="주문 관리" />
 
-      <AdminFilterChips
-        items={STATUS_FILTERS}
-        value={filters.status}
-        onToggle={(value) => setFilter('status', value)}
-        ariaLabel="주문 상태 필터"
-        size="sm"
-      />
+      <div className="flex flex-wrap items-center gap-2">
+        <AdminFilterChips
+          items={STATUS_FILTERS}
+          value={filters.status}
+          onToggle={(value) => setFilter('status', value)}
+          ariaLabel="주문 상태 필터"
+          size="sm"
+        />
+        {hasActiveFilters && (
+          <button type="button" onClick={resetFilters} className="rounded-md border px-3 py-1 typo-button text-muted-foreground hover:bg-muted">
+            {localMessage('admin.common.resetFilters')}
+          </button>
+        )}
+      </div>
 
 
       {serviceRequests.length > 0 && (

--- a/src/app/[locale]/admin/pages/__tests__/AdminPagesPage.test.tsx
+++ b/src/app/[locale]/admin/pages/__tests__/AdminPagesPage.test.tsx
@@ -139,6 +139,7 @@ describe('AdminPagesPage', () => {
 
     const deleteBtn = screen.getByLabelText('블록 삭제');
     fireEvent.click(deleteBtn);
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }));
 
     await waitFor(() => {
       expect(screen.queryByText('환영합니다')).not.toBeInTheDocument();

--- a/src/app/[locale]/admin/pages/page.tsx
+++ b/src/app/[locale]/admin/pages/page.tsx
@@ -6,7 +6,7 @@ import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { adminPagesApi } from '@/lib/api';
 import type { Page } from '@/lib/api';
 import { useUnsavedChanges } from '@/components/shared/hooks/useUnsavedChanges';
-import { draftReducer } from '@/components/shared/admin/page-editor/useDraftReducer';
+import { createDraftBlockId, draftReducer } from '@/components/shared/admin/page-editor/useDraftReducer';
 import { usePageEditor } from '@/components/shared/admin/page-editor/usePageEditor';
 import PageListSidebar from '@/components/shared/admin/page-editor/PageListSidebar';
 import EditorTopBar from '@/components/shared/admin/page-editor/EditorTopBar';
@@ -14,6 +14,9 @@ import BlockPalette from '@/components/shared/admin/page-editor/BlockPalette';
 import EditorCanvas from '@/components/shared/admin/page-editor/EditorCanvas';
 import BlockPropertyPanel from '@/components/shared/admin/page-editor/BlockPropertyPanel';
 import PreviewModal from '@/components/shared/admin/page-editor/PreviewModal';
+import { ConfirmDialog } from '@/components/shared/admin/ConfirmDialog';
+import { AdminEmptyState, AdminLoadingState } from '@/components/shared/admin/AdminStates';
+import { localMessage } from '@/utils/localMessages';
 
 export default function AdminPagesPage() {
   const { isLoading: authLoading, isAdmin } = useAdminGuard();
@@ -22,6 +25,7 @@ export default function AdminPagesPage() {
   const [selectedBlockId, setSelectedBlockId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
+  const [confirmPublishOpen, setConfirmPublishOpen] = useState(false);
 
   const [draft, dispatch] = useReducer(draftReducer, {
     title: '',
@@ -61,7 +65,7 @@ export default function AdminPagesPage() {
   if (authLoading || loading) {
     return (
       <div className="flex h-full items-center justify-center">
-        <span className="text-sm text-muted-foreground">로딩 중...</span>
+        <AdminLoadingState title={localMessage('admin.pages.loading')} />
       </div>
     );
   }
@@ -85,16 +89,18 @@ export default function AdminPagesPage() {
             saving={saving}
             onTitleChange={(title) => dispatch({ type: 'SET_TITLE', title })}
             onSlugChange={(slug) => dispatch({ type: 'SET_SLUG', slug })}
-            onTogglePublish={handleTogglePublish}
+            onTogglePublish={() => setConfirmPublishOpen(true)}
             onSave={handleSave}
             onDelete={handleDeletePage}
             onPreview={() => setShowPreview(true)}
           />
           <div className="flex flex-1 overflow-hidden">
             <BlockPalette
-              onAddBlock={(blockType, content) =>
-                dispatch({ type: 'ADD_BLOCK', blockType, content })
-              }
+              onAddBlock={(blockType, content) => {
+                const nextId = createDraftBlockId();
+                dispatch({ type: 'ADD_BLOCK', blockType, content, id: nextId });
+                setSelectedBlockId(nextId);
+              }}
             />
             <EditorCanvas
               blocks={draft.blocks}
@@ -120,21 +126,11 @@ export default function AdminPagesPage() {
           </div>
         </div>
       ) : (
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center text-muted-foreground">
-          <p className="text-base font-medium text-foreground">편집할 페이지를 선택하세요</p>
-          <p className="text-sm max-w-sm">
-            왼쪽 목록에서 페이지를 선택하면 블록 편집기가 열립니다.<br />
-            새 페이지는 왼쪽 상단 <b>+</b> 버튼으로 만들 수 있습니다.
-          </p>
-          <div className="mt-2 rounded-lg border bg-muted/40 px-6 py-4 text-xs text-left space-y-1.5 max-w-sm">
-            <p className="font-semibold text-foreground mb-2">블록이란?</p>
-            <p>🖼 <b>히어로 배너</b> — 페이지 최상단 큰 이미지 영역</p>
-            <p>🛍 <b>상품 그리드</b> — 상품을 격자 형태로 나열</p>
-            <p>🎠 <b>상품 캐러셀</b> — 상품을 슬라이드로 표시</p>
-            <p>🗂 <b>카테고리 내비</b> — 카테고리 바로가기 버튼</p>
-            <p>📢 <b>프로모션 배너</b> — 할인·이벤트 안내 띠 배너</p>
-            <p>📝 <b>텍스트</b> — 자유 형식 HTML 텍스트</p>
-          </div>
+        <div className="flex flex-1 items-center justify-center p-8">
+          <AdminEmptyState
+            title={localMessage('admin.pages.emptyTitle')}
+            description={localMessage('admin.pages.emptyDescription')}
+          />
         </div>
       )}
 
@@ -144,6 +140,21 @@ export default function AdminPagesPage() {
           onClose={() => setShowPreview(false)}
         />
       )}
+      <ConfirmDialog
+        open={confirmPublishOpen}
+        title={selectedPage?.is_published ? localMessage('admin.pages.publishDialog.unpublishTitle') : localMessage('admin.pages.publishDialog.publishTitle')}
+        description={selectedPage?.is_published
+          ? localMessage('admin.pages.publishDialog.unpublishDescription')
+          : localMessage('admin.pages.publishDialog.publishDescription')}
+        confirmLabel={selectedPage?.is_published ? localMessage('admin.pages.publishDialog.unpublishConfirm') : localMessage('admin.pages.publishDialog.publishConfirm')}
+        cancelLabel={localMessage('admin.pages.publishDialog.cancel')}
+        destructive={selectedPage?.is_published}
+        onCancel={() => setConfirmPublishOpen(false)}
+        onConfirm={() => {
+          setConfirmPublishOpen(false);
+          void handleTogglePublish();
+        }}
+      />
     </div>
   );
 }

--- a/src/app/[locale]/admin/products/page.tsx
+++ b/src/app/[locale]/admin/products/page.tsx
@@ -14,6 +14,7 @@ import { ProductStatusBadge } from '@/components/shared/admin/StatusBadge';
 import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
 import { AdminFilterChips } from '@/components/shared/admin/AdminFilterChips';
 import { PaginatedAdminTableShell } from '@/components/shared/admin/PaginatedAdminTableShell';
+import { ConfirmDialog } from '@/components/shared/admin/ConfirmDialog';
 
 const PAGE_SIZE = 20;
 
@@ -21,6 +22,7 @@ type ProductStatus = 'active' | 'soldout' | 'draft' | 'hidden';
 
 export default function AdminProductsPage() {
   const t = useTranslations('admin.products');
+  const tCommon = useTranslations('admin.common');
   const { isAdmin } = useAdminGuard();
   const [products, setProducts] = useState<Product[]>([]);
   const [total, setTotal] = useState(0);
@@ -32,7 +34,8 @@ export default function AdminProductsPage() {
   >(null);
   const [showAllImportRows, setShowAllImportRows] = useState(false);
   const [showFailedImportRowsOnly, setShowFailedImportRowsOnly] = useState(false);
-  const { page, setPage, filters, setFilter } = useAdminListPage({
+  const [productPendingDelete, setProductPendingDelete] = useState<Product | null>(null);
+  const { page, setPage, filters, setFilter, resetFilters, hasActiveFilters } = useAdminListPage({
     initialFilters: {
       status: '',
     },
@@ -194,7 +197,13 @@ export default function AdminProductsPage() {
     void toggleLocaleVisibility({ product, locale });
 
   const handleDelete = (product: Product) => {
-    if (!window.confirm(t('deleteConfirm', { name: product.name }))) return;
+    setProductPendingDelete(product);
+  };
+
+  const confirmDeleteProduct = () => {
+    if (!productPendingDelete) return;
+    const product = productPendingDelete;
+    setProductPendingDelete(null);
     void deleteProduct(product);
   };
 
@@ -490,13 +499,20 @@ export default function AdminProductsPage() {
         )}
       </section>
 
-      <AdminFilterChips
-        items={statusFilters}
-        value={filters.status}
-        onToggle={(value) => setFilter('status', value)}
-        ariaLabel={t('statusFilterAria')}
-        size="sm"
-      />
+      <div className="flex flex-wrap items-center gap-2">
+        <AdminFilterChips
+          items={statusFilters}
+          value={filters.status}
+          onToggle={(value) => setFilter('status', value)}
+          ariaLabel={t('statusFilterAria')}
+          size="sm"
+        />
+        {hasActiveFilters && (
+          <button type="button" onClick={resetFilters} className="rounded-md border px-3 py-1 typo-button text-muted-foreground hover:bg-muted">
+            {tCommon('resetFilters')}
+          </button>
+        )}
+      </div>
 
       <PaginatedAdminTableShell
         loading={loading}
@@ -582,6 +598,16 @@ export default function AdminProductsPage() {
           </table>
         </div>
       </PaginatedAdminTableShell>
+      <ConfirmDialog
+        open={productPendingDelete !== null}
+        title={t('deleteDialog.title')}
+        description={t('deleteDialog.description', { name: productPendingDelete?.name ?? '' })}
+        confirmLabel={t('deleteDialog.confirm')}
+        cancelLabel={t('deleteDialog.cancel')}
+        destructive
+        onCancel={() => setProductPendingDelete(null)}
+        onConfirm={confirmDeleteProduct}
+      />
     </div>
   );
 }

--- a/src/components/AdminHeader.tsx
+++ b/src/components/AdminHeader.tsx
@@ -1,13 +1,32 @@
 'use client';
 
-import { Menu } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { ExternalLink, Menu, Search, UserCircle } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { cn } from '@/components/ui/utils';
 
-const ROLE_LABELS: Record<string, string> = {
-  admin: '관리자',
-  super_admin: '최고관리자',
+const ROLE_LABEL_KEYS: Record<string, string> = {
+  admin: 'roles.admin',
+  super_admin: 'roles.superAdmin',
 };
+
+const SECTION_LABEL_KEYS: Array<{ segment: string; key: string }> = [
+  { segment: '/admin/dashboard', key: 'sections.dashboard' },
+  { segment: '/admin/products', key: 'sections.products' },
+  { segment: '/admin/categories', key: 'sections.categories' },
+  { segment: '/admin/orders', key: 'sections.orders' },
+  { segment: '/admin/members', key: 'sections.members' },
+  { segment: '/admin/reviews', key: 'sections.reviews' },
+  { segment: '/admin/inquiries', key: 'sections.inquiries' },
+  { segment: '/admin/pages', key: 'sections.pages' },
+  { segment: '/admin/navigation', key: 'sections.navigation' },
+  { segment: '/admin/localization', key: 'sections.localization' },
+  { segment: '/admin/attributes', key: 'sections.attributes' },
+  { segment: '/admin/collections', key: 'sections.collections' },
+  { segment: '/admin/settings', key: 'sections.settings' },
+];
 
 type AdminHeaderProps = {
   onMenuClick: () => void;
@@ -15,43 +34,64 @@ type AdminHeaderProps = {
 
 export function AdminHeader({ onMenuClick }: AdminHeaderProps) {
   const { user, logout } = useAuth();
+  const pathname = usePathname();
+  const t = useTranslations('admin.common');
 
-  const roleLabel = user?.role ? (ROLE_LABELS[user.role] ?? user.role) : '';
+  const normalizedPath = pathname.replace(/^\/(ko|en)/, '');
+  const section = SECTION_LABEL_KEYS.find((item) => normalizedPath.startsWith(item.segment));
+  const sectionLabel = section ? t(section.key) : t('sections.dashboard');
+  const roleLabel = user?.role ? t(ROLE_LABEL_KEYS[user.role] ?? 'roles.unknown') : '';
 
   return (
-    <header className="flex h-14 items-center justify-between border-b bg-background px-4">
-      <div className="flex items-center gap-3">
+    <header className="flex min-h-14 items-center justify-between gap-3 border-b bg-background px-4 py-2">
+      <div className="flex min-w-0 items-center gap-3">
         <button
+          type="button"
           onClick={onMenuClick}
-          className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:hidden"
-          aria-label="메뉴 열기"
+          className="min-h-11 min-w-11 rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:hidden"
+          aria-label={t('openMenu')}
         >
           <Menu className="h-5 w-5" />
         </button>
-        <span className="text-sm font-medium text-muted-foreground">Commerce Admin</span>
+        <div className="min-w-0">
+          <p className="typo-label text-muted-foreground">{t('brand')}</p>
+          <p className="truncate typo-body-sm font-medium text-foreground">{sectionLabel}</p>
+        </div>
       </div>
-      <div className="flex items-center gap-3">
-        {user && (
-          <>
-            <span className="text-sm">{user.name}</span>
-            <span
-              className={cn(
-                'rounded-full px-2 py-0.5 text-xs font-medium',
-                user.role === 'super_admin'
-                  ? 'bg-amber-100 text-amber-800'
-                  : 'bg-blue-100 text-blue-800',
-              )}
-            >
-              {roleLabel}
-            </span>
-          </>
-        )}
-        <button
-          onClick={() => void logout()}
-          className="rounded-md px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+
+      <div className="flex shrink-0 items-center gap-2">
+        <Link
+          href="/"
+          target="_blank"
+          className="hidden min-h-11 items-center gap-1 rounded-md border px-3 typo-button text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:flex"
         >
-          로그아웃
-        </button>
+          <ExternalLink className="h-4 w-4" />
+          {t('viewShop')}
+        </Link>
+        <Link
+          href="/admin/products"
+          className="hidden min-h-11 items-center gap-1 rounded-md border px-3 typo-button text-muted-foreground transition-colors hover:bg-muted hover:text-foreground md:flex"
+          aria-label={t('quickSearch')}
+        >
+          <Search className="h-4 w-4" />
+          {t('quickSearch')}
+        </Link>
+        <div className="flex min-h-11 items-center gap-2 rounded-md border px-2">
+          <UserCircle className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          {user && (
+            <div className="hidden text-right sm:block">
+              <p className="typo-body-sm leading-tight">{user.name}</p>
+              <p className="typo-label text-muted-foreground">{roleLabel}</p>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => void logout()}
+            className={cn('rounded px-2 py-1 typo-label text-muted-foreground transition-colors hover:bg-muted hover:text-foreground')}
+          >
+            {t('logout')}
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -16,10 +16,17 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
+import { adminInquiriesApi, adminOrdersApi } from '@/lib/api';
 
 type NavLeaf = {
   labelKey: string;
   href: string;
+  badgeKey?: keyof AdminWorkBadges;
+};
+
+type AdminWorkBadges = {
+  pendingInquiries: number;
+  paidOrders: number;
 };
 
 type NavGroup = {
@@ -54,10 +61,10 @@ const NAV_ITEMS: NavItem[] = [
     labelKey: 'operationsGroup',
     icon: ShoppingBag,
     children: [
-      { labelKey: 'orders', href: '/admin/orders' },
+      { labelKey: 'orders', href: '/admin/orders?status=paid', badgeKey: 'paidOrders' },
       { labelKey: 'members', href: '/admin/members' },
       { labelKey: 'reviews', href: '/admin/reviews' },
-      { labelKey: 'inquiries', href: '/admin/inquiries' },
+      { labelKey: 'inquiries', href: '/admin/inquiries?status=pending', badgeKey: 'pendingInquiries' },
     ],
   },
   {
@@ -87,7 +94,7 @@ function isNavGroup(item: NavItem): item is NavGroup {
 function getInitialOpenGroups(pathname: string): Record<string, boolean> {
   return NAV_ITEMS.reduce<Record<string, boolean>>((acc, item) => {
     if (isNavGroup(item)) {
-      acc[item.labelKey] = item.children.some((c) => pathname.startsWith(c.href));
+      acc[item.labelKey] = item.children.some((c) => pathname.startsWith(c.href.split('?')[0]));
     }
     return acc;
   }, {});
@@ -103,6 +110,24 @@ function SidebarContent({ onClose }: SidebarContentProps) {
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() =>
     getInitialOpenGroups(pathname),
   );
+  const [badges, setBadges] = useState<AdminWorkBadges>({ pendingInquiries: 0, paidOrders: 0 });
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.allSettled([
+      adminInquiriesApi.getAll({ status: 'pending', limit: 1 }),
+      adminOrdersApi.getList({ status: 'paid', limit: 1 }),
+    ]).then(([inquiries, orders]) => {
+      if (cancelled) return;
+      setBadges({
+        pendingInquiries: inquiries.status === 'fulfilled' ? inquiries.value.counts.pending : 0,
+        paidOrders: orders.status === 'fulfilled' ? orders.value.total : 0,
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const toggleGroup = (labelKey: string) => {
     setOpenGroups((prev) => ({ ...prev, [labelKey]: !prev[labelKey] }));
@@ -137,7 +162,7 @@ function SidebarContent({ onClose }: SidebarContentProps) {
           {NAV_ITEMS.map((item) => {
             if (isNavGroup(item)) {
               const isOpen = openGroups[item.labelKey] ?? false;
-              const isGroupActive = item.children.some((c) => pathname.startsWith(c.href));
+              const isGroupActive = item.children.some((c) => pathname.startsWith(c.href.split('?')[0]));
               return (
                 <li key={item.labelKey}>
                   <button
@@ -161,21 +186,27 @@ function SidebarContent({ onClose }: SidebarContentProps) {
                   {isOpen && (
                     <ul className="mt-1 space-y-1 pl-9">
                       {item.children.map((child) => {
+                        const childPath = child.href.split('?')[0];
                         const isActive =
-                          pathname === child.href || pathname.startsWith(child.href + '/');
+                          pathname === childPath || pathname.startsWith(childPath + '/');
                         return (
                           <li key={child.href}>
                             <Link
                               href={child.href}
                               onClick={onClose}
                               className={cn(
-                                'block rounded-md px-3 py-1.5 text-sm transition-colors',
+                                'flex items-center justify-between rounded-md px-3 py-1.5 typo-body-sm transition-colors',
                                 isActive
                                   ? 'bg-foreground text-background'
                                   : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                               )}
                             >
-                              {t(child.labelKey)}
+                              <span>{t(child.labelKey)}</span>
+                              {child.badgeKey && badges[child.badgeKey] > 0 && (
+                                <span className="ml-2 rounded-full bg-destructive px-2 py-0.5 typo-label text-destructive-foreground">
+                                  {badges[child.badgeKey]}
+                                </span>
+                              )}
                             </Link>
                           </li>
                         );
@@ -186,7 +217,8 @@ function SidebarContent({ onClose }: SidebarContentProps) {
               );
             }
 
-            const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
+            const itemPath = item.href.split('?')[0];
+            const isActive = pathname === itemPath || pathname.startsWith(itemPath + '/');
             return (
               <li key={item.href}>
                 <Link

--- a/src/components/shared/admin/AdminOrdersTable.tsx
+++ b/src/components/shared/admin/AdminOrdersTable.tsx
@@ -17,8 +17,43 @@ export function AdminOrdersTable({ orders, onStatusChange, onShippingRegister }:
   }
 
   return (
-    <div className="overflow-x-auto rounded-lg border">
-      <table className="w-full text-sm">
+    <>
+      <div className="grid gap-3 md:hidden">
+        {orders.map((order) => {
+          const productLabel = order.items.length > 0
+            ? order.items.length === 1
+              ? order.items[0].productName
+              : `${order.items[0].productName} 외 ${order.items.length - 1}건`
+            : '-';
+
+          return (
+            <article key={order.id} className="rounded-lg border bg-card p-4 shadow-sm" aria-labelledby={`order-${order.id}`}>
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 id={`order-${order.id}`} className="truncate font-mono typo-body-sm font-semibold">{order.orderNumber}</h3>
+                  <p className="typo-body-sm text-muted-foreground">{order.recipientName}</p>
+                </div>
+                <span className={`shrink-0 rounded-full px-2 py-0.5 typo-label ${ORDER_STATUS_COLORS[order.status] ?? 'bg-secondary'}`}>
+                  {ORDER_STATUS_LABELS[order.status] ?? order.status}
+                </span>
+              </div>
+              <dl className="mt-3 grid gap-2 typo-body-sm">
+                <div className="flex justify-between gap-3"><dt className="text-muted-foreground">상품</dt><dd className="text-right">{productLabel}</dd></div>
+                <div className="flex justify-between gap-3"><dt className="text-muted-foreground">금액</dt><dd className="font-medium">{formatCurrency(order.totalAmount)}</dd></div>
+                <div className="flex justify-between gap-3"><dt className="text-muted-foreground">주문일</dt><dd>{new Date(order.createdAt).toLocaleDateString('ko-KR')}</dd></div>
+              </dl>
+              <div className="mt-4 flex flex-wrap justify-end gap-2">
+                <OrderStatusSelect orderId={order.id} currentStatus={order.status} onStatusChange={onStatusChange} />
+                {(order.status === 'preparing' || order.status === 'paid') && (
+                  <button type="button" onClick={() => onShippingRegister(order)} className="min-h-11 rounded border px-3 typo-button hover:bg-secondary">운송장</button>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+      <div className="hidden overflow-x-auto rounded-lg border md:block">
+      <table className="w-full typo-body-sm">
         <thead className="bg-secondary">
           <tr>
             <th className="px-4 py-3 text-left">주문번호</th>
@@ -77,6 +112,7 @@ export function AdminOrdersTable({ orders, onStatusChange, onShippingRegister }:
           ))}
         </tbody>
       </table>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/components/shared/admin/AdminPageHeader.tsx
+++ b/src/components/shared/admin/AdminPageHeader.tsx
@@ -3,23 +3,45 @@ import { cn } from '@/components/ui/utils';
 
 interface AdminPageHeaderProps {
   title: string;
+  description?: ReactNode;
+  breadcrumbs?: ReactNode;
+  actions?: ReactNode;
   action?: ReactNode;
   meta?: ReactNode;
+  filters?: ReactNode;
   className?: string;
   titleClassName?: string;
 }
 
 export function AdminPageHeader({
   title,
+  description,
+  breadcrumbs,
+  actions,
   action,
   meta,
+  filters,
   className,
   titleClassName,
 }: AdminPageHeaderProps) {
+  const actionContent = actions ?? action;
+
   return (
-    <div className={cn('flex items-center justify-between gap-4', className)}>
-      <h1 className={cn('text-2xl font-bold', titleClassName)}>{title}</h1>
-      {meta ?? action}
-    </div>
+    <header className={cn('space-y-4', className)}>
+      {breadcrumbs && <div className="typo-label text-muted-foreground">{breadcrumbs}</div>}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <h1 className={cn('typo-h1 font-display text-foreground', titleClassName)}>{title}</h1>
+          {description && <div className="typo-body-sm text-muted-foreground">{description}</div>}
+        </div>
+        {(meta || actionContent) && (
+          <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+            {meta && <div className="typo-body-sm text-muted-foreground">{meta}</div>}
+            {actionContent}
+          </div>
+        )}
+      </div>
+      {filters && <div className="rounded-lg border bg-card p-4 shadow-sm">{filters}</div>}
+    </header>
   );
 }

--- a/src/components/shared/admin/AdminPagination.tsx
+++ b/src/components/shared/admin/AdminPagination.tsx
@@ -1,7 +1,24 @@
+import { cn } from '@/components/ui/utils';
+import { localMessage } from '@/utils/localMessages';
+
 interface AdminPaginationProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
+}
+
+type PageItem = number | 'ellipsis';
+
+export function getAdminPaginationItems(currentPage: number, totalPages: number): PageItem[] {
+  if (totalPages <= 7) return Array.from({ length: totalPages }, (_, i) => i + 1);
+  const pages = new Set([1, totalPages, currentPage - 1, currentPage, currentPage + 1]);
+  const valid = [...pages].filter((p) => p >= 1 && p <= totalPages).sort((a, b) => a - b);
+  return valid.reduce<PageItem[]>((acc, page) => {
+    const previous = acc[acc.length - 1];
+    if (typeof previous === 'number' && page - previous > 1) acc.push('ellipsis');
+    acc.push(page);
+    return acc;
+  }, []);
 }
 
 export default function AdminPagination({
@@ -10,20 +27,36 @@ export default function AdminPagination({
   onPageChange,
 }: AdminPaginationProps) {
   if (totalPages <= 1) return null;
+  const safePage = Math.min(Math.max(currentPage, 1), totalPages);
+  const items = getAdminPaginationItems(safePage, totalPages);
 
   return (
-    <div className="mt-4 flex justify-center gap-2">
-      {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
-        <button
-          key={p}
-          onClick={() => onPageChange(p)}
-          className={`rounded px-3 py-1 text-sm ${
-            currentPage === p ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
-          }`}
-        >
-          {p}
-        </button>
-      ))}
-    </div>
+    <nav className="mt-4 flex flex-col items-center gap-3" aria-label={localMessage('admin.common.pagination.ariaLabel')}>
+      <p className="typo-body-sm text-muted-foreground">
+        {localMessage('admin.common.pagination.status', { current: safePage, total: totalPages })}
+      </p>
+      <div className="flex flex-wrap justify-center gap-2">
+        <button type="button" onClick={() => onPageChange(1)} disabled={safePage === 1} className="rounded border px-3 py-1 typo-body-sm disabled:opacity-40">{localMessage('admin.common.pagination.first')}</button>
+        <button type="button" onClick={() => onPageChange(safePage - 1)} disabled={safePage === 1} className="rounded border px-3 py-1 typo-body-sm disabled:opacity-40">{localMessage('admin.common.pagination.previous')}</button>
+        {items.map((item, index) => item === 'ellipsis' ? (
+          <span key={`ellipsis-${index}`} className="px-2 py-1 typo-body-sm text-muted-foreground" aria-hidden="true">…</span>
+        ) : (
+          <button
+            key={item}
+            type="button"
+            onClick={() => onPageChange(item)}
+            aria-current={safePage === item ? 'page' : undefined}
+            className={cn(
+              'rounded px-3 py-1 typo-body-sm transition-colors',
+              safePage === item ? 'bg-primary text-primary-foreground' : 'border hover:bg-secondary',
+            )}
+          >
+            {item}
+          </button>
+        ))}
+        <button type="button" onClick={() => onPageChange(safePage + 1)} disabled={safePage === totalPages} className="rounded border px-3 py-1 typo-body-sm disabled:opacity-40">{localMessage('admin.common.pagination.next')}</button>
+        <button type="button" onClick={() => onPageChange(totalPages)} disabled={safePage === totalPages} className="rounded border px-3 py-1 typo-body-sm disabled:opacity-40">{localMessage('admin.common.pagination.last')}</button>
+      </div>
+    </nav>
   );
 }

--- a/src/components/shared/admin/AdminStates.tsx
+++ b/src/components/shared/admin/AdminStates.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+import { AlertCircle, Inbox } from 'lucide-react';
+import { cn } from '@/components/ui/utils';
+
+interface AdminStateProps {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function AdminLoadingState({ title, description, className }: AdminStateProps) {
+  return (
+    <div className={cn('rounded-lg border bg-card p-6 text-center', className)} role="status" aria-live="polite">
+      <div className="mx-auto mb-4 h-12 w-12 rounded-full bg-muted animate-skeleton-shimmer" />
+      <p className="typo-body font-medium">{title}</p>
+      {description && <p className="mt-1 typo-body-sm text-muted-foreground">{description}</p>}
+    </div>
+  );
+}
+
+export function AdminEmptyState({ title, description, action, className }: AdminStateProps) {
+  return (
+    <div className={cn('rounded-lg border bg-card p-6 text-center', className)}>
+      <Inbox className="mx-auto mb-3 h-8 w-8 text-muted-foreground" aria-hidden="true" />
+      <p className="typo-body font-medium">{title}</p>
+      {description && <p className="mt-1 typo-body-sm text-muted-foreground">{description}</p>}
+      {action && <div className="mt-4 flex justify-center">{action}</div>}
+    </div>
+  );
+}
+
+export function AdminErrorState({ title, description, action, className }: AdminStateProps) {
+  return (
+    <div className={cn('rounded-lg border border-destructive/30 bg-card p-6 text-center', className)} role="alert">
+      <AlertCircle className="mx-auto mb-3 h-8 w-8 text-destructive" aria-hidden="true" />
+      <p className="typo-body font-medium">{title}</p>
+      {description && <p className="mt-1 typo-body-sm text-muted-foreground">{description}</p>}
+      {action && <div className="mt-4 flex justify-center">{action}</div>}
+    </div>
+  );
+}

--- a/src/components/shared/admin/ConfirmDialog.tsx
+++ b/src/components/shared/admin/ConfirmDialog.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Modal from '@/components/ui/Modal';
+import { cn } from '@/components/ui/utils';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Modal isOpen={open} onClose={onCancel} maxWidth="sm">
+      <div className="space-y-4 pr-6">
+        <div>
+          <h2 className="typo-h3 font-semibold">{title}</h2>
+          <p className="mt-2 whitespace-pre-line typo-body-sm text-muted-foreground">{description}</p>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="rounded-md border px-4 py-2 typo-button hover:bg-muted">
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={cn(
+              'rounded-md px-4 py-2 typo-button text-primary-foreground',
+              destructive ? 'bg-destructive hover:bg-destructive/90' : 'bg-primary hover:bg-primary/90',
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/shared/admin/PaginatedAdminTableShell.tsx
+++ b/src/components/shared/admin/PaginatedAdminTableShell.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode } from 'react';
 import AdminPagination from './AdminPagination';
+import { AdminEmptyState, AdminLoadingState } from './AdminStates';
 
 interface PaginatedAdminTableShellProps {
   loading: boolean;
   loadingMessage?: string;
   isEmpty?: boolean;
   emptyMessage?: string;
+  emptyAction?: ReactNode;
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
@@ -17,6 +19,7 @@ export function PaginatedAdminTableShell({
   loadingMessage = '불러오는 중...',
   isEmpty = false,
   emptyMessage = '데이터가 없습니다.',
+  emptyAction,
   currentPage,
   totalPages,
   onPageChange,
@@ -25,9 +28,9 @@ export function PaginatedAdminTableShell({
   return (
     <>
       {loading ? (
-        <p className="py-8 text-center text-muted-foreground">{loadingMessage}</p>
+        <AdminLoadingState title={loadingMessage} />
       ) : isEmpty ? (
-        <p className="py-8 text-center text-muted-foreground">{emptyMessage}</p>
+        <AdminEmptyState title={emptyMessage} action={emptyAction} />
       ) : (
         children
       )}

--- a/src/components/shared/admin/__tests__/AdminPagination.test.tsx
+++ b/src/components/shared/admin/__tests__/AdminPagination.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AdminPagination, { getAdminPaginationItems } from '@/components/shared/admin/AdminPagination';
+
+describe('AdminPagination', () => {
+  it('compacts large page ranges with ellipsis and edge controls', () => {
+    expect(getAdminPaginationItems(50, 100)).toEqual([1, 'ellipsis', 49, 50, 51, 'ellipsis', 100]);
+
+    render(<AdminPagination currentPage={50} totalPages={100} onPageChange={vi.fn()} />);
+
+    expect(screen.getByText('50 / 100 페이지')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '처음' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '끝' })).toBeInTheDocument();
+    expect(screen.getAllByText('…')).toHaveLength(2);
+  });
+});

--- a/src/components/shared/admin/page-editor/BlockPalette.tsx
+++ b/src/components/shared/admin/page-editor/BlockPalette.tsx
@@ -138,12 +138,29 @@ function getDefaultContent(type: BlockType): Record<string, unknown> {
 
 export default function BlockPalette({ onAddBlock }: BlockPaletteProps) {
   const [tooltip, setTooltip] = useState<BlockType | null>(null);
+  const [query, setQuery] = useState('');
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleBlockTypes = normalizedQuery
+    ? BLOCK_TYPES.filter(({ label, description, detail, type }) =>
+        [label, description, detail, type].some((value) => value.toLowerCase().includes(normalizedQuery)),
+      )
+    : BLOCK_TYPES;
 
   return (
-    <div className="w-52 shrink-0 overflow-y-auto border-r p-3">
-      <h3 className="mb-3 text-xs font-semibold uppercase text-muted-foreground">블록 추가</h3>
+    <div className="w-60 shrink-0 overflow-y-auto border-r p-3">
+      <h3 className="mb-3 typo-label font-semibold uppercase text-muted-foreground">블록 추가</h3>
+      <label className="mb-3 block">
+        <span className="sr-only">블록 검색</span>
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="블록 검색"
+          className="w-full rounded-md border px-3 py-2 typo-body-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </label>
       <div className="space-y-1.5">
-        {BLOCK_TYPES.map(({ type, label, description, detail, icon: Icon }) => (
+        {visibleBlockTypes.map(({ type, label, description, detail, icon: Icon }) => (
           <div key={type} className="relative">
             <div className="flex items-stretch gap-1">
               <button
@@ -175,6 +192,11 @@ export default function BlockPalette({ onAddBlock }: BlockPaletteProps) {
             )}
           </div>
         ))}
+        {visibleBlockTypes.length === 0 && (
+          <p className="rounded-md border border-dashed p-3 text-center typo-body-sm text-muted-foreground">
+            검색 결과가 없습니다.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/components/shared/admin/page-editor/SortableBlockItem.tsx
+++ b/src/components/shared/admin/page-editor/SortableBlockItem.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Trash2, Eye, EyeOff } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
+import { ConfirmDialog } from '@/components/shared/admin/ConfirmDialog';
+import { localMessage } from '@/utils/localMessages';
 import type { PageBlock } from '@/lib/api';
 
 const BLOCK_TYPE_LABELS: Record<PageBlock['type'], string> = {
@@ -82,6 +85,8 @@ export default function SortableBlockItem({
   onDelete,
   onToggleVisibility,
 }: SortableBlockItemProps) {
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
   const {
     attributes,
     listeners,
@@ -96,11 +101,7 @@ export default function SortableBlockItem({
     transition,
   };
 
-  const handleDelete = () => {
-    if (window.confirm('이 블록을 삭제하시겠습니까?\n저장 전까지 되돌릴 수 없습니다.')) {
-      onDelete();
-    }
-  };
+  const handleDelete = () => setConfirmDeleteOpen(true);
 
   return (
     <div
@@ -160,6 +161,19 @@ export default function SortableBlockItem({
       >
         <Trash2 className="h-4 w-4" />
       </button>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        title={localMessage('admin.pages.blockDeleteDialog.title')}
+        description={localMessage('admin.pages.blockDeleteDialog.description', { type: BLOCK_TYPE_LABELS[block.type] })}
+        confirmLabel={localMessage('admin.pages.blockDeleteDialog.confirm')}
+        cancelLabel={localMessage('admin.pages.blockDeleteDialog.cancel')}
+        destructive
+        onCancel={() => setConfirmDeleteOpen(false)}
+        onConfirm={() => {
+          setConfirmDeleteOpen(false);
+          onDelete();
+        }}
+      />
     </div>
   );
 }

--- a/src/components/shared/admin/page-editor/__tests__/EditorCanvas.test.tsx
+++ b/src/components/shared/admin/page-editor/__tests__/EditorCanvas.test.tsx
@@ -144,7 +144,7 @@ describe('EditorCanvas', () => {
     expect(onToggleVisibility).toHaveBeenCalledWith(1);
   });
 
-  it('삭제 버튼 + confirm → onDeleteBlock(id)', async () => {
+  it('삭제 버튼 + 전용 모달 확인 → onDeleteBlock(id)', async () => {
     const onDeleteBlock = vi.fn();
     render(
       <EditorCanvas
@@ -158,12 +158,11 @@ describe('EditorCanvas', () => {
     );
     const deleteButtons = screen.getAllByRole('button', { name: '블록 삭제' });
     await userEvent.click(deleteButtons[1]);
-    expect(window.confirm).toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }));
     expect(onDeleteBlock).toHaveBeenCalledWith(2);
   });
 
-  it('삭제 버튼 + confirm=false → onDeleteBlock 호출 안 됨', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
+  it('삭제 모달 취소 → onDeleteBlock 호출 안 됨', async () => {
     const onDeleteBlock = vi.fn();
     render(
       <EditorCanvas
@@ -176,6 +175,7 @@ describe('EditorCanvas', () => {
       />,
     );
     await userEvent.click(screen.getAllByRole('button', { name: '블록 삭제' })[0]);
+    await userEvent.click(screen.getByRole('button', { name: '취소' }));
     expect(onDeleteBlock).not.toHaveBeenCalled();
   });
 

--- a/src/components/shared/admin/page-editor/useDraftReducer.ts
+++ b/src/components/shared/admin/page-editor/useDraftReducer.ts
@@ -16,13 +16,17 @@ export type DraftAction =
   | { type: 'INIT'; blocks: PageBlock[]; title: string; slug: string }
   | { type: 'SET_TITLE'; title: string }
   | { type: 'SET_SLUG'; slug: string }
-  | { type: 'ADD_BLOCK'; blockType: PageBlock['type']; content: Record<string, unknown> }
+  | { type: 'ADD_BLOCK'; blockType: PageBlock['type']; content: Record<string, unknown>; id?: number }
   | { type: 'DELETE_BLOCK'; blockId: number }
   | { type: 'UPDATE_CONTENT'; blockId: number; content: Record<string, unknown> }
   | { type: 'TOGGLE_VISIBILITY'; blockId: number }
   | { type: 'REORDER'; activeId: number; overId: number };
 
 let nextTempId = -1;
+
+export function createDraftBlockId(): number {
+  return nextTempId--;
+}
 
 export function draftReducer(state: DraftState, action: DraftAction): DraftState {
   switch (action.type) {
@@ -43,7 +47,7 @@ export function draftReducer(state: DraftState, action: DraftAction): DraftState
       return { ...state, slug: action.slug, hasChanges: true };
 
     case 'ADD_BLOCK': {
-      const id = nextTempId--;
+      const id = action.id ?? createDraftBlockId();
       const newBlock: DraftBlock = {
         id,
         type: action.blockType,

--- a/src/components/shared/admin/page-editor/usePageEditor.ts
+++ b/src/components/shared/admin/page-editor/usePageEditor.ts
@@ -81,10 +81,6 @@ export function usePageEditor({
 
   const handleTogglePublish = async () => {
     if (!selectedPage) return;
-    const message = selectedPage.is_published
-      ? '이 페이지를 비공개로 전환합니다.\n방문자에게 보이지 않게 됩니다. 계속하시겠습니까?'
-      : '이 페이지를 공개하면 쇼핑몰에 바로 노출됩니다.\n계속하시겠습니까?';
-    if (!window.confirm(message)) return;
     try {
       const updated = await adminPagesApi.update(selectedPage.id, {
         is_published: !selectedPage.is_published,

--- a/src/components/shared/hooks/__tests__/useAdminListPage.test.tsx
+++ b/src/components/shared/hooks/__tests__/useAdminListPage.test.tsx
@@ -1,8 +1,24 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAdminListPage } from '@/components/shared/hooks/useAdminListPage';
 
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+let params = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock, push: pushMock }),
+  usePathname: () => '/admin/products',
+  useSearchParams: () => params,
+}));
+
 describe('useAdminListPage', () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+    pushMock.mockClear();
+    params = new URLSearchParams();
+  });
+
   it('resets page to 1 when a filter changes', () => {
     const { result } = renderHook(() => useAdminListPage({
       initialFilters: {
@@ -38,5 +54,22 @@ describe('useAdminListPage', () => {
 
     expect(result.current.keyword).toBe('admin@example.com');
     expect(result.current.page).toBe(1);
+  });
+
+  it('initializes from URL and keeps query string in sync', () => {
+    params = new URLSearchParams('status=active&q=tea&page=3');
+    const { result } = renderHook(() => useAdminListPage({
+      initialFilters: { status: '' },
+    }));
+
+    expect(result.current.page).toBe(3);
+    expect(result.current.keyword).toBe('tea');
+    expect(result.current.filters.status).toBe('active');
+
+    act(() => {
+      result.current.setFilter('status', 'hidden');
+    });
+
+    expect(pushMock).toHaveBeenCalledWith('/admin/products?status=hidden&q=tea', { scroll: false });
   });
 });

--- a/src/components/shared/hooks/useAdminListPage.ts
+++ b/src/components/shared/hooks/useAdminListPage.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useState, type FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 type FilterState = Record<string, string>;
 
@@ -8,38 +9,116 @@ interface UseAdminListPageOptions<TFilters extends FilterState> {
   initialFilters: TFilters;
   initialPage?: number;
   initialKeyword?: string;
+  syncWithUrl?: boolean;
+}
+
+function readPage(searchParams: URLSearchParams, fallback: number): number {
+  const raw = Number(searchParams.get('page'));
+  return Number.isInteger(raw) && raw > 0 ? raw : fallback;
+}
+
+function readFilters<TFilters extends FilterState>(
+  searchParams: URLSearchParams,
+  initialFilters: TFilters,
+): TFilters {
+  return Object.keys(initialFilters).reduce<TFilters>((acc, key) => {
+    acc[key as keyof TFilters] = (searchParams.get(key) ?? initialFilters[key]) as TFilters[keyof TFilters];
+    return acc;
+  }, { ...initialFilters });
 }
 
 export function useAdminListPage<TFilters extends FilterState>({
   initialFilters,
   initialPage = 1,
   initialKeyword = '',
+  syncWithUrl = true,
 }: UseAdminListPageOptions<TFilters>) {
-  const [page, setPage] = useState(initialPage);
-  const [keyword, setKeyword] = useState(initialKeyword);
-  const [searchInput, setSearchInput] = useState(initialKeyword);
-  const [filters, setFilters] = useState<TFilters>(initialFilters);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentParams = useMemo(() => new URLSearchParams(searchParams.toString()), [searchParams]);
+
+  const [page, setPage] = useState(() => syncWithUrl ? readPage(currentParams, initialPage) : initialPage);
+  const [keyword, setKeyword] = useState(() => syncWithUrl ? currentParams.get('q') ?? initialKeyword : initialKeyword);
+  const [searchInput, setSearchInput] = useState(() => syncWithUrl ? currentParams.get('q') ?? initialKeyword : initialKeyword);
+  const [filters, setFilters] = useState<TFilters>(() => syncWithUrl ? readFilters(currentParams, initialFilters) : initialFilters);
+
+  useEffect(() => {
+    if (!syncWithUrl) return;
+    setPage(readPage(currentParams, initialPage));
+    const nextKeyword = currentParams.get('q') ?? initialKeyword;
+    setKeyword(nextKeyword);
+    setSearchInput(nextKeyword);
+    setFilters(readFilters(currentParams, initialFilters));
+    // initialFilters is intentionally caller-owned and expected to be stable by shape.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [syncWithUrl, currentParams.toString(), initialPage, initialKeyword]);
+
+  const updateUrl = useCallback((next: { page?: number; keyword?: string; filters?: TFilters }) => {
+    if (!syncWithUrl) return;
+    const params = new URLSearchParams(currentParams.toString());
+    const nextPage = next.page ?? page;
+    const nextKeyword = next.keyword ?? keyword;
+    const nextFilters = next.filters ?? filters;
+
+    if (nextPage > 1) params.set('page', String(nextPage));
+    else params.delete('page');
+
+    if (nextKeyword.trim()) params.set('q', nextKeyword.trim());
+    else params.delete('q');
+
+    Object.entries(nextFilters).forEach(([key, value]) => {
+      if (value) params.set(key, value);
+      else params.delete(key);
+    });
+
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [currentParams, filters, keyword, page, pathname, router, syncWithUrl]);
+
+  const setSyncedPage = useCallback((nextPage: number) => {
+    setPage(nextPage);
+    updateUrl({ page: nextPage });
+  }, [updateUrl]);
 
   const setFilter = useCallback(<K extends keyof TFilters>(key: K, nextValue: TFilters[K]) => {
-    setFilters((prev) => ({ ...prev, [key]: nextValue }));
+    setFilters((prev) => {
+      const nextFilters = { ...prev, [key]: nextValue };
+      updateUrl({ page: 1, filters: nextFilters });
+      return nextFilters;
+    });
     setPage(1);
-  }, []);
+  }, [updateUrl]);
+
+  const resetFilters = useCallback(() => {
+    setFilters(initialFilters);
+    setKeyword('');
+    setSearchInput('');
+    setPage(1);
+    updateUrl({ page: 1, keyword: '', filters: initialFilters });
+  }, [initialFilters, updateUrl]);
 
   const submitSearch = useCallback((event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
-    setKeyword(searchInput.trim());
+    const trimmed = searchInput.trim();
+    setKeyword(trimmed);
     setPage(1);
-  }, [searchInput]);
+    updateUrl({ page: 1, keyword: trimmed });
+  }, [searchInput, updateUrl]);
+
+  const hasActiveFilters = keyword !== '' || Object.values(filters).some(Boolean);
 
   return {
     page,
-    setPage,
+    setPage: setSyncedPage,
     keyword,
     setKeyword,
     searchInput,
     setSearchInput,
     filters,
     setFilter,
+    resetFilters,
+    hasActiveFilters,
     submitSearch,
   };
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -873,7 +873,13 @@
       "hidden": "hidden",
       "localeVisibilityChanged": "{locale} page is now {status}.",
       "localeVisibilityChangeError": "Failed to change locale visibility.",
-      "localeVisibilityAria": "Manage locale visibility for {name}"
+      "localeVisibilityAria": "Manage locale visibility for {name}",
+      "deleteDialog": {
+        "title": "Delete product",
+        "description": "Delete \"{name}\". It will no longer appear in product lists or detail pages, and restoring it requires registering it again.",
+        "confirm": "Delete",
+        "cancel": "Cancel"
+      }
     },
     "productForm": {
       "createTitle": "Add Product",
@@ -1203,6 +1209,63 @@
       "emptyText": "Click or drag to upload an image",
       "helperText": "JPEG, PNG, WebP · auto-resize above 20MB",
       "uploading": "Uploading..."
+    },
+    "common": {
+      "brand": "Commerce Admin",
+      "openMenu": "Open menu",
+      "viewShop": "View shop",
+      "quickSearch": "Quick search",
+      "logout": "Log out",
+      "roles": {
+        "admin": "Admin",
+        "superAdmin": "Super admin",
+        "unknown": "Admin"
+      },
+      "sections": {
+        "dashboard": "Dashboard",
+        "products": "Products",
+        "categories": "Categories",
+        "orders": "Orders",
+        "members": "Members",
+        "reviews": "Reviews",
+        "inquiries": "Inquiries",
+        "pages": "Pages",
+        "navigation": "Navigation",
+        "localization": "Localization",
+        "attributes": "Attributes",
+        "collections": "Collections",
+        "settings": "Settings"
+      },
+      "resetFilters": "Reset filters",
+      "pagination": {
+        "ariaLabel": "Admin pagination",
+        "status": "Page {current} of {total}",
+        "first": "First",
+        "previous": "Previous",
+        "next": "Next",
+        "last": "Last"
+      }
+    },
+    "pages": {
+      "loading": "Loading page editor...",
+      "emptyTitle": "Select a page to edit",
+      "emptyDescription": "Choose a page from the list or create a new page, then add blocks.",
+      "resetFilters": "Reset filters",
+      "publishDialog": {
+        "publishTitle": "Publish page",
+        "unpublishTitle": "Unpublish page",
+        "publishDescription": "Publishing this page makes it visible on the storefront immediately.",
+        "unpublishDescription": "Unpublishing this page hides it from visitors.",
+        "publishConfirm": "Publish",
+        "unpublishConfirm": "Unpublish",
+        "cancel": "Cancel"
+      },
+      "blockDeleteDialog": {
+        "title": "Delete block",
+        "description": "Remove the {type} block from this page draft.",
+        "confirm": "Delete",
+        "cancel": "Cancel"
+      }
     }
   },
   "search": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -873,7 +873,13 @@
       "hidden": "숨김",
       "localeVisibilityChanged": "{locale} 페이지가 {status} 상태로 변경되었습니다.",
       "localeVisibilityChangeError": "언어별 노출 상태 변경에 실패했습니다.",
-      "localeVisibilityAria": "{name} 언어별 노출 관리"
+      "localeVisibilityAria": "{name} 언어별 노출 관리",
+      "deleteDialog": {
+        "title": "상품 삭제",
+        "description": "\"{name}\" 상품을 삭제합니다. 상품 목록과 상세 화면에서 더 이상 노출되지 않으며, 복구하려면 다시 등록해야 합니다.",
+        "confirm": "삭제",
+        "cancel": "취소"
+      }
     },
     "productForm": {
       "createTitle": "상품 등록",
@@ -1203,6 +1209,63 @@
       "emptyText": "클릭하거나 드래그하여 이미지 업로드",
       "helperText": "JPEG, PNG, WebP · 20MB 초과 시 자동 리사이징",
       "uploading": "업로드 중..."
+    },
+    "common": {
+      "brand": "Commerce Admin",
+      "openMenu": "메뉴 열기",
+      "viewShop": "쇼핑몰 보기",
+      "quickSearch": "빠른 검색",
+      "logout": "로그아웃",
+      "roles": {
+        "admin": "관리자",
+        "superAdmin": "최고관리자",
+        "unknown": "관리자"
+      },
+      "sections": {
+        "dashboard": "대시보드",
+        "products": "상품 관리",
+        "categories": "카테고리 관리",
+        "orders": "주문 관리",
+        "members": "회원 관리",
+        "reviews": "리뷰 관리",
+        "inquiries": "문의 관리",
+        "pages": "페이지 관리",
+        "navigation": "네비게이션 관리",
+        "localization": "번역 상태",
+        "attributes": "속성 관리",
+        "collections": "컬렉션 관리",
+        "settings": "설정"
+      },
+      "resetFilters": "필터 초기화",
+      "pagination": {
+        "ariaLabel": "관리자 페이지네이션",
+        "status": "{current} / {total} 페이지",
+        "first": "처음",
+        "previous": "이전",
+        "next": "다음",
+        "last": "끝"
+      }
+    },
+    "pages": {
+      "loading": "페이지 편집기를 불러오는 중...",
+      "emptyTitle": "편집할 페이지를 선택하세요",
+      "emptyDescription": "왼쪽 목록에서 페이지를 선택하거나 새 페이지를 만든 뒤 블록을 추가하세요.",
+      "resetFilters": "필터 초기화",
+      "publishDialog": {
+        "publishTitle": "페이지 공개",
+        "unpublishTitle": "페이지 비공개 전환",
+        "publishDescription": "이 페이지를 공개하면 쇼핑몰에 바로 노출됩니다.",
+        "unpublishDescription": "이 페이지를 비공개로 전환합니다. 방문자에게 보이지 않게 됩니다.",
+        "publishConfirm": "공개",
+        "unpublishConfirm": "비공개 전환",
+        "cancel": "취소"
+      },
+      "blockDeleteDialog": {
+        "title": "블록 삭제",
+        "description": "{type} 블록을 이 페이지 초안에서 삭제합니다.",
+        "confirm": "삭제",
+        "cancel": "취소"
+      }
     }
   },
   "search": {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,6 +8,21 @@ vi.mock('next/image', () => ({
   default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
 }));
 
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+    push: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+  }),
+  notFound: vi.fn(),
+}));
+
 vi.mock('@/i18n/navigation', () => {
   const localizeHref = (href: unknown, locale?: string) => {
     const value = typeof href === 'string' ? href : String(href);


### PR DESCRIPTION
## 요약
- 어드민 공통 헤더/페이지 헤더/상태 컴포넌트/확인 모달을 추가해 주요 운영 화면 UX를 표준화했습니다.
- 어드민 목록 상태를 URL query string과 동기화하고, 대량 페이지네이션 축약/처음·끝 이동을 지원했습니다.
- CMS 페이지 편집기 블록 검색, 추가 후 자동 선택, 공개 전환/블록 삭제 전용 모달, 저장/빈 상태 안내를 개선했습니다.
- 주문 목록 모바일 카드 뷰, 사이드바 업무 뱃지, AdminHeader breadcrumb/쇼핑몰 이동/검색 진입점을 추가했습니다.
- 공통 admin locale namespace와 관련 ko/en 메시지를 보강했습니다.

Closes #1040
Closes #1041
Closes #1042
Closes #1043
Closes #1044
Closes #1045
Closes #1046
Closes #1047
Closes #1048
Closes #1049

## 검증
- [x] `npm run build`
- [x] `npm run test:run`
- [x] `cd backend && npm run build && npm run test`
- [x] `bash scripts/codex-project-guard.sh`
- [x] Code review pass performed; requested changes addressed

## 메모
- DB/entity/migration 변경 없음: backend e2e는 생략했습니다.
- 대상 이슈 범위 밖의 기존 `window.confirm()` 사용처는 보존했습니다.
