### PR TITLE
Improve commerce log traceability

### DIFF
--- a/backend/ecosystem.config.js
+++ b/backend/ecosystem.config.js
@@ -15,7 +15,6 @@ module.exports = {
       JWT_PUBLIC_KEY_FILE: '/app/shop-okhwadang/shop-okhwadang/backend/keys/jwt-public.pem',
     },
     max_memory_restart: '512M',
-    log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
     merge_logs: true,
   }]
 };

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { HealthModule } from './modules/health/health.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { ProductsModule } from './modules/products/products.module';
@@ -37,6 +37,8 @@ import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.guard';
 import { AuthConfigModule } from './config/auth-config.module';
+import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { ContextualLogger } from './common/logging/contextual-logger.service';
 
 @Module({
   imports: [
@@ -134,6 +136,11 @@ import { AuthConfigModule } from './config/auth-config.module';
       provide: APP_GUARD,
       useClass: RolesGuard,
     },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: LoggingInterceptor,
+    },
+    ContextualLogger,
   ],
 })
 export class AppModule {}

--- a/backend/src/common/interceptors/logging.interceptor.spec.ts
+++ b/backend/src/common/interceptors/logging.interceptor.spec.ts
@@ -1,6 +1,6 @@
 import { LoggingInterceptor } from './logging.interceptor';
 import { ExecutionContext, CallHandler } from '@nestjs/common';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 describe('LoggingInterceptor', () => {
   let interceptor: LoggingInterceptor;
@@ -11,6 +11,7 @@ describe('LoggingInterceptor', () => {
 
   const createMockContext = (
     body: Record<string, unknown>,
+    overrides: Record<string, unknown> = {},
   ): ExecutionContext =>
     ({
       switchToHttp: () => ({
@@ -18,11 +19,18 @@ describe('LoggingInterceptor', () => {
           method: 'POST',
           url: '/api/test',
           body,
+          params: {},
+          query: {},
+          ...overrides,
         }),
+        getResponse: () => ({ statusCode: 201 }),
       }),
       getClass: () => ({}),
       getHandler: () => ({}),
     }) as unknown as ExecutionContext;
+
+  const lastLogPayload = (spy: jest.SpyInstance): string =>
+    JSON.stringify(spy.mock.calls.at(-1)?.[0]);
 
   const mockCallHandler: CallHandler = {
     handle: () => of({ result: 'ok' }),
@@ -41,8 +49,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('secret123'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('secret123');
         done();
       },
     });
@@ -57,8 +65,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Bearer token123'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('Bearer token123');
         done();
       },
     });
@@ -74,8 +82,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('4111111111111111'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('4111111111111111');
         done();
       },
     });
@@ -90,8 +98,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('nested-secret'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('nested-secret');
         done();
       },
     });
@@ -100,14 +108,14 @@ describe('LoggingInterceptor', () => {
   it('should pass through normal fields unchanged', (done) => {
     const logSpy = jest.spyOn(interceptor['logger'], 'log');
     const context = createMockContext({
-      name: 'John',
+      productName: 'John',
       quantity: 2,
     });
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('John'));
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('2'));
+        expect(lastLogPayload(logSpy)).toContain('John');
+        expect(lastLogPayload(logSpy)).toContain('2');
         done();
       },
     });
@@ -132,8 +140,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('4111111111111111'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('4111111111111111');
         done();
       },
     });
@@ -148,8 +156,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('987654321'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('987654321');
         done();
       },
     });
@@ -163,8 +171,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('111-222-333'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('111-222-333');
         done();
       },
     });
@@ -178,8 +186,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('5500005555555559'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('5500005555555559');
         done();
       },
     });
@@ -193,10 +201,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(
-          expect.stringContaining('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'),
-        );
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
         done();
       },
     });
