### PR TITLE
fix: #1054 상품명 용량 자동 옵션 생성 방지

### DIFF
--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -233,6 +233,58 @@ describe('NaverCommerceProductImportService', () => {
     expect(ingestService.ingest).toHaveBeenCalledTimes(2);
   });
 
+  it('clears generated capacity options when Naver Commerce source has no options (issue #1054)', async () => {
+    const existing = { id: 35, sku: 'naver-13622684792', slug: 'naver-13622684792' } as Product;
+    const fetchedProducts: NaverCommerceFetchedProduct[] = [
+      {
+        rowNumber: 1,
+        listProduct: { originProductNo: 13622684792, channelProducts: [{ sellerManagementCode: 'naver-13622684792' }] },
+        detailProduct: {
+          originProduct: {
+            name: '옥화당 자사호 본산녹니 전수공 한와호 70cc',
+            salePrice: 1750000,
+            stockQuantity: 1,
+            statusType: 'SALE',
+            detailAttribute: {
+              manufacturerName: '옥화당',
+              originAreaInfo: { content: '중국산(옥화당)' },
+            },
+          },
+        },
+      },
+    ];
+    const { service, commandService, attributesService } = createService(fetchedProducts, [existing]);
+
+    const result = await service.commit();
+
+    expect(result.rows[0]).toMatchObject({
+      identifier: 'naver-13622684792',
+      action: 'update',
+      stock: 1,
+      optionCount: 0,
+      stockSource: 'product_stock',
+      automaticMapping: expect.objectContaining({
+        options: [],
+        attributes: expect.arrayContaining([
+          expect.objectContaining({ code: 'capacity', value: '70cc', attributeTypeId: 12 }),
+        ]),
+      }),
+    });
+    expect(commandService.update).toHaveBeenCalledWith(
+      35,
+      expect.objectContaining({
+        stock: 1,
+        noticeInfo: expect.objectContaining({ sizeCapacity: '70cc' }),
+        options: [],
+      }),
+    );
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(
+      35,
+      12,
+      expect.objectContaining({ value: '70cc', displayValue: '70cc' }),
+    );
+  });
+
   it('maps Naver Commerce detailAttribute option combinations and derives product stock when stockQuantity is omitted', async () => {
     const existing = { id: 8, sku: 'SKU-OPTION', slug: 'option-product' } as Product;
     const fetchedProducts: NaverCommerceFetchedProduct[] = [

--- a/backend/src/modules/products/__tests__/product-keyword-mapping.service.spec.ts
+++ b/backend/src/modules/products/__tests__/product-keyword-mapping.service.spec.ts
@@ -12,9 +12,7 @@ describe('ProductKeywordMappingService', () => {
       expect.objectContaining({ code: 'clay_type', value: 'old_duanni', displayValue: '노단니' }),
       expect.objectContaining({ code: 'capacity', value: '120ml', displayValue: '120ml' }),
     ]));
-    expect(result.options).toEqual([
-      expect.objectContaining({ name: '용량', value: '120ml' }),
-    ]);
+    expect(result.options).toEqual([]);
   });
 
   it('prefers more specific clay keywords such as 노단니 over 단니', () => {
@@ -32,7 +30,7 @@ describe('ProductKeywordMappingService', () => {
     ]));
     expect(result.warnings.join(' ')).toContain('단니');
     expect(result.noticeInfoType).toBe(ProductNoticeInfoType.TEAWARE);
-    expect(result.options).toEqual([expect.objectContaining({ name: '용량', value: '110cc' })]);
+    expect(result.options).toEqual([]);
   });
 
   it('extracts all deterministic mappings from a SmartStore teapot product name', () => {
@@ -48,7 +46,7 @@ describe('ProductKeywordMappingService', () => {
       expect.objectContaining({ code: 'clay_origin', value: 'huanglongshan' }),
       expect.objectContaining({ code: 'capacity', value: '130cc' }),
     ]));
-    expect(result.options).toEqual([expect.objectContaining({ value: '130cc' })]);
+    expect(result.options).toEqual([]);
   });
 
 

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -133,7 +133,7 @@ describe('SmartStoreProductImportService', () => {
         expect.objectContaining({ code: 'teapot_shape', value: 'lianzi', displayValue: '연자호', attributeTypeId: 11 }),
         expect.objectContaining({ code: 'clay_origin', value: 'huanglongshan', displayValue: '황룡산', attributeTypeId: 14 }),
       ]),
-      options: [expect.objectContaining({ name: '용량', value: '110cc' })],
+      options: [],
       noticeInfoType: 'teaware',
     });
     expect(result.rows[0].mappingWarnings.join(' ')).toContain('단니');
@@ -141,7 +141,7 @@ describe('SmartStoreProductImportService', () => {
     expect(attributesService.createOrUpdateProductAttribute).not.toHaveBeenCalled();
   });
 
