### PR TITLE
[codex] Soften customer-facing order surfaces

### DIFF
--- a/.claude/rules/frontend-patterns.md
+++ b/.claude/rules/frontend-patterns.md
@@ -30,6 +30,7 @@ Reusable components (ImageGallery, ProductList, etc.) must accept:
 ## Typography & Scroll Logo
 
 - Typography: use `typo-h1`, `typo-h2`, `typo-body`, `typo-label`, `typo-button` utility classes — no raw `text-*` size overrides on headings. Font families: `font-display-ko` (Korean display), `font-body` (body text)
+- Surfaces/borders: customer-facing cards, fields, and passive dividers default to `surface-card`, `field-soft`, `border-soft`, and `divide-soft` from `src/styles/globals.css`; reserve stronger `border-foreground`, default `border`, or high-contrast lines for active, selected, destructive, or brand-emphasis states.
 - Scroll logo: HeroBanner wraps content in `<ScrollLogoProvider>`. Use `useScrollLogoTransition({ heroRef })` to get `heroLogoStyle` / `headerLogoStyle` / `progress` / `isHeroVisible` — do not duplicate scroll logic inline
 
 ## CMS Block Hooks

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -75,6 +75,27 @@ All colors are CSS variables in `src/styles/globals.css`. Use tokens, not raw he
 | `--radius-md` | 4px | Buttons, cards |
 | `--radius-lg` | 8px | Modals, large cards |
 
+## Surfaces & Borders
+
+옥화당의 기본 UI는 **진한 박스 라인보다 여백·타입·은은한 구분선**으로 구조를 만든다.
+고객-facing 화면에서 카드, 입력창, 요약 패널, 수동적인 안내 박스는 기본 `border`/`border-border` 대신 아래 공통 유틸리티를 우선 사용한다.
+
+| Utility | Usage |
+|---------|-------|
+| `surface-card` | 기본 카드/패널. `rounded-lg border bg-card` 대체 기본값 |
+| `border-soft` | 단일 구분선, dashed border, 작은 버튼/칩의 부담 없는 선색 |
+| `border-divider-soft` | 기존 구분선 호환 유틸. 신규 고객 화면은 `border-soft`를 우선한다 |
+| `field-soft` | 입력창/select/textarea 기본 선색과 배경 |
+| `divide-soft` | 리스트 내부 `divide-y` 구분선 완화 |
+
+### Border Rules
+
+- Default: `surface-card`, `border-soft`, `field-soft`, `divide-soft`를 사용한다.
+- Strong borders (`border-foreground`, plain `border`, `border-border`)은 **선택됨/활성/포커스/브랜드 CTA/오류**처럼 강조가 필요한 상태에만 사용한다.
+- 고객 화면의 큰 카드에 `shadow`를 추가하기보다 먼저 `surface-card` + 충분한 spacing으로 계층을 만든다.
+- Admin table처럼 정보 밀도와 스캔성이 중요한 화면은 기존 admin utilities(`admin-surface`, table dividers)를 우선한다.
+- 새 폼 컴포넌트는 공통 `FormInput`/`FormSelect` 또는 `field-soft`를 사용한다.
+
 ## Animation Utilities
 
 | Class | Description |
@@ -203,6 +224,7 @@ All CMS block `<section>` elements must use `py-16 md:py-24` — never `py-12`.
 - [ ] Font families: max 3种 (display, body, mono)
 - [ ] Colors use `--color-*` tokens (no hardcoded hex)
 - [ ] Border radius uses `radius-*` tokens
+- [ ] Customer-facing cards/fields/dividers use `surface-card`, `field-soft`, `border-soft`, or `divide-soft` by default
 - [ ] Animations use `animate-*` utilities
 - [ ] Interactive elements have focus states
 - [ ] Mobile touch targets are 44px+

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -9,6 +9,7 @@ Next.js 15 (App Router) + React 19 + TS + TailwindCSS v4. Inherits root CLAUDE.m
 - `@/` import alias, `cn()` for Tailwind merging
 - TypeScript strict — **`any` is forbidden**
 - shadcn/ui component patterns
+- Customer-facing cards, fields, and passive dividers should use the soft-line utilities from `DESIGN.md` (`surface-card`, `field-soft`, `border-soft`, `divide-soft`) instead of default strong borders, unless the element is active/selected/destructive/brand-emphasis.
 - All mutations must show sonner/toast feedback (success/failure)
 - OAuth callbacks: shared OAuthCallbackHandler — no per-provider copies
 - `console.log` in committed code is forbidden