@@ -210,9 +216,56 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(
-          expect.stringContaining('my-client-secret-value'),
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('my-client-secret-value');
+        done();
+      },
+    });
+  });
+
+  it('should include request ids, member id, status, and duration for easier PM2 tracing', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext(
+      { orderId: 'ORD-1', transactionId: 'TX-1', productName: 'tea' },
+      { user: { id: 42, role: 'user' }, query: { paymentKey: 'PAY-1' } },
+    );
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+          event: 'http_request',
+          outcome: 'completed',
+          method: 'POST',
+          path: '/api/test',
+          statusCode: 201,
+          ids: expect.objectContaining({
+            orderId: 'ORD-1',
+            transactionId: 'TX-1',
+            paymentKey: 'PAY-1',
+          }),
+          durationMs: expect.any(Number),
+        }));
+        done();
+      },
+    });
+  });
+
+  it('should log failed requests with an error summary', (done) => {
+    const errorSpy = jest.spyOn(interceptor['logger'], 'error').mockImplementation();
+    const context = createMockContext({ orderId: 'ORD-2' });
+    const failingHandler: CallHandler = {
+      handle: () => throwError(() => new Error('boom')),
+    };
+
+    interceptor.intercept(context, failingHandler).subscribe({
+      error: () => {
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: 'http_request',
+            outcome: 'failed',
+            error: { name: 'Error', message: 'boom' },
+          }),
+          expect.any(String),
         );
         done();
       },
@@ -227,8 +280,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('900101-1234567'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('900101-1234567');
         done();
       },
     });
@@ -242,8 +295,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('010-1234-5678'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('010-1234-5678');
         done();
       },
     });
@@ -257,10 +310,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(
-          expect.stringContaining('서울특별시 강남구 테헤란로 123'),
-        );
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('서울특별시 강남구 테헤란로 123');
         done();
       },
     });
@@ -274,8 +325,8 @@ describe('LoggingInterceptor', () => {
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
-        expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('user@example.com'));
+        expect(lastLogPayload(logSpy)).toContain('[REDACTED]');
+        expect(lastLogPayload(logSpy)).not.toContain('user@example.com');
         done();
       },
     });

--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -5,26 +5,29 @@ import {
   ExecutionContext,
   CallHandler,
 } from '@nestjs/common';
-import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { Observable, throwError } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { redactSensitiveFields } from '../utils/redaction.util';
+import { updateRequestLogContext } from '../logging/request-context';
 