-  it('commits keyword mappings to categoryId, generated options, notice info, and product_attributes', async () => {
+  it('commits keyword mappings to categoryId, notice info, and product_attributes without generated purchase options', async () => {
     const repository = createRepositoryMock([]);
     const commandService = createCommandServiceMock();
     const attributesService = createAttributesServiceMock();
@@ -163,7 +163,9 @@ describe('SmartStoreProductImportService', () => {
     expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
       categoryId: 1,
       noticeInfo: expect.objectContaining({ type: 'teaware', productName: '옥화당 자사호 황룡산 강파니 방고호 130cc', sizeCapacity: '130cc' }),
-      options: [expect.objectContaining({ name: '용량', value: '130cc', priceAdjustment: 0, stock: 0 })],
+    }));
+    expect(commandService.create).toHaveBeenCalledWith(expect.not.objectContaining({
+      options: expect.anything(),
     }));
     expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(100, 10, expect.objectContaining({
       attributeTypeId: 10,
@@ -180,6 +182,11 @@ describe('SmartStoreProductImportService', () => {
       value: 'huanglongshan',
       displayValue: '황룡산',
     }));
+    expect(attributesService.createOrUpdateProductAttribute).toHaveBeenCalledWith(100, 12, expect.objectContaining({
+      attributeTypeId: 12,
+      value: '130cc',
+      displayValue: '130cc',
+    }));
   });
 
   it('keeps explicit SmartStore options over keyword option candidates', async () => {
@@ -191,9 +198,8 @@ describe('SmartStoreProductImportService', () => {
       ['SKU-1', '옥화당 자사호 노단니 연자호 120cc', 10000, '단독형', '색상', '노단니,자니'],
     ]);
 
-    const result = await service.commit(createFile(buffer));
+    await service.commit(createFile(buffer));
 
-    expect(result.rows[0].mappingWarnings.join(' ')).toContain('명시 옵션');
     expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
       options: [
         expect.objectContaining({ name: '색상', value: '노단니' }),

--- a/backend/src/modules/products/naver-commerce-product-import.service.ts
+++ b/backend/src/modules/products/naver-commerce-product-import.service.ts
@@ -157,7 +157,8 @@ export class NaverCommerceProductImportService {
               alt: productName,
               sortOrder: index,
             })),
-            options,
+            // 네이버 커머스 API는 원격 원본 전체 동기화이므로 옵션이 없으면 기존 로컬 자동 옵션을 제거한다.
+            options: options ?? [],
           };
 
     if (dto?.detailImages?.length === 0) delete dto.detailImages;

--- a/backend/src/modules/products/product-keyword-mapping.service.ts
+++ b/backend/src/modules/products/product-keyword-mapping.service.ts
@@ -221,33 +221,10 @@ export class ProductKeywordMappingService {
     return matches.length > 0 ? this.selectBest(matches).rule.noticeInfoType : undefined;
   }
 
-  private extractOptions(normalizedName: string): ProductKeywordOptionMapping[] {
-    const options: ProductKeywordOptionMapping[] = [];
-    const capacityMatch = /\b(\d{2,4})\s?(cc|ml)\b/i.exec(normalizedName);
-    if (capacityMatch) {
-      options.push({
-        name: '용량',
-        value: `${capacityMatch[1]}${capacityMatch[2].toLowerCase()}`,
-        priceAdjustment: 0,
-        stock: 0,
-        sortOrder: 0,
-        keyword: capacityMatch[0],
-      });
-    }
-
-    const setMatch = /\b(\d+)\s?개\s?세트\b/.exec(normalizedName) ?? /\b세트\b/.exec(normalizedName);
-    if (setMatch) {
-      options.push({
-        name: '구성',
-        value: setMatch[1] ? `${setMatch[1]}개 세트` : '세트',
-        priceAdjustment: 0,
-        stock: 0,
-        sortOrder: options.length,
-        keyword: setMatch[0],
-      });
-    }
-
-    return options;
+  private extractOptions(_normalizedName: string): ProductKeywordOptionMapping[] {
+    // 상품명 키워드는 재고 정보를 갖지 않으므로 구매 옵션을 만들지 않는다.
+    // 용량 텍스트는 capacity attribute/noticeInfo 로만 반영한다. (issue #1054)
+    return [];
   }
 
   private findMatches<TRule extends StaticKeywordRule>(normalizedName: string, type: TRule['type']): Array<MatchedRule<TRule>> {

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -522,12 +522,14 @@ export class SmartStoreProductImportService {
   }
 
   private applyKeywordMapping(dto: CreateProductDto, mapping: ResolvedProductKeywordMapping): CreateProductDto {
-    const noticeInfo = mapping.noticeInfoType || mapping.options.length > 0
+    const capacity = mapping.attributes.find((attribute) => attribute.code === 'capacity');
+    const mappedSizeCapacity = capacity?.displayValue ?? capacity?.value;
+    const noticeInfo = mapping.noticeInfoType || mappedSizeCapacity
       ? {
           ...(dto.noticeInfo ?? {}),
           ...(mapping.noticeInfoType ? { type: mapping.noticeInfoType } : {}),
           productName: dto.noticeInfo?.productName ?? dto.name,
-          sizeCapacity: dto.noticeInfo?.sizeCapacity ?? mapping.options.find((option) => option.name === '용량')?.value,
+          sizeCapacity: dto.noticeInfo?.sizeCapacity ?? mappedSizeCapacity,
         }
       : dto.noticeInfo;
 


### PR DESCRIPTION
## Summary
- stop creating purchase options from product-name capacity keywords such as `70cc`
- keep capacity mapping for product attributes and `noticeInfo.sizeCapacity`
- make Naver Commerce API full-source sync send `options: []` when the remote product has no options, so old auto-generated stock-0 options are removed

Closes #1054

## Root cause
Commerce products with no remote options still went through product-name keyword mapping. The keyword mapper treated `70cc` as a generated purchase option with `stock: 0`, while the product itself kept `stock: 1`, producing the visible mismatch on product 35.

## Verification
- npm --prefix backend test -- --runInBand src/modules/products/__tests__/product-keyword-mapping.service.spec.ts src/modules/products/__tests__/smartstore-product-import.service.spec.ts src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts src/modules/products/__tests__/product-command.service.spec.ts src/modules/products/__tests__/product-import-stock.util.spec.ts
- bash scripts/codex-project-guard.sh
- npm run build && npm run test:run
- cd backend && npm run build && npm run test
- runtime smoke: /api/health, /ko, /ko/admin/products
