### PR TITLE
Expose client IP in admin logs

### DIFF
--- a/backend/src/common/interceptors/logging.interceptor.spec.ts
+++ b/backend/src/common/interceptors/logging.interceptor.spec.ts
@@ -122,9 +122,7 @@ describe('LoggingInterceptor', () => {
   });
 
   it('should handle null body gracefully', (done) => {
-    const context = createMockContext(
-      null as unknown as Record<string, unknown>,
-    );
+    const context = createMockContext(null as unknown as Record<string, unknown>);
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => done(),
@@ -223,28 +221,85 @@ describe('LoggingInterceptor', () => {
     });
   });
 
-  it('should include request ids, member id, status, and duration for easier PM2 tracing', (done) => {
+  it('should include request ids, member id, status, duration, and IP for easier PM2 tracing', (done) => {
     const logSpy = jest.spyOn(interceptor['logger'], 'log');
     const context = createMockContext(
       { orderId: 'ORD-1', transactionId: 'TX-1', productName: 'tea' },
-      { user: { id: 42, role: 'user' }, query: { paymentKey: 'PAY-1' } },
+      {
+        user: { id: 42, role: 'user' },
+        query: { paymentKey: 'PAY-1' },
+        ip: '203.0.113.10',
+      },
     );
 
     interceptor.intercept(context, mockCallHandler).subscribe({
       complete: () => {
-        expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
-          event: 'http_request',
-          outcome: 'completed',
-          method: 'POST',
-          path: '/api/test',
-          statusCode: 201,
-          ids: expect.objectContaining({
-            orderId: 'ORD-1',
-            transactionId: 'TX-1',
-            paymentKey: 'PAY-1',
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: 'http_request',
+            outcome: 'completed',
+            method: 'POST',
+            path: '/api/test',
+            statusCode: 201,
+            ids: expect.objectContaining({
+              orderId: 'ORD-1',
+              transactionId: 'TX-1',
+              paymentKey: 'PAY-1',
+            }),
+            ip: '203.0.113.10',
+            durationMs: expect.any(Number),
           }),
-          durationMs: expect.any(Number),
-        }));
+        );
+        done();
+      },
+    });
+  });
+
+  it('should prefer the Cloudflare visitor IP over proxy addresses', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext(
+      {},
+      {
+        headers: {
+          'cf-connecting-ip': '198.51.100.20',
+          'x-forwarded-for': '198.51.100.21, 172.70.38.94',
+        },
+        ip: '172.70.38.94',
+        socket: { remoteAddress: '10.0.0.1' },
+      },
+    );
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ip: '198.51.100.20',
+          }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('should use the first x-forwarded-for IP when Cloudflare IP is absent', (done) => {
+    const logSpy = jest.spyOn(interceptor['logger'], 'log');
+    const context = createMockContext(
+      {},
+      {
+        headers: {
+          'x-forwarded-for': '198.51.100.30, 172.70.38.94',
+        },
+        ip: '172.70.38.94',
+      },
+    );
+
+    interceptor.intercept(context, mockCallHandler).subscribe({
+      complete: () => {
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ip: '198.51.100.30',
+          }),
+        );
         done();
       },
     });