-const SENSITIVE_FIELDS = [
-  'password',
-  'token',
-  'authorization',
-  'credit_card',
-  'cvv',
-  'cardnumber',
-  'accountnumber',
-  'bankaccount',
-  'cardno',
-  'refreshtoken',
-  'secret',
-  'ssn',
-  'phone',
-  'address',
-  'email',
-];
+const MAX_BODY_LOG_LENGTH = 4000;
+
+type RequestForLogging = {
+  method: string;
+  originalUrl?: string;
+  url: string;
+  body?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+  ip?: string;
+  socket?: { remoteAddress?: string };
+  headers?: Record<string, string | string[] | undefined>;
+  user?: { id?: number | string; role?: string };
+};
+
+type ResponseForLogging = {
+  statusCode?: number;
+};
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
@@ -34,34 +37,114 @@ export class LoggingInterceptor implements NestInterceptor {
     context: ExecutionContext,
     next: CallHandler,
   ): Observable<unknown> {
-    const req = context.switchToHttp().getRequest<{
-      method: string;
-      url: string;
-      body: Record<string, unknown>;
-    }>();
-    const { method, url, body } = req;
-    const sanitizedBody = this.sanitize(body);
+    const req = context.switchToHttp().getRequest<RequestForLogging>();
+    const res = context.switchToHttp().getResponse<ResponseForLogging>();
     const start = Date.now();
+
+    this.attachUserContext(req);
 
     return next.handle().pipe(
       tap(() => {
-        this.logger.log(
-          `${method} ${url} ${Date.now() - start}ms body=${JSON.stringify(sanitizedBody)}`,
+        this.logger.log(this.buildPayload(req, res, start, 'completed'));
+      }),
+      catchError((error: unknown) => {
+        this.logger.error(
+          this.buildPayload(req, res, start, 'failed', error),
+          error instanceof Error ? error.stack : undefined,
         );
+        return throwError(() => error);
       }),
     );
   }
 
-  private sanitize(
-    obj: Record<string, unknown>,
+  private attachUserContext(req: RequestForLogging): void {
+    const userId = req.user?.id ?? null;
+    updateRequestLogContext({
+      userId,
+      memberId: userId,
+      role: req.user?.role ?? null,
+    });
+  }
+
+  private buildPayload(
+    req: RequestForLogging,
+    res: ResponseForLogging,
+    start: number,
+    event: 'completed' | 'failed',
+    error?: unknown,
   ): Record<string, unknown> {
-    if (!obj || typeof obj !== 'object') return obj;
+    return {
+      event: 'http_request',
+      outcome: event,
+      method: req.method,
+      path: req.originalUrl || req.url,
+      statusCode: this.statusCodeOf(res, error),
+      durationMs: Date.now() - start,
+      ip: req.ip ?? req.socket?.remoteAddress ?? null,
+      ids: this.extractUsefulIds(req),
+      body: this.sanitizeAndTruncate(req.body),
+      ...(error ? { error: this.errorSummary(error) } : {}),
+    };
+  }
+
+  private statusCodeOf(res: ResponseForLogging, error?: unknown): number | undefined {
+    if (res.statusCode) return res.statusCode;
+    if (error && typeof error === 'object' && 'status' in error) {
+      const status = (error as { status?: unknown }).status;
+      return typeof status === 'number' ? status : undefined;
+    }
+    return undefined;
+  }
+
+  private extractUsefulIds(req: RequestForLogging): Record<string, unknown> {
+    const source = {
+      ...(req.params ?? {}),
+      ...(req.query ?? {}),
+      ...(req.body ?? {}),
+    };
+    const keys = [
+      'id',
+      'userId',
+      'memberId',
+      'orderId',
+      'orderNo',
+      'paymentId',
+      'paymentKey',
+      'transactionId',
+      'transaction_id',
+      'refundId',
+      'productId',
+      'cartItemId',
+    ];
+
     return Object.fromEntries(
-      Object.entries(obj).map(([k, v]) =>
-        SENSITIVE_FIELDS.some((f) => k.toLowerCase().includes(f))
-          ? [k, '[REDACTED]']
-          : [k, typeof v === 'object' && v !== null ? this.sanitize(v as Record<string, unknown>) : v],
-      ),
+      keys
+        .filter((key) => source[key] !== undefined && source[key] !== null && source[key] !== '')
+        .map((key) => [key, source[key]]),
     );
+  }
+
+  private sanitizeAndTruncate(body: Record<string, unknown> | undefined): unknown {
+    const sanitized = redactSensitiveFields(body);
+    if (!sanitized) return null;
+
+    const serialized = JSON.stringify(sanitized);
+    if (serialized.length <= MAX_BODY_LOG_LENGTH) return sanitized;
+
+    return {
+      truncated: true,
+      length: serialized.length,
+      preview: serialized.slice(0, MAX_BODY_LOG_LENGTH),
+    };
+  }
+
+  private errorSummary(error: unknown): Record<string, unknown> {
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+      };
+    }
+    return { message: String(error) };
   }
 }

--- a/backend/src/common/logging/contextual-logger.service.spec.ts
+++ b/backend/src/common/logging/contextual-logger.service.spec.ts
@@ -1,0 +1,59 @@
+import { ContextualLogger } from './contextual-logger.service';
+import { runWithRequestContext } from './request-context';
+
+describe('ContextualLogger', () => {
+  let logger: ContextualLogger;
+  let stdoutSpy: jest.SpyInstance;
+  let stderrSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logger = new ContextualLogger();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('writes structured JSON with transaction and member context', () => {
+    runWithRequestContext(
+      {
+        txId: 'tx-123',
+        method: 'POST',
+        path: '/api/orders',
+        ip: '127.0.0.1',
+        userAgent: 'jest',
+        userId: 42,
+        memberId: 42,
+        role: 'user',
+      },
+      () => logger.log({ event: 'checkout', orderId: 'ORD-1' }, 'OrdersService'),
+    );
+
+    const raw = String(stdoutSpy.mock.calls[0][0]).trim();
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(parsed).toEqual(expect.objectContaining({
+      level: 'log',
+      service: 'commerce',
+      context: 'OrdersService',
+      txId: 'tx-123',
+      transactionId: 'tx-123',
+      userId: 42,
+      memberId: 42,
+      event: 'checkout',
+      orderId: 'ORD-1',
+    }));
+  });
+
+  it('redacts sensitive fields from object messages', () => {
+    logger.log({ password: 'secret', visible: 'ok' });
+
+    const parsed = JSON.parse(String(stdoutSpy.mock.calls[0][0]).trim()) as Record<string, unknown>;
+
+    expect(parsed.password).toBe('[REDACTED]');
+    expect(parsed.visible).toBe('ok');
+  });
+});

