### PR TITLE
feat: #1077 어드민 원격 로그 조회 기능 추가

### DIFF
--- a/backend/src/modules/admin/__tests__/admin-logs.controller.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-logs.controller.spec.ts
@@ -1,0 +1,37 @@
+import 'reflect-metadata';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext } from '@nestjs/common';
+import { AdminLogsController } from '../admin-logs.controller';
+import { AdminLogsService } from '../admin-logs.service';
+import { ROLES_KEY } from '../../../common/decorators/roles.decorator';
+import { RolesGuard } from '../../../common/guards/roles.guard';
+
+describe('AdminLogsController access policy', () => {
+  it('limits remote log lookup API to super_admin only', () => {
+    expect(Reflect.getMetadata(ROLES_KEY, AdminLogsController)).toEqual(['super_admin']);
+  });
+
+  it('blocks regular admin from remote log lookup', () => {
+    const reflector = new Reflector();
+    const guard = new RolesGuard(reflector);
+    const context = {
+      getHandler: () => AdminLogsController.prototype.getLogs,
+      getClass: () => AdminLogsController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { id: 7, role: 'admin' } }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('delegates query values to the service', async () => {
+    const service = {
+      getLogs: jest.fn().mockResolvedValue({ content: 'ok' }),
+    } as unknown as AdminLogsService;
+    const controller = new AdminLogsController(service);
+
+    await expect(controller.getLogs({ type: 'error', lines: 100 })).resolves.toEqual({ content: 'ok' });
+    expect(service.getLogs).toHaveBeenCalledWith('error', 100);
+  });
+});

--- a/backend/src/modules/admin/__tests__/admin-logs.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-logs.service.spec.ts
@@ -1,0 +1,61 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ServiceUnavailableException } from '@nestjs/common';
+import { AdminLogsService } from '../admin-logs.service';
+
+const ORIGINAL_ENV = process.env;
+
+describe('AdminLogsService', () => {
+  let tmpDir: string;
+  let service: AdminLogsService;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'admin-logs-'));
+    process.env = { ...ORIGINAL_ENV, ADMIN_LOG_PM2_LOG_DIR: tmpDir, ADMIN_LOG_PM2_APP_NAME: 'commerce' };
+    service = new AdminLogsService();
+  });
+
+  afterEach(async () => {
+    process.env = ORIGINAL_ENV;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads recent normal PM2 out logs', async () => {
+    await fs.writeFile(path.join(tmpDir, 'commerce-out.log'), Array.from({ length: 20 }, (_, i) => `out-${i + 1}`).join('\n'));
+
+    const result = await service.getLogs('normal', 10);
+
+    expect(result.type).toBe('normal');
+    expect(result.source).toBe('pm2:commerce:out');
+    expect(result.lineCount).toBe(10);
+    expect(result.content.split('\n')[0]).toBe('out-11');
+    expect(result.content.split('\n')[9]).toBe('out-20');
+    expect(result.truncated).toBe(true);
+  });
+
+  it('reads recent error PM2 logs', async () => {
+    await fs.writeFile(path.join(tmpDir, 'commerce-error.log'), 'first\nsecond\nthird\n');
+
+    const result = await service.getLogs('error', 10);
+
+    expect(result.type).toBe('error');
+    expect(result.source).toBe('pm2:commerce:error');
+    expect(result.content).toBe('first\nsecond\nthird');
+    expect(result.lineCount).toBe(3);
+    expect(result.updatedAt).toEqual(expect.any(String));
+  });
+
+  it('clamps requested lines to the supported range', async () => {
+    await fs.writeFile(path.join(tmpDir, 'commerce-out.log'), Array.from({ length: 12 }, (_, i) => `line-${i + 1}`).join('\n'));
+
+    const result = await service.getLogs('normal', 1);
+
+    expect(result.lines).toBe(10);
+    expect(result.lineCount).toBe(10);
+  });
+
+  it('returns a service-unavailable error when the log file is unavailable', async () => {
+    await expect(service.getLogs('error', 10)).rejects.toThrow(ServiceUnavailableException);
+  });
+});

