### PR TITLE
결제대기 주문의 사용자 즉시 취소 허용

### DIFF
--- a/backend/src/modules/orders/__tests__/order-service-requests.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/order-service-requests.service.spec.ts
@@ -13,7 +13,7 @@ import {
 import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import type { PaymentsService } from '../../payments/payments.service';
-import { PaymentStatus } from '../../payments/entities/payment.entity';
+import { Payment, PaymentStatus } from '../../payments/entities/payment.entity';
 import { UpdateOrderServiceRequestDto } from '../dto/update-order-service-request.dto';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order => ({
@@ -194,7 +194,79 @@ describe('OrderServiceRequestsService', () => {
     });
 
     expect(paymentsService.cancelPaidOrder).not.toHaveBeenCalled();
-    expect(manager.update).toHaveBeenCalledWith(Order, order.id, { status: OrderStatus.CANCELLED });
+    expect(manager.update).toHaveBeenCalledWith(Order, order.id, expect.objectContaining({
+      status: OrderStatus.CANCELLED,
+      cancelReason: request.reason,
+      cancelledAt: expect.any(Date),
+    }));
+    expect(manager.update).toHaveBeenCalledWith(
+      Payment,
+      { orderId: order.id, status: PaymentStatus.PENDING },
+      expect.objectContaining({ status: PaymentStatus.CANCELLED, cancelReason: request.reason }),
+    );
+  });
+
+  it('pending cancel request is completed immediately by the user without admin approval', async () => {
+    const order = makeOrder({ status: OrderStatus.PENDING, pointsUsed: 0 });
+    const request = makeRequest(order, { id: 77, status: OrderServiceRequestStatus.REQUESTED, reason: '단순 변심' });
+    const completed = makeRequest(order, {
+      id: 77,
+      status: OrderServiceRequestStatus.COMPLETED,
+      reason: '단순 변심',
+      adminNote: '결제대기 주문 사용자 즉시 취소',
+      processedAt: new Date(),
+    });
+    orderRepository.findOne.mockResolvedValue(order);
+    requestRepository.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(completed);
+    requestRepository.create.mockReturnValue(request);
+    manager.save.mockResolvedValue(completed);
+    manager.findOne.mockResolvedValue(order);
+
+    const result = await service.create(order.id, order.userId, {
+      type: OrderServiceRequestType.CANCEL,
+      reason: '단순 변심',
+      useShippingAddress: true,
+    });
+
+    expect(result).toBe(completed);
+    expect(requestRepository.save).not.toHaveBeenCalled();
+    expect(manager.save).toHaveBeenCalledWith(OrderServiceRequest, expect.objectContaining({
+      status: OrderServiceRequestStatus.COMPLETED,
+      adminNote: '결제대기 주문 사용자 즉시 취소',
+      processedAt: expect.any(Date),
+    }));
+    expect(manager.update).toHaveBeenCalledWith(Order, order.id, expect.objectContaining({
+      status: OrderStatus.CANCELLED,
+      cancelReason: '단순 변심',
+      cancelledAt: expect.any(Date),
+    }));
+    expect(manager.update).toHaveBeenCalledWith(
+      Payment,
+      { orderId: order.id, status: PaymentStatus.PENDING },
+      expect.objectContaining({ status: PaymentStatus.CANCELLED, cancelReason: '단순 변심' }),
+    );
+    expect(paymentsService.cancelPaidOrder).not.toHaveBeenCalled();
+  });
+
+
+  it('pending immediate cancellation rechecks pending status inside the transaction', async () => {
+    const order = makeOrder({ status: OrderStatus.PENDING, pointsUsed: 0 });
+    const request = makeRequest(order, { id: 78, status: OrderServiceRequestStatus.REQUESTED, reason: '단순 변심' });
+    orderRepository.findOne.mockResolvedValue(order);
+    requestRepository.findOne.mockResolvedValueOnce(null);
+    requestRepository.create.mockReturnValue(request);
+    manager.findOne.mockResolvedValueOnce(makeOrder({ status: OrderStatus.PAID }));
+
+    await expect(service.create(order.id, order.userId, {
+      type: OrderServiceRequestType.CANCEL,
+      reason: '단순 변심',
+      useShippingAddress: true,
+    })).rejects.toThrow('결제 상태가 변경되었습니다. 새로고침 후 다시 시도해주세요.');
+
+    expect(manager.save).not.toHaveBeenCalled();
+    expect(manager.update).not.toHaveBeenCalledWith(Order, order.id, expect.any(Object));
   });
 
   it('escapes HTML-like recipient names in received request notification email HTML', async () => {

--- a/backend/src/modules/orders/order-service-requests.service.ts
+++ b/backend/src/modules/orders/order-service-requests.service.ts
@@ -18,6 +18,7 @@ import { NotificationDispatchHelper } from '../notification/notification-dispatc
 import { escapeHtml } from '../notification/templates/sanitize';
 import { restoreOrderStock } from './order-stock.util';
 import { PointHistory } from '../coupons/entities/point-history.entity';
+import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
 import { ModuleRef } from '@nestjs/core';
 
 const CANCELLABLE_STATUSES = new Set<OrderStatus>([OrderStatus.PENDING, OrderStatus.PAID]);
@@ -55,9 +56,30 @@ export class OrderServiceRequestsService {
       throw new BadRequestException('이미 처리 중인 신청이 있습니다.');
     }
 
+    const request = this.buildRequest(order, userId, dto);
+
+    if (dto.type === OrderServiceRequestType.CANCEL && order.status === OrderStatus.PENDING) {
+      const saved = await this.createCompletedPendingCancellation(order, request);
+      this.logger.log(`Pending order cancelled by user: requestId=${saved.id}, orderId=${orderId}`);
+      const completed = await this.findOneForUser(Number(saved.id), userId);
+      void this.notifyRequestStatusChanged(completed);
+      return completed;
+    }
+
+    const saved = await this.requestRepository.save(request);
+    this.logger.log(`Order service request created: id=${saved.id}, orderId=${orderId}, type=${dto.type}`);
+    void this.notifyRequestReceived(saved, order);
+    return this.findOneForUser(Number(saved.id), userId);
+  }
+
+  private buildRequest(
+    order: Order,
+    userId: number,
+    dto: CreateOrderServiceRequestDto,
+  ): OrderServiceRequest {
     const useShippingAddress = dto.useShippingAddress ?? true;
-    const request = this.requestRepository.create({
-      orderId,
+    return this.requestRepository.create({
+      orderId: Number(order.id),
       userId,
       type: dto.type,
       reason: dto.reason.trim(),
@@ -70,11 +92,37 @@ export class OrderServiceRequestsService {
       pickupAddress: useShippingAddress ? order.address : dto.pickupAddress ?? null,
       pickupAddressDetail: useShippingAddress ? order.addressDetail : dto.pickupAddressDetail ?? null,
     });
+  }
 
-    const saved = await this.requestRepository.save(request);
-    this.logger.log(`Order service request created: id=${saved.id}, orderId=${orderId}, type=${dto.type}`);
-    void this.notifyRequestReceived(saved, order);
-    return this.findOneForUser(Number(saved.id), userId);
+  private async createCompletedPendingCancellation(
+    order: Order,
+    request: OrderServiceRequest,
+  ): Promise<OrderServiceRequest> {
+    return this.dataSource.transaction(async (manager) => {
+      const lockedOrder = await manager.findOne(Order, {
+        where: { id: order.id },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!lockedOrder) throw new BadRequestException('주문을 찾을 수 없습니다.');
+      if (lockedOrder.status !== OrderStatus.PENDING) {
+        throw new BadRequestException('결제 상태가 변경되었습니다. 새로고침 후 다시 시도해주세요.');
+      }
+
+      const processedAt = new Date();
+      const saved = await manager.save(OrderServiceRequest, {
+        ...request,
+        status: OrderServiceRequestStatus.COMPLETED,
+        adminNote: '결제대기 주문 사용자 즉시 취소',
+        processedAt,
+      });
+
+      await this.applyCompletedRequest(manager, {
+        ...saved,
+        order: lockedOrder,
+      } as OrderServiceRequest);
+
+      return saved;
+    });
   }
 
   async findByOrderForUser(orderId: number, userId: number): Promise<OrderServiceRequest[]> {
@@ -197,7 +245,17 @@ export class OrderServiceRequestsService {
         return;
       }
 
-      await manager.update(Order, order.id, { status: OrderStatus.CANCELLED });
+      const cancelledAt = new Date();
+      await manager.update(Order, order.id, {
+        status: OrderStatus.CANCELLED,
+        cancelReason: request.reason,
+        cancelledAt,
+      });
+      await manager.update(
+        Payment,
+        { orderId: Number(order.id), status: PaymentStatus.PENDING },
+        { status: PaymentStatus.CANCELLED, cancelReason: request.reason, cancelledAt },
+      );
       await restoreOrderStock(manager, Number(order.id));
       await this.restorePoints(manager, order);
       return;

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -5,6 +5,7 @@ import { OrderServiceRequest } from './entities/order-service-request.entity';
 import { OrderItem } from './entities/order-item.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { PolicyConsent } from '../pages/entities/policy-consent.entity';
+import { Payment } from '../payments/entities/payment.entity';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 import { AdminOrderServiceRequestsController, OrderServiceRequestsController } from './order-service-requests.controller';
@@ -16,7 +17,7 @@ import { OrderServiceRequestsService } from './order-service-requests.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Order, OrderItem, OrderServiceRequest, PointHistory, PolicyConsent]),
+    TypeOrmModule.forFeature([Order, OrderItem, OrderServiceRequest, PointHistory, PolicyConsent, Payment]),
     PointsModule,
     CouponsModule,
     ShippingModule,

--- a/src/app/[locale]/my/orders/[id]/page.tsx
+++ b/src/app/[locale]/my/orders/[id]/page.tsx
@@ -116,6 +116,7 @@ export default function OrderDetailPage() {
   const isPaymentPending = order.status === 'pending';
   const shouldShowShippingTracking = !['pending', 'cancelled', 'refunded'].includes(order.status);
   const payableAmount = Number(order.totalAmount);
+  const isImmediatePendingCancel = order.status === 'pending' && requestType === 'cancel';
   const canCancel = ['pending', 'paid'].includes(order.status);
   const canAfterDeliveryRequest = ['delivered', 'completed'].includes(order.status);
   const requestTypeLabels: Record<OrderServiceRequestType, string> = {
@@ -149,7 +150,9 @@ export default function OrderDetailPage() {
         detail: requestDetail.trim() || undefined,
         useShippingAddress: true,
       });
-      toast.success(t('serviceRequests.submitSuccess'));
+      toast.success(
+        isImmediatePendingCancel ? t('serviceRequests.immediateCancelSuccess') : t('serviceRequests.submitSuccess'),
+      );
       setRequestReason('');
       setRequestDetail('');
       const requests = await ordersApi.getServiceRequests(order.id);
@@ -347,7 +350,13 @@ export default function OrderDetailPage() {
         <section className="surface-card p-6">
           <h2 className="mb-4 text-base font-semibold">{t('serviceRequests.title')}</h2>
           <p className="mb-4 text-sm text-muted-foreground">
-            {canCancel ? t('serviceRequests.cancelGuide') : canAfterDeliveryRequest ? t('serviceRequests.afterDeliveryGuide') : t('serviceRequests.unavailableGuide')}
+            {order.status === 'pending'
+              ? t('serviceRequests.pendingCancelGuide')
+              : canCancel
+                ? t('serviceRequests.cancelGuide')
+                : canAfterDeliveryRequest
+                  ? t('serviceRequests.afterDeliveryGuide')
+                  : t('serviceRequests.unavailableGuide')}
           </p>
 
           {(canCancel || canAfterDeliveryRequest) && (
@@ -388,7 +397,7 @@ export default function OrderDetailPage() {
                 />
               </label>
               <Button type="button" onClick={submitServiceRequest}>
-                {t('serviceRequests.submit')}
+                {isImmediatePendingCancel ? t('serviceRequests.immediateCancelSubmit') : t('serviceRequests.submit')}
               </Button>
             </div>
           )}

--- a/src/components/__tests__/OrderDetailPage.test.tsx
+++ b/src/components/__tests__/OrderDetailPage.test.tsx
@@ -30,6 +30,30 @@ function makeTranslator(namespace?: string) {
     taxReceiptGuideDescription: '현금영수증 또는 세금계산서가 필요하시면 주문번호를 포함해 고객센터로 요청해 주세요.',
     taxReceiptPersonal: '개인소득공제와 사업자지출증빙은 결제수단 정책에 따라 처리 범위가 달라질 수 있습니다.',
     taxInvoiceBusiness: '세금계산서는 사업자등록번호와 담당자 연락처를 함께 전달해 주세요.',
+    'serviceRequests.title': '취소/교환/반품/환불 신청',
+    'serviceRequests.pendingCancelGuide': '결제대기 상태에서는 관리자 승인 없이 바로 주문을 취소할 수 있습니다.',
+    'serviceRequests.cancelGuide': '결제대기/결제완료 상태에서는 주문 취소를 신청할 수 있습니다.',
+    'serviceRequests.afterDeliveryGuide': '배송 완료 후 반품/교환/환불 신청을 접수할 수 있습니다.',
+    'serviceRequests.unavailableGuide': '현재 주문 상태에서는 온라인 신청이 제한됩니다.',
+    'serviceRequests.typeLabel': '신청 유형',
+    'serviceRequests.reasonLabel': '사유',
+    'serviceRequests.reasonPlaceholder': '취소 사유를 입력하세요.',
+    'serviceRequests.detailLabel': '상세 내용',
+    'serviceRequests.detailPlaceholder': '상세 내용을 입력하세요.',
+    'serviceRequests.submit': '신청 접수',
+    'serviceRequests.immediateCancelSubmit': '주문 바로 취소',
+    'serviceRequests.submitSuccess': '신청이 접수되었습니다.',
+    'serviceRequests.immediateCancelSuccess': '주문이 취소되었습니다.',
+    'serviceRequests.submitError': '신청에 실패했습니다.',
+    'serviceRequests.reasonRequired': '사유를 입력해주세요.',
+    'serviceRequests.types.cancel': '주문 취소',
+    'serviceRequests.types.return': '반품',
+    'serviceRequests.types.exchange': '교환',
+    'serviceRequests.types.refund': '환불',
+    'serviceRequests.status.requested': '접수',
+    'serviceRequests.status.approved': '승인',
+    'serviceRequests.status.rejected': '반려',
+    'serviceRequests.status.completed': '처리 완료',
     paypalPayment: 'PayPal',
     naverpayPayment: '네이버페이',
     bankTransferPayment: '무통장입금',
@@ -113,7 +137,7 @@ vi.mock('@/components/shared/checkout/PaymentGateway', () => ({
 }));
 
 vi.mock('@/lib/api', () => ({
-  ordersApi: { getById: vi.fn() },
+  ordersApi: { getById: vi.fn(), getServiceRequests: vi.fn(), createServiceRequest: vi.fn() },
   paymentsApi: { prepare: vi.fn() },
 }));
 
@@ -140,6 +164,26 @@ describe('OrderDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(ordersApi.getById).mockResolvedValue(pendingOrder);
+    vi.mocked(ordersApi.getServiceRequests).mockResolvedValue([]);
+    vi.mocked(ordersApi.createServiceRequest).mockResolvedValue({
+      id: 1,
+      orderId: 16,
+      userId: 10,
+      type: 'cancel',
+      status: 'completed',
+      reason: '단순 변심',
+      detail: null,
+      imageUrls: null,
+      useShippingAddress: true,
+      pickupName: null,
+      pickupPhone: null,
+      pickupZipcode: null,
+      pickupAddress: null,
+      pickupAddressDetail: null,
+      adminNote: null,
+      processedAt: '2026-07-07T00:00:00.000Z',
+      createdAt: '2026-07-07T00:00:00.000Z',
+    });
   });
 
   it('결제대기 주문에서는 배송 추적을 숨기고 결제 수단 선택을 노출한다', async () => {
@@ -155,6 +199,30 @@ describe('OrderDetailPage', () => {
     expect(screen.getByRole('button', { name: '결제하기' })).toBeInTheDocument();
     expect(screen.getByText('현금영수증/세금계산서 안내')).toBeInTheDocument();
     expect(screen.getByText(/주문번호를 포함해 고객센터로 요청/)).toBeInTheDocument();
+  });
+
+
+  it('결제대기 주문에서 주문 바로 취소 신청을 즉시 완료 API로 접수한다', async () => {
+    const user = userEvent.setup();
+
+    render(<OrderDetailPage />);
+
+    expect(await screen.findByText('ORD-16')).toBeInTheDocument();
+    expect(screen.getByText('결제대기 상태에서는 관리자 승인 없이 바로 주문을 취소할 수 있습니다.')).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText('취소 사유를 입력하세요.'), '단순 변심');
+    await user.click(screen.getByRole('button', { name: '주문 바로 취소' }));
+
+    await waitFor(() => {
+      expect(ordersApi.createServiceRequest).toHaveBeenCalledWith(16, {
+        type: 'cancel',
+        reason: '단순 변심',
+        detail: undefined,
+        useShippingAddress: true,
+      });
+    });
+    expect(ordersApi.getServiceRequests).toHaveBeenCalledWith(16);
+    expect(ordersApi.getById).toHaveBeenCalledTimes(2);
   });
 
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1727,7 +1727,10 @@
         "approved": "Approved",
         "rejected": "Rejected",
         "completed": "Completed"
-      }
+      },
+      "pendingCancelGuide": "Pending orders can be cancelled immediately without admin approval.",
+      "immediateCancelSubmit": "Cancel order now",
+      "immediateCancelSuccess": "Your order has been cancelled."
     }
   },
   "checkoutResult": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1727,7 +1727,10 @@
         "approved": "승인",
         "rejected": "반려",
         "completed": "처리 완료"
-      }
+      },
+      "pendingCancelGuide": "결제대기 상태에서는 관리자 승인 없이 바로 주문을 취소할 수 있습니다.",
+      "immediateCancelSubmit": "주문 바로 취소",
+      "immediateCancelSuccess": "주문이 취소되었습니다."
     }
   },
   "checkoutResult": {


### PR DESCRIPTION
## Summary\n- 결제대기 주문 취소 신청을 생성 즉시 completed 처리하고 주문을 취소합니다.\n- pending payment 레코드를 cancelled로 정리해 이후 결제 승인으로 주문이 되살아나지 않게 했습니다.\n- 마이페이지 주문 상세에 결제대기 즉시 취소 안내/버튼/성공 메시지를 locale 기반으로 추가했습니다.\n\nCloses #1087\n\n## Verification\n- npm run build\n- npm run test:run\n- cd backend && npm run build\n- cd backend && npm run test\n- bash scripts/codex-project-guard.sh\n- bash scripts/start-local.sh\n- curl http://localhost:3000/api/health\n- curl -I http://localhost:5173/ko