--- a/backend/src/common/logging/contextual-logger.service.ts
+++ b/backend/src/common/logging/contextual-logger.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, LoggerService } from '@nestjs/common';
+import { getRequestLogContext } from './request-context';
+import { redactSensitiveFields } from '../utils/redaction.util';
+
+type LogLevel = 'log' | 'error' | 'warn' | 'debug' | 'verbose' | 'fatal';
+
+type LogPayload = Record<string, unknown>;
+
+function normalizeMessage(message: unknown): LogPayload {
+  if (message && typeof message === 'object') {
+    return redactSensitiveFields(message as Record<string, unknown>) ?? { msg: String(message) };
+  }
+  return { msg: String(message) };
+}
+
+function normalizeContext(optionalParams: unknown[]): { context?: string; meta?: unknown[] } {
+  if (optionalParams.length === 0) return {};
+  const last = optionalParams[optionalParams.length - 1];
+  if (typeof last === 'string') {
+    const meta = optionalParams.slice(0, -1);
+    return { context: last, ...(meta.length ? { meta } : {}) };
+  }
+  return { meta: optionalParams };
+}
+
+function writeLine(level: LogLevel, line: string): void {
+  const stream = level === 'error' || level === 'fatal' ? process.stderr : process.stdout;
+  stream.write(`${line}\n`);
+}
+
+@Injectable()
+export class ContextualLogger implements LoggerService {
+  log(message: unknown, ...optionalParams: unknown[]): void {
+    this.write('log', message, optionalParams);
+  }
+
+  error(message: unknown, ...optionalParams: unknown[]): void {
+    const [first, ...rest] = optionalParams;
+    const stack = typeof first === 'string' && first.includes('\n') ? first : undefined;
+    this.write('error', message, stack ? rest : optionalParams, stack);
+  }
+
+  warn(message: unknown, ...optionalParams: unknown[]): void {
+    this.write('warn', message, optionalParams);
+  }
+
+  debug(message: unknown, ...optionalParams: unknown[]): void {
+    this.write('debug', message, optionalParams);
+  }
+
+  verbose(message: unknown, ...optionalParams: unknown[]): void {
+    this.write('verbose', message, optionalParams);
+  }
+
+  fatal(message: unknown, ...optionalParams: unknown[]): void {
+    this.write('fatal', message, optionalParams);
+  }
+
+  private write(level: LogLevel, message: unknown, optionalParams: unknown[], stack?: string): void {
+    const request = getRequestLogContext();
+    const { context, meta } = normalizeContext(optionalParams);
+    const payload = normalizeMessage(message);
+
+    const line = JSON.stringify({
+      ts: new Date().toISOString(),
+      level,
+      service: 'commerce',
+      pid: process.pid,
+      ...(context ? { context } : {}),
+      ...(request
+        ? {
+            txId: request.txId,
+            transactionId: request.txId,
+            method: request.method,
+            path: request.path,
+            ip: request.ip,
+            userAgent: request.userAgent,
+            userId: request.userId ?? null,
+            memberId: request.memberId ?? request.userId ?? null,
+            role: request.role ?? null,
+          }
+        : {}),
+      ...payload,
+      ...(stack ? { stack } : {}),
+      ...(meta ? { meta: redactSensitiveFields({ values: meta })?.values } : {}),
+    });
+
+    writeLine(level, line);
+  }
+}

--- a/backend/src/common/logging/request-context.middleware.ts
+++ b/backend/src/common/logging/request-context.middleware.ts
@@ -1,0 +1,33 @@
+import { randomUUID } from 'crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { runWithRequestContext } from './request-context';
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function cleanHeaderId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length <= 128 ? trimmed : undefined;
+}
+
+export function requestContextMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const txId =
+    cleanHeaderId(firstHeaderValue(req.headers['x-request-id'])) ??
+    cleanHeaderId(firstHeaderValue(req.headers['x-correlation-id'])) ??
+    randomUUID();
+
+  res.setHeader('x-request-id', txId);
+
+  runWithRequestContext(
+    {
+      txId,
+      method: req.method,
+      path: req.originalUrl || req.url,
+      ip: req.ip ?? req.socket?.remoteAddress ?? null,
+      userAgent: firstHeaderValue(req.headers['user-agent']) ?? null,
+    },
+    next,
+  );
+}

