### PR TITLE
fix: #1102 로컬 저널 API 404 로그 제거

### DIFF
--- a/src/app/[locale]/journal/[slug]/__tests__/page.test.tsx
+++ b/src/app/[locale]/journal/[slug]/__tests__/page.test.tsx
@@ -62,6 +62,29 @@ describe('/[locale]/journal/[slug] detail page', () => {
     vi.clearAllMocks();
   });
 
+  it('renders a bundled local journal without calling the backend API', async () => {
+    const jsx = await JournalDetailPage({
+      params: Promise.resolve({ locale: 'en', slug: 'spring-tea-table' }),
+    });
+    render(jsx);
+
+    expect(mockFetchJournal).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'A Spring Tea Table' })).toBeInTheDocument();
+    expect(screen.getByText('Tea Table')).toBeInTheDocument();
+  });
+
+  it('uses a bundled local journal for metadata without calling the backend API', async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: 'en', slug: 'spring-tea-table' }),
+    });
+
+    expect(mockFetchJournal).not.toHaveBeenCalled();
+    expect(metadata.title).toBe('A Spring Tea Table — Journal');
+    expect(metadata.description).toBe(
+      'Tea table ideas for spring, from green and white tea pairings to teaware, cloth, and floral details.',
+    );
+  });
+
   it('fetches an API-created journal by slug and route locale before rendering', async () => {
     mockFetchJournal.mockResolvedValue(apiCreatedJournal);
 
@@ -87,5 +110,17 @@ describe('/[locale]/journal/[slug] detail page', () => {
     expect(mockFetchJournal).toHaveBeenCalledWith('cms-created-journal', 'en');
     expect(metadata.title).toBe('CMS Created Journal — Journal');
     expect(metadata.description).toBe('A journal entry created through the API.');
+  });
+
+  it('does not fall back to local content after a missing API journal for an unknown slug', async () => {
+    mockFetchJournal.mockResolvedValue(null);
+
+    await expect(
+      JournalDetailPage({
+        params: Promise.resolve({ locale: 'en', slug: 'unknown-cms-journal' }),
+      }),
+    ).rejects.toThrow('notFound');
+
+    expect(mockFetchJournal).toHaveBeenCalledWith('unknown-cms-journal', 'en');
   });
 });

--- a/src/app/[locale]/journal/[slug]/page.tsx
+++ b/src/app/[locale]/journal/[slug]/page.tsx
@@ -50,17 +50,24 @@ async function resolveJournal(
   slug: string,
   locale: 'ko' | 'en',
 ): Promise<RenderableJournal | null> {
+  const localEntry = getLocalizedJournalBySlug(slug, locale);
+  if (localEntry) {
+    return normalizeLocalJournal(localEntry);
+  }
+
   const apiJournal = await fetchJournal(slug, locale);
   if (apiJournal) {
     const tCategory = await getTranslations({ locale, namespace: 'journalCategories' });
     return normalizeApiJournal(apiJournal, tCategory);
   }
 
-  const fallbackEntry = getLocalizedJournalBySlug(slug, locale);
-  return fallbackEntry ? normalizeLocalJournal(fallbackEntry) : null;
+  return null;
 }
 
-function normalizeApiJournal(journal: Journal, tCategory: (key: string) => string): RenderableJournal {
+function normalizeApiJournal(
+  journal: Journal,
+  tCategory: (key: string) => string,
+): RenderableJournal {
   return {
     title: journal.title,
     subtitle: journal.subtitle,
@@ -141,17 +148,15 @@ export default async function JournalDetailPage({ params }: PageProps) {
             {entry.readTime ? (
               <>
                 <span className="text-xs text-background/40">·</span>
-                <span className="text-xs text-background/60">{entry.readTime} {t('readSuffix')}</span>
+                <span className="text-xs text-background/60">
+                  {entry.readTime} {t('readSuffix')}
+                </span>
               </>
             ) : null}
           </div>
-          <h1 className="font-display typo-h1 tracking-tight mb-3">
-            {entry.title}
-          </h1>
+          <h1 className="font-display typo-h1 tracking-tight mb-3">{entry.title}</h1>
           {entry.subtitle ? (
-            <p className="typo-h3 text-background/70 font-display">
-              {entry.subtitle}
-            </p>
+            <p className="typo-h3 text-background/70 font-display">{entry.subtitle}</p>
           ) : null}
         </div>
       </section>


### PR DESCRIPTION
## Summary
- 로컬 내장 저널 slug는 백엔드 API 조회 없이 바로 로컬 콘텐츠로 렌더링
- CMS/API 전용 slug만 기존처럼 백엔드 `/journals/:slug` 조회
- API miss를 로컬 fallback으로 쓰던 정상 경로 제거
- `spring-tea-table` 접근 시 백엔드 404 로그가 생기지 않음을 테스트/런타임 검증

Closes #1102

## Verification
- `npm run build`
- `npm run test:run`
- `cd backend && npm run build && npx jest --runInBand`
- `bash scripts/codex-project-guard.sh`
- `curl -I http://localhost:5173/en/journal/spring-tea-table`
- `/tmp/commerce-backend.log`에서 `/api/journals/spring-tea-table` count before=0 after=0
- `curl http://localhost:3000/api/health`

## Notes
- `make bootstrap`은 npm 의존성 설치 후 `code-review-graph` Python package resolution 단계에서 실패했지만, required npm/backend deps와 all requested verification completed successfully.