--- a/backend/src/modules/admin/admin-logs.controller.ts
+++ b/backend/src/modules/admin/admin-logs.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { AdminLogsService } from './admin-logs.service';
+import { AdminLogQueryDto } from './dto/admin-log-query.dto';
+
+@ApiTags('관리자 - 원격 로그')
+@Controller('admin/logs')
+@Roles('super_admin')
+export class AdminLogsController {
+  constructor(private readonly adminLogsService: AdminLogsService) {}
+
+  @Get()
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '원격 PM2 로그 조회', description: '운영 서버의 최근 일반/에러 로그를 조회합니다.' })
+  @ApiResponse({ status: 200, description: '원격 로그 조회 성공' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  getLogs(@Query() query: AdminLogQueryDto) {
+    return this.adminLogsService.getLogs(query.type, query.lines);
+  }
+}

--- a/backend/src/modules/admin/admin-logs.service.ts
+++ b/backend/src/modules/admin/admin-logs.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AdminLogType } from './dto/admin-log-query.dto';
+
+const DEFAULT_APP_NAME = 'commerce';
+const DEFAULT_LINES = 500;
+const MAX_READ_BYTES = 2 * 1024 * 1024;
+
+export interface AdminLogResponse {
+  type: AdminLogType;
+  app: string;
+  lines: number;
+  content: string;
+  lineCount: number;
+  updatedAt: string | null;
+  source: string;
+  truncated: boolean;
+}
+
+@Injectable()
+export class AdminLogsService {
+  private readonly logger = new Logger(AdminLogsService.name);
+
+  async getLogs(type: AdminLogType = 'normal', lines = DEFAULT_LINES): Promise<AdminLogResponse> {
+    const normalizedLines = this.normalizeLines(lines);
+    const app = process.env.ADMIN_LOG_PM2_APP_NAME || process.env.PM2_APP_NAME || DEFAULT_APP_NAME;
+    const logFile = this.getLogFilePath(app, type);
+
+    try {
+      const { content, lineCount, truncated, updatedAt } = await this.readRecentLines(logFile, normalizedLines);
+      return {
+        type,
+        app,
+        lines: normalizedLines,
+        content,
+        lineCount,
+        updatedAt,
+        source: `pm2:${app}:${type === 'error' ? 'error' : 'out'}`,
+        truncated,
+      };
+    } catch (err) {
+      this.logger.warn(`관리자 로그 조회 실패: ${this.describeReadError(err)}`);
+      throw new ServiceUnavailableException('원격 로그 파일을 조회할 수 없습니다.');
+    }
+  }
+
+  private getLogFilePath(app: string, type: AdminLogType): string {
+    const logDir = process.env.ADMIN_LOG_PM2_LOG_DIR || process.env.PM2_LOG_DIR || path.join(os.homedir(), '.pm2', 'logs');
+    const suffix = type === 'error' ? 'error' : 'out';
+    return path.join(logDir, `${app}-${suffix}.log`);
+  }
+
+  private normalizeLines(lines: number): number {
+    if (!Number.isFinite(lines)) {
+      return DEFAULT_LINES;
+    }
+    return Math.min(5000, Math.max(10, Math.trunc(lines)));
+  }
+
+  private async readRecentLines(filePath: string, lines: number): Promise<{
+    content: string;
+    lineCount: number;
+    updatedAt: string | null;
+    truncated: boolean;
+  }> {
+    const stat = await fs.stat(filePath);
+    const readBytes = Math.min(stat.size, MAX_READ_BYTES);
+    const buffer = Buffer.alloc(readBytes);
+    const handle = await fs.open(filePath, 'r');
+
+    try {
+      await handle.read(buffer, 0, readBytes, stat.size - readBytes);
+    } finally {
+      await handle.close();
+    }
+
+    const allLines = buffer.toString('utf8').replace(/^\uFEFF/, '').split(/\r?\n/);
+    if (allLines.length > 0 && allLines[allLines.length - 1] === '') {
+      allLines.pop();
+    }
+    const selectedLines = allLines.slice(-lines);
+
+    return {
+      content: selectedLines.join('\n'),
+      lineCount: selectedLines.length,
+      updatedAt: Number.isFinite(stat.mtimeMs) ? stat.mtime.toISOString() : null,
+      truncated: stat.size > readBytes || allLines.length > selectedLines.length,
+    };
+  }
+
+  private describeReadError(err: unknown): string {
+    if (err instanceof Error) {
+      return err.message;
+    }
+    return '알 수 없는 오류';
+  }
+}

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -10,8 +10,10 @@ import { AdminMembersController } from './admin-members.controller';
 import { AdminMembersService } from './admin-members.service';
 import { AdminExportController } from './admin-export.controller';
 import { AdminLocalizationController } from './admin-localization.controller';
