### PR TITLE
#1068 Fix cart summary CTA at intermediate widths

### DIFF
--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -181,7 +181,7 @@ export default function CartPage() {
   );
 
   return (
-    <div className="layout-container layout-page pb-36 md:pb-8">
+    <div className="layout-container layout-page pb-36 lg:pb-8">
       <h1 className="typo-h1">{t('title')}</h1>
 
       <div className="mt-6 grid gap-6 lg:grid-cols-3">
@@ -210,7 +210,7 @@ export default function CartPage() {
             />
           ))}
 
-          <section className="mt-6 md:hidden">
+          <section className="mt-6 lg:hidden">
             <Accordion.Root type="single" collapsible className="rounded-lg border border-divider-soft">
               <Accordion.Item value="summary">
                 <Accordion.Header>
@@ -244,7 +244,7 @@ export default function CartPage() {
 
       <div
         className={cn(
-          'mobile-sticky-cta fixed z-40 border-t border-divider-soft bg-background md:hidden',
+          'mobile-sticky-cta fixed z-40 border-t border-divider-soft bg-background lg:hidden',
           isNavVisible ? 'mobile-sticky-cta--above-nav' : 'mobile-sticky-cta--bottom',
         )}
       >

--- a/src/components/__tests__/CartPage.test.tsx
+++ b/src/components/__tests__/CartPage.test.tsx
@@ -154,6 +154,19 @@ describe('CartPage', () => {
     expect(screen.getByText('상품 B')).toBeInTheDocument();
   });
 
+  it('keeps order summary and selected-order CTA available below desktop breakpoint', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockUseCart.mockReturnValue({ ...defaultCart, items: [cartItem1] });
+
+    const { container } = render(<CartPage />);
+
+    expect(container.querySelector('section.mt-6')).toHaveClass('lg:hidden');
+    expect(container.querySelector('.mobile-sticky-cta')).toHaveClass('lg:hidden');
+    expect(container.querySelector('aside')).toHaveClass('hidden', 'lg:block');
+    expect(screen.getAllByText('주문 요약').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByRole('button', { name: '선택 상품 주문하기' }).length).toBeGreaterThanOrEqual(2);
+  });
+
   it('calculates selected total for checked items', async () => {
     const user = userEvent.setup();
     mockUseAuth.mockReturnValue({ isAuthenticated: true });


### PR DESCRIPTION
## Summary
- Fix cart responsive breakpoint gap where order summary and selected-order CTA disappeared at tablet/intermediate widths.
- Keep the mobile/tablet summary accordion and sticky CTA visible until `lg`, matching the desktop aside breakpoint.
- Add a CartPage regression test to lock continuous summary/CTA availability below desktop.

## Review
- Self code-review pass found no merge-blocking issues. Architectural status: CLEAR.

## Verification
- `bash scripts/codex-project-guard.sh`
- `npx vitest run src/components/__tests__/CartPage.test.tsx`
- `npm run build`
- `npm run test:run`
- `cd backend && npm run build`
- `cd backend && npm run test`
- `bash scripts/start-local.sh`
- `curl http://localhost:3000/api/health`
- `curl -I http://localhost:5173/ko/cart`

Closes #1068