--- a/backend/src/common/logging/request-context.ts
+++ b/backend/src/common/logging/request-context.ts
@@ -1,0 +1,28 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+export interface RequestLogContext {
+  txId: string;
+  method?: string;
+  path?: string;
+  ip?: string | null;
+  userAgent?: string | null;
+  userId?: number | string | null;
+  memberId?: number | string | null;
+  role?: string | null;
+}
+
+const requestContextStorage = new AsyncLocalStorage<RequestLogContext>();
+
+export function runWithRequestContext<T>(context: RequestLogContext, callback: () => T): T {
+  return requestContextStorage.run(context, callback);
+}
+
+export function getRequestLogContext(): RequestLogContext | undefined {
+  return requestContextStorage.getStore();
+}
+
+export function updateRequestLogContext(patch: Partial<RequestLogContext>): void {
+  const context = requestContextStorage.getStore();
+  if (!context) return;
+  Object.assign(context, patch);
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -14,12 +14,15 @@ import { assertEnv } from './config/env-validator';
 import { resolveTrustProxy } from './config/trust-proxy';
 import { SentryExceptionFilter } from './common/filters/sentry-exception.filter';
 import { redactSensitiveFields } from './common/utils/redaction.util';
+import { ContextualLogger } from './common/logging/contextual-logger.service';
+import { requestContextMiddleware } from './common/logging/request-context.middleware';
 
 // 프로덕션 환경에서 필수 env 키 사전 검증 — 누락 시 명확한 에러 메시지와 함께 종료
 assertEnv();
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  app.useLogger(app.get(ContextualLogger));
   const logger = new Logger('Bootstrap');
   app.enableShutdownHooks();
 
@@ -55,6 +58,7 @@ async function bootstrap() {
     return value;
   });
 
+  app.use(requestContextMiddleware);
   app.use(helmet());
   app.use(cookieParser());
   app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));

--- a/src/app/[locale]/admin/logs/page.tsx
+++ b/src/app/[locale]/admin/logs/page.tsx
@@ -5,6 +5,7 @@ import { RefreshCw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { adminLogsApi, type AdminLogResponse, type AdminLogType } from '@/lib/api';
+import { parseAdminLogContent, type ParsedAdminLogEntry } from '@/lib/admin-log-format';
 import { useAdminGuard } from '@/components/shared/hooks/useAdminGuard';
 import { useAsyncAction } from '@/components/shared/hooks/useAsyncAction';
 import { handleApiError } from '@/utils/error';
@@ -46,6 +47,7 @@ export default function AdminLogsPage() {
     void fetchLogs();
   }, [fetchLogs, isAdmin, type, lines, user?.role]);
 