+import { AdminLogsController } from './admin-logs.controller';
 import { AdminExportService } from './admin-export.service';
 import { AdminLocalizationService } from './admin-localization.service';
+import { AdminLogsService } from './admin-logs.service';
 import { Order } from '../orders/entities/order.entity';
 import { OrderServiceRequest } from '../orders/entities/order-service-request.entity';
 import { Payment } from '../payments/entities/payment.entity';
@@ -57,6 +59,7 @@ import { PointsModule } from '../points/points.module';
     AdminMembersController,
     AdminExportController,
     AdminLocalizationController,
+    AdminLogsController,
   ],
   providers: [
     AdminService,
@@ -65,6 +68,7 @@ import { PointsModule } from '../points/points.module';
     AdminMembersService,
     AdminExportService,
     AdminLocalizationService,
+    AdminLogsService,
   ],
 })
 export class AdminModule {}

--- a/backend/src/modules/admin/dto/admin-log-query.dto.ts
+++ b/backend/src/modules/admin/dto/admin-log-query.dto.ts
@@ -1,0 +1,29 @@
+import { Transform } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export type AdminLogType = 'normal' | 'error';
+
+export class AdminLogQueryDto {
+  @ApiPropertyOptional({
+    enum: ['normal', 'error'],
+    default: 'normal',
+    description: '조회할 PM2 로그 종류',
+  })
+  @IsOptional()
+  @IsIn(['normal', 'error'])
+  type?: AdminLogType = 'normal';
+
+  @ApiPropertyOptional({
+    minimum: 10,
+    maximum: 5000,
+    default: 500,
+    description: '조회할 최근 로그 줄 수',
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(10)
+  @Max(5000)
+  lines?: number = 500;
+}

--- a/src/app/[locale]/admin/logs/error.tsx
+++ b/src/app/[locale]/admin/logs/error.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+export default function AdminLogsError({ reset }: { reset: () => void }) {
+  const t = useTranslations('admin.logs.errorBoundary');
+
+  return (
+    <div className="flex min-h-96 flex-col items-center justify-center gap-4">
+      <div className="text-center">
+        <h2 className="typo-h3 font-semibold">{t('title')}</h2>
+        <p className="mt-2 typo-body-sm text-muted-foreground">{t('description')}</p>
+      </div>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md bg-primary px-4 py-2 typo-button text-primary-foreground"
+      >
+        {t('retry')}
+      </button>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/logs/page.tsx
+++ b/src/app/[locale]/admin/logs/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { adminLogsApi, type AdminLogResponse, type AdminLogType } from '@/lib/api';
+import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
+import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
+import { handleApiError } from '@/utils/error';
+import { cn } from '@/components/ui/utils';
+
+const LOG_TYPES: AdminLogType[] = ['normal', 'error'];
+const LINE_OPTIONS = [100, 500, 1000, 3000, 5000];
+
+function formatUpdatedAt(value: string | null): string {
+  if (!value) return '-';
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  }).format(new Date(value));
+}
+
+export default function AdminLogsPage() {
+  const t = useTranslations('admin.logs');
+  const { user, isAdmin } = useAdminGuard();
+  const [type, setType] = useState<AdminLogType>('normal');
+  const [lines, setLines] = useState(500);
+  const [data, setData] = useState<AdminLogResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { execute: fetchLogs, isLoading } = useAsyncAction(
+    async () => {
+      setError(null);
+      const result = await adminLogsApi.get({ type, lines });
+      setData(result);
+    },
+    {
+      errorMessage: t('loadError'),
+      onError: (err) => setError(handleApiError(err, t('loadError'))),
+    },
+  );
+
+  useEffect(() => {
+    if (!isAdmin || user?.role !== 'super_admin') return;
+    void fetchLogs();
+  }, [fetchLogs, isAdmin, type, lines, user?.role]);
+
+  const logContent = useMemo(() => data?.content || t('empty'), [data?.content, t]);
+
+  if (isAdmin && user?.role !== 'super_admin') {
+    return (
+      <div className="rounded-lg border bg-card p-6">
+        <h1 className="typo-h2 font-semibold">{t('title')}</h1>
+        <p className="mt-3 typo-body-sm text-muted-foreground">{t('superAdminOnly')}</p>
+      </div>
+    );
+  }
+
+  const handleCopy = async () => {
+    if (!data?.content) return;
+    try {
+      await navigator.clipboard.writeText(data.content);
+      toast.success(t('copySuccess'));
+    } catch (err) {
+      toast.error(handleApiError(err, t('copyError')));
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h1 className="typo-h2 font-semibold">{t('title')}</h1>
+          <p className="mt-2 typo-body-sm text-muted-foreground">{t('description')}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void fetchLogs()}
+          disabled={isLoading}
+          className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 typo-button text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
+          {t('refresh')}
+        </button>
+      </div>
+
+      <section className="rounded-lg border bg-card p-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap gap-2">
+            {LOG_TYPES.map((item) => (
+              <button
+                key={item}
+                type="button"
+                onClick={() => setType(item)}
+                className={cn(
+                  'rounded-md px-3 py-2 typo-button transition-colors',
+                  type === item
+                    ? 'bg-foreground text-background'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground',
+                )}
+              >
+                {t(`types.${item}`)}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <label htmlFor="admin-log-lines" className="typo-body-sm text-muted-foreground">
+              {t('lineCount')}
+            </label>
+            <select
+              id="admin-log-lines"
+              value={lines}
+              onChange={(event) => setLines(Number(event.target.value))}
+              className="rounded-md border bg-background px-3 py-2 typo-body-sm"
+            >
+              {LINE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {t('lineOption', { count: option })}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => void handleCopy()}
+              disabled={!data?.content}
+              className="rounded-md border px-3 py-2 typo-button text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {t('copy')}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-4 typo-body-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <section className="overflow-hidden rounded-lg border bg-card">
+        <div className="flex flex-col gap-2 border-b bg-muted/40 px-4 py-3 md:flex-row md:items-center md:justify-between">
+          <div className="typo-body-sm font-medium">
+            {data ? t('summary', { app: data.app, source: data.source }) : t('summaryPending')}
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 typo-label text-muted-foreground">
+            <span>{t('updatedAt', { value: formatUpdatedAt(data?.updatedAt ?? null) })}</span>
+            <span>{t('loadedLines', { count: data?.lineCount ?? 0 })}</span>
+            {data?.truncated && <span>{t('truncated')}</span>}
+          </div>
+        </div>
+        <pre className="h-96 overflow-auto whitespace-pre-wrap bg-foreground p-4 font-mono typo-label leading-relaxed text-background">
+          {isLoading && !data ? t('loading') : logContent}
+        </pre>
+      </section>
+    </div>
+  );
+}

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useAuth } from '@/contexts/AuthContext';
 import {
   LayoutDashboard,
   Package,
@@ -22,6 +23,7 @@ type NavLeaf = {
   labelKey: string;
   href: string;
   badgeKey?: keyof AdminWorkBadges;
+  superAdminOnly?: boolean;
 };
 
 type AdminWorkBadges = {
@@ -65,6 +67,7 @@ const NAV_ITEMS: NavItem[] = [
       { labelKey: 'members', href: '/admin/members' },
       { labelKey: 'reviews', href: '/admin/reviews' },
       { labelKey: 'inquiries', href: '/admin/inquiries?status=pending', badgeKey: 'pendingInquiries' },
+      { labelKey: 'logs', href: '/admin/logs', superAdminOnly: true },
     ],
   },
   {
@@ -107,6 +110,7 @@ type SidebarContentProps = {
 function SidebarContent({ onClose }: SidebarContentProps) {
   const pathname = usePathname();
   const t = useTranslations('admin.sidebar');
+  const { user } = useAuth();
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() =>
     getInitialOpenGroups(pathname),
   );
@@ -185,7 +189,7 @@ function SidebarContent({ onClose }: SidebarContentProps) {
                   </button>
                   {isOpen && (
                     <ul className="mt-1 space-y-1 pl-9">
-                      {item.children.map((child) => {
+                      {item.children.filter((child) => !child.superAdminOnly || user?.role === 'super_admin').map((child) => {
                         const childPath = child.href.split('?')[0];
                         const isActive =
                           pathname === childPath || pathname.startsWith(childPath + '/');

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1004,7 +1004,8 @@
       "cmsGroup": "CMS",
       "reviews": "Reviews",
       "localization": "Localization",
-      "attributes": "Attributes"
+      "attributes": "Attributes",
+      "logs": "Remote Logs"
     },
     "navigation": {
       "title": "Navigation Management"
@@ -1309,6 +1310,34 @@
         "confirm": "Delete",
         "cancel": "Cancel"
       }
+    },
+    "logs": {
+      "title": "Remote Logs",
+      "description": "View recent PM2 normal and error logs from the production server.",
+      "refresh": "Refresh",
+      "loadError": "Unable to load remote logs",
+      "empty": "No logs to display.",
+      "copy": "Copy",
+      "copySuccess": "Logs copied.",
+      "copyError": "Unable to copy logs.",
+      "lineCount": "Lines",
+      "lineOption": "{count} lines",
+      "summary": "{app} · {source}",
+      "summaryPending": "Loading log source",
+      "updatedAt": "Updated: {value}",
+      "loadedLines": "{count} lines shown",
+      "truncated": "Recent logs only",
+      "loading": "Loading logs...",
+      "types": {
+        "normal": "Normal",
+        "error": "Error"
+      },
+      "errorBoundary": {
+        "title": "Log page error",
+        "description": "A problem occurred while rendering the remote log page.",
+        "retry": "Try again"
+      },
+      "superAdminOnly": "Remote logs are available to super admins only."
     }
   },
   "search": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1004,7 +1004,8 @@
       "cmsGroup": "CMS",
       "reviews": "리뷰관리",
       "localization": "번역 상태",
-      "attributes": "속성"
+      "attributes": "속성",
+      "logs": "원격 로그"
     },
     "navigation": {
       "title": "네비게이션 관리"
@@ -1309,6 +1310,34 @@
         "confirm": "삭제",
         "cancel": "취소"
       }
+    },
+    "logs": {
+      "title": "원격 로그",
+      "description": "운영 서버의 PM2 일반 로그와 에러 로그를 최근 줄 수 기준으로 확인합니다.",
+      "refresh": "새로고침",
+      "loadError": "원격 로그를 불러올 수 없습니다",
+      "empty": "표시할 로그가 없습니다.",
+      "copy": "복사",
+      "copySuccess": "로그를 복사했습니다.",
+      "copyError": "로그를 복사할 수 없습니다.",
+      "lineCount": "조회 줄 수",
+      "lineOption": "{count}줄",
+      "summary": "{app} · {source}",
+      "summaryPending": "로그 소스를 불러오는 중",
+      "updatedAt": "수정: {value}",
+      "loadedLines": "{count}줄 표시",
+      "truncated": "최근 로그만 표시",
+      "loading": "로그 로딩 중...",
+      "types": {
+        "normal": "일반 로그",
+        "error": "에러 로그"
+      },
+      "errorBoundary": {
+        "title": "로그 화면 오류",
+        "description": "원격 로그 화면을 표시하는 중 문제가 발생했습니다.",
+        "retry": "다시 시도"
+      },
+      "superAdminOnly": "원격 로그는 슈퍼 관리자만 조회할 수 있습니다."
     }
   },
   "search": {

--- a/src/lib/api/admin/logs.ts
+++ b/src/lib/api/admin/logs.ts
@@ -1,0 +1,26 @@
+import { apiClient } from '../core';
+
+export type AdminLogType = 'normal' | 'error';
+
+export interface AdminLogResponse {
+  type: AdminLogType;
+  app: string;
+  lines: number;
+  content: string;
+  lineCount: number;
+  updatedAt: string | null;
+  source: string;
+  truncated: boolean;
+}
+
+export interface AdminLogQueryParams {
+  type?: AdminLogType;
+  lines?: number;
+}
+
+export const adminLogsApi = {
+  get: (params?: AdminLogQueryParams) =>
+    apiClient.get<AdminLogResponse>('/admin/logs', {
+      params: params as Record<string, string | number | undefined>,
+    }),
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -46,3 +46,4 @@ export * from './admin/inquiries';
 export * from './admin/settings';
 export * from './admin/journals';
 export * from './admin/localization';
+export * from './admin/logs';


### PR DESCRIPTION
## Summary
- Closes #1077
- super_admin 전용 원격 PM2 로그 조회 API 추가
- 어드민 `/admin/logs` 화면에서 일반/에러 로그 전환, 줄 수 선택, 새로고침, 복사 지원
- 사이드바 및 ko/en i18n 메시지 추가

## Verification
- `bash scripts/codex-project-guard.sh`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:run`
- `cd backend && npm run build && npm run test`
- `curl http://localhost:3000/api/health`
- `curl -I http://localhost:5173/ko/admin/logs`

## Notes
- PM2 앱명/로그 경로는 `ADMIN_LOG_PM2_APP_NAME`, `ADMIN_LOG_PM2_LOG_DIR`로 조정 가능합니다.
- 운영 서버 실제 PM2 로그 파일 권한은 배포 환경에서 확인 필요합니다.
