### PR TITLE
fix: #1052 커머스 API 단일 옵션 재고 0 재발 수정

### DIFF
--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -199,9 +199,9 @@ describe('NaverCommerceProductImportService', () => {
         isVisibleEn: false,
         description: '<p>상세</p>',
         noticeInfo: expect.objectContaining({ manufacturer: '옥화당', countryOfOrigin: '중국' }),
-        // 단일 원본 옵션(용량 100cc)은 상품 재고(2)로 흡수되어 제거되고,
-        // 상품명 키워드에서 파생된 용량 옵션(110cc)만 남는다. (issue #1036)
-        options: [expect.objectContaining({ name: '용량', value: '110cc' })],
+        // 단일 원본 옵션은 상품 재고로 흡수되고, 상품명 기반 옵션도 다시 생성하지 않는다.
+        // 빈 배열을 전달해 기존 0재고 옵션까지 제거한다. (issue #1052, regression of #1036)
+        options: [],
         images: [
           expect.objectContaining({
             url: expect.stringContaining(encodeURIComponent('https://img.example.com/rep.jpg')),

--- a/backend/src/modules/products/__tests__/product-command.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-command.service.spec.ts
@@ -245,6 +245,20 @@ describe('ProductCommandService', () => {
       expect(manager.delete).toHaveBeenCalledWith(ProductOption, { id: expect.anything() });
     });
 
+    it('options 빈 배열 지정 시 기존 옵션을 모두 삭제하고 새 옵션을 저장하지 않음', async () => {
+      const existing = { id: 1, stock: 4 } as Product;
+      productRepo.findOne.mockResolvedValue(existing);
+      manager.save.mockResolvedValue(existing);
+      manager.find.mockResolvedValue([
+        { id: 11, productId: 1, name: '용량', value: '100cc', priceAdjustment: 0, stock: 0, sortOrder: 0 },
+      ]);
+
+      await service.update(1, { options: [] });
+
+      expect(manager.delete).toHaveBeenCalledWith(ProductOption, { id: expect.anything() });
+      expect(manager.save).not.toHaveBeenCalledWith(ProductOption, expect.anything());
+    });
+
     it('options 미지정 시 옵션을 건드리지 않음', async () => {
       const existing = { id: 1, stock: 0 } as Product;
       productRepo.findOne.mockResolvedValue(existing);

--- a/backend/src/modules/products/__tests__/product-import-stock.util.spec.ts
+++ b/backend/src/modules/products/__tests__/product-import-stock.util.spec.ts
@@ -9,7 +9,7 @@ describe('resolveImportOptionsStock', () => {
   it('collapses a single option into base stock and drops the option (issue #1036)', () => {
     const result = resolveImportOptionsStock(0, [option({ stock: 5 })]);
 
-    expect(result.options).toBeUndefined();
+    expect(result.options).toEqual([]);
     expect(result.stock).toBe(5);
     expect(result.optionStockTotal).toBeNull();
     expect(result.stockSource).toBe('single_option_collapsed');

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -619,7 +619,7 @@ describe('SmartStoreProductImportService', () => {
         expect.objectContaining({ stock: 4, status: ProductStatus.ACTIVE }),
       );
       expect(commandService.create).toHaveBeenCalledWith(
-        expect.not.objectContaining({ options: expect.anything() }),
+        expect.objectContaining({ options: [] }),
       );
     });
 

--- a/backend/src/modules/products/product-import-stock.util.ts
+++ b/backend/src/modules/products/product-import-stock.util.ts
@@ -33,7 +33,9 @@ export function resolveImportOptionsStock(
     const singleOptionStock = options[0].stock ?? 0;
     const stock = Math.max(rawStock ?? 0, singleOptionStock);
     return {
-      options: undefined,
+      // 명시적으로 빈 배열을 전달해 후속 자동매핑이 단일 옵션을 다시 만들지 못하게 하고,
+      // 기존 상품 업데이트에서는 남아 있던 옵션을 제거한다.
+      options: [],
       stock,
       optionStockTotal: null,
       stockSource: 'single_option_collapsed',


### PR DESCRIPTION
## Summary
- fix the #1036 regression where collapsed single-option imports could still leave/recreate a zero-stock option
- return `options: []` for single-option collapse so keyword option auto-mapping cannot re-add a stockless option
- ensure product update clears existing options when the import path intentionally collapses a single option into product stock

Closes #1052

## Root cause
#1036 normalized the import parse result, but `dto.options === undefined` had two downstream meanings:
1. keyword mapping was allowed to synthesize a capacity option from the product name with `stock: 0`
2. product update preserved existing DB options, so an old single option with stock 0 remained

Using `options: []` preserves the distinction between “do not touch options” and “intentionally clear collapsed options”.

## Verification
- npm --prefix backend test -- --runInBand src/modules/products/__tests__/product-command.service.spec.ts src/modules/products/__tests__/product-import-stock.util.spec.ts src/modules/products/__tests__/smartstore-product-import.service.spec.ts src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
- bash scripts/codex-project-guard.sh
- npm run build && npm run test:run
- cd backend && npm run build && npm run test
- runtime smoke: /api/health, /ko, /ko/admin/products