+  const parsedEntries = useMemo(() => parseAdminLogContent(data?.content ?? ''), [data?.content]);
   const logContent = useMemo(() => data?.content || t('empty'), [data?.content, t]);
 
   if (isAdmin && user?.role !== 'super_admin') {
@@ -150,10 +152,90 @@ export default function AdminLogsPage() {
             {data?.truncated && <span>{t('truncated')}</span>}
           </div>
         </div>
-        <pre className="h-96 overflow-auto whitespace-pre-wrap bg-foreground p-4 font-mono typo-label leading-relaxed text-background">
-          {isLoading && !data ? t('loading') : logContent}
-        </pre>
+        {isLoading && !data ? (
+          <div className="h-96 bg-foreground p-4 font-mono typo-label text-background">
+            {t('loading')}
+          </div>
+        ) : (
+          <div className="max-h-[36rem] overflow-auto bg-muted/20 p-4">
+            <div className="mb-3 typo-label font-medium text-muted-foreground">{t('structuredView')}</div>
+            {parsedEntries.length > 0 ? (
+              <div className="space-y-3">
+                {parsedEntries.map((entry) => (
+                  <LogEntryCard key={`${entry.lineNumber}-${entry.raw.slice(0, 24)}`} entry={entry} />
+                ))}
+              </div>
+            ) : (
+              <pre className="whitespace-pre-wrap rounded-md bg-foreground p-4 font-mono typo-label leading-relaxed text-background">
+                {logContent}
+              </pre>
+            )}
+          </div>
+        )}
       </section>
     </div>
+  );
+}
+
+function levelClassName(level: string | undefined): string {
+  switch (level) {
+    case 'error':
+    case 'fatal':
+      return 'border-destructive/40 bg-destructive/5 text-destructive';
+    case 'warn':
+      return 'border-amber-300 bg-amber-50 text-amber-700';
+    default:
+      return 'border-border bg-background text-foreground';
+  }
+}
+
+function LogEntryCard({ entry }: { entry: ParsedAdminLogEntry }) {
+  const t = useTranslations('admin.logs');
+
+  if (!entry.parsed) {
+    return (
+      <article className="rounded-md border bg-background p-3">
+        <div className="mb-2 flex items-center gap-2 typo-label text-muted-foreground">
+          <span>{t('entry.lineNumber', { number: entry.lineNumber })}</span>
+          <span>{t('entry.raw')}</span>
+        </div>
+        <pre className="whitespace-pre-wrap break-words font-mono typo-label text-foreground">{entry.raw}</pre>
+      </article>
+    );
+  }
+
+  return (
+    <article className={cn('rounded-md border p-3', levelClassName(entry.level))}>
+      <div className="mb-3 flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded bg-foreground px-2 py-1 typo-label text-background">
+            {t('entry.lineNumber', { number: entry.lineNumber })}
+          </span>
+          {entry.level && <span className="rounded border px-2 py-1 typo-label uppercase">{entry.level}</span>}
+          <span className="typo-body-sm font-medium">{entry.summary}</span>
+        </div>
+        {entry.timestamp && <time className="typo-label text-muted-foreground">{entry.timestamp}</time>}
+      </div>
+
+      <dl className="grid gap-2">
+        {entry.fields.map((field) => (
+          <div
+            key={`${entry.lineNumber}-${field.key}`}
+            className="grid gap-1 rounded border bg-background/80 p-2 md:grid-cols-[4rem_10rem_minmax(0,1fr)] md:items-start"
+          >
+            <dt className="typo-label text-muted-foreground">
+              {t('entry.order', { number: field.order })}
+            </dt>
+            <dd className="typo-label font-semibold text-foreground">
+              {t(`fields.${field.labelKey}`)}
+              {field.labelKey === 'extra' && <span className="ml-1 text-muted-foreground">({field.key})</span>}
+            </dd>
+            <dd className="min-w-0 whitespace-pre-wrap break-words font-mono typo-label text-foreground">
+              {field.formattedValue}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </article>
   );
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1356,7 +1356,40 @@
         "description": "A problem occurred while rendering the remote log page.",
         "retry": "Try again"
       },
-      "superAdminOnly": "Remote logs are available to super admins only."
+      "superAdminOnly": "Remote logs are available to super admins only.",
+      "structuredView": "Structured view",
+      "entry": {
+        "lineNumber": "#{number}",
+        "order": "{number}",
+        "raw": "Raw"
+      },
+      "fields": {
+        "timestamp": "Time",
+        "level": "Level",
+        "service": "Service",
+        "context": "Logger context",
+        "txId": "Transaction ID",
+        "transactionId": "Transaction ID (alias)",
+        "userId": "User ID",
+        "memberId": "Member ID",
+        "role": "Role",
+        "method": "HTTP method",
+        "path": "Request path",
+        "statusCode": "Status code",
+        "durationMs": "Duration (ms)",
+        "event": "Event",
+        "outcome": "Outcome",
+        "ids": "Related IDs",
+        "message": "Message",
+        "error": "Error",
+        "body": "Request body",
+        "stack": "Stack",
+        "pid": "Process ID",
+        "ip": "IP",
+        "userAgent": "User-Agent",
+        "meta": "Meta",
+        "extra": "Extra field"
+      }
     }
   },
   "search": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1356,7 +1356,40 @@
         "description": "원격 로그 화면을 표시하는 중 문제가 발생했습니다.",
         "retry": "다시 시도"
       },
