### PR TITLE
속성 기반 동적 상품 필터와 어드민 상품 선택 개선

### DIFF
--- a/backend/src/database/migrations/1786400000000-MarkAllAttributesFilterable.ts
+++ b/backend/src/database/migrations/1786400000000-MarkAllAttributesFilterable.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MarkAllAttributesFilterable1786400000000 implements MigrationInterface {
+  name = 'MarkAllAttributesFilterable1786400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`UPDATE \`attribute_types\` SET \`is_filterable\` = 1 WHERE \`is_active\` = 1`);
+  }
+
+  public async down(): Promise<void> {
+    // Data-only migration. Do not guess which legacy rows were non-filterable.
+  }
+}

--- a/backend/src/modules/products/__tests__/attributes.service.spec.ts
+++ b/backend/src/modules/products/__tests__/attributes.service.spec.ts
@@ -37,6 +37,7 @@ function createQueryBuilderMock(overrides: Record<string, unknown> = {}) {
     orderBy: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
     addSelect: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockResolvedValue([]),
     getRawMany: jest.fn().mockResolvedValue([]),
   };
@@ -89,7 +90,7 @@ describe('AttributesService', () => {
           code: 'clay',
           name: '니료',
           inputType: AttributeInputType.TEXT,
-          isFilterable: false,
+          isFilterable: true,
           isSearchable: false,
           sortOrder: 0,
         }),
@@ -271,14 +272,22 @@ describe('AttributesService', () => {
           { value: 'hongni', displayValue: '홍니' },
         ]),
       });
-      attrRepo.createQueryBuilder.mockReturnValue(qb);
+      const countQb = createQueryBuilderMock({
+        getRawMany: jest.fn().mockResolvedValue([
+          { value: 'duanni', productCount: '2' },
+          { value: 'hongni', productCount: '1' },
+        ]),
+      });
+      attrRepo.createQueryBuilder
+        .mockReturnValueOnce(qb)
+        .mockReturnValueOnce(countQb);
 
       const result = await service.getAttributeValuesByTypeCode('clay');
 
       expect(result).toEqual([
-        { value: 'zhuni', displayValue: null },
-        { value: 'duanni', displayValue: '단니' },
-        { value: 'hongni', displayValue: '홍니' },
+        { value: 'zhuni', displayValue: null, productCount: 0 },
+        { value: 'duanni', displayValue: '단니', productCount: 2 },
+        { value: 'hongni', displayValue: '홍니', productCount: 1 },
       ]);
     });
 
@@ -294,14 +303,16 @@ describe('AttributesService', () => {
       const qb = createQueryBuilderMock({
         getRawMany: jest.fn().mockResolvedValue([]),
       });
-      attrRepo.createQueryBuilder.mockReturnValue(qb);
+      attrRepo.createQueryBuilder
+        .mockReturnValueOnce(qb)
+        .mockReturnValueOnce(createQueryBuilderMock({ getRawMany: jest.fn().mockResolvedValue([]) }));
 
       const result = await service.getAttributeValuesByTypeCode('clay_type');
 
       expect(result).toEqual([
-        { value: 'nokni', displayValue: '녹니' },
-        { value: 'dicaoqing', displayValue: '저조청' },
-        { value: 'hongni', displayValue: '홍니' },
+        { value: 'nokni', displayValue: '녹니', productCount: 0 },
+        { value: 'dicaoqing', displayValue: '저조청', productCount: 0 },
+        { value: 'hongni', displayValue: '홍니', productCount: 0 },
       ]);
     });
 
@@ -318,13 +329,15 @@ describe('AttributesService', () => {
           { value: 'b', displayValue: null },
         ]),
       });
-      attrRepo.createQueryBuilder.mockReturnValue(qb);
+      attrRepo.createQueryBuilder
+        .mockReturnValueOnce(qb)
+        .mockReturnValueOnce(createQueryBuilderMock({ getRawMany: jest.fn().mockResolvedValue([{ value: 'a', productCount: '1' }]) }));
 
       const result = await service.getAttributeValuesByTypeCode('clay');
 
       expect(result).toEqual([
-        { value: 'a', displayValue: '에이' },
-        { value: 'b', displayValue: null },
+        { value: 'a', displayValue: '에이', productCount: 1 },
+        { value: 'b', displayValue: null, productCount: 0 },
       ]);
     });
   });
