### PR TITLE
상품고시 A/S 연락처에서 품질보증 중복 제거

### DIFF
--- a/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/naver-commerce-product-import.service.spec.ts
@@ -198,7 +198,12 @@ describe('NaverCommerceProductImportService', () => {
         isVisibleKo: true,
         isVisibleEn: false,
         description: '<p>상세</p>',
-        noticeInfo: expect.objectContaining({ manufacturer: '옥화당', countryOfOrigin: '중국' }),
+        noticeInfo: expect.objectContaining({
+          manufacturer: '옥화당',
+          countryOfOrigin: '중국',
+          asContact: '010-0000-0000',
+          warrantyPolicy: '품질 보증 안내',
+        }),
         // 단일 원본 옵션은 상품 재고로 흡수되고, 상품명 기반 옵션도 다시 생성하지 않는다.
         // 빈 배열을 전달해 기존 0재고 옵션까지 제거한다. (issue #1052, regression of #1036)
         options: [],

--- a/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
+++ b/backend/src/modules/products/__tests__/smartstore-product-import.service.spec.ts
@@ -290,7 +290,26 @@ describe('SmartStoreProductImportService', () => {
         manufacturer: '옥화당',
         countryOfOrigin: '중국산(옥화당)',
         origin: '중국산(옥화당)',
-        asContact: '01029080393 / 품질 보증 및 관리 안내',
+        asContact: '01029080393',
+        warrantyPolicy: '품질 보증 및 관리 안내',
+      }),
+    }));
+  });
+
+  it('maps A/S 책임자와 전화번호 to asContact without copying it into warrantyPolicy', async () => {
+    const repository = createRepositoryMock([]);
+    const commandService = createCommandServiceMock();
+    const service = createService(repository, commandService);
+    const buffer = await createWorkbookBuffer([
+      ['판매자상품코드', '상품명', '판매가', 'A/S 책임자와 전화번호', '품질보증기준'],
+      ['SKU-AS', '옥화당 자사호 한와호 70cc', 10000, '고객센터 010-2908-0393', '품질 보증 및 관리 안내'],
+    ]);
+
+    await service.commit(createFile(buffer));
+
+    expect(commandService.create).toHaveBeenCalledWith(expect.objectContaining({
+      noticeInfo: expect.objectContaining({
+        asContact: '고객센터 010-2908-0393',
         warrantyPolicy: '품질 보증 및 관리 안내',
       }),
     }));

--- a/backend/src/modules/products/naver-commerce-product-import.service.ts
+++ b/backend/src/modules/products/naver-commerce-product-import.service.ts
@@ -289,7 +289,7 @@ export class NaverCommerceProductImportService {
       manufacturer: manufacturer ?? undefined,
       countryOfOrigin: origin ?? undefined,
       origin: origin ?? undefined,
-      asContact: [asPhone, asGuide].filter(Boolean).join(' / ') || undefined,
+      asContact: asPhone ?? undefined,
       warrantyPolicy: asGuide ?? undefined,
     };
   }

--- a/backend/src/modules/products/smartstore-product-import.service.ts
+++ b/backend/src/modules/products/smartstore-product-import.service.ts
@@ -131,8 +131,8 @@ const HEADER_ALIASES = {
   shortDescription: ['요약설명', '짧은설명', '간단설명'],
   manufacturer: ['제조사', '제조자', '제조자/수입자'],
   origin: ['원산지 직접입력', '원산지', '제조국', '생산지'],
-  asPhone: ['A/S 전화번호', 'AS 전화번호', '고객센터 전화번호', '소비자상담 전화번호'],
-  asGuide: ['A/S 안내', 'AS 안내', '품질보증기준', 'A/S 책임자와 전화번호'],
+  asPhone: ['A/S 전화번호', 'AS 전화번호', '고객센터 전화번호', '소비자상담 전화번호', 'A/S 책임자와 전화번호'],
+  asGuide: ['A/S 안내', 'AS 안내', '품질보증기준'],
   shippingFeeType: ['배송비유형', '배송비 유형'],
   baseShippingFee: ['기본배송비', '기본 배송비'],
   optionType: ['옵션형태'],
@@ -827,7 +827,7 @@ export class SmartStoreProductImportService {
       manufacturer: manufacturer || undefined,
       countryOfOrigin: origin || undefined,
       origin: origin || undefined,
-      asContact: [asPhone, asGuide].filter(Boolean).join(' / ') || undefined,
+      asContact: asPhone || undefined,
       warrantyPolicy: asGuide || undefined,
     };
   }

--- a/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
+++ b/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
@@ -345,11 +345,11 @@ describe('ProductDetailClient', () => {
       />,
     );
 
-    expect(screen.getByRole('link', { name: '진흙: old_duanni' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: '진흙: 노단니' })).toHaveAttribute(
       'href',
       '/ko/products?attrs=clay_type:old_duanni',
     );
-    expect(screen.getByRole('link', { name: '모양: lianzi' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: '모양: 연자호' })).toHaveAttribute(
       'href',
       '/ko/products?attrs=teapot_shape:lianzi',
     );


### PR DESCRIPTION
## Summary
- Fix product notice import mapping so A/S contact no longer concatenates the warranty guide text.
- Map `A/S 책임자와 전화번호` to the contact alias instead of the warranty alias for SmartStore spreadsheets.
- Add regression coverage for SmartStore and Naver Commerce noticeInfo separation.
- Align a stale product-attribute badge test with localized display labels from current main.

Closes #1056.

## Root cause
`buildNoticeInfo()` copied `asGuide` into both `asContact` and `warrantyPolicy` by joining `[asPhone, asGuide]`. SmartStore header aliasing also classified `A/S 책임자와 전화번호` as `asGuide`, so warranty text could be stored and displayed in the A/S contact area.

## Verification
- `bash scripts/codex-project-guard.sh`
- `npm run build`
- `npm run test:run -- src/components/shared/products/__tests__/ProductDetailClient.test.tsx`
- `npm run test:run -- --reporter=dot` (147 files / 845 tests)
- `cd backend && npm run build && npm run test` (119 suites / 1201 tests)
- Local smoke: `curl /api/health`, `curl -I /ko`, `curl -I /ko/products/35`

## Notes
- Not tested against live production Commerce API credentials.