-      "superAdminOnly": "원격 로그는 슈퍼 관리자만 조회할 수 있습니다."
+      "superAdminOnly": "원격 로그는 슈퍼 관리자만 조회할 수 있습니다.",
+      "structuredView": "구조화 보기",
+      "entry": {
+        "lineNumber": "#{number}",
+        "order": "{number}번째",
+        "raw": "원문"
+      },
+      "fields": {
+        "timestamp": "시간",
+        "level": "레벨",
+        "service": "서비스",
+        "context": "로그 위치",
+        "txId": "트랜잭션 ID",
+        "transactionId": "트랜잭션 ID(별칭)",
+        "userId": "회원 ID",
+        "memberId": "회원 ID(표시)",
+        "role": "권한",
+        "method": "HTTP 메서드",
+        "path": "요청 경로",
+        "statusCode": "상태 코드",
+        "durationMs": "처리 시간(ms)",
+        "event": "이벤트",
+        "outcome": "결과",
+        "ids": "관련 ID",
+        "message": "메시지",
+        "error": "에러",
+        "body": "요청 본문",
+        "stack": "스택",
+        "pid": "프로세스 ID",
+        "ip": "IP",
+        "userAgent": "User-Agent",
+        "meta": "메타",
+        "extra": "추가 필드"
+      }
     }
   },
   "search": {

--- a/src/lib/__tests__/admin-log-format.test.ts
+++ b/src/lib/__tests__/admin-log-format.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { parseAdminLogContent, parseAdminLogLine } from '../admin-log-format';
+
+describe('admin log formatter', () => {
+  it('parses structured JSON logs in the display order used by the admin UI', () => {
+    const entry = parseAdminLogLine(JSON.stringify({
+      body: { orderId: 'ORD-1' },
+      txId: 'tx-1',
+      level: 'log',
+      ts: '2026-07-07T05:03:19.700Z',
+      context: 'LoggingInterceptor',
+      memberId: 42,
+      method: 'POST',
+      path: '/api/orders',
+      statusCode: 201,
+      durationMs: 13,
+      event: 'http_request',
+      ids: { orderId: 'ORD-1' },
+    }), 1);
+
+    expect(entry.parsed).toBe(true);
+    expect(entry.fields.map((field) => field.key)).toEqual([
+      'ts',
+      'level',
+      'context',
+      'txId',
+      'memberId',
+      'method',
+      'path',
+      'statusCode',
+      'durationMs',
+      'event',
+      'ids',
+      'body',
+    ]);
+    expect(entry.fields[0].order).toBe(1);
+    expect(entry.summary).toContain('POST /api/orders');
+  });
+
+  it('keeps legacy non-json log lines readable', () => {
+    const entry = parseAdminLogLine('[Nest] WARN legacy log', 7);
+
+    expect(entry).toMatchObject({
+      lineNumber: 7,
+      parsed: false,
+      summary: '[Nest] WARN legacy log',
+      raw: '[Nest] WARN legacy log',
+    });
+  });
+
+  it('parses JSON after a PM2-style prefix', () => {
+    const [entry] = parseAdminLogContent('0|commerce | {"level":"error","msg":"boom"}');
+
+    expect(entry.parsed).toBe(true);
+    expect(entry.fields.map((field) => field.key)).toEqual(['level', 'msg']);
+  });
+});

--- a/src/lib/admin-log-format.ts
+++ b/src/lib/admin-log-format.ts
@@ -1,0 +1,174 @@
+const ORDERED_FIELD_KEYS = [
+  'ts',
+  'level',
+  'service',
+  'context',
+  'txId',
+  'transactionId',
+  'userId',
+  'memberId',
+  'role',
+  'method',
+  'path',
+  'statusCode',
+  'durationMs',
+  'event',
+  'outcome',
+  'ids',
+  'msg',
+  'error',
+  'body',
+  'stack',
+  'pid',
+  'ip',
+  'userAgent',
+  'meta',
+] as const;
+
+const FIELD_LABEL_KEYS: Record<string, string> = {
+  ts: 'timestamp',
+  level: 'level',
+  service: 'service',
+  context: 'context',
+  txId: 'txId',
+  transactionId: 'transactionId',
+  userId: 'userId',
+  memberId: 'memberId',
+  role: 'role',
+  method: 'method',
+  path: 'path',
+  statusCode: 'statusCode',
+  durationMs: 'durationMs',
+  event: 'event',
+  outcome: 'outcome',
+  ids: 'ids',
+  msg: 'message',
+  error: 'error',
+  body: 'body',
+  stack: 'stack',
+  pid: 'pid',
+  ip: 'ip',
+  userAgent: 'userAgent',
+  meta: 'meta',
+};
+
+export interface ParsedAdminLogField {
+  key: string;
+  labelKey: string;
+  order: number;
+  value: unknown;
+  formattedValue: string;
+}
+
+export interface ParsedAdminLogEntry {
+  lineNumber: number;
+  raw: string;
+  parsed: boolean;
+  fields: ParsedAdminLogField[];
+  summary: string;
+  level?: string;
+  timestamp?: string;
+}
+
+function extractJsonCandidate(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) return trimmed;
+
+  const jsonStart = trimmed.indexOf('{');
+  if (jsonStart < 0) return null;
+
+  const candidate = trimmed.slice(jsonStart);
+  return candidate.endsWith('}') ? candidate : null;
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '-';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value, null, 2);
+}
+
+function buildSummary(record: Record<string, unknown>): string {
+  const parts = [
+    record.level,
+    record.context,
+    record.method && record.path ? `${record.method} ${record.path}` : record.msg,
+    record.statusCode ? `status=${record.statusCode}` : null,
+    record.durationMs !== undefined ? `${record.durationMs}ms` : null,
+  ].filter(Boolean);
+
+  return parts.map(String).join(' · ') || '-';
+}
+
+export function parseAdminLogContent(content: string): ParsedAdminLogEntry[] {
+  return content
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line, index) => parseAdminLogLine(line, index + 1));
+}
+
+export function parseAdminLogLine(line: string, lineNumber: number): ParsedAdminLogEntry {
+  const jsonCandidate = extractJsonCandidate(line);
+  if (!jsonCandidate) {
+    return {
+      lineNumber,
+      raw: line,
+      parsed: false,
+      fields: [],
+      summary: line,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(jsonCandidate) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('log line is not an object');
+    }
+
+    const record = parsed as Record<string, unknown>;
+    const seen = new Set<string>();
+    const fields: ParsedAdminLogField[] = [];
+
+    for (const key of ORDERED_FIELD_KEYS) {
+      if (!(key in record)) continue;
+      seen.add(key);
+      fields.push({
+        key,
+        labelKey: FIELD_LABEL_KEYS[key] ?? 'extra',
+        order: fields.length + 1,
+        value: record[key],
+        formattedValue: formatValue(record[key]),
+      });
+    }
+
+    for (const [key, value] of Object.entries(record)) {
+      if (seen.has(key)) continue;
+      fields.push({
+        key,
+        labelKey: 'extra',
+        order: fields.length + 1,
+        value,
+        formattedValue: formatValue(value),
+      });
+    }
+
+    return {
+      lineNumber,
+      raw: line,
+      parsed: true,
+      fields,
+      summary: buildSummary(record),
+      level: typeof record.level === 'string' ? record.level : undefined,
+      timestamp: typeof record.ts === 'string' ? record.ts : undefined,
+    };
+  } catch {
+    return {
+      lineNumber,
+      raw: line,
+      parsed: false,
+      fields: [],
+      summary: line,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Emit structured JSON logs for the commerce backend, including request transaction IDs, member/user IDs, roles, HTTP metadata, status, duration, useful order/payment IDs, and sanitized request bodies.
- Add request context propagation so logs written inside a request can be correlated by `txId` / `transactionId`.
- Update the admin remote log page to parse JSON log lines and render each field in a labelled, ordered layout while preserving legacy raw lines.

## Why
PM2 logs were difficult to inspect because important values such as transaction IDs and member IDs were either missing or embedded in raw strings. Operators can now scan logs by field order and understand what each value means.

## Validation
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd backend && npm test -- --runInBand`
- `npm run test:run -- src/lib/__tests__/admin-log-format.test.ts`
- `npm run typecheck`
- `npm run lint`
- `bash scripts/start-local.sh`