@@ -341,6 +354,7 @@ describe('AttributesService', () => {
       optionRepo.find.mockResolvedValue([
         { id: 7, attributeTypeId: 1, value: 'nokni', displayValue: '녹니 수정', sortOrder: 0, isActive: true } as AttributeValueOptionEntity,
       ]);
+      attrRepo.createQueryBuilder.mockReturnValueOnce(createQueryBuilderMock({ getRawMany: jest.fn().mockResolvedValue([]) }));
       attrRepo.createQueryBuilder.mockReturnValueOnce(createQueryBuilderMock({ getRawMany: jest.fn().mockResolvedValue([]) }));
       attrRepo.createQueryBuilder.mockReturnValueOnce(createQueryBuilderMock({ getRawMany: jest.fn().mockResolvedValue([]) }));
       attrRepo.update.mockResolvedValue({ affected: 2 } as unknown as Awaited<ReturnType<Repository<ProductAttribute>['update']>>);
@@ -365,6 +379,9 @@ describe('AttributesService', () => {
         { id: 7, attributeTypeId: 1, value: 'nokni', displayValue: '녹니', sortOrder: 0, isActive: true } as AttributeValueOptionEntity,
       ]);
       attrRepo.createQueryBuilder.mockReturnValueOnce(createQueryBuilderMock({ getRawMany: jest.fn().mockResolvedValue([]) }));
+      attrRepo.createQueryBuilder.mockReturnValueOnce(createQueryBuilderMock({
+        getRawMany: jest.fn().mockResolvedValue([{ value: 'nokni', productCount: '1' }]),
+      }));
       attrRepo.createQueryBuilder.mockReturnValueOnce(createQueryBuilderMock({
         getRawMany: jest.fn().mockResolvedValue([{ value: 'nokni', id: '10', name: '상품', slug: 'p' }]),
       }));

--- a/backend/src/modules/products/attributes.service.ts
+++ b/backend/src/modules/products/attributes.service.ts
@@ -128,7 +128,7 @@ export class AttributesService {
       nameKo: dto.nameKo ?? null,
       nameEn: dto.nameEn ?? null,
       inputType: dto.inputType ?? AttributeInputType.TEXT,
-      isFilterable: dto.isFilterable ?? false,
+      isFilterable: dto.isFilterable ?? true,
       isSearchable: dto.isSearchable ?? false,
       validValues: dto.validValues ?? null,
       parentId: dto.parentId ?? null,
@@ -366,6 +366,18 @@ export class AttributesService {
     return displayValueByValue;
   }
 
+  private async getProductCountMap(type: AttributeType): Promise<Map<string, number>> {
+    const rows = await this.productAttributeRepository
+      .createQueryBuilder('pa')
+      .select('pa.value', 'value')
+      .addSelect('COUNT(DISTINCT pa.product_id)', 'productCount')
+      .where('pa.attribute_type_id = :attributeTypeId', { attributeTypeId: type.id })
+      .groupBy('pa.value')
+      .getRawMany<{ value: string; productCount: string }>();
+
+    return new Map(rows.map((row) => [row.value, Number(row.productCount) || 0]));
+  }
+
   private async findOrCreateValueOption(
     type: AttributeType,
     value: string,
@@ -402,6 +414,7 @@ export class AttributesService {
       order: { sortOrder: 'ASC', value: 'ASC' },
     });
     const displayValueByValue = await this.getDisplayValueMap(type);
+    const productCountByValue = await this.getProductCountMap(type);
     const canonicalDisplayValues = CANONICAL_ATTRIBUTE_DISPLAY_VALUES[code] ?? {};
     const values = Array.from(
       new Set([
@@ -440,7 +453,7 @@ export class AttributesService {
           option?.displayValue ?? displayValueByValue.get(value) ?? canonicalDisplayValues[value] ?? null,
         sortOrder: option?.sortOrder ?? 999,
         isActive: option?.isActive ?? true,
-        productCount: products.length,
+        productCount: productCountByValue.get(value) ?? products.length,
         products,
       };
     }).sort((a, b) => a.sortOrder - b.sortOrder || a.value.localeCompare(b.value));
@@ -561,6 +574,7 @@ export class AttributesService {
     }
 
     const displayValueByValue = await this.getDisplayValueMap(type);
+    const productCountByValue = await this.getProductCountMap(type);
     const options = await this.attributeValueOptionRepository.find({
       where: { attributeTypeId: type.id, isActive: true },
       order: { sortOrder: 'ASC', value: 'ASC' },
@@ -575,6 +589,7 @@ export class AttributesService {
         value,
         displayValue:
           optionByValue.get(value) ?? displayValueByValue.get(value) ?? canonicalDisplayValues[value] ?? null,
+        productCount: productCountByValue.get(value) ?? 0,
       }),
     );
   }

--- a/backend/src/modules/products/dto/product-attribute.dto.ts
+++ b/backend/src/modules/products/dto/product-attribute.dto.ts
@@ -4,6 +4,7 @@ import { IsString, IsOptional, IsNumber, IsArray, IsBoolean, Min, MaxLength } fr
 export interface AttributeValueOption {
   value: string;
   displayValue: string | null;
+  productCount?: number;
 }
 
 export class CreateProductAttributeDto {

--- a/backend/test/suites/attributes.e2e-spec.ts
+++ b/backend/test/suites/attributes.e2e-spec.ts
@@ -141,8 +141,8 @@ export function registerAttributesSuite(getApp: () => INestApplication) {
             expect(Array.isArray(res.body)).toBe(true);
             expect(res.body).toEqual(
               expect.arrayContaining([
-                { value: 'val1', displayValue: null },
-                { value: 'val2', displayValue: null },
+                { value: 'val1', displayValue: null, productCount: 0 },
+                { value: 'val2', displayValue: null, productCount: 0 },
               ]),
             );
           });

--- a/src/app/[locale]/admin/attributes/__tests__/AdminAttributesPage.test.tsx
+++ b/src/app/[locale]/admin/attributes/__tests__/AdminAttributesPage.test.tsx
@@ -11,6 +11,7 @@ const mockGetTypeValueOptions = vi.fn();
 const mockUpdateTypeValueOption = vi.fn();
 const mockLinkProductToTypeValue = vi.fn();
 const mockUnlinkProductFromTypeValue = vi.fn();
+const mockGetProducts = vi.fn();
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
@@ -21,6 +22,9 @@ vi.mock('@/components/shared/hooks/useAdminGuard', () => ({
 }));
 
 vi.mock('@/lib/api', () => ({
+  productsApi: {
+    getList: (...args: unknown[]) => mockGetProducts(...args),
+  },
   attributesApi: {
     getTypes: (...args: unknown[]) => mockGetTypes(...args),
     createType: (...args: unknown[]) => mockCreateType(...args),
@@ -74,6 +78,15 @@ describe('AdminAttributesPage', () => {
     mockCreateType.mockResolvedValue(attributes[0]);
     mockUpdateType.mockResolvedValue(attributes[1]);
     mockDeleteType.mockResolvedValue(undefined);
+    mockGetProducts.mockResolvedValue({
+      items: [
+        { id: 10, name: '옥화당 녹니호', slug: 'nokni-pot', status: 'active', category: { name: '자사호' } },
+        { id: 11, name: '옥화당 추가 상품', slug: 'extra-pot', status: 'active', category: { name: '자사호' } },
+      ],
+      total: 2,
+      page: 1,
+      limit: 100,
+    });
     mockGetTypeValueOptions.mockResolvedValue([
       {
         id: 1,
@@ -130,12 +143,11 @@ describe('AdminAttributesPage', () => {
     await waitFor(() => {
       expect(mockUpdateTypeValueOption).toHaveBeenCalledWith('clay_type', 'nokni', expect.objectContaining({ displayValue: '녹니 수정' }));
     });
-    fireEvent.change(screen.getByLabelText('productId'), { target: { value: '11' } });
-    fireEvent.click(screen.getByRole('button', { name: 'linkProduct' }));
+    fireEvent.click(await screen.findByRole('button', { name: /옥화당 추가 상품/ }));
     await waitFor(() => {
       expect(mockLinkProductToTypeValue).toHaveBeenCalledWith('clay_type', 'nokni', 11);
     });
-    fireEvent.click(screen.getAllByRole('button', { name: 'unlinkProduct' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: '선택 해제 옥화당 녹니호' }));
     await waitFor(() => {
       expect(mockUnlinkProductFromTypeValue).toHaveBeenCalledWith('clay_type', 'nokni', 10);
     });

--- a/src/app/[locale]/admin/attributes/page.tsx
+++ b/src/app/[locale]/admin/attributes/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { AdminPageHeader } from '@/components/shared/admin/AdminPageHeader';
+import EntitySelector from '@/components/shared/admin/page-editor/EntitySelector';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { attributesApi } from '@/lib/api';
 import type { AttributeType, ManagedAttributeValueOption } from '@/lib/api';
@@ -80,7 +81,6 @@ export default function AdminAttributesPage() {
   const [selectedAttribute, setSelectedAttribute] = useState<AttributeType | null>(null);
   const [valueOptions, setValueOptions] = useState<ManagedAttributeValueOption[]>([]);
   const [valueOptionDrafts, setValueOptionDrafts] = useState<Record<string, string>>({});
-  const [productIdDrafts, setProductIdDrafts] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [loadingValues, setLoadingValues] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -97,7 +97,6 @@ export default function AdminAttributesPage() {
       setSelectedAttribute(attribute);
       setValueOptions(options);
       setValueOptionDrafts(Object.fromEntries(options.map((option) => [option.value, option.displayValue ?? ''])));
-      setProductIdDrafts({});
     } catch (err) {
       toast.error(handleApiError(err, t('valueOptionsLoadError')));
     } finally {
@@ -195,17 +194,27 @@ export default function AdminAttributesPage() {
     }
   };
 
-  const linkProduct = async (option: ManagedAttributeValueOption) => {
+  const linkProduct = async (option: ManagedAttributeValueOption, productId: number) => {
     if (!selectedAttribute) return;
-    const productId = Number(productIdDrafts[option.value]);
-    if (!Number.isFinite(productId) || productId <= 0) return;
     try {
       const updated = await attributesApi.linkProductToTypeValue(selectedAttribute.code, option.value, productId);
       setValueOptions((prev) => prev.map((item) => (item.value === option.value ? updated : item)));
-      setProductIdDrafts((prev) => ({ ...prev, [option.value]: '' }));
       toast.success(t('productLinkSuccess'));
     } catch (err) {
       toast.error(handleApiError(err, t('productLinkError')));
+    }
+  };
+
+  const handleLinkedProductsChange = (option: ManagedAttributeValueOption, nextProductIds: number[]) => {
+    const currentProductIds = option.products.map((product) => product.id);
+    const addedProductId = nextProductIds.find((id) => !currentProductIds.includes(id));
+    if (addedProductId !== undefined) {
+      void linkProduct(option, addedProductId);
+      return;
+    }
+    const removedProductId = currentProductIds.find((id) => !nextProductIds.includes(id));
+    if (removedProductId !== undefined) {
+      void unlinkProduct(option, removedProductId);
     }
   };
 
@@ -461,57 +470,22 @@ export default function AdminAttributesPage() {
                   </button>
                 </div>
                 <div className="space-y-2">
-                  <div className="flex items-center justify-between gap-3">
+                  <div className="space-y-2">
                     <h3 className="typo-label text-muted-foreground">
                       {t('linkedProducts', { count: option.productCount })}
                     </h3>
-                    <div className="flex min-w-0 gap-2">
-                      <input
-                        aria-label={t('productId')}
-                        type="number"
-                        min="1"
-                        value={productIdDrafts[option.value] ?? ''}
-                        onChange={(event) => {
-                          const next = event.target.value;
-                          setProductIdDrafts((prev) => ({ ...prev, [option.value]: next }));
-                        }}
-                        placeholder={t('productIdPlaceholder')}
-                        className="min-w-0 rounded border bg-background px-3 py-2 typo-body-sm"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => void linkProduct(option)}
-                        className="rounded border px-3 py-2 typo-body-sm hover:bg-secondary"
-                      >
-                        {t('linkProduct')}
-                      </button>
-                    </div>
+                    <EntitySelector
+                      type="product"
+                      selectedIds={option.products.map((product) => product.id)}
+                      selectedItems={option.products.map((product) => ({
+                        id: product.id,
+                        label: product.name,
+                        sublabel: product.slug,
+                      }))}
+                      onChange={(nextProductIds) => handleLinkedProductsChange(option, nextProductIds)}
+                      placeholder={t('productSearchPlaceholder')}
+                    />
                   </div>
-                  {option.products.length === 0 ? (
-                    <p className="rounded border border-dashed p-3 typo-body-sm text-muted-foreground">
-                      {t('noLinkedProducts')}
-                    </p>
-                  ) : (
-                    <ul className="grid gap-2 md:grid-cols-2">
-                      {option.products.map((product) => (
-                        <li
-                          key={product.id}
-                          className="flex items-center justify-between gap-2 rounded border px-3 py-2 typo-body-sm"
-                        >
-                          <span className="min-w-0 truncate">
-                            #{product.id} {product.name}
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() => void unlinkProduct(option, product.id)}
-                            className="shrink-0 rounded border px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
-                          >
-                            {t('unlinkProduct')}
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
                 </div>
               </article>
             ))}

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -64,7 +64,7 @@ export default async function ProductsPage({ params, searchParams }: ProductsPag
     [productsData, categories, filterOptions] = await Promise.all([
       fetchProducts({ page, limit: 20, sort, categoryId, q, price_min: priceMin, price_max: priceMax, isFeatured, locale: safeLocale, attrs }),
       fetchCategories(safeLocale),
-      fetchCatalogFilterOptions(),
+      fetchCatalogFilterOptions(safeLocale),
     ]);
   } catch {
     error = true;
@@ -73,8 +73,7 @@ export default async function ProductsPage({ params, searchParams }: ProductsPag
     filterOptions = null;
   }
 
-  const clayOptions = filterOptions?.clay ?? [];
-  const shapeOptions = filterOptions?.shape ?? [];
+  const filterGroups = filterOptions ?? [];
 
   const selectedCategory = categoryId
     ? categories.find((c) => c.id === categoryId || c.children?.some((child) => child.id === categoryId))
@@ -102,14 +101,14 @@ export default async function ProductsPage({ params, searchParams }: ProductsPag
 
       <div className="md:hidden">
         <Suspense fallback={null}>
-          <MobileFilterBar categories={categories ?? []} clayOptions={clayOptions} shapeOptions={shapeOptions} />
+          <MobileFilterBar categories={categories ?? []} filterGroups={filterGroups} />
         </Suspense>
       </div>
 
       <div className="flex gap-8 pb-12">
         <div className="hidden md:block md:w-48 md:shrink-0">
           <Suspense fallback={null}>
-            <FilterSidebar categories={categories ?? []} clayOptions={clayOptions} shapeOptions={shapeOptions} />
+            <FilterSidebar categories={categories ?? []} filterGroups={filterGroups} />
           </Suspense>
         </div>
 

--- a/src/components/__tests__/FilterSidebar.test.tsx
+++ b/src/components/__tests__/FilterSidebar.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Category } from '@/lib/api';
-import type { AttributeFilterOption } from '@/lib/attributeFilterOptions';
+import type { AttributeFilterGroup } from '@/lib/attributeFilterOptions';
 
 const mockPush = vi.fn();
 let mockSearchParamsString = '';
@@ -54,14 +54,9 @@ const mockCategories: Category[] = [
   { id: 2, name: '신발', slug: 'shoes', parentId: null, imageUrl: null, children: [] },
 ];
 
-const clayOptions: AttributeFilterOption[] = [
-  { value: 'sin-zhi', label: '신치' },
-  { value: 'jook-jin', label: '죽전' },
-];
-
-const shapeOptions: AttributeFilterOption[] = [
-  { value: 'sin-zhi', label: '신치' },
-  { value: 'jook-jin', label: '죽전' },
+const filterGroups: AttributeFilterGroup[] = [
+  { code: 'clay_type', label: '니료', options: [{ value: 'sin-zhi', label: '신치', productCount: 4 }] },
+  { code: 'teapot_shape', label: '모양', options: [{ value: 'jook-jin', label: '죽전', productCount: 1 }] },
 ];
 
 describe('FilterSidebar', () => {
@@ -72,14 +67,15 @@ describe('FilterSidebar', () => {
 
   it('renders category tree and price filter', async () => {
     const { default: FilterSidebar } = await import('@/components/shared/filters/FilterSidebar');
-    render(<FilterSidebar categories={mockCategories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={mockCategories} filterGroups={filterGroups} />);
     expect(screen.getByText('카테고리')).toBeInTheDocument();
     expect(screen.getByText('가격 범위')).toBeInTheDocument();
+    expect(screen.getByText('신치 (4)')).toBeInTheDocument();
   });
 
   it('renders 전체 and category names', async () => {
     const { default: FilterSidebar } = await import('@/components/shared/filters/FilterSidebar');
-    render(<FilterSidebar categories={mockCategories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={mockCategories} filterGroups={filterGroups} />);
     expect(screen.getAllByText('전체').length).toBeGreaterThan(0);
     expect(screen.getByText('의류')).toBeInTheDocument();
     expect(screen.getByText('신발')).toBeInTheDocument();
@@ -87,21 +83,21 @@ describe('FilterSidebar', () => {
 
   it('필터 초기화 button not shown when no filters active', async () => {
     const { default: FilterSidebar } = await import('@/components/shared/filters/FilterSidebar');
-    render(<FilterSidebar categories={mockCategories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={mockCategories} filterGroups={filterGroups} />);
     expect(screen.queryByText('필터 초기화')).not.toBeInTheDocument();
   });
 
   it('필터 초기화 button shown when category filter is active', async () => {
     mockSearchParamsString = 'categoryId=1';
     const { default: FilterSidebar } = await import('@/components/shared/filters/FilterSidebar');
-    render(<FilterSidebar categories={mockCategories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={mockCategories} filterGroups={filterGroups} />);
     expect(screen.getByText('필터 초기화')).toBeInTheDocument();
   });
 
   it('필터 초기화 clears all filter params from URL', async () => {
     mockSearchParamsString = 'categoryId=1&price_min=10000&price_max=50000';
     const { default: FilterSidebar } = await import('@/components/shared/filters/FilterSidebar');
-    render(<FilterSidebar categories={mockCategories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={mockCategories} filterGroups={filterGroups} />);
     await act(async () => {
       await userEvent.click(screen.getByText('필터 초기화'));
     });
@@ -110,7 +106,7 @@ describe('FilterSidebar', () => {
 
   it('selecting a category updates URL with categoryId', async () => {
     const { default: FilterSidebar } = await import('@/components/shared/filters/FilterSidebar');
-    render(<FilterSidebar categories={mockCategories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={mockCategories} filterGroups={filterGroups} />);
     await act(async () => {
       await userEvent.click(screen.getByText('신발'));
     });
@@ -119,7 +115,7 @@ describe('FilterSidebar', () => {
 
   it('mobile filter toggle button is rendered', async () => {
     const { default: FilterSidebar } = await import('@/components/shared/filters/FilterSidebar');
-    render(<FilterSidebar categories={mockCategories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={mockCategories} filterGroups={filterGroups} />);
     expect(screen.getByText('필터 열기')).toBeInTheDocument();
   });
 });

--- a/src/components/shared/admin/page-editor/EntitySelector.tsx
+++ b/src/components/shared/admin/page-editor/EntitySelector.tsx
@@ -12,9 +12,16 @@ interface EntitySelectorProps {
   onChange: (ids: number[]) => void;
   placeholder?: string;
   categoryId?: number;
+  selectedItems?: SelectedEntityItem[];
 }
 
 interface EntityItem {
+  id: number;
+  label: string;
+  sublabel?: string;
+}
+
+interface SelectedEntityItem {
   id: number;
   label: string;
   sublabel?: string;
@@ -38,6 +45,7 @@ export default function EntitySelector({
   onChange,
   placeholder,
   categoryId,
+  selectedItems = [],
 }: EntitySelectorProps) {
   const [allItems, setAllItems] = useState<EntityItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -74,9 +82,11 @@ export default function EntitySelector({
     return () => { cancelled = true; };
   }, [type, categoryId]);
 
-  const selectedItems = useMemo(
-    () => selectedIds.map((id) => allItems.find((item) => item.id === id)).filter(Boolean) as EntityItem[],
-    [selectedIds, allItems],
+  const selectedDisplayItems = useMemo(
+    () => selectedIds
+      .map((id) => allItems.find((item) => item.id === id) ?? selectedItems.find((item) => item.id === id))
+      .filter(Boolean) as EntityItem[],
+    [selectedIds, allItems, selectedItems],
   );
 
   const filteredAvailable = useMemo(() => {
@@ -159,12 +169,12 @@ export default function EntitySelector({
           <span className="text-xs text-muted-foreground">선택됨 ({selectedIds.length})</span>
         </div>
         <div className="rounded border border-input bg-background max-h-48 overflow-y-auto">
-          {selectedItems.length === 0 ? (
+          {selectedDisplayItems.length === 0 ? (
             <div className="px-3 py-2 text-xs text-muted-foreground">
               클릭으로 추가
             </div>
           ) : (
-            selectedItems.map((item, index) => (
+            selectedDisplayItems.map((item, index) => (
               <div
                 key={item.id}
                 className="flex items-center gap-1 border-b border-input last:border-b-0 px-2 py-1"
@@ -175,6 +185,7 @@ export default function EntitySelector({
                     type="button"
                     onClick={() => moveUp(index)}
                     disabled={index === 0}
+                    aria-label={`위로 이동 ${item.label}`}
                     className={cn('p-0.5 rounded hover:bg-muted', index === 0 && 'opacity-30 cursor-not-allowed')}
                   >
                     <ChevronUp className="h-3 w-3" />
@@ -182,14 +193,16 @@ export default function EntitySelector({
                   <button
                     type="button"
                     onClick={() => moveDown(index)}
-                    disabled={index === selectedItems.length - 1}
-                    className={cn('p-0.5 rounded hover:bg-muted', index === selectedItems.length - 1 && 'opacity-30 cursor-not-allowed')}
+                    disabled={index === selectedDisplayItems.length - 1}
+                    aria-label={`아래로 이동 ${item.label}`}
+                    className={cn('p-0.5 rounded hover:bg-muted', index === selectedDisplayItems.length - 1 && 'opacity-30 cursor-not-allowed')}
                   >
                     <ChevronDown className="h-3 w-3" />
                   </button>
                   <button
                     type="button"
                     onClick={() => removeItem(item.id)}
+                    aria-label={`선택 해제 ${item.label}`}
                     className="p-0.5 rounded text-destructive hover:bg-destructive/10"
                   >
                     <X className="h-3 w-3" />

--- a/src/components/shared/filters/AttributeValueFilter.tsx
+++ b/src/components/shared/filters/AttributeValueFilter.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import SegmentedOptionGroup from '@/components/shared/ui/SegmentedOptionGroup';
+import type { AttributeFilterOption } from '@/lib/attributeFilterOptions';
+
+interface AttributeValueFilterProps {
+  code: string;
+  options: AttributeFilterOption[];
+  selected: string | undefined;
+  onSelect: (value: string | undefined) => void;
+}
+
+function formatLabel(option: AttributeFilterOption): string {
+  return option.productCount > 0 ? `${option.label} (${option.productCount})` : `${option.label} (0)`;
+}
+
+export default function AttributeValueFilter({ code, options, selected, onSelect }: AttributeValueFilterProps) {
+  const tCommon = useTranslations('common');
+
+  return (
+    <SegmentedOptionGroup
+      items={[
+        { label: tCommon('all'), value: '' },
+        ...options.map((item) => ({
+          label: formatLabel(item),
+          value: item.value,
+        })),
+      ]}
+      value={selected ?? ''}
+      onToggle={(value) => onSelect(value === selected ? undefined : value || undefined)}
+      ariaLabel={code}
+      size="xs"
+      radius="full"
+      tone="primary"
+    />
+  );
+}

--- a/src/components/shared/filters/FilterSidebar.tsx
+++ b/src/components/shared/filters/FilterSidebar.tsx
@@ -7,19 +7,17 @@ import { useUrlModal } from '@/hooks/useUrlModal';
 import { buildAttrs, useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
 import CategoryTree from './CategoryTree';
 import PriceRangeFilter from './PriceRangeFilter';
-import ClayTypeFilter from './ClayTypeFilter';
-import TeapotShapeFilter from './TeapotShapeFilter';
+import AttributeValueFilter from './AttributeValueFilter';
 import FilterSection from './FilterSection';
 import type { Category } from '@/lib/api';
-import type { AttributeFilterOption } from '@/lib/attributeFilterOptions';
+import type { AttributeFilterGroup } from '@/lib/attributeFilterOptions';
 
 interface FilterSidebarProps {
   categories: Category[];
-  clayOptions: AttributeFilterOption[];
-  shapeOptions: AttributeFilterOption[];
+  filterGroups: AttributeFilterGroup[];
 }
 
-export default function FilterSidebar({ categories, clayOptions, shapeOptions }: FilterSidebarProps) {
+export default function FilterSidebar({ categories, filterGroups }: FilterSidebarProps) {
   const t = useTranslations('product.filter');
   const [mobileOpen, setMobileOpen] = useUrlModal('filters');
   const {
@@ -31,15 +29,13 @@ export default function FilterSidebar({ categories, clayOptions, shapeOptions }:
     resetQuery,
   } = useCatalogQueryParams();
 
-  const selectedClayType = attrs.get('clay_type');
-  const selectedShape = attrs.get('teapot_shape');
+  const selectedAttributeValues = filterGroups.map((group) => attrs.get(group.code));
 
   const hasActiveFilters =
     categoryId !== undefined ||
     priceMin !== undefined ||
     priceMax !== undefined ||
-    selectedClayType !== undefined ||
-    selectedShape !== undefined;
+    selectedAttributeValues.some((value) => value !== undefined);
 
   const handleCategorySelect = useCallback((id: number | undefined) => {
     updateQuery({ categoryId: id });
@@ -52,13 +48,8 @@ export default function FilterSidebar({ categories, clayOptions, shapeOptions }:
     });
   }, [updateQuery]);
 
-  const handleClayTypeSelect = useCallback((value: string | undefined) => {
-    const nextAttrs = buildAttrs(attrs, 'clay_type', value);
-    updateQuery({ attrs: nextAttrs });
-  }, [attrs, updateQuery]);
-
-  const handleShapeSelect = useCallback((value: string | undefined) => {
-    const nextAttrs = buildAttrs(attrs, 'teapot_shape', value);
+  const handleAttributeSelect = useCallback((code: string, value: string | undefined) => {
+    const nextAttrs = buildAttrs(attrs, code, value);
     updateQuery({ attrs: nextAttrs });
   }, [attrs, updateQuery]);
 
@@ -89,21 +80,16 @@ export default function FilterSidebar({ categories, clayOptions, shapeOptions }:
         />
       </FilterSection>
 
-      <FilterSection title={t('clayType')} defaultOpen={selectedClayType !== undefined}>
-        <ClayTypeFilter
-          options={clayOptions}
-          selected={selectedClayType}
-          onSelect={handleClayTypeSelect}
-        />
-      </FilterSection>
-
-      <FilterSection title={t('teapotShape')} defaultOpen={selectedShape !== undefined}>
-        <TeapotShapeFilter
-          options={shapeOptions}
-          selected={selectedShape}
-          onSelect={handleShapeSelect}
-        />
-      </FilterSection>
+      {filterGroups.map((group) => (
+        <FilterSection key={group.code} title={group.label} defaultOpen={attrs.get(group.code) !== undefined}>
+          <AttributeValueFilter
+            code={group.code}
+            options={group.options}
+            selected={attrs.get(group.code)}
+            onSelect={(value) => handleAttributeSelect(group.code, value)}
+          />
+        </FilterSection>
+      ))}
 
       <FilterSection title={t('priceRange')} defaultOpen={priceMin !== undefined || priceMax !== undefined}>
         <PriceRangeFilter

--- a/src/components/shared/filters/MobileFilterBar.tsx
+++ b/src/components/shared/filters/MobileFilterBar.tsx
@@ -5,18 +5,16 @@ import { useUrlModal } from '@/hooks/useUrlModal';
 import { buildAttrs, useCatalogQueryParams } from '@/components/shared/hooks/useCatalogQueryParams';
 import SegmentedOptionGroup from '@/components/shared/ui/SegmentedOptionGroup';
 import PriceRangeFilter from './PriceRangeFilter';
-import ClayTypeFilter from './ClayTypeFilter';
-import TeapotShapeFilter from './TeapotShapeFilter';
+import AttributeValueFilter from './AttributeValueFilter';
 import type { Category } from '@/lib/api';
-import type { AttributeFilterOption } from '@/lib/attributeFilterOptions';
+import type { AttributeFilterGroup } from '@/lib/attributeFilterOptions';
 
 interface MobileFilterBarProps {
   categories: Category[];
-  clayOptions: AttributeFilterOption[];
-  shapeOptions: AttributeFilterOption[];
+  filterGroups: AttributeFilterGroup[];
 }
 
-export default function MobileFilterBar({ categories, clayOptions, shapeOptions }: MobileFilterBarProps) {
+export default function MobileFilterBar({ categories, filterGroups }: MobileFilterBarProps) {
   const t = useTranslations('product.filter');
   const tCommon = useTranslations('common');
   const [filterOpen, setFilterOpen] = useUrlModal('filters');
@@ -29,8 +27,6 @@ export default function MobileFilterBar({ categories, clayOptions, shapeOptions 
     resetQuery,
   } = useCatalogQueryParams();
 
-  const selectedClayType = attrs.get('clay_type');
-  const selectedShape = attrs.get('teapot_shape');
 
   const rootCategories = categories.filter((category) => category.parentId === null);
   const categoryItems = [
@@ -58,13 +54,8 @@ export default function MobileFilterBar({ categories, clayOptions, shapeOptions 
     });
   };
 
-  const handleClayTypeSelect = (value: string | undefined) => {
-    const nextAttrs = buildAttrs(attrs, 'clay_type', value);
-    updateQuery({ attrs: nextAttrs });
-  };
-
-  const handleShapeSelect = (value: string | undefined) => {
-    const nextAttrs = buildAttrs(attrs, 'teapot_shape', value);
+  const handleAttributeSelect = (code: string, value: string | undefined) => {
+    const nextAttrs = buildAttrs(attrs, code, value);
     updateQuery({ attrs: nextAttrs });
   };
 
@@ -91,23 +82,17 @@ export default function MobileFilterBar({ categories, clayOptions, shapeOptions 
 
       {filterOpen && (
         <div className="mt-4 space-y-4 rounded-lg border border-border bg-background p-4">
-          <div className="space-y-2">
-            <p className="text-sm font-semibold text-foreground">{t('clayType')}</p>
-            <ClayTypeFilter
-              options={clayOptions}
-              selected={selectedClayType}
-              onSelect={handleClayTypeSelect}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <p className="text-sm font-semibold text-foreground">{t('teapotShape')}</p>
-            <TeapotShapeFilter
-              options={shapeOptions}
-              selected={selectedShape}
-              onSelect={handleShapeSelect}
-            />
-          </div>
+          {filterGroups.map((group) => (
+            <div key={group.code} className="space-y-2">
+              <p className="text-sm font-semibold text-foreground">{group.label}</p>
+              <AttributeValueFilter
+                code={group.code}
+                options={group.options}
+                selected={attrs.get(group.code)}
+                onSelect={(value) => handleAttributeSelect(group.code, value)}
+              />
+            </div>
+          ))}
 
           <PriceRangeFilter
             min={priceMin}

--- a/src/components/shared/filters/__tests__/FilterSidebar.test.tsx
+++ b/src/components/shared/filters/__tests__/FilterSidebar.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import FilterSidebar from '@/components/shared/filters/FilterSidebar';
 import type { Category } from '@/lib/api';
-import type { AttributeFilterOption } from '@/lib/attributeFilterOptions';
+import type { AttributeFilterGroup } from '@/lib/attributeFilterOptions';
 
 const { updateQueryMock, resetQueryMock, useCatalogQueryParamsMock, setMobileOpenMock } = vi.hoisted(() => ({
   updateQueryMock: vi.fn(),
@@ -60,12 +60,9 @@ const categories: Category[] = [
   },
 ];
 
-const clayOptions: AttributeFilterOption[] = [
-  { value: 'zini', label: 'Zisha' },
-];
-
-const shapeOptions: AttributeFilterOption[] = [
-  { value: 'round', label: 'Byeonpyeong' },
+const filterGroups: AttributeFilterGroup[] = [
+  { code: 'clay_type', label: '니료', options: [{ value: 'zini', label: 'Zisha', productCount: 3 }] },
+  { code: 'teapot_shape', label: '형태', options: [{ value: 'round', label: 'Byeonpyeong', productCount: 2 }] },
 ];
 
 describe('FilterSidebar', () => {
@@ -84,7 +81,7 @@ describe('FilterSidebar', () => {
   });
 
   it('toggles the mobile filter panel', async () => {
-    render(<FilterSidebar categories={categories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={categories} filterGroups={filterGroups} />);
 
     await userEvent.click(screen.getByRole('button', { name: '필터 닫기' }));
 
@@ -92,7 +89,7 @@ describe('FilterSidebar', () => {
   });
 
   it('applies category and price filters through query params', async () => {
-    render(<FilterSidebar categories={categories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={categories} filterGroups={filterGroups} />);
 
     const filterRegions = screen.getAllByLabelText('상품 필터');
     await userEvent.click(within(filterRegions[0]).getByRole('button', { name: /다기/ }));
@@ -117,15 +114,15 @@ describe('FilterSidebar', () => {
       resetQuery: resetQueryMock,
     });
 
-    render(<FilterSidebar categories={categories} clayOptions={clayOptions} shapeOptions={shapeOptions} />);
+    render(<FilterSidebar categories={categories} filterGroups={filterGroups} />);
 
     expect(screen.queryByRole('button', { name: /Collection/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('radio', { name: /Collection/ })).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getAllByRole('button', { name: 'Zisha' })[0]);
+    await userEvent.click(screen.getAllByRole('button', { name: 'Zisha (3)' })[0]);
     expect(updateQueryMock).toHaveBeenCalledWith({ attrs: undefined });
 
-    await userEvent.click(screen.getAllByRole('radio', { name: 'Byeonpyeong' })[0]);
+    await userEvent.click(screen.getAllByRole('button', { name: 'Byeonpyeong (2)' })[0]);
     expect(updateQueryMock).toHaveBeenCalledWith({ attrs: 'clay_type:zini,teapot_shape:round' });
 
     await userEvent.click(screen.getAllByRole('button', { name: '초기화' })[0]);

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1226,7 +1226,8 @@
       "productLinkSuccess": "Product linked.",
       "productLinkError": "Failed to link product.",
       "productUnlinkSuccess": "Product link removed.",
-      "productUnlinkError": "Failed to remove product link."
+      "productUnlinkError": "Failed to remove product link.",
+      "productSearchPlaceholder": "Search products to add"
     },
     "imageUpload": {
       "label": "Image",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1226,7 +1226,8 @@
       "productLinkSuccess": "상품을 연결했습니다.",
       "productLinkError": "상품을 연결하지 못했습니다.",
       "productUnlinkSuccess": "상품 연결을 제거했습니다.",
-      "productUnlinkError": "상품 연결을 제거하지 못했습니다."
+      "productUnlinkError": "상품 연결을 제거하지 못했습니다.",
+      "productSearchPlaceholder": "상품 검색으로 추가"
     },
     "imageUpload": {
       "label": "이미지",

--- a/src/lib/__tests__/attributeFilterOptions.test.ts
+++ b/src/lib/__tests__/attributeFilterOptions.test.ts
@@ -4,11 +4,11 @@ import { toAttributeFilterOptions } from '@/lib/attributeFilterOptions';
 describe('toAttributeFilterOptions', () => {
   it('uses attrs values as the filter source and keeps display labels separate', () => {
     expect(toAttributeFilterOptions([
-      { value: 'zini', displayValue: '자니' },
-      { value: 'duanni', displayValue: '단니' },
+      { value: 'zini', displayValue: '자니', productCount: 2 },
+      { value: 'duanni', displayValue: '단니', productCount: 0 },
     ])).toEqual([
-      { value: 'zini', label: '자니' },
-      { value: 'duanni', label: '단니' },
+      { value: 'zini', label: '자니', productCount: 2 },
+      { value: 'duanni', label: '단니', productCount: 0 },
     ]);
   });
 
@@ -20,8 +20,8 @@ describe('toAttributeFilterOptions', () => {
       { value: 'duanni', displayValue: '단니' },
       { value: ' ', displayValue: '빈 값' },
     ])).toEqual([
-      { value: 'zini', label: '자니' },
-      { value: 'duanni', label: '단니' },
+      { value: 'zini', label: '자니', productCount: 0 },
+      { value: 'duanni', label: '단니', productCount: 0 },
     ]);
   });
 });

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,6 +1,6 @@
 import { cache } from 'react';
-import type { ProductListResponse, ProductSort, Category, ProductDetail, Page, SiteSetting, Journal, AttributeValueOption } from '@/lib/api';
-import { toAttributeFilterOptions, type AttributeFilterOption } from '@/lib/attributeFilterOptions';
+import type { ProductListResponse, ProductSort, Category, ProductDetail, Page, SiteSetting, Journal, AttributeType, AttributeValueOption } from '@/lib/api';
+import { toAttributeFilterOptions, type AttributeFilterGroup } from '@/lib/attributeFilterOptions';
 
 const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
 
@@ -112,18 +112,29 @@ export async function fetchJournal(slug: string, locale?: string): Promise<Journ
 }
 
 
-export async function fetchCatalogFilterOptions(): Promise<{
-  clay: AttributeFilterOption[];
-  shape: AttributeFilterOption[];
-}> {
-  const [clayValues, shapeValues] = await Promise.all([
-    fetchFromBackend<Array<string | AttributeValueOption>>('/attributes/types/clay_type/values', undefined, CACHE_POLICIES.catalog),
-    fetchFromBackend<Array<string | AttributeValueOption>>('/attributes/types/teapot_shape/values', undefined, CACHE_POLICIES.catalog),
-  ]);
-  return {
-    clay: toAttributeFilterOptions(clayValues),
-    shape: toAttributeFilterOptions(shapeValues),
-  };
+export async function fetchCatalogFilterOptions(locale?: string): Promise<AttributeFilterGroup[]> {
+  const types = await fetchFromBackend<AttributeType[]>(
+    '/attributes/types/filterable',
+    locale ? { locale } : undefined,
+    CACHE_POLICIES.catalog,
+  );
+  const valueLists = await Promise.all(
+    types.map((type) =>
+      fetchFromBackend<Array<string | AttributeValueOption>>(
+        `/attributes/types/${type.code}/values`,
+        undefined,
+        CACHE_POLICIES.catalog,
+      ),
+    ),
+  );
+
+  return types
+    .map((type, index) => ({
+      code: type.code,
+      label: type.name,
+      options: toAttributeFilterOptions(valueLists[index] ?? []),
+    }))
+    .filter((group) => group.options.length > 0);
 }
 
 

--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -61,6 +61,7 @@ export interface ProductAttribute {
 export interface AttributeValueOption {
   value: string;
   displayValue: string | null;
+  productCount?: number;
 }
 
 export interface AttributeValueLinkedProduct {

--- a/src/lib/attributeFilterOptions.ts
+++ b/src/lib/attributeFilterOptions.ts
@@ -3,6 +3,13 @@ import type { AttributeValueOption } from '@/lib/api';
 export interface AttributeFilterOption {
   value: string;
   label: string;
+  productCount: number;
+}
+
+export interface AttributeFilterGroup {
+  code: string;
+  label: string;
+  options: AttributeFilterOption[];
 }
 
 export function toAttributeFilterOptions(
@@ -15,7 +22,7 @@ export function toAttributeFilterOptions(
     const displayValue = typeof item === 'string' ? null : item.displayValue?.trim() || null;
     const existing = byValue.get(value);
     if (!existing || existing.label === existing.value) {
-      byValue.set(value, { value, label: displayValue || value });
+      byValue.set(value, { value, label: displayValue || value, productCount: typeof item === 'string' ? 0 : item.productCount ?? 0 });
     }
   }
   return Array.from(byValue.values());


### PR DESCRIPTION
## Summary
- 상품 목록 필터를 `clay_type`/`teapot_shape` 고정값에서 `/api/attributes/types/filterable` 기반 동적 attrs 필터 그룹으로 전환했습니다.
- 각 속성값 응답과 필터 UI에 연결 상품 수(`productCount`)를 노출했습니다.
- 상품속성관리 어드민에서 상품 ID 입력 대신 상품 목록 선택 UI로 속성값-상품 연결을 추가/제거하도록 변경했습니다.
- 모든 활성 속성 유형을 필터 대상으로 전환하는 데이터 마이그레이션을 추가했습니다.

## Verification
- `npm run lint`
- `cd backend && npm run lint`
- `npm run typecheck`
- `npm run build`
- `cd backend && npm run build`
- `npm run test:run`
- `cd backend && npm run test -- --runInBand`
- `bash scripts/codex-project-guard.sh`
- `bash scripts/test.sh e2e`

Closes #1062
