### PR TITLE
fix: 사이트맵 상품 수집 제한 수정

### DIFF
--- a/src/app/__tests__/seo.test.ts
+++ b/src/app/__tests__/seo.test.ts
@@ -43,7 +43,7 @@ describe('SEO', () => {
 
   describe('sitemap.ts', () => {
     it('includes static routes', async () => {
-      mockFetchProducts.mockResolvedValue({ items: [], total: 0, page: 1, limit: 1000 });
+      mockFetchProducts.mockResolvedValue({ items: [], total: 0, page: 1, limit: 100 });
       const result = await sitemap();
       const urls = result.map((r) => r.url);
       expect(urls).toContain('https://ockhwadang.com/ko');
@@ -53,35 +53,91 @@ describe('SEO', () => {
     });
 
     it('includes product routes from each locale-specific product list', async () => {
-      mockFetchProducts.mockImplementation(({ locale }: { locale: string }) => Promise.resolve({
-        items: [
-          {
-            id: locale === 'ko' ? 1 : 2,
-            name: 'Test Product',
-            slug: 'test',
-            price: 10000,
-            salePrice: null,
-            shortDescription: null,
-            rating: 0,
-            reviewCount: 0,
-            status: 'active',
-            isFeatured: false,
-            viewCount: 0,
-            category: null,
-            images: [],
-          },
-        ],
-        total: 1,
-        page: 1,
-        limit: 1000,
-      }));
+      mockFetchProducts.mockImplementation(({ locale }: { locale: string }) =>
+        Promise.resolve({
+          items: [
+            {
+              id: locale === 'ko' ? 1 : 2,
+              name: 'Test Product',
+              slug: 'test',
+              price: 10000,
+              salePrice: null,
+              shortDescription: null,
+              rating: 0,
+              reviewCount: 0,
+              status: 'active',
+              isFeatured: false,
+              viewCount: 0,
+              category: null,
+              images: [],
+            },
+          ],
+          total: 1,
+          page: 1,
+          limit: 100,
+        }),
+      );
       const result = await sitemap();
       const urls = result.map((r) => r.url);
-      expect(mockFetchProducts).toHaveBeenCalledWith({ limit: 1000, locale: 'ko' });
-      expect(mockFetchProducts).toHaveBeenCalledWith({ limit: 1000, locale: 'en' });
+      expect(mockFetchProducts).toHaveBeenCalledWith({ page: 1, limit: 100, locale: 'ko' });
+      expect(mockFetchProducts).toHaveBeenCalledWith({ page: 1, limit: 100, locale: 'en' });
       expect(urls).toContain('https://ockhwadang.com/ko/products/1');
       expect(urls).toContain('https://ockhwadang.com/en/products/2');
       expect(urls).not.toContain('https://ockhwadang.com/en/products/1');
+    });
+
+    it('paginates product routes without exceeding the backend product limit', async () => {
+      mockFetchProducts.mockImplementation(({ page, locale }: { page: number; locale: string }) =>
+        Promise.resolve({
+          items:
+            page === 1
+              ? Array.from({ length: 100 }, (_, index) => ({
+                  id: locale === 'ko' ? index + 1 : index + 101,
+                  name: 'Test Product',
+                  slug: 'test',
+                  price: 10000,
+                  salePrice: null,
+                  shortDescription: null,
+                  rating: 0,
+                  reviewCount: 0,
+                  status: 'active',
+                  isFeatured: false,
+                  viewCount: 0,
+                  category: null,
+                  images: [],
+                }))
+              : [
+                  {
+                    id: locale === 'ko' ? 1000 : 2000,
+                    name: 'Last Product',
+                    slug: 'last',
+                    price: 10000,
+                    salePrice: null,
+                    shortDescription: null,
+                    rating: 0,
+                    reviewCount: 0,
+                    status: 'active',
+                    isFeatured: false,
+                    viewCount: 0,
+                    category: null,
+                    images: [],
+                  },
+                ],
+          total: 101,
+          page,
+          limit: 100,
+        }),
+      );
+
+      const result = await sitemap();
+      const urls = result.map((r) => r.url);
+
+      expect(mockFetchProducts).toHaveBeenCalledWith({ page: 1, limit: 100, locale: 'ko' });
+      expect(mockFetchProducts).toHaveBeenCalledWith({ page: 2, limit: 100, locale: 'ko' });
+      expect(mockFetchProducts).toHaveBeenCalledWith({ page: 1, limit: 100, locale: 'en' });
+      expect(mockFetchProducts).toHaveBeenCalledWith({ page: 2, limit: 100, locale: 'en' });
+      expect(urls).toContain('https://ockhwadang.com/ko/products/1000');
+      expect(urls).toContain('https://ockhwadang.com/en/products/2000');
     });
 
     it('returns only static routes when fetchProducts fails', async () => {
@@ -104,7 +160,16 @@ describe('SEO', () => {
         salePrice: 25000,
         stock: 10,
         sku: 'TEST-001',
-        images: [{ id: 1, url: '/images/test.jpg', alt: 'Test', sortOrder: 0, isThumbnail: true, isDescriptionImage: false }],
+        images: [
+          {
+            id: 1,
+            url: '/images/test.jpg',
+            alt: 'Test',
+            sortOrder: 0,
+            isThumbnail: true,
+            isDescriptionImage: false,
+          },
+        ],
         detailImages: [],
         rating: 0,
         reviewCount: 0,
@@ -129,7 +194,8 @@ describe('SEO', () => {
           '@type': 'Offer',
           priceCurrency: 'KRW',
           price: product.salePrice ?? product.price,
-          availability: product.stock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
+          availability:
+            product.stock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
           seller: { '@type': 'Organization', name: '옥화당' },
         },
       };
@@ -148,7 +214,8 @@ describe('SEO', () => {
 
     it('shows OutOfStock when stock is 0', () => {
       const stock = 0;
-      const availability = stock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock';
+      const availability =
+        stock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock';
       expect(availability).toBe('https://schema.org/OutOfStock');
     });
   });
@@ -156,12 +223,15 @@ describe('SEO', () => {
   describe('root layout metadata', () => {
     it('includes 자사호 keyword in default title and keywords', async () => {
       const { metadata } = await import('@/app/layout');
-      const title = typeof metadata.title === 'object' && metadata.title !== null && 'default' in metadata.title
-        ? (metadata.title as { default: string }).default
-        : String(metadata.title);
+      const title =
+        typeof metadata.title === 'object' && metadata.title !== null && 'default' in metadata.title
+          ? (metadata.title as { default: string }).default
+          : String(metadata.title);
       expect(title).toContain('자사호');
       expect(metadata.description).toContain('자사호');
-      expect(metadata.keywords).toEqual(expect.arrayContaining(['자사호', '보이차', '다구', '옥화당']));
+      expect(metadata.keywords).toEqual(
+        expect.arrayContaining(['자사호', '보이차', '다구', '옥화당']),
+      );
     });
   });
 
@@ -176,7 +246,16 @@ describe('SEO', () => {
         salePrice: null,
         stock: 10,
         sku: 'TEST-001',
-        images: [{ id: 1, url: '/images/test.jpg', alt: 'Test', sortOrder: 0, isThumbnail: true, isDescriptionImage: false }],
+        images: [
+          {
+            id: 1,
+            url: '/images/test.jpg',
+            alt: 'Test',
+            sortOrder: 0,
+            isThumbnail: true,
+            isDescriptionImage: false,
+          },
+        ],
         detailImages: [],
         rating: 0,
         reviewCount: 0,
@@ -189,7 +268,9 @@ describe('SEO', () => {
       });
 
       const { generateMetadata } = await import('@/app/[locale]/products/[id]/page');
-      const metadata = await generateMetadata({ params: Promise.resolve({ id: '1', locale: 'ko' }) });
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: '1', locale: 'ko' }),
+      });
 
       expect(metadata.title).toBe('Test Product');
       expect(metadata.description).toBe('Short desc');
@@ -202,7 +283,9 @@ describe('SEO', () => {
       mockFetchProduct.mockResolvedValue(null);
 
       const { generateMetadata } = await import('@/app/[locale]/products/[id]/page');
-      const metadata = await generateMetadata({ params: Promise.resolve({ id: '999', locale: 'ko' }) });
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ id: '999', locale: 'ko' }),
+      });
 
       expect(metadata.title).toBe('상품을 찾을 수 없습니다');
     });

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,10 @@
 import type { MetadataRoute } from 'next';
 import { fetchProducts } from '@/lib/api-server';
+import type { Product } from '@/lib/api';
 import { routing } from '@/i18n/routing';
 import { SITE_URL } from '@/lib/site-url';
 const locales = routing.locales;
+const PRODUCT_SITEMAP_PAGE_SIZE = 100;
 
 const staticPaths = [
   { path: '', changeFrequency: 'daily' as const, priority: 1 },
@@ -14,24 +16,25 @@ const staticPaths = [
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
 
-  const staticRoutes: MetadataRoute.Sitemap = staticPaths.flatMap(({ path, changeFrequency, priority }) =>
-    locales.map((locale) => ({
-      url: `${SITE_URL}/${locale}${path}`,
-      lastModified: now,
-      changeFrequency,
-      priority,
-    }))
+  const staticRoutes: MetadataRoute.Sitemap = staticPaths.flatMap(
+    ({ path, changeFrequency, priority }) =>
+      locales.map((locale) => ({
+        url: `${SITE_URL}/${locale}${path}`,
+        lastModified: now,
+        changeFrequency,
+        priority,
+      })),
   );
 
   try {
     const productsByLocale = await Promise.all(
       locales.map(async (locale) => ({
         locale,
-        result: await fetchProducts({ limit: 1000, locale }),
+        products: await fetchSitemapProducts(locale),
       })),
     );
-    const productRoutes: MetadataRoute.Sitemap = productsByLocale.flatMap(({ locale, result }) =>
-      result.items.map((p) => ({
+    const productRoutes: MetadataRoute.Sitemap = productsByLocale.flatMap(({ locale, products }) =>
+      products.map((p) => ({
         url: `${SITE_URL}/${locale}/products/${p.id}`,
         lastModified: now,
         changeFrequency: 'weekly' as const,
@@ -42,4 +45,28 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   } catch {
     return staticRoutes;
   }
+}
+
+async function fetchSitemapProducts(locale: string) {
+  const products: Product[] = [];
+  let page = 1;
+  let total = Number.POSITIVE_INFINITY;
+
+  while (products.length < total) {
+    const result = await fetchProducts({
+      page,
+      limit: PRODUCT_SITEMAP_PAGE_SIZE,
+      locale,
+    });
+
+    products.push(...result.items);
+    total = result.total;
+
+    if (result.items.length === 0) {
+      break;
+    }
+    page += 1;
+  }
+
+  return products;
 }


### PR DESCRIPTION
## Summary
- sitemap 상품 URL 수집에서 백엔드 허용치를 초과하던 상품 목록 호출 제거
- 백엔드 상품 API 최대 limit 100에 맞춰 페이지네이션으로 전체 상품 URL 수집
- SEO 테스트를 페이지네이션 동작으로 갱신

## Verification
- npm run test:run -- src/app/__tests__/seo.test.ts
- npm run build
- bash scripts/codex-project-guard.sh
- curl http://localhost:3000/api/health
- curl http://localhost:5173/sitemap.xml
- curl /api/products?limit=100 returns 200

## Notes
- 반복 로그의 원인이던 sitemap 내부의 과도한 상품 목록 요청을 제거했습니다.