--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -1,10 +1,4 @@
-import {
-  Injectable,
-  Logger,
-  NestInterceptor,
-  ExecutionContext,
-  CallHandler,
-} from '@nestjs/common';
+import { Injectable, Logger, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
 import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { redactSensitiveFields } from '../utils/redaction.util';
@@ -33,10 +27,7 @@ type ResponseForLogging = {
 export class LoggingInterceptor implements NestInterceptor {
   private readonly logger = new Logger(LoggingInterceptor.name);
 
-  intercept(
-    context: ExecutionContext,
-    next: CallHandler,
-  ): Observable<unknown> {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const req = context.switchToHttp().getRequest<RequestForLogging>();
     const res = context.switchToHttp().getResponse<ResponseForLogging>();
     const start = Date.now();
@@ -80,11 +71,59 @@ export class LoggingInterceptor implements NestInterceptor {
       path: req.originalUrl || req.url,
       statusCode: this.statusCodeOf(res, error),
       durationMs: Date.now() - start,
-      ip: req.ip ?? req.socket?.remoteAddress ?? null,
+      ip: this.clientIpOf(req),
       ids: this.extractUsefulIds(req),
       body: this.sanitizeAndTruncate(req.body),
       ...(error ? { error: this.errorSummary(error) } : {}),
     };
+  }
+
+  private clientIpOf(req: RequestForLogging): string | null {
+    return (
+      this.headerValue(req.headers, 'cf-connecting-ip') ??
+      this.firstForwardedIp(this.rawHeaderValue(req.headers, 'x-forwarded-for')) ??
+      this.headerValue(req.headers, 'x-real-ip') ??
+      this.cleanIp(req.ip) ??
+      this.cleanIp(req.socket?.remoteAddress) ??
+      null
+    );
+  }
+
+  private rawHeaderValue(
+    headers: RequestForLogging['headers'],
+    name: string,
+  ): string | string[] | undefined {
+    if (!headers) return undefined;
+    const direct = headers[name] ?? headers[name.toLowerCase()];
+    if (direct !== undefined) return direct;
+
+    const found = Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase());
+    return found?.[1];
+  }
+
+  private headerValue(headers: RequestForLogging['headers'], name: string): string | null {
+    const raw = this.rawHeaderValue(headers, name);
+    const values = Array.isArray(raw) ? raw : [raw];
+    for (const value of values) {
+      const cleaned = this.cleanIp(value);
+      if (cleaned) return cleaned;
+    }
+    return null;
+  }
+
+  private firstForwardedIp(value: string | string[] | undefined): string | null {
+    const values = Array.isArray(value) ? value : [value];
+    for (const item of values) {
+      const first = item?.split(',')[0];
+      const cleaned = this.cleanIp(first);
+      if (cleaned) return cleaned;
+    }
+    return null;
+  }
+
+  private cleanIp(value: string | undefined): string | null {
+    const cleaned = value?.trim();
+    return cleaned ? cleaned : null;
   }
 
   private statusCodeOf(res: ResponseForLogging, error?: unknown): number | undefined {

--- a/src/app/[locale]/admin/logs/page.tsx
+++ b/src/app/[locale]/admin/logs/page.tsx
@@ -323,6 +323,9 @@ function LogTable({ entries, emptyText }: { entries: ParsedAdminLogEntry[]; empt
               {t('table.transaction')}
             </th>
             <th scope="col" className="px-3 py-3 font-semibold">
+              {t('table.ip')}
+            </th>
+            <th scope="col" className="px-3 py-3 font-semibold">
               {t('table.request')}
             </th>
             <th scope="col" className="px-3 py-3 font-semibold">
@@ -349,6 +352,7 @@ function LogTable({ entries, emptyText }: { entries: ParsedAdminLogEntry[]; empt
 function LogTableRow({ entry }: { entry: ParsedAdminLogEntry }) {
   const t = useTranslations('admin.logs');
   const transaction = getAdminLogField(entry, ['txId', 'transactionId', 'requestId', 'traceId']);
+  const ip = getAdminLogField(entry, ['ip', 'clientIp', 'remoteAddress']);
   const request = [getAdminLogField(entry, ['method']), getAdminLogField(entry, ['path'])]
     .filter(Boolean)
     .join(' ');
@@ -372,6 +376,7 @@ function LogTableRow({ entry }: { entry: ParsedAdminLogEntry }) {
         </span>
       </td>
       <td className="max-w-xs break-words px-3 py-3 font-mono typo-label">{transaction || '-'}</td>
+      <td className="whitespace-nowrap px-3 py-3 font-mono typo-label">{ip || '-'}</td>
       <td className="max-w-xs break-words px-3 py-3 font-mono typo-label">{request || '-'}</td>
       <td className="min-w-72 max-w-xl whitespace-pre-wrap break-words px-3 py-3">{message}</td>
       <td className="max-w-xs break-words px-3 py-3 typo-label text-muted-foreground">

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1394,7 +1394,7 @@
       },
       "filters": {
         "search": "Search",
-        "searchPlaceholder": "Search transaction ID, request ID, message, or path",
+        "searchPlaceholder": "Search transaction ID, request ID, IP, message, or path",
         "startAt": "Start time",
         "endAt": "End time",
         "apply": "Search",
@@ -1416,7 +1416,8 @@
         "message": "Message",
         "context": "Context",
         "details": "Details",
-        "showDetails": "Show raw/fields"
+        "showDetails": "Show raw/fields",
+        "ip": "IP"
       }
     }
   },

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1394,7 +1394,7 @@
       },
       "filters": {
         "search": "검색어",
-        "searchPlaceholder": "트랜잭션 ID, 요청 ID, 메시지, 경로 검색",
+        "searchPlaceholder": "트랜잭션 ID, 요청 ID, IP, 메시지, 경로 검색",
         "startAt": "시작 시간",
         "endAt": "종료 시간",
         "apply": "검색",
@@ -1416,7 +1416,8 @@
         "message": "메시지",
         "context": "위치",
         "details": "상세",
-        "showDetails": "원문/필드 보기"
+        "showDetails": "원문/필드 보기",
+        "ip": "IP"
       }
     }
   },

--- a/src/lib/__tests__/admin-log-format.test.ts
+++ b/src/lib/__tests__/admin-log-format.test.ts
@@ -18,6 +18,7 @@ describe('admin log formatter', () => {
         durationMs: 13,
         event: 'http_request',
         ids: { orderId: 'ORD-1' },
+        ip: '203.0.113.10',
       }),
       1,
     );
@@ -37,10 +38,12 @@ describe('admin log formatter', () => {
       'event',
       'ids',
       'body',
+      'ip',
     ]);
     expect(entry.fields[0].order).toBe(1);
     expect(entry.summary).toContain('POST /api/orders');
     expect(getAdminLogField(entry, ['requestId', 'txId'])).toBe('req-1');
+    expect(getAdminLogField(entry, ['ip'])).toBe('203.0.113.10');
   });
 
   it('keeps legacy non-json log lines readable', () => {


### PR DESCRIPTION
## Summary
- collect client IPs from Cloudflare/proxy headers before falling back to socket/request IP
- show IP as a first-class column in the admin remote logs table
- include IP in admin log search placeholder copy and parser coverage

## Why
Operators need to correlate repeated remote log entries by transaction/request ID and IP without expanding raw JSON details. Behind Cloudflare, `req.ip` can point at an edge/proxy address, so the logger now prefers `cf-connecting-ip` and then standard forwarding headers.

## Validation
- `npm run test:run -- src/lib/__tests__/admin-log-format.test.ts`
- `cd backend && npm run test -- logging.interceptor.spec.ts`
- `npm run build`
- `cd backend && npm run build`
- `bash scripts/codex-project-guard.sh`
- `bash scripts/start-local.sh`
- `curl -fsS http://localhost:3000/api/health`
- `curl -I -s http://localhost:5173/ko`
