### PR TITLE
fix: #1067 상품상세 탭 sticky 위치 보정

### DIFF
--- a/src/components/__tests__/ProductTabs.test.tsx
+++ b/src/components/__tests__/ProductTabs.test.tsx
@@ -79,6 +79,15 @@ describe('ProductTabs', () => {
     mockCreate.mockResolvedValue({ id: 1 })
   })
 
+  it('keeps the tab bar sticky below the runtime header offset', () => {
+    render(<ProductTabs description={null} descriptionImages={[]} />)
+
+    const tabBar = screen.getByRole('button', { name: '상세정보' }).parentElement
+
+    expect(tabBar).toHaveClass('sticky', 'sticky-below-header')
+    expect(tabBar).not.toHaveClass('top-88')
+  })
+
   it('default tab shows description content', async () => {
     render(<ProductTabs description="<p>상품 상세 내용입니다.</p>" descriptionImages={[]} />)
     expect(screen.getByText('상세정보')).toBeInTheDocument()

--- a/src/components/shared/products/ProductDetailClient.tsx
+++ b/src/components/shared/products/ProductDetailClient.tsx
@@ -184,7 +184,7 @@ export default function ProductDetailClient({ product, locale = 'ko' }: ProductD
       {/* 갤러리 + 정보 영역 */}
       <div className="grid grid-cols-1 gap-8 md:grid-cols-[1.2fr_1fr]">
         {/* Left: Image gallery */}
-        <div className="md:sticky md:top-88 md:self-start">
+        <div className="md:sticky sticky-below-header md:self-start">
           <ImageGallery images={product.images} locale={locale} />
         </div>
 

--- a/src/components/shared/products/ProductTabs.tsx
+++ b/src/components/shared/products/ProductTabs.tsx
@@ -235,7 +235,7 @@ export default function ProductTabs({ description, descriptionImages, productId,
 
   return (
     <div className="mt-8">
-      <div className="flex justify-center md:justify-start border-b border-border sticky top-88 z-30 bg-background">
+      <div className="flex justify-center md:justify-start border-b border-border sticky sticky-below-header z-30 bg-background">
         {TABS.map((tab) => (
           <button
             key={tab}

--- a/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
+++ b/src/components/shared/products/__tests__/ProductDetailClient.test.tsx
@@ -227,6 +227,15 @@ describe('ProductDetailClient', () => {
     });
   });
 
+  it('keeps the desktop gallery sticky below the runtime header offset', () => {
+    render(<ProductDetailClient product={productWithoutOptions} locale="ko" />);
+
+    const galleryWrapper = screen.getByTestId('image-gallery').parentElement;
+
+    expect(galleryWrapper).toHaveClass('md:sticky', 'sticky-below-header', 'md:self-start');
+    expect(galleryWrapper).not.toHaveClass('md:top-88');
+  });
+
   it('옵션 미선택 + 장바구니 담기 → 에러 토스트, addItem 호출 안 됨', async () => {
     render(<ProductDetailClient product={productWithOptions} locale="ko" />);
     await userEvent.click(screen.getAllByRole('button', { name: '장바구니 담기' })[0]);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -38,6 +38,9 @@
   --font-size-label-sm: 0.5625rem;  /* 9px */
   --font-size-button: 0.875rem;    /* 14px */
 
+  /* Layout — Header publishes --header-bottom at runtime; sticky UI uses this stable contract. */
+  --sticky-header-offset: var(--header-bottom, var(--spacing-88, 5.5rem));
+
   /* Typography — line-height and weight scale */
   --line-height-heading: 1.25;
   --line-height-body: var(--db-line-height-base, 1.6);
@@ -196,6 +199,10 @@ body.overflow-hidden .mobile-sticky-cta {
 }
 
 /* ── Layout utilities ──────────────────────────────────────────── */
+@utility sticky-below-header {
+  top: var(--sticky-header-offset);
+}
+
 @utility layout-container {
   width: 100%;
   max-width: var(--layout-max-width);


### PR DESCRIPTION
## Summary
- 상품상세 탭과 데스크톱 갤러리 sticky offset을 정적 `top-88`에서 헤더 런타임 하단값 기반 유틸리티로 변경
- `Header`의 `--header-bottom` CSS variable을 재사용하는 `.sticky-below-header` 추가
- 상품상세 탭/갤러리 sticky class 회귀 테스트 추가

Closes #1067

## Verification
- `npm run test:run -- src/components/__tests__/ProductTabs.test.tsx src/components/shared/products/__tests__/ProductDetailClient.test.tsx`
- `npm run build`
- `bash scripts/codex-project-guard.sh`
- `cd backend && npm run build`
- `cd backend && npx jest src/modules/reviews/__tests__/reviews.controller.spec.ts --runInBand --detectOpenHandles`

## Notes
- `npm run test:run` full suite was retried with dot reporter and a 240s timeout; it was still progressing with existing React act / Next mock warnings and no assertion failure before timeout.
- `cd backend && npm run test` initially had one unrelated multipart limit timeout in `reviews.controller.spec.ts`; the same spec passed when rerun in isolation.