--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -156,7 +156,7 @@ export default function CartPage() {
         </div>
       </div>
 
-      <div className="mt-4 rounded-md border border-border bg-muted/30 p-3">
+      <div className="mt-4 rounded-md border border-soft bg-muted/20 p-3">
         <p className="text-xs text-muted-foreground">
           {remainingForFreeShipping === 0
             ? t('freeShippingUnlocked')
@@ -171,7 +171,7 @@ export default function CartPage() {
         </div>
       </div>
 
-      <div className="mt-4 border-t border-divider-soft pt-4">
+      <div className="mt-4 border-t border-soft pt-4">
         <div className="flex items-end justify-between">
           <span className="typo-title">{t('total')}</span>
           <span className="typo-price-lg text-foreground">{formatCurrency(grandTotal, locale)}</span>
@@ -186,7 +186,7 @@ export default function CartPage() {
 
       <div className="mt-6 grid gap-6 lg:grid-cols-3">
         <div className="lg:col-span-2">
-          <div className="mb-3 flex items-center justify-between border-b border-divider-soft pb-3">
+          <div className="mb-3 flex items-center justify-between border-b border-soft pb-3">
             <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="checkbox"
@@ -211,7 +211,7 @@ export default function CartPage() {
           ))}
 
           <section className="mt-6 md:hidden">
-            <Accordion.Root type="single" collapsible className="rounded-lg border border-divider-soft">
+            <Accordion.Root type="single" collapsible className="surface-card">
               <Accordion.Item value="summary">
                 <Accordion.Header>
                   <Accordion.Trigger className="group flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-muted/30">
@@ -224,7 +224,7 @@ export default function CartPage() {
                     <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
                   </Accordion.Trigger>
                 </Accordion.Header>
-                <Accordion.Content className="overflow-hidden border-t border-divider-soft data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up">
+                <Accordion.Content className="overflow-hidden border-t border-soft data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up">
                   <div className="p-4">{orderSummaryContent}</div>
                 </Accordion.Content>
               </Accordion.Item>
@@ -232,7 +232,7 @@ export default function CartPage() {
           </section>
         </div>
 
-        <aside className="hidden h-fit rounded-lg border border-divider-soft p-6 lg:sticky lg:top-24 lg:block">
+        <aside className="hidden h-fit surface-card p-6 lg:sticky lg:top-24 lg:block">
           <h2 className="typo-h3">{t('orderSummary')}</h2>
           <div className="mt-4">{orderSummaryContent}</div>
 
@@ -244,7 +244,7 @@ export default function CartPage() {
 
       <div
         className={cn(
-          'mobile-sticky-cta fixed z-40 border-t border-divider-soft bg-background md:hidden',
+          'mobile-sticky-cta fixed z-40 border-t border-soft bg-background md:hidden',
           isNavVisible ? 'mobile-sticky-cta--above-nav' : 'mobile-sticky-cta--bottom',
         )}
       >

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -261,7 +261,7 @@ export default function CheckoutPage({
     <div className="layout-container layout-page pb-36 md:pb-8">
       <h1 className="typo-h1">{t('title')}</h1>
 
-      <ol className="mt-4 flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/20 px-3 py-2 text-xs text-muted-foreground md:max-w-xl">
+      <ol className="mt-4 flex flex-wrap items-center gap-2 rounded-md border border-soft bg-muted/20 px-3 py-2 text-xs text-muted-foreground md:max-w-xl">
         <li className="rounded-full bg-primary px-2.5 py-1 text-primary-foreground">{t('flow.shipping')}</li>
         <span aria-hidden>→</span>
         <li className="rounded-full bg-secondary px-2.5 py-1 text-secondary-foreground">{t('flow.payment')}</li>
@@ -272,7 +272,7 @@ export default function CheckoutPage({
       <form id="checkout-form" onSubmit={handleSubmit} className="mt-6">
         <div className="grid gap-6 lg:grid-cols-3">
           <div className="layout-stack-md lg:col-span-2">
-            <section className="rounded-lg border p-6">
+            <section className="surface-card p-6">
               <h2 className="typo-h3">{t('shippingInfo')}</h2>
 
               <div className="mt-4 layout-stack-md">
@@ -293,7 +293,7 @@ export default function CheckoutPage({
               </div>
             </section>
 
-            <section className="rounded-lg border p-6">
+            <section className="surface-card p-6">
               <h2 className="typo-h3">{t('paymentMethod')}</h2>
               <div className="mt-4">
                 {prepareResult ? (
@@ -317,7 +317,7 @@ export default function CheckoutPage({
               </div>
             </section>
 
-            <section className="rounded-lg border p-6">
+            <section className="surface-card p-6">
               <h2 className="typo-h3">{t('couponPoints')}</h2>
               <div className="mt-4">
                 <CouponSelector
@@ -331,10 +331,10 @@ export default function CheckoutPage({
               </div>
             </section>
 
-            <section className="rounded-lg border p-6">
+            <section className="surface-card p-6">
               <h2 className="typo-h3">{t('consent.title')}</h2>
               <div className="mt-4 space-y-4">
-                <label className="flex gap-3 rounded-md border border-border bg-muted/20 p-3 text-sm text-foreground">
+                <label className="flex gap-3 rounded-md border border-soft bg-muted/20 p-3 text-sm text-foreground">
                   <input
                     type="checkbox"
                     checked={requiredConsent}
@@ -349,7 +349,7 @@ export default function CheckoutPage({
                     </span>
                   </span>
                 </label>
-                <label className="flex gap-3 rounded-md border border-border p-3 text-sm text-foreground">
+                <label className="flex gap-3 rounded-md border border-soft p-3 text-sm text-foreground">
                   <input
                     type="checkbox"
                     checked={marketingConsent}
@@ -373,7 +373,7 @@ export default function CheckoutPage({
               freeShippingThreshold={freeShippingThreshold}
               discountAmount={discountAmount}
             />
-            <div className="hidden rounded-lg border border-border p-4 md:block">
+            <div className="hidden surface-card p-4 md:block">
               <div className="mb-2 flex items-end justify-between">
                 <span className="text-sm text-muted-foreground">{t('total')}</span>
                 <span className="typo-price-lg text-foreground">{formatCurrency(grandTotal, locale)}</span>
@@ -388,7 +388,7 @@ export default function CheckoutPage({
 
       <div
         className={cn(
-          'mobile-sticky-cta fixed z-40 border-t border-border bg-background md:hidden',
+          'mobile-sticky-cta fixed z-40 border-t border-soft bg-background md:hidden',
           isNavVisible ? 'mobile-sticky-cta--above-nav' : 'mobile-sticky-cta--bottom',
         )}
       >

--- a/src/app/[locale]/my/orders/[id]/page.tsx
+++ b/src/app/[locale]/my/orders/[id]/page.tsx
@@ -206,7 +206,7 @@ export default function OrderDetailPage() {
       <div className="space-y-6">
         {/* Status timeline */}
         {!['cancelled', 'refunded'].includes(order.status) && (
-          <section className="rounded-lg border p-6">
+          <section className="surface-card p-6">
             <h2 className="mb-4 text-base font-semibold">{t('shippingStatus')}</h2>
             <div className="flex items-center justify-between">
               {STATUS_TIMELINE.map((status, index) => (
@@ -245,7 +245,7 @@ export default function OrderDetailPage() {
 
         {/* Pending payment */}
         {isPaymentPending && (
-          <section className="rounded-lg border p-6">
+          <section className="surface-card p-6">
             <h2 className="mb-4 text-base font-semibold">{tCheckout('paymentMethod')}</h2>
             {prepareResult ? (
               <PaymentGateway
@@ -276,9 +276,9 @@ export default function OrderDetailPage() {
         )}
 
         {/* Order items */}
-        <section className="rounded-lg border p-6">
+        <section className="surface-card p-6">
           <h2 className="mb-4 text-base font-semibold">{t('orderItems')}</h2>
-          <ul className="divide-y">
+          <ul className="divide-y divide-soft">
             {order.items.map((item) => (
               <li key={item.id} className="py-3 text-sm">
                 <div className="flex justify-between gap-4">
@@ -301,7 +301,7 @@ export default function OrderDetailPage() {
         </section>
 
         {/* Order amounts */}
-        <section className="rounded-lg border p-6">
+        <section className="surface-card p-6">
           <h2 className="mb-4 text-base font-semibold">{t('paymentSummary')}</h2>
           <dl className="space-y-2 text-sm">
             <div className="flex justify-between">
@@ -320,7 +320,7 @@ export default function OrderDetailPage() {
                   : formatCurrency(order.shippingFee, locale)}
               </dd>
             </div>
-            <div className="flex justify-between border-t pt-2 font-bold">
+            <div className="flex justify-between border-t border-soft pt-2 font-bold">
               <dt>{t('total')}</dt>
               <dd>
                 {formatCurrency(
@@ -336,7 +336,7 @@ export default function OrderDetailPage() {
 
 
         {/* Cancellation / return / exchange / refund requests */}
-        <section className="rounded-lg border p-6">
+        <section className="surface-card p-6">
           <h2 className="mb-4 text-base font-semibold">{t('serviceRequests.title')}</h2>
           <p className="mb-4 text-sm text-muted-foreground">
             {canCancel ? t('serviceRequests.cancelGuide') : canAfterDeliveryRequest ? t('serviceRequests.afterDeliveryGuide') : t('serviceRequests.unavailableGuide')}
@@ -350,7 +350,7 @@ export default function OrderDetailPage() {
                   <select
                     value={requestType}
                     onChange={(event) => setRequestType(event.target.value as OrderServiceRequestType)}
-                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    className="w-full rounded-md border field-soft px-3 py-2 text-sm"
                   >
                     {canCancel && <option value="cancel">{requestTypeLabels.cancel}</option>}
                     {canAfterDeliveryRequest && <option value="return">{requestTypeLabels.return}</option>}
@@ -364,7 +364,7 @@ export default function OrderDetailPage() {
                     value={requestReason}
                     onChange={(event) => setRequestReason(event.target.value)}
                     maxLength={100}
-                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    className="w-full rounded-md border field-soft px-3 py-2 text-sm"
                     placeholder={t('serviceRequests.reasonPlaceholder')}
                   />
                 </label>
@@ -375,7 +375,7 @@ export default function OrderDetailPage() {
                   value={requestDetail}
                   onChange={(event) => setRequestDetail(event.target.value)}
                   rows={3}
-                  className="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  className="w-full resize-none rounded-md border field-soft px-3 py-2 text-sm"
                   placeholder={t('serviceRequests.detailPlaceholder')}
                 />
               </label>
@@ -388,7 +388,7 @@ export default function OrderDetailPage() {
           {serviceRequests.length > 0 && (
             <ul className="mt-4 space-y-2">
               {serviceRequests.map((request) => (
-                <li key={request.id} className="rounded-md border bg-card p-3 text-sm">
+                <li key={request.id} className="rounded-md border border-soft bg-card p-3 text-sm">
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <span className="font-medium">{requestTypeLabels[request.type]}</span>
                     <span className="rounded-full bg-secondary px-2 py-0.5 text-xs">{requestStatusLabels[request.status] ?? request.status}</span>
@@ -402,7 +402,7 @@ export default function OrderDetailPage() {
         </section>
 
         {/* Tax receipt / invoice guide */}
-        <section className="rounded-lg border p-6">
+        <section className="surface-card p-6">
           <h2 className="mb-4 text-base font-semibold">{t('taxReceiptGuideTitle')}</h2>
           <div className="space-y-3 text-sm text-muted-foreground">
             <p>{t('taxReceiptGuideDescription')}</p>
@@ -414,7 +414,7 @@ export default function OrderDetailPage() {
         </section>
 
         {/* Shipping address */}
-        <section className="rounded-lg border p-6">
+        <section className="surface-card p-6">
           <h2 className="mb-4 text-base font-semibold">{t('shippingAddress')}</h2>
           <dl className="space-y-1 text-sm">
             <div className="flex gap-4">

--- a/src/app/[locale]/my/orders/page.tsx
+++ b/src/app/[locale]/my/orders/page.tsx
@@ -81,7 +81,7 @@ export default function OrdersPage() {
           </button>
         </div>
       ) : orders.length === 0 ? (
-        <div className="rounded-lg border p-12 text-center">
+        <div className="surface-card p-12 text-center">
           <p className="text-muted-foreground">{t('noOrders')}</p>
           <Link
             href="/products"
@@ -97,7 +97,7 @@ export default function OrdersPage() {
               <li key={order.id}>
                 <Link
                   href={`/my/orders/${order.id}`}
-                  className="block rounded-lg border p-4 hover:bg-muted/50 transition-colors"
+                  className="block surface-card p-4 hover:bg-muted/50 transition-colors"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex-1 min-w-0">
@@ -128,7 +128,7 @@ export default function OrdersPage() {
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page === 1}
-                className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-40 hover:bg-muted transition-colors"
+                className="rounded-md border border-soft px-3 py-1.5 text-sm disabled:opacity-40 hover:bg-muted transition-colors"
               >
                 {tMy('previousPage')}
               </button>
@@ -138,7 +138,7 @@ export default function OrdersPage() {
               <button
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page === totalPages}
-                className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-40 hover:bg-muted transition-colors"
+                className="rounded-md border border-soft px-3 py-1.5 text-sm disabled:opacity-40 hover:bg-muted transition-colors"
               >
                 {tMy('nextPage')}
               </button>

--- a/src/app/[locale]/order/complete/page.tsx
+++ b/src/app/[locale]/order/complete/page.tsx
@@ -79,9 +79,9 @@ function OrderCompleteContent({ locale }: { locale: string }) {
         </p>
       </div>
 
-      <section className="rounded-lg border p-6 space-y-4 mb-8">
+      <section className="surface-card p-6 space-y-4 mb-8">
         <h2 className="font-semibold text-lg">{t('items')}</h2>
-        <ul className="divide-y text-sm">
+        <ul className="divide-y divide-soft text-sm">
           {order.items.map((item) => (
             <li key={item.id} className="py-3 flex justify-between gap-2">
               <div>
@@ -98,7 +98,7 @@ function OrderCompleteContent({ locale }: { locale: string }) {
           ))}
         </ul>
 
-        <div className="border-t pt-4 space-y-2 text-sm">
+        <div className="border-t border-soft pt-4 space-y-2 text-sm">
           <div className="flex justify-between">
             <span className="text-muted-foreground">{t('shippingFee')}</span>
             <span>{order.shippingFee === 0 ? t('free') : formatCurrency(order.shippingFee, locale === 'en' ? 'en' : 'ko')}</span>
@@ -111,7 +111,7 @@ function OrderCompleteContent({ locale }: { locale: string }) {
           )}
         </div>
 
-        <div className="border-t pt-4 flex justify-between font-bold">
+        <div className="border-t border-soft pt-4 flex justify-between font-bold">
           <span>{t('paymentAmount')}</span>
           <span>{formatCurrency(order.totalAmount, locale === 'en' ? 'en' : 'ko')}</span>
         </div>
@@ -120,7 +120,7 @@ function OrderCompleteContent({ locale }: { locale: string }) {
       <div className="flex gap-3">
         <Link
           href="/my/orders"
-          className="flex-1 rounded-md border py-3 text-center text-sm font-semibold hover:bg-muted transition-colors"
+          className="flex-1 rounded-md border border-soft py-3 text-center text-sm font-semibold hover:bg-muted transition-colors"
         >
           {t('viewOrders')}
         </Link>

--- a/src/components/shared/ShippingTimeline.tsx
+++ b/src/components/shared/ShippingTimeline.tsx
@@ -72,7 +72,7 @@ export default function ShippingTimeline({ orderId }: Props) {
 
   if (loading) {
     return (
-      <section className="rounded-lg border p-6" aria-busy="true">
+      <section className="surface-card p-6" aria-busy="true">
         <h2 className="mb-4 text-base font-semibold">{t('title')}</h2>
         <div className="space-y-2">
           <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
@@ -104,7 +104,7 @@ export default function ShippingTimeline({ orderId }: Props) {
   const carrierName = getCarrierName(shipping.carrier, locale);
 
   return (
-    <section className="rounded-lg border p-6">
+    <section className="surface-card p-6">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-base font-semibold">{t('title')}</h2>
         <div className="flex items-center gap-2">

--- a/src/components/shared/checkout/AddressSelectorSection.tsx
+++ b/src/components/shared/checkout/AddressSelectorSection.tsx
@@ -24,7 +24,7 @@ export function AddressSelectorSection({
 
   if (addresses.length === 0) {
     return (
-      <div className="flex items-center justify-between rounded-md border border-dashed p-4">
+      <div className="flex items-center justify-between rounded-md border border-dashed border-soft p-4">
         <p className="text-sm text-muted-foreground">{localMessage('checkout.noSavedAddress')}</p>
         <button
           type="button"
@@ -38,7 +38,7 @@ export function AddressSelectorSection({
   }
 
   return (
-    <div className="space-y-2 border-b pb-4">
+    <div className="space-y-2 border-b border-soft pb-4">
       {addresses.map((addr) => (
         <label key={addr.id} className="flex items-start gap-3 cursor-pointer">
           <input

--- a/src/components/shared/checkout/CouponSelector.tsx
+++ b/src/components/shared/checkout/CouponSelector.tsx
@@ -89,7 +89,7 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
         onChange={handleChange}
         disabled={calculating}
         className={cn(
-          'w-full rounded-md border px-3 py-2 text-sm',
+          'w-full rounded-md border field-soft px-3 py-2 text-sm',
           'focus:outline-none focus:ring-2 focus:ring-ring',
           calculating && 'opacity-50 cursor-not-allowed',
         )}
@@ -118,14 +118,14 @@ export default function CouponSelector({ orderAmount, onDiscountChange }: Coupon
           value={pointsInput}
           onChange={(event) => setPointsInput(event.target.value)}
           disabled={calculating || pointsBalance <= 0}
-          className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          className="w-full rounded-md border field-soft px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
           placeholder={localMessage('checkout.pointsPlaceholder')}
         />
         <button
           type="button"
           onClick={handleApplyPoints}
           disabled={calculating || pointsBalance <= 0}
-          className="rounded-md border px-4 py-2 text-sm font-medium transition-colors enabled:hover:bg-muted disabled:opacity-50"
+          className="rounded-md border border-soft px-4 py-2 text-sm font-medium transition-colors enabled:hover:bg-muted disabled:opacity-50"
         >
           {localMessage('checkout.applyPoints')}
         </button>

--- a/src/components/shared/checkout/OrderSummarySection.tsx
+++ b/src/components/shared/checkout/OrderSummarySection.tsx
@@ -29,10 +29,10 @@ export function OrderSummarySection({
     : 100;
 
   return (
-    <section className="rounded-lg border p-6">
+    <section className="surface-card p-6">
       <h2 className="typo-h3">{t('orderItems')}</h2>
 
-      <ul className="mt-4 divide-y text-sm">
+      <ul className="mt-4 divide-y divide-soft text-sm">
         {checkoutItems.map((item) => (
           <li key={item.id} className="space-y-0.5 py-3">
             <p className="font-medium">{item.product.name}</p>
@@ -48,7 +48,7 @@ export function OrderSummarySection({
         ))}
       </ul>
 
-      <div className="mt-4 rounded-md border border-border bg-muted/30 p-3">
+      <div className="mt-4 rounded-md border border-soft bg-muted/20 p-3">
         <p className="text-xs text-muted-foreground">
           {remainingForFreeShipping === 0
             ? t('freeShippingUnlocked')
@@ -63,7 +63,7 @@ export function OrderSummarySection({
         </div>
       </div>
 
-      <div className="mt-4 border-t pt-4 text-sm">
+      <div className="mt-4 border-t border-soft pt-4 text-sm">
         <div className="flex justify-between">
           <span className="text-muted-foreground">{t('productAmount')}</span>
           <span className="typo-price">{formatCurrency(totalAmount, locale)}</span>
@@ -80,7 +80,7 @@ export function OrderSummarySection({
         )}
       </div>
 
-      <div className="mt-4 border-t pt-4">
+      <div className="mt-4 border-t border-soft pt-4">
         <div className="flex items-end justify-between">
           <span className="typo-title">{t('total')}</span>
           <span className="typo-price-lg text-foreground">{formatCurrency(grandTotal, locale)}</span>

--- a/src/components/shared/checkout/PaymentMethodOption.tsx
+++ b/src/components/shared/checkout/PaymentMethodOption.tsx
@@ -24,10 +24,10 @@ export function PaymentMethodOption({
   return (
     <label
       className={cn(
-        'flex min-h-11 cursor-pointer items-center gap-3 rounded-md border border-border bg-card px-3 py-2 transition-colors',
+        'flex min-h-11 cursor-pointer items-center gap-3 rounded-md border border-soft bg-card px-3 py-2 transition-colors',
         'hover:border-foreground/30 hover:bg-muted/30',
         selected && 'border-foreground bg-muted/35',
-        readOnly && 'cursor-default hover:border-border hover:bg-card',
+        readOnly && 'cursor-default hover:border-soft hover:bg-card',
       )}
       aria-label={label}
     >
@@ -46,7 +46,7 @@ export function PaymentMethodOption({
           <span>{label}</span>
         </span>
         {gateway === 'naverpay' && (
-          <span className="rounded-sm border border-border bg-muted px-2 py-0.5 typo-label text-muted-foreground">
+          <span className="rounded-sm border border-soft bg-muted px-2 py-0.5 typo-label text-muted-foreground">
             {t('naverpayDomesticBadge')}
           </span>
         )}

--- a/src/components/shared/checkout/SecureCardEntryShell.tsx
+++ b/src/components/shared/checkout/SecureCardEntryShell.tsx
@@ -22,9 +22,9 @@ export function SecureCardEntryShell({ showSubmitButton = false }: SecureCardEnt
         <p className="mt-1 typo-body-sm text-muted-foreground">{t('cardPaymentSubtitle')}</p>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-foreground/80 bg-card text-card-foreground">
+      <div className="overflow-hidden surface-card text-card-foreground">
         <div className="flex min-h-14 items-center justify-between gap-3 bg-muted/45 px-4 py-3">
-          <span className="typo-body-sm font-bold text-foreground">{t('creditCardTitle')}</span>
+          <span className="typo-body-sm font-medium text-foreground">{t('creditCardTitle')}</span>
           <div className="flex shrink-0 items-center gap-1.5" aria-label={t('cardBrandsLabel')}>
             {CARD_BRANDS.map((brand) => (
               <PaymentBrandIcon key={brand} brand={brand} />
@@ -32,7 +32,7 @@ export function SecureCardEntryShell({ showSubmitButton = false }: SecureCardEnt
           </div>
         </div>
 
-        <div className="border-t border-border p-4">
+        <div className="border-t border-soft p-4">
           <div className="grid gap-3">
             <SecureInputPreview
               placeholder={t('cardNumberPlaceholder')}
@@ -69,7 +69,7 @@ export function SecureCardEntryShell({ showSubmitButton = false }: SecureCardEnt
         </div>
       </div>
 
-      <div className="border-t border-dashed border-border pt-4">
+      <div className="border-t border-dashed border-soft pt-4">
         <label className="flex items-start gap-3 typo-body-sm text-muted-foreground">
           <input
             type="checkbox"
@@ -108,7 +108,7 @@ function SecureInputPreview({
         tabIndex={-1}
         placeholder={placeholder}
         className={cn(
-          'min-h-11 w-full rounded-md border border-input bg-background px-3 typo-body-sm text-foreground placeholder:text-muted-foreground',
+          'min-h-11 w-full rounded-md border field-soft px-3 typo-body-sm text-foreground placeholder:text-muted-foreground',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
           icon ? 'pr-10' : '',
         )}

--- a/src/components/shared/checkout/ShippingFormSection.tsx
+++ b/src/components/shared/checkout/ShippingFormSection.tsx
@@ -22,7 +22,7 @@ export function ShippingFormSection({ form, errors, onChange }: ShippingFormSect
         value={form.recipientName}
         onChange={onChange}
         placeholder={localMessage('checkout.recipientName')}
-        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+        className="w-full rounded-md border field-soft px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
       />
       {errors.recipientName && (
         <p className="typo-label text-destructive">{errors.recipientName}</p>
@@ -50,7 +50,7 @@ export function PhoneInputSection({ form, errors, onChange }: PhoneInputSectionP
         value={form.recipientPhone}
         onChange={onChange}
         placeholder="010-1234-5678"
-        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+        className="w-full rounded-md border field-soft px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
       />
       {errors.recipientPhone && (
         <p className="typo-label text-destructive">{errors.recipientPhone}</p>
@@ -79,7 +79,7 @@ export function ZipcodeInputSection({ form, errors, onChange }: ZipcodeInputSect
         onChange={onChange}
         placeholder="12345"
         maxLength={5}
-        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+        className="w-full rounded-md border field-soft px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
       />
       {errors.zipcode && (
         <p className="typo-label text-destructive">{errors.zipcode}</p>
@@ -107,7 +107,7 @@ export function AddressInputSection({ form, errors, onChange }: AddressInputSect
         value={form.address}
         onChange={onChange}
         placeholder={localMessage('checkout.addressPlaceholder')}
-        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+        className="w-full rounded-md border field-soft px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
       />
       {errors.address && (
         <p className="typo-label text-destructive">{errors.address}</p>
@@ -134,7 +134,7 @@ export function AddressDetailInputSection({ form, onChange }: AddressDetailInput
         value={form.addressDetail}
         onChange={onChange}
         placeholder={localMessage('checkout.addressDetailPlaceholder')}
-        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
+        className="w-full rounded-md border field-soft px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20"
       />
     </div>
   );
@@ -158,7 +158,7 @@ export function MemoInputSection({ form, onChange }: MemoInputSectionProps) {
         onChange={onChange}
         placeholder={localMessage('checkout.shippingMemoPlaceholder')}
         rows={3}
-        className="w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20 resize-none"
+        className="w-full rounded-md border field-soft px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-foreground/20 resize-none"
       />
     </div>
   );

--- a/src/components/ui/FormInput.tsx
+++ b/src/components/ui/FormInput.tsx
@@ -26,11 +26,11 @@ export default function FormInput({
       <input
         id={id}
         className={cn(
-          'w-full rounded-md border bg-background px-3 py-2 text-sm outline-none',
+          'w-full rounded-md border px-3 py-2 text-sm outline-none',
+          error ? 'border-destructive bg-background' : 'field-soft',
           'focus:ring-2 focus:ring-foreground/20',
           'placeholder:text-muted-foreground',
           'disabled:cursor-not-allowed disabled:opacity-50',
-          error && 'border-destructive',
           className,
         )}
         {...props}

--- a/src/components/ui/FormSelect.tsx
+++ b/src/components/ui/FormSelect.tsx
@@ -36,10 +36,10 @@ export default function FormSelect({
       <select
         id={id}
         className={cn(
-          'w-full rounded-md border bg-background px-3 py-2 text-sm outline-none',
+          'w-full rounded-md border px-3 py-2 text-sm outline-none',
+          error ? 'border-destructive bg-background' : 'field-soft',
           'focus:ring-2 focus:ring-foreground/20',
           'disabled:cursor-not-allowed disabled:opacity-50',
-          error && 'border-destructive',
           !props.value && placeholder && 'text-muted-foreground',
           className,
         )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -116,7 +116,7 @@
   --admin-row-hover: color-mix(in srgb, var(--color-muted) 40%, transparent);
   --admin-row-height: 2.875rem;
   --admin-row-height-compact: 2.5rem;
-  --divider-soft: color-mix(in srgb, var(--color-border) 70%, var(--color-foreground) 30%);
+  --divider-soft: color-mix(in srgb, var(--color-border) 65%, var(--color-background) 35%);
 
   /* ── 타이포그래피 — 폰트 패밀리 (3종) ── */
   --font-display: 'Noto Serif KR', 'Georgia', serif;
@@ -253,6 +253,30 @@ body.overflow-hidden .mobile-sticky-cta {
 
 @utility bg-divider-soft {
   background-color: var(--divider-soft);
+}
+
+/* ── Minimal soft-line utilities ─────────────────────────────────
+   Default for customer-facing cards, form fields, dividers, and passive panels.
+   Use stronger border-* only for selected/active, destructive, or brand-emphasis states. */
+@utility surface-card {
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, var(--color-background) 35%);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-card);
+}
+
+@utility border-soft {
+  border-color: color-mix(in srgb, var(--color-border) 65%, var(--color-background) 35%);
+}
+
+@utility field-soft {
+  border-color: color-mix(in srgb, var(--color-border) 75%, var(--color-background) 25%);
+  background-color: var(--color-background);
+}
+
+@utility divide-soft {
+  & > :not(:last-child) {
+    border-color: color-mix(in srgb, var(--color-border) 65%, var(--color-background) 35%);
+  }
 }
 
 /* ── Typography utility classes ────────────────────────────────── */


### PR DESCRIPTION
## Summary
- add reusable soft-line utilities for customer-facing cards, fields, and dividers
- document the new surface/border rule in DESIGN.md and frontend guidance files
- apply the lighter minimal border treatment across checkout, cart, order complete, my orders, order detail, and shared order/checkout components

## Validation
- `npm run lint -- --quiet`
- `npx vitest run 'src/components/shared/checkout/__tests__' 'src/app/[locale]/checkout/success/__tests__' --reporter=verbose`
- `npm run typecheck`
- restarted local services with `bash scripts/start-local.sh`
- visually checked local checkout page via `/tmp/checkout-preview.png`

Closes #1073
