### PR TITLE
Checkout 결제수단 UI와 국가별 노출 개선

### DIFF
--- a/backend/src/modules/payments/__tests__/payments.module.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.module.spec.ts
@@ -77,15 +77,15 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
   });
 });
 
-describe('locale gateway policy — Eximbay/PayPal/NaverPay ordering', () => {
-  it('ko → naverpay default, eximbay card, paypal fallback', () => {
+describe('locale gateway policy — express payments first and country-specific visibility', () => {
+  it('ko → naverpay default, paypal express, eximbay card fallback', () => {
     expect(resolveGatewayByLocale('ko')).toBe('naverpay');
-    expect(getAvailableGatewaysByLocale('ko')).toEqual(['naverpay', 'eximbay', 'paypal']);
+    expect(getAvailableGatewaysByLocale('ko')).toEqual(['naverpay', 'paypal', 'eximbay']);
   });
 
-  it('en and other locales → eximbay default, paypal/naverpay fallback', () => {
-    expect(resolveGatewayByLocale('en')).toBe('eximbay');
-    expect(resolveGatewayByLocale('ja')).toBe('eximbay');
-    expect(getAvailableGatewaysByLocale('en')).toEqual(['eximbay', 'paypal', 'naverpay']);
+  it('en and other locales → paypal default, eximbay card, no naverpay', () => {
+    expect(resolveGatewayByLocale('en')).toBe('paypal');
+    expect(resolveGatewayByLocale('ja')).toBe('paypal');
+    expect(getAvailableGatewaysByLocale('en')).toEqual(['paypal', 'eximbay']);
   });
 });

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -254,7 +254,7 @@ describe('PaymentsService', () => {
       await expect(service.prepare({ orderId: 1 }, 10)).rejects.toThrow(ConflictException);
     });
 
-    it('locale=ko 기본 prepare → NAVERPAY 저장 + eximbay/paypal 선택지 반환 (#769/#1057)', async () => {
+    it('locale=ko 기본 prepare → NAVERPAY 저장 + paypal/eximbay 선택지 반환 (#769/#1057)', async () => {
       const order = makeOrder();
       mockOrderRepo.findOne.mockResolvedValue(order);
       mockPaymentRepo.findOne.mockResolvedValue(null);
@@ -266,29 +266,29 @@ describe('PaymentsService', () => {
       const result = await service.prepare({ orderId: 1, locale: 'ko' }, 10);
 
       expect(result.gateway).toBe('naverpay');
-      expect(result.availableGateways).toEqual(['naverpay', 'eximbay', 'paypal']);
+      expect(result.availableGateways).toEqual(['naverpay', 'paypal', 'eximbay']);
       expect(mockNaverpayAdapter.prepare).toHaveBeenCalledWith('1', 30000, expect.objectContaining({ locale: 'ko' }));
       expect(mockPaymentRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({ gateway: PaymentGatewayType.NAVERPAY }),
       );
     });
 
-    it('locale=en 기본 prepare → EXIMBAY 저장 + paypal/naverpay 선택지 반환 (#1057)', async () => {
+    it('locale=en 기본 prepare → PAYPAL 저장 + 카드 선택지 반환 (#1057/#1066)', async () => {
       const order = makeOrder();
       mockOrderRepo.findOne.mockResolvedValue(order);
       mockPaymentRepo.findOne.mockResolvedValue(null);
-      const savedPayment = makePayment({ gateway: PaymentGatewayType.EXIMBAY });
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.PAYPAL });
       mockPaymentRepo.create.mockReturnValue(savedPayment);
       mockPaymentRepo.save.mockResolvedValue(savedPayment);
-      mockEximbayAdapter.prepare.mockResolvedValue({ clientKey: 'eximbay-mid', orderId: 'ORD-20240101-ABCD1' });
+      mockPaypalAdapter.prepare.mockResolvedValue({ clientKey: 'paypal-client', orderId: 'paypal-order-id' });
 
       const result = await service.prepare({ orderId: 1, locale: 'en' }, 10);
 
-      expect(result.gateway).toBe('eximbay');
-      expect(result.availableGateways).toEqual(['eximbay', 'paypal', 'naverpay']);
-      expect(mockEximbayAdapter.prepare).toHaveBeenCalledWith('1', 30000, expect.objectContaining({ locale: 'en' }));
+      expect(result.gateway).toBe('paypal');
+      expect(result.availableGateways).toEqual(['paypal', 'eximbay']);
+      expect(mockPaypalAdapter.prepare).toHaveBeenCalledWith('1', 30000, expect.objectContaining({ locale: 'en' }));
       expect(mockPaymentRepo.create).toHaveBeenCalledWith(
-        expect.objectContaining({ gateway: PaymentGatewayType.EXIMBAY }),
+        expect.objectContaining({ gateway: PaymentGatewayType.PAYPAL }),
       );
     });
 
@@ -327,7 +327,7 @@ describe('PaymentsService', () => {
       const result = await service.prepare({ orderId: 1, locale: 'ko', gateway: 'eximbay' }, 10);
 
       expect(result.gateway).toBe('eximbay');
-      expect(result.availableGateways).toEqual(['naverpay', 'eximbay', 'paypal']);
+      expect(result.availableGateways).toEqual(['naverpay', 'paypal', 'eximbay']);
       expect(mockEximbayAdapter.prepare).toHaveBeenCalledWith('1', 30000, expect.objectContaining({ locale: 'ko' }));
       expect(mockPaymentRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({ gateway: PaymentGatewayType.EXIMBAY }),
@@ -473,20 +473,21 @@ describe('PaymentsService', () => {
       expect(recoveryManager.increment).toHaveBeenCalled();
     });
 
-    it('locale=en prepare → payment.gateway 가 EXIMBAY 로 저장되어야 함 (#1057)', async () => {
+    it('locale=en prepare → payment.gateway 가 PAYPAL 로 저장되고 네이버페이를 숨김 (#1057/#1066)', async () => {
       const order = makeOrder();
       mockOrderRepo.findOne.mockResolvedValue(order);
       mockPaymentRepo.findOne.mockResolvedValue(null);
-      const savedPayment = makePayment({ gateway: PaymentGatewayType.EXIMBAY });
+      const savedPayment = makePayment({ gateway: PaymentGatewayType.PAYPAL });
       mockPaymentRepo.create.mockReturnValue(savedPayment);
       mockPaymentRepo.save.mockResolvedValue(savedPayment);
-      mockEximbayAdapter.prepare.mockResolvedValue({ clientKey: 'eximbay-mid', orderId: 'ORD-20240101-ABCD1' });
+      mockPaypalAdapter.prepare.mockResolvedValue({ clientKey: 'paypal-client', orderId: 'paypal-order-id' });
 
       const result = await service.prepare({ orderId: 1, locale: 'en' }, 10);
 
-      expect(result.gateway).toBe('eximbay');
+      expect(result.gateway).toBe('paypal');
+      expect(result.availableGateways).toEqual(['paypal', 'eximbay']);
       expect(mockPaymentRepo.create).toHaveBeenCalledWith(
-        expect.objectContaining({ gateway: PaymentGatewayType.EXIMBAY }),
+        expect.objectContaining({ gateway: PaymentGatewayType.PAYPAL }),
       );
       expect(mockPaymentRepo.create).not.toHaveBeenCalledWith(
         expect.objectContaining({ gateway: PaymentGatewayType.INICIS }),

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -31,11 +31,11 @@ export function resolvePaymentGateway(config: PaymentConfig): string {
 export type CheckoutGatewayName = 'naverpay' | 'eximbay' | 'paypal';
 
 /**
- * 로케일 기반 결제 게이트웨이 노출 정책 (#769)
+ * 국가/로케일 기반 결제 게이트웨이 노출 정책 (#1066)
  *
- * 두 PG를 모두 제공하되 로케일별 ordering/default만 바꾼다.
- * - ko: 네이버페이 기본, Eximbay 카드, PayPal 추가 선택지
- * - 그 외: Eximbay 카드 기본, PayPal, 네이버페이 추가 선택지
+ * 간편결제를 우선 노출하고, 국내 전용 수단은 해외 사이트에서 숨긴다.
+ * - ko/KR: 네이버페이 기본, PayPal, Eximbay 카드
+ * - 글로벌: PayPal 기본, Eximbay 카드 (네이버페이 숨김)
  */
 function getEnabledCheckoutGateways(env: NodeJS.ProcessEnv = process.env): CheckoutGatewayName[] {
   const configured = env.CHECKOUT_ENABLED_GATEWAYS;
@@ -51,8 +51,8 @@ function getEnabledCheckoutGateways(env: NodeJS.ProcessEnv = process.env): Check
 
 export function getAvailableGatewaysByLocale(locale: string): CheckoutGatewayName[] {
   const localeOrder: CheckoutGatewayName[] = locale === 'ko'
-    ? ['naverpay', 'eximbay', 'paypal']
-    : ['eximbay', 'paypal', 'naverpay'];
+    ? ['naverpay', 'paypal', 'eximbay']
+    : ['paypal', 'eximbay'];
   const enabled = getEnabledCheckoutGateways();
   return localeOrder.filter((gateway) => enabled.includes(gateway));
 }

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -174,7 +174,7 @@ export class PaymentsService {
 
     const locale = dto.locale ?? 'ko';
     const availableGateways = getAvailableGatewaysByLocale(locale);
-    const gatewayName = dto.gateway && isCheckoutGatewayName(dto.gateway)
+    const gatewayName = dto.gateway && isCheckoutGatewayName(dto.gateway) && availableGateways.includes(dto.gateway)
       ? dto.gateway
       : dto.locale
         ? resolveGatewayByLocale(locale)

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/components/ui/utils';
 import type { CartItem, CheckoutGatewayName, PreparePaymentResponse, ShippingQuoteResponse, UserAddress, CalculateDiscountResponse } from '@/lib/api';
 import { shippingApi, usersApi } from '@/lib/api';
 import { SESSION_KEYS } from '@/constants/storage';
+import { getDefaultCheckoutGateway, getGatewayOptionsByLocale } from '@/constants/checkoutPaymentMethods';
 import type { Locale } from '@/i18n/routing';
 import PaymentGateway, { type PaymentGatewayHandle } from '@/components/shared/checkout/PaymentGateway';
 import { PaymentMethodSelector } from '@/components/shared/checkout/PaymentMethodSelector';
@@ -46,32 +47,6 @@ export interface FormErrors {
 }
 
 
-function isCheckoutGatewayName(value: string): value is CheckoutGatewayName {
-  return value === 'naverpay' || value === 'eximbay' || value === 'paypal';
-}
-
-function getEnabledCheckoutGateways(): CheckoutGatewayName[] {
-  const configured = process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
-  if (!configured || configured.trim() === '') return ['naverpay', 'eximbay', 'paypal'];
-  const gateways = configured
-    .split(',')
-    .map((value) => value.trim().toLowerCase())
-    .filter(isCheckoutGatewayName);
-  return [...new Set(gateways)];
-}
-
-function getGatewayOptions(locale: Locale): CheckoutGatewayName[] {
-  const localeOrder: CheckoutGatewayName[] = locale === 'ko'
-    ? ['eximbay', 'naverpay', 'paypal']
-    : ['eximbay', 'paypal', 'naverpay'];
-  const enabled = getEnabledCheckoutGateways();
-  return localeOrder.filter((gateway) => enabled.includes(gateway));
-}
-
-function getDefaultGateway(locale: Locale): CheckoutGatewayName {
-  return getGatewayOptions(locale)[0] ?? 'naverpay';
-}
-
 function normalizeInputValue(value: unknown): string {
   if (value == null) return '';
   return String(value);
@@ -100,7 +75,7 @@ export default function CheckoutPage({
   const [sessionChecked, setSessionChecked] = useState(false);
   const [step, setStep] = useState<PaymentStep>('idle');
   const [prepareResult, setPrepareResult] = useState<PreparePaymentResponse | null>(null);
-  const [selectedGateway, setSelectedGateway] = useState<CheckoutGatewayName>(() => getDefaultGateway(locale));
+  const [selectedGateway, setSelectedGateway] = useState<CheckoutGatewayName>(() => getDefaultCheckoutGateway(locale));
   const [currentOrderId, setCurrentOrderId] = useState<number | null>(null);
   const [currentOrderNumber, setCurrentOrderNumber] = useState('');
   const [confirmedGrandTotal, setConfirmedGrandTotal] = useState<number | null>(null);
@@ -139,7 +114,7 @@ export default function CheckoutPage({
     success: t('steps.success'),
   };
   const loadAddressErrorMessage = t('loadAddressError');
-  const gatewayOptions = getGatewayOptions(locale);
+  const gatewayOptions = getGatewayOptionsByLocale(locale);
 
   const fillFormFromAddress = (addr: UserAddress) => {
     setForm({
@@ -153,7 +128,7 @@ export default function CheckoutPage({
   };
 
   useEffect(() => {
-    setSelectedGateway(getDefaultGateway(locale));
+    setSelectedGateway(getDefaultCheckoutGateway(locale));
   }, [locale]);
 
   useEffect(() => {

--- a/src/app/[locale]/my/orders/[id]/page.tsx
+++ b/src/app/[locale]/my/orders/[id]/page.tsx
@@ -18,6 +18,7 @@ import type { PaymentStep } from '@/components/shared/hooks/useCheckout';
 import { handleApiError } from '@/utils/error';
 import { toast } from 'sonner';
 import type { Locale } from '@/i18n/routing';
+import { getDefaultCheckoutGateway, getGatewayOptionsByLocale } from '@/constants/checkoutPaymentMethods';
 import { toastMessage } from '@/utils/toastMessages';
 
 const STATUS_TIMELINE = ['pending', 'paid', 'preparing', 'shipped', 'delivered'];
@@ -34,7 +35,7 @@ export default function OrderDetailPage() {
   const [notFound, setNotFound] = useState(false);
   const checkoutLocale: Locale = locale === 'en' ? 'en' : 'ko';
   const [selectedGateway, setSelectedGateway] = useState<CheckoutGatewayName>(
-    'eximbay',
+    () => getDefaultCheckoutGateway(checkoutLocale),
   );
   const [prepareResult, setPrepareResult] = useState<PreparePaymentResponse | null>(null);
   const [paymentStep, setPaymentStep] = useState<PaymentStep>('idle');
@@ -62,7 +63,7 @@ export default function OrderDetailPage() {
   );
 
   useEffect(() => {
-    setSelectedGateway('eximbay');
+    setSelectedGateway(getDefaultCheckoutGateway(checkoutLocale));
     setPrepareResult(null);
     setPaymentStep('idle');
   }, [checkoutLocale]);
@@ -104,9 +105,7 @@ export default function OrderDetailPage() {
   }
 
   const currentStatusIndex = STATUS_TIMELINE.indexOf(order.status);
-  const gatewayOptions: CheckoutGatewayName[] = checkoutLocale === 'ko'
-    ? ['eximbay', 'naverpay', 'paypal']
-    : ['eximbay', 'paypal', 'naverpay'];
+  const gatewayOptions: CheckoutGatewayName[] = getGatewayOptionsByLocale(checkoutLocale);
   const stepLabels: Record<PaymentStep, string> = {
     idle: tCheckout('steps.idle'),
     creating_order: tCheckout('steps.creating_order'),

--- a/src/components/__tests__/CheckoutPage.test.tsx
+++ b/src/components/__tests__/CheckoutPage.test.tsx
@@ -29,11 +29,11 @@ vi.mock('next-intl', () => ({
       paypalPayment: 'PayPal',
       naverpayPayment: '네이버페이',
       naverpayDomesticBadge: '국내 전용',
-      naverpayDomesticHint: '해외 사용자는 결제가 실패할 수 있습니다.',
-      eximbayPayment: '카드 결제 (Visa/Master/JCB/Amex)',
+      naverpayDomesticHint: '국내 전용 간편결제',
+      eximbayPayment: 'Credit card',
       eximbayHostedPaymentHint: '카드 정보는 Eximbay 보안 결제창에서 입력됩니다.',
       cardPaymentTitle: 'Payment',
-      cardPaymentSubtitle: '일반 해외 커머스 방식의 카드 결제 화면입니다.',
+      cardPaymentSubtitle: '카드 정보는 결제사의 보안 결제창에서 입력됩니다.',
       creditCardTitle: 'Credit card',
       cardBrandsLabel: '지원 카드 브랜드',
       cardNumberLabel: '카드 번호',
@@ -49,7 +49,7 @@ vi.mock('next-intl', () => ({
       cardTermsAgreement: 'I agree to the payment terms and authorize the secure card payment.',
       payNow: 'Pay now',
       cardSecurePageNotice: '카드번호·유효기간·CVC는 저장되지 않습니다.',
-      paypalRedirectHint: 'PayPal 승인 페이지로 이동합니다.',
+      paypalRedirectHint: 'PayPal',
       couponPoints: '쿠폰 / 적립금',
       couponPointsComingSoon: '쿠폰/적립금 적용은 추후 지원 예정입니다.',
       orderItems: '주문 상품',
@@ -254,14 +254,22 @@ describe('CheckoutPage', () => {
 
 
 
-  it('ko checkout은 카드 결제를 기본 선택하고 해외 커머스 카드 입력 shell을 표시한다', async () => {
+  it('ko checkout은 간편결제를 기본 선택하고 카드 선택 시 입력 shell을 표시한다', async () => {
+    const user = userEvent.setup();
     mockUseAuth.mockReturnValue({ isAuthenticated: true, token: 'tok', user: null, isLoading: false });
     sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
 
     await renderCheckoutPage();
 
+    expect(await screen.findByRole('radio', { name: /네이버페이/ })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /PayPal/ })).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: /Credit card/ })).not.toBeChecked();
+    expect(screen.queryByTestId('secure-card-entry-shell')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: /Credit card/ }));
+
     expect(await screen.findByTestId('secure-card-entry-shell')).toBeInTheDocument();
-    expect(screen.getByLabelText(/Credit card/)).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Credit card/ })).toBeChecked();
     expect(screen.getByPlaceholderText('Card number')).toHaveAttribute('readonly');
     expect(screen.getByPlaceholderText('MM / YY')).toHaveAttribute('readonly');
     expect(screen.getByPlaceholderText('Security code')).toHaveAttribute('readonly');
@@ -288,8 +296,8 @@ describe('CheckoutPage', () => {
     });
 
     await renderCheckoutPage();
-    expect(await screen.findByLabelText(/Credit card/)).toBeChecked();
-    await user.click(screen.getByLabelText(/PayPal/));
+    expect(await screen.findByRole('radio', { name: /네이버페이/ })).toBeChecked();
+    await user.click(screen.getByRole('radio', { name: /PayPal/ }));
     await user.type(screen.getByLabelText(/받는 분 이름/), '홍길동');
     await user.type(screen.getByLabelText(/연락처/), '010-1234-5678');
     await user.type(screen.getByLabelText(/우편번호/), '12345');

--- a/src/components/__tests__/OrderDetailPage.test.tsx
+++ b/src/components/__tests__/OrderDetailPage.test.tsx
@@ -34,11 +34,11 @@ function makeTranslator(namespace?: string) {
     paypalPayment: 'PayPal',
     naverpayPayment: '네이버페이',
     naverpayDomesticBadge: '국내 전용',
-    naverpayDomesticHint: '해외 사용자는 결제가 실패할 수 있습니다.',
-    eximbayPayment: '카드 결제 (Visa/Master/JCB/Amex)',
+    naverpayDomesticHint: '국내 전용 간편결제',
+    eximbayPayment: 'Credit card',
     eximbayHostedPaymentHint: '카드 정보는 Eximbay 보안 결제창에서 입력됩니다.',
     cardPaymentTitle: 'Payment',
-    cardPaymentSubtitle: '일반 해외 커머스 방식의 카드 결제 화면입니다.',
+    cardPaymentSubtitle: '카드 정보는 결제사의 보안 결제창에서 입력됩니다.',
     creditCardTitle: 'Credit card',
     cardBrandsLabel: '지원 카드 브랜드',
     cardNumberLabel: '카드 번호',
@@ -54,7 +54,7 @@ function makeTranslator(namespace?: string) {
     cardTermsAgreement: 'I agree to the payment terms and authorize the secure card payment.',
     payNow: 'Pay now',
     cardSecurePageNotice: '카드번호·유효기간·CVC는 저장되지 않습니다.',
-    paypalRedirectHint: 'PayPal 승인 페이지로 이동합니다.',
+    paypalRedirectHint: 'PayPal',
     'steps.idle': '결제하기',
     'steps.creating_order': '주문 생성 중...',
     'steps.preparing_payment': '결제 준비 중...',
@@ -141,10 +141,10 @@ describe('OrderDetailPage', () => {
 
     expect(await screen.findByText('ORD-16')).toBeInTheDocument();
     expect(screen.queryByTestId('shipping-timeline')).toBeNull();
-    expect(screen.getByLabelText(/Credit card/)).toBeChecked();
-    expect(screen.getByPlaceholderText('Card number')).toHaveAttribute('readonly');
-    expect(screen.getByLabelText(/네이버페이/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/PayPal/)).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /네이버페이/ })).toBeChecked();
+    expect(screen.queryByPlaceholderText('Card number')).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Credit card/ })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /PayPal/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '결제하기' })).toBeInTheDocument();
     expect(screen.getByText('현금영수증/세금계산서 안내')).toBeInTheDocument();
     expect(screen.getByText(/주문번호를 포함해 고객센터로 요청/)).toBeInTheDocument();
@@ -166,7 +166,7 @@ describe('OrderDetailPage', () => {
     render(<OrderDetailPage />);
 
     await screen.findByText('ORD-16');
-    await user.click(screen.getByLabelText(/PayPal/));
+    await user.click(screen.getByRole('radio', { name: /PayPal/ }));
     await user.click(screen.getByRole('button', { name: '결제하기' }));
 
     await waitFor(() => {

--- a/src/components/shared/checkout/PaymentBrandIcon.tsx
+++ b/src/components/shared/checkout/PaymentBrandIcon.tsx
@@ -1,0 +1,100 @@
+import type { CheckoutGatewayName } from '@/lib/api';
+import { cn } from '@/components/ui/utils';
+
+export type PaymentBrand = CheckoutGatewayName | 'visa' | 'mastercard' | 'amex';
+
+interface PaymentBrandIconProps {
+  brand: PaymentBrand;
+  className?: string;
+}
+
+export function PaymentBrandIcon({ brand, className }: PaymentBrandIconProps) {
+  const label = BRAND_LABELS[brand];
+
+  return (
+    <span
+      className={cn(
+        'inline-flex h-7 min-w-11 items-center justify-center overflow-hidden rounded-sm border border-border bg-card shadow-sm',
+        className,
+      )}
+      aria-label={label}
+      role="img"
+    >
+      {brand === 'paypal' && <PayPalMark />}
+      {brand === 'naverpay' && <NaverPayMark />}
+      {brand === 'eximbay' && <CardMark />}
+      {brand === 'visa' && <VisaMark />}
+      {brand === 'mastercard' && <MastercardMark />}
+      {brand === 'amex' && <AmexMark />}
+    </span>
+  );
+}
+
+const BRAND_LABELS: Record<PaymentBrand, string> = {
+  paypal: 'PayPal',
+  naverpay: 'Naver Pay',
+  eximbay: 'Credit card',
+  visa: 'Visa',
+  mastercard: 'Mastercard',
+  amex: 'American Express',
+};
+
+function PayPalMark() {
+  return (
+    <svg viewBox="0 0 64 28" className="h-full w-16" aria-hidden="true">
+      <rect width="64" height="28" rx="3" fill="#fff" />
+      <text x="7" y="18" fill="#003087" fontSize="11" fontWeight="700" fontFamily="Arial, sans-serif">Pay</text>
+      <text x="29" y="18" fill="#009CDE" fontSize="11" fontWeight="700" fontFamily="Arial, sans-serif">Pal</text>
+    </svg>
+  );
+}
+
+function NaverPayMark() {
+  return (
+    <svg viewBox="0 0 72 28" className="h-full w-18" aria-hidden="true">
+      <rect width="72" height="28" rx="3" fill="#03C75A" />
+      <path d="M10 8h5.3l4.7 6.7V8h5v12h-5.2l-4.8-6.8V20h-5V8Z" fill="#fff" />
+      <text x="33" y="18" fill="#fff" fontSize="10" fontWeight="800" fontFamily="Arial, sans-serif">Pay</text>
+    </svg>
+  );
+}
+
+function CardMark() {
+  return (
+    <svg viewBox="0 0 44 28" className="h-full w-11" aria-hidden="true">
+      <rect x="4" y="6" width="36" height="16" rx="3" fill="currentColor" opacity="0.12" />
+      <rect x="4" y="10" width="36" height="3" fill="currentColor" opacity="0.45" />
+      <rect x="9" y="17" width="10" height="2" rx="1" fill="currentColor" opacity="0.55" />
+      <rect x="23" y="17" width="8" height="2" rx="1" fill="currentColor" opacity="0.35" />
+    </svg>
+  );
+}
+
+function VisaMark() {
+  return (
+    <svg viewBox="0 0 54 28" className="h-full w-14" aria-hidden="true">
+      <rect width="54" height="28" rx="3" fill="#fff" />
+      <text x="8" y="19" fill="#1A1F71" fontSize="15" fontStyle="italic" fontWeight="800" fontFamily="Arial, sans-serif">VISA</text>
+    </svg>
+  );
+}
+
+function MastercardMark() {
+  return (
+    <svg viewBox="0 0 54 28" className="h-full w-14" aria-hidden="true">
+      <rect width="54" height="28" rx="3" fill="#fff" />
+      <circle cx="22" cy="14" r="8" fill="#EB001B" />
+      <circle cx="32" cy="14" r="8" fill="#F79E1B" fillOpacity="0.92" />
+      <path d="M27 7.7a8 8 0 0 1 0 12.6 8 8 0 0 1 0-12.6Z" fill="#FF5F00" />
+    </svg>
+  );
+}
+
+function AmexMark() {
+  return (
+    <svg viewBox="0 0 54 28" className="h-full w-14" aria-hidden="true">
+      <rect width="54" height="28" rx="3" fill="#2E77BB" />
+      <text x="8" y="18" fill="#fff" fontSize="11" fontWeight="900" fontFamily="Arial, sans-serif">AMEX</text>
+    </svg>
+  );
+}

--- a/src/components/shared/checkout/PaymentGateway.tsx
+++ b/src/components/shared/checkout/PaymentGateway.tsx
@@ -7,6 +7,7 @@ import type { PreparePaymentResponse } from '@/lib/api';
 import { handleApiError } from '@/utils/error';
 import { SESSION_KEYS } from '@/constants/storage';
 import { SecureCardEntryShell } from './SecureCardEntryShell';
+import { PaymentMethodOption } from './PaymentMethodOption';
 
 export interface PaymentGatewayHandle {
   confirm: () => Promise<void>;
@@ -346,7 +347,6 @@ const ExternalRedirectGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayP
     ref,
   ) {
     const t = useTranslations('checkout');
-    const isNaverPay = prepareResult.gateway === 'naverpay';
     const isEximbay = prepareResult.gateway === 'eximbay';
 
     useImperativeHandle(ref, () => ({
@@ -438,29 +438,11 @@ const ExternalRedirectGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayP
     }
 
     return (
-      <label className="flex items-start gap-3 rounded-md border border-border p-3">
-        <input
-          type="radio"
-          name="paymentMethod"
-          value={prepareResult.gateway}
-          defaultChecked
-          readOnly
-          className="mt-1 accent-foreground"
-        />
-        <span className="layout-stack-xs">
-          <span className="flex items-center gap-2 typo-body-sm text-foreground">
-            {isNaverPay ? t('naverpayPayment') : isEximbay ? t('eximbayPayment') : t('paypalPayment')}
-            {isNaverPay && (
-              <span className="rounded-sm bg-muted px-2 py-0.5 typo-label text-muted-foreground" title={t('naverpayDomesticHint')}>
-                {t('naverpayDomesticBadge')}
-              </span>
-            )}
-          </span>
-          <span className="typo-label text-muted-foreground">
-            {isNaverPay ? t('naverpayDomesticHint') : isEximbay ? t('eximbayHostedPaymentHint') : t('paypalRedirectHint')}
-          </span>
-        </span>
-      </label>
+      <PaymentMethodOption
+        gateway={prepareResult.gateway === 'naverpay' ? 'naverpay' : 'paypal'}
+        selected
+        readOnly
+      />
     );
   },
 );

--- a/src/components/shared/checkout/PaymentMethodOption.tsx
+++ b/src/components/shared/checkout/PaymentMethodOption.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import type { CheckoutGatewayName } from '@/lib/api';
+import { cn } from '@/components/ui/utils';
+import { PaymentBrandIcon } from './PaymentBrandIcon';
+
+interface PaymentMethodOptionProps {
+  gateway: CheckoutGatewayName;
+  selected?: boolean;
+  onSelect?: (gateway: CheckoutGatewayName) => void;
+  readOnly?: boolean;
+}
+
+export function PaymentMethodOption({
+  gateway,
+  selected = false,
+  onSelect,
+  readOnly = false,
+}: PaymentMethodOptionProps) {
+  const t = useTranslations('checkout');
+  const label = getPaymentMethodLabel(gateway, t);
+
+  return (
+    <label
+      className={cn(
+        'flex min-h-11 cursor-pointer items-center gap-3 rounded-md border border-border bg-card px-3 py-2 transition-colors',
+        'hover:border-foreground/30 hover:bg-muted/30',
+        selected && 'border-foreground bg-muted/35',
+        readOnly && 'cursor-default hover:border-border hover:bg-card',
+      )}
+      aria-label={label}
+    >
+      <input
+        type="radio"
+        name={readOnly ? 'paymentMethod' : 'checkoutGateway'}
+        value={gateway}
+        checked={selected}
+        readOnly={readOnly}
+        onChange={() => onSelect?.(gateway)}
+        className="h-4 w-4 shrink-0 accent-foreground"
+      />
+      <span className="flex flex-1 items-center justify-between gap-3">
+        <span className="flex items-center gap-2 typo-body-sm font-semibold text-foreground">
+          <PaymentBrandIcon brand={gateway} />
+          <span>{label}</span>
+        </span>
+        {gateway === 'naverpay' && (
+          <span className="rounded-sm border border-border bg-muted px-2 py-0.5 typo-label text-muted-foreground">
+            {t('naverpayDomesticBadge')}
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}
+
+function getPaymentMethodLabel(
+  gateway: CheckoutGatewayName,
+  t: ReturnType<typeof useTranslations>,
+): string {
+  if (gateway === 'naverpay') return t('naverpayPayment');
+  if (gateway === 'paypal') return t('paypalPayment');
+  return t('eximbayPayment');
+}

--- a/src/components/shared/checkout/PaymentMethodSelector.tsx
+++ b/src/components/shared/checkout/PaymentMethodSelector.tsx
@@ -2,8 +2,8 @@
 
 import { useTranslations } from 'next-intl';
 import type { CheckoutGatewayName } from '@/lib/api';
-import { cn } from '@/components/ui/utils';
 import { SecureCardEntryShell } from './SecureCardEntryShell';
+import { PaymentMethodOption } from './PaymentMethodOption';
 
 interface PaymentMethodSelectorProps {
   gatewayOptions: CheckoutGatewayName[];
@@ -20,65 +20,24 @@ export function PaymentMethodSelector({
 }: PaymentMethodSelectorProps) {
   const t = useTranslations('checkout');
 
-  const labels: Record<CheckoutGatewayName, string> = {
-    naverpay: t('naverpayPayment'),
-    eximbay: t('eximbayPayment'),
-    paypal: t('paypalPayment'),
-  };
-
-  const descriptions: Partial<Record<CheckoutGatewayName, string>> = {
-    naverpay: t('naverpayDomesticHint'),
-    eximbay: t('eximbayHostedPaymentHint'),
-    paypal: t('paypalRedirectHint'),
-  };
-
   return (
     <div className="layout-stack-sm">
       <p className="typo-body-sm text-muted-foreground">{t('paymentMethodHint')}</p>
       <div className="layout-stack-md" role="radiogroup" aria-label={t('paymentMethod')}>
-        {gatewayOptions.includes('eximbay') && (
-          <SecureCardEntryShell
-            selected={selectedGateway === 'eximbay'}
-            onSelect={() => onSelect('eximbay')}
-            showSubmitButton={showCardSubmitButton}
-          />
-        )}
-        <div className="grid gap-3 md:grid-cols-2">
-          {gatewayOptions.filter((gateway) => gateway !== 'eximbay').map((gateway) => (
-            <label
+        <div className="grid gap-2">
+          {gatewayOptions.map((gateway) => (
+            <PaymentMethodOption
               key={gateway}
-              className={cn(
-                'flex min-h-11 cursor-pointer items-start gap-3 rounded-md border border-border p-3 transition-colors',
-                selectedGateway === gateway ? 'bg-muted/40' : 'bg-background',
-              )}
-            >
-              <input
-                type="radio"
-                name="checkoutGateway"
-                value={gateway}
-                checked={selectedGateway === gateway}
-                onChange={() => onSelect(gateway)}
-                className="mt-1 accent-foreground"
-              />
-              <span className="layout-stack-xs">
-                <span className="flex items-center gap-2 typo-body-sm text-foreground">
-                  {labels[gateway]}
-                  {gateway === 'naverpay' && (
-                    <span
-                      className="rounded-sm bg-muted px-2 py-0.5 typo-label text-muted-foreground"
-                      title={t('naverpayDomesticHint')}
-                    >
-                      {t('naverpayDomesticBadge')}
-                    </span>
-                  )}
-                </span>
-                {descriptions[gateway] && (
-                  <span className="typo-label text-muted-foreground">{descriptions[gateway]}</span>
-                )}
-              </span>
-            </label>
+              gateway={gateway}
+              selected={selectedGateway === gateway}
+              onSelect={onSelect}
+            />
           ))}
         </div>
+
+        {gatewayOptions.includes('eximbay') && selectedGateway === 'eximbay' && (
+          <SecureCardEntryShell showSubmitButton={showCardSubmitButton} />
+        )}
       </div>
     </div>
   );

--- a/src/components/shared/checkout/SecureCardEntryShell.tsx
+++ b/src/components/shared/checkout/SecureCardEntryShell.tsx
@@ -1,53 +1,33 @@
 'use client';
 
+import { CircleHelp, LockKeyhole } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/components/ui/utils';
+import { PaymentBrandIcon } from './PaymentBrandIcon';
 
 interface SecureCardEntryShellProps {
-  selected?: boolean;
-  onSelect?: () => void;
   showSubmitButton?: boolean;
 }
 
-const CARD_BRANDS = ['Visa', 'Mastercard', 'Amex'] as const;
+const CARD_BRANDS = ['visa', 'mastercard', 'amex'] as const;
 
-export function SecureCardEntryShell({
-  selected = true,
-  onSelect,
-  showSubmitButton = false,
-}: SecureCardEntryShellProps) {
+export function SecureCardEntryShell({ showSubmitButton = false }: SecureCardEntryShellProps) {
   const t = useTranslations('checkout');
 
   return (
     <div className="layout-stack-md text-left" data-testid="secure-card-entry-shell">
       <div>
-        <p className="text-xl font-bold text-foreground">{t('cardPaymentTitle')}</p>
+        <p className="typo-h3 font-bold text-foreground">{t('cardPaymentTitle')}</p>
         <p className="mt-1 typo-body-sm text-muted-foreground">{t('cardPaymentSubtitle')}</p>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-foreground bg-background">
-        <div className="flex min-h-14 items-center justify-between gap-3 px-4 py-3" style={{ backgroundColor: '#F6F6F6' }}>
-          <label className="flex cursor-pointer items-center gap-3">
-            {onSelect && (
-              <input
-                type="radio"
-                name="checkoutGateway"
-                value="eximbay"
-                checked={selected}
-                onChange={onSelect}
-                className="accent-foreground"
-              />
-            )}
-            <span className="typo-body-sm font-bold text-foreground">{t('creditCardTitle')}</span>
-          </label>
-          <div className="flex shrink-0 items-center gap-1" aria-label={t('cardBrandsLabel')}>
+      <div className="overflow-hidden rounded-lg border border-foreground/80 bg-card text-card-foreground">
+        <div className="flex min-h-14 items-center justify-between gap-3 bg-muted/45 px-4 py-3">
+          <span className="typo-body-sm font-bold text-foreground">{t('creditCardTitle')}</span>
+          <div className="flex shrink-0 items-center gap-1.5" aria-label={t('cardBrandsLabel')}>
             {CARD_BRANDS.map((brand) => (
-              <span
-                key={brand}
-                className="rounded-sm border border-border bg-background px-2 py-1 typo-label font-semibold text-foreground shadow-sm"
-              >
-                {brand}
-              </span>
+              <PaymentBrandIcon key={brand} brand={brand} />
             ))}
           </div>
         </div>
@@ -101,14 +81,9 @@ export function SecureCardEntryShell({
       </div>
 
       {showSubmitButton && (
-        <button
-          type="submit"
-          form="checkout-form"
-          className="min-h-11 w-full rounded-md px-4 py-3 typo-body-sm font-semibold text-white transition-opacity hover:opacity-90"
-          style={{ backgroundColor: '#8FA8C4' }}
-        >
+        <Button type="submit" form="checkout-form" className="w-full">
           {t('payNow')}
-        </button>
+        </Button>
       )}
 
       <p className="typo-label text-muted-foreground">{t('cardSecurePageNotice')}</p>
@@ -133,13 +108,14 @@ function SecureInputPreview({
         tabIndex={-1}
         placeholder={placeholder}
         className={cn(
-          'min-h-11 w-full rounded-md border border-border bg-background px-3 typo-body-sm text-foreground placeholder:text-muted-foreground',
+          'min-h-11 w-full rounded-md border border-input bg-background px-3 typo-body-sm text-foreground placeholder:text-muted-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
           icon ? 'pr-10' : '',
         )}
       />
       {icon && (
         <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground" aria-hidden="true">
-          {icon === 'lock' ? '🔒' : '?'}
+          {icon === 'lock' ? <LockKeyhole className="h-4 w-4" /> : <CircleHelp className="h-4 w-4" />}
         </span>
       )}
     </div>

--- a/src/components/shared/checkout/__tests__/PaymentGateway.test.tsx
+++ b/src/components/shared/checkout/__tests__/PaymentGateway.test.tsx
@@ -13,12 +13,12 @@ vi.mock('next-intl', () => ({
       paypalPayment: 'PayPal',
       naverpayPayment: '네이버페이',
       naverpayDomesticBadge: '국내 전용',
-      naverpayDomesticHint: '해외 사용자는 결제가 실패할 수 있습니다.',
-      paypalRedirectHint: 'PayPal 승인 페이지로 이동합니다.',
-      eximbayPayment: '카드 결제 (Visa/Master/JCB/Amex)',
+      naverpayDomesticHint: '국내 전용 간편결제',
+      paypalRedirectHint: 'PayPal',
+      eximbayPayment: 'Credit card',
       eximbayHostedPaymentHint: '카드 정보는 Eximbay 보안 결제창에서 입력됩니다.',
       cardPaymentTitle: 'Payment',
-      cardPaymentSubtitle: '일반 해외 커머스 방식의 카드 결제 화면입니다.',
+      cardPaymentSubtitle: '카드 정보는 결제사의 보안 결제창에서 입력됩니다.',
       creditCardTitle: 'Credit card',
       cardBrandsLabel: '지원 카드 브랜드',
       cardNumberLabel: '카드 번호',
@@ -171,8 +171,8 @@ describe('PaymentGateway', () => {
         {...baseProps}
       />,
     );
-    expect(screen.getByText('PayPal')).toBeInTheDocument();
-    expect(screen.getByText('PayPal 승인 페이지로 이동합니다.')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /PayPal/ })).toBeInTheDocument();
+    expect(screen.queryByText('PayPal 승인 페이지로 이동합니다.')).not.toBeInTheDocument();
   });
 
   it('gateway=naverpay → 국내 전용 배지를 표시', () => {
@@ -193,9 +193,9 @@ describe('PaymentGateway', () => {
         {...baseProps}
       />,
     );
-    expect(screen.getByText('네이버페이')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /네이버페이/ })).toBeInTheDocument();
     expect(screen.getByText('국내 전용')).toBeInTheDocument();
-    expect(screen.getByText('해외 사용자는 결제가 실패할 수 있습니다.')).toBeInTheDocument();
+    expect(screen.queryByText('해외 사용자는 결제가 실패할 수 있습니다.')).not.toBeInTheDocument();
   });
 
 
@@ -272,9 +272,9 @@ describe('PaymentGateway', () => {
     expect(screen.getByTestId('secure-card-entry-shell')).toBeInTheDocument();
     expect(screen.getByText('Payment')).toBeInTheDocument();
     expect(screen.getByText('Credit card')).toBeInTheDocument();
-    expect(screen.getByText('Visa')).toBeInTheDocument();
-    expect(screen.getByText('Mastercard')).toBeInTheDocument();
-    expect(screen.getByText('Amex')).toBeInTheDocument();
+    expect(screen.getByLabelText('Visa')).toBeInTheDocument();
+    expect(screen.getByLabelText('Mastercard')).toBeInTheDocument();
+    expect(screen.getByLabelText('American Express')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Card number')).toHaveAttribute('readonly');
     expect(screen.getByPlaceholderText('Security code')).toHaveAttribute('readonly');
     expect(screen.queryByRole('button', { name: 'Pay now' })).not.toBeInTheDocument();

--- a/src/components/shared/checkout/__tests__/PaymentMethodSelector.test.tsx
+++ b/src/components/shared/checkout/__tests__/PaymentMethodSelector.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PaymentMethodSelector } from '@/components/shared/checkout/PaymentMethodSelector';
+import { getDefaultCheckoutGateway, getGatewayOptionsByLocale } from '@/constants/checkoutPaymentMethods';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const dict: Record<string, string> = {
+      paymentMethod: 'Payment Method',
+      paymentMethodHint: 'Choose an express payment first, or select Credit card if you prefer card checkout.',
+      paypalPayment: 'PayPal',
+      naverpayPayment: '네이버페이',
+      naverpayDomesticBadge: '국내 전용',
+      eximbayPayment: 'Credit card',
+      cardPaymentTitle: 'Payment',
+      cardPaymentSubtitle: 'Card details are entered only in the payment provider’s secure page.',
+      creditCardTitle: 'Credit card',
+      cardBrandsLabel: 'Supported card brands',
+      cardNumberLabel: 'Card number',
+      cardNumberPlaceholder: 'Card number',
+      cardExpiryLabel: 'Expiry date',
+      cardExpiryPlaceholder: 'MM / YY',
+      cardCvcLabel: 'Security code',
+      cardCvcPlaceholder: 'Security code',
+      cardHolderLabel: 'Name on card',
+      cardHolderPlaceholder: 'Name on card',
+      billingSameAsShipping: 'Use shipping address as billing address',
+      cardTermsAriaLabel: 'Card payment terms agreement',
+      cardTermsAgreement: 'I agree to the payment terms and authorize the secure card payment.',
+      payNow: 'Pay now',
+      cardSecurePageNotice: 'Card details are never stored by Okhwadang.',
+    };
+    return dict[key] ?? key;
+  },
+}));
+
+describe('PaymentMethodSelector', () => {
+  it('ko 정책은 네이버페이 → PayPal → Credit card 순서이고 카드는 선택할 때만 열린다', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const options = getGatewayOptionsByLocale('ko');
+
+    const { rerender } = render(
+      <PaymentMethodSelector
+        gatewayOptions={options}
+        selectedGateway={getDefaultCheckoutGateway('ko')}
+        onSelect={onSelect}
+        showCardSubmitButton
+      />,
+    );
+
+    expect(options).toEqual(['naverpay', 'paypal', 'eximbay']);
+    expect(screen.getByRole('radio', { name: /네이버페이/ })).toBeChecked();
+    expect(screen.queryByTestId('secure-card-entry-shell')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: /Credit card/ }));
+    expect(onSelect).toHaveBeenCalledWith('eximbay');
+
+    rerender(
+      <PaymentMethodSelector
+        gatewayOptions={options}
+        selectedGateway="eximbay"
+        onSelect={onSelect}
+        showCardSubmitButton
+      />,
+    );
+
+    const cardShell = screen.getByTestId('secure-card-entry-shell');
+    expect(cardShell).toBeInTheDocument();
+    expect(cardShell.querySelector('[style]')).toBeNull();
+    expect(screen.getByLabelText('Visa')).toBeInTheDocument();
+    expect(screen.getByLabelText('Mastercard')).toBeInTheDocument();
+    expect(screen.getByLabelText('American Express')).toBeInTheDocument();
+  });
+
+  it('en 정책은 네이버페이를 숨기고 PayPal을 기본으로 둔다', () => {
+    const options = getGatewayOptionsByLocale('en');
+
+    render(
+      <PaymentMethodSelector
+        gatewayOptions={options}
+        selectedGateway={getDefaultCheckoutGateway('en')}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(options).toEqual(['paypal', 'eximbay']);
+    expect(screen.getByRole('radio', { name: /PayPal/ })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Credit card/ })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: /네이버페이|Naver Pay/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/constants/checkoutPaymentMethods.ts
+++ b/src/constants/checkoutPaymentMethods.ts
@@ -1,0 +1,44 @@
+import type { Locale } from '@/i18n/routing';
+import type { CheckoutGatewayName } from '@/lib/api';
+
+export type CheckoutPaymentCountry = 'KR' | 'GLOBAL';
+
+export const CHECKOUT_PAYMENT_COUNTRY_BY_LOCALE = {
+  ko: 'KR',
+  en: 'GLOBAL',
+} as const satisfies Record<Locale, CheckoutPaymentCountry>;
+
+export const CHECKOUT_PAYMENT_METHODS_BY_COUNTRY = {
+  KR: ['naverpay', 'paypal', 'eximbay'],
+  GLOBAL: ['paypal', 'eximbay'],
+} as const satisfies Record<CheckoutPaymentCountry, readonly CheckoutGatewayName[]>;
+
+function isCheckoutGatewayName(value: string): value is CheckoutGatewayName {
+  return value === 'naverpay' || value === 'eximbay' || value === 'paypal';
+}
+
+export function getEnabledCheckoutGateways(): CheckoutGatewayName[] {
+  const configured = process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
+  if (!configured || configured.trim() === '') return ['naverpay', 'eximbay', 'paypal'];
+
+  const gateways = configured
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(isCheckoutGatewayName);
+
+  return [...new Set(gateways)];
+}
+
+export function getCheckoutPaymentCountry(locale: Locale): CheckoutPaymentCountry {
+  return CHECKOUT_PAYMENT_COUNTRY_BY_LOCALE[locale] ?? 'GLOBAL';
+}
+
+export function getGatewayOptionsByLocale(locale: Locale): CheckoutGatewayName[] {
+  const enabled = getEnabledCheckoutGateways();
+  const country = getCheckoutPaymentCountry(locale);
+  return CHECKOUT_PAYMENT_METHODS_BY_COUNTRY[country].filter((gateway) => enabled.includes(gateway));
+}
+
+export function getDefaultCheckoutGateway(locale: Locale): CheckoutGatewayName {
+  return getGatewayOptionsByLocale(locale)[0] ?? 'paypal';
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -435,15 +435,15 @@
       "payment": "Payment",
       "complete": "Done"
     },
-    "paymentMethodHint": "Payment methods appear after shipping info is complete.",
+    "paymentMethodHint": "Choose an express payment first, or select Credit card if you prefer card checkout.",
     "freeShipping": "Free",
     "freeShippingUnlocked": "Free shipping is now applied.",
     "freeShippingRemaining": "Add {amount} more for free shipping",
     "paypalPayment": "PayPal",
     "naverpayPayment": "Naver Pay",
     "naverpayDomesticBadge": "Korea only",
-    "naverpayDomesticHint": "Naver Pay may fail for overseas users.",
-    "paypalRedirectHint": "You will be redirected to PayPal approval.",
+    "naverpayDomesticHint": "Korea-only express payment",
+    "paypalRedirectHint": "PayPal",
     "externalPaymentUnavailable": "Unable to open the payment page.",
     "consent": {
       "title": "Required Consent",
@@ -471,10 +471,10 @@
     "pointsPlaceholder": "Points to use",
     "applyPoints": "Apply",
     "pointsBalance": "Available points: {amount}",
-    "eximbayPayment": "International card",
+    "eximbayPayment": "Credit card",
     "eximbayHostedPaymentHint": "Card details are entered only in Eximbay’s secure payment page.",
     "cardPaymentTitle": "Payment",
-    "cardPaymentSubtitle": "A familiar international card checkout layout. Actual card details are entered only in the payment provider’s secure page.",
+    "cardPaymentSubtitle": "Card details are entered only in the payment provider’s secure page.",
     "creditCardTitle": "Credit card",
     "cardBrandsLabel": "Supported card brands",
     "cardNumberLabel": "Card number",
@@ -489,7 +489,7 @@
     "cardTermsAriaLabel": "Card payment terms agreement",
     "cardTermsAgreement": "I agree to the payment terms and authorize the secure card payment.",
     "payNow": "Pay now",
-    "cardSecurePageNotice": "Card number, expiry date, and CVC are never stored in Okhwadang server or browser state; they are entered in Eximbay’s secure payment page after Pay now."
+    "cardSecurePageNotice": "Card number, expiry date, and CVC are never stored in Okhwadang server or browser state."
   },
   "order": {
     "orderHistory": "Order History",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -435,15 +435,15 @@
       "payment": "결제 수단",
       "complete": "결제 완료"
     },
-    "paymentMethodHint": "주문 정보 입력 후 결제 수단이 표시됩니다.",
+    "paymentMethodHint": "간편결제를 먼저 선택하고, 카드 결제가 필요하면 Credit card를 선택하세요.",
     "freeShipping": "무료",
     "freeShippingUnlocked": "무료배송이 적용되었습니다.",
     "freeShippingRemaining": "{amount} 더 담으면 무료배송",
     "paypalPayment": "PayPal",
     "naverpayPayment": "네이버페이",
     "naverpayDomesticBadge": "국내 전용",
-    "naverpayDomesticHint": "해외 사용자는 네이버페이 결제가 실패할 수 있습니다.",
-    "paypalRedirectHint": "PayPal 승인 페이지로 이동합니다.",
+    "naverpayDomesticHint": "국내 전용 간편결제",
+    "paypalRedirectHint": "PayPal",
     "externalPaymentUnavailable": "결제 페이지를 열 수 없습니다.",
     "consent": {
       "title": "필수 동의",
@@ -471,10 +471,10 @@
     "pointsPlaceholder": "사용할 적립금",
     "applyPoints": "적용",
     "pointsBalance": "사용 가능 적립금: {amount}",
-    "eximbayPayment": "카드 결제 (Visa/Master/JCB/Amex)",
+    "eximbayPayment": "Credit card",
     "eximbayHostedPaymentHint": "카드 정보는 Eximbay 보안 결제창에서 입력됩니다.",
     "cardPaymentTitle": "Payment",
-    "cardPaymentSubtitle": "일반 해외 커머스 방식의 카드 결제 화면입니다. 실제 카드 정보는 PG 보안 결제창에서만 입력됩니다.",
+    "cardPaymentSubtitle": "카드 정보는 결제사의 보안 결제창에서 입력됩니다.",
     "creditCardTitle": "Credit card",
     "cardBrandsLabel": "지원 카드 브랜드",
     "cardNumberLabel": "카드 번호",
@@ -489,7 +489,7 @@
     "cardTermsAriaLabel": "카드 결제 약관 동의",
     "cardTermsAgreement": "I agree to the payment terms and authorize the secure card payment.",
     "payNow": "Pay now",
-    "cardSecurePageNotice": "카드번호·유효기간·CVC는 옥화당 서버나 브라우저 상태에 저장되지 않으며, Pay now 이후 Eximbay 보안 결제창에서 입력됩니다."
+    "cardSecurePageNotice": "카드번호·유효기간·CVC는 옥화당 서버나 브라우저 상태에 저장되지 않습니다."
   },
   "order": {
     "orderHistory": "주문 내역",


### PR DESCRIPTION
## Summary
- Reorders checkout payment methods to express payments first: KR shows Naver Pay → PayPal → Credit card, global shows PayPal → Credit card and hides Naver Pay.
- Moves the card entry shell behind explicit Credit card selection instead of showing it by default.
- Replaces text-only payment/card brand badges with reusable SVG brand mark components and compact shared payment option tiles.
- Updates card shell styling to use existing design tokens/components (`bg-card`, `bg-muted`, `border`, `input`, `Button`) for dark-mode compatibility.
- Keeps PCI-safe behavior: PAN/CVC fields remain read-only visual shell; actual entry stays in Eximbay secure flow.

Closes #1066

## Verification
- `npm run test:run -- src/components/shared/checkout/__tests__/PaymentMethodSelector.test.tsx src/components/shared/checkout/__tests__/PaymentGateway.test.tsx src/components/__tests__/CheckoutPage.test.tsx src/components/__tests__/OrderDetailPage.test.tsx`
- `cd backend && npm run test -- payments.service.spec.ts`
- `cd backend && npm run test -- payments.module.spec.ts reviews.controller.spec.ts`
- `npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `bash scripts/codex-project-guard.sh && git diff --check`
