### PR TITLE
fix: #1105 영어 사이트 로고 이미지 통일

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -84,7 +84,7 @@ export default function Header() {
           {/* 로고 */}
           <Link href="/" className="shrink-0">
             <div style={scrollLogo?.headerLogoStyle}>
-              <Logo variant="header" />
+              <Logo variant="header" alt={t('okhwadang')} />
             </div>
           </Link>
 

--- a/src/components/LogoSlider.tsx
+++ b/src/components/LogoSlider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useLocale } from 'next-intl';
+import Logo from '@/components/Logo';
 
 /**
  * 히어로 섹션 위에 fixed로 표시되는 브랜드 워드마크.
@@ -9,7 +9,6 @@ import { useLocale } from 'next-intl';
  * 헤더의 로고가 페이드인되어 자연스럽게 이어진다.
  */
 export default function LogoSlider() {
-  const locale = useLocale();
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
@@ -35,18 +34,7 @@ export default function LogoSlider() {
         transition: 'opacity 0.3s ease, transform 0.3s ease',
       }}
     >
-      <span
-        style={{
-          fontFamily: 'var(--font-display, serif)',
-          fontWeight: 700,
-          fontSize: '1.25rem',
-          color: 'white',
-          letterSpacing: '-0.02em',
-          textShadow: '0 1px 8px rgba(0,0,0,0.4)',
-        }}
-      >
-        {locale === 'en' ? 'Ockhwadang' : '옥화당'}
-      </span>
+      <Logo variant="hero" alt="" priority={false} className="drop-shadow-lg" />
     </div>
   );
 }

--- a/src/components/__tests__/EnglishLogoSpelling.test.tsx
+++ b/src/components/__tests__/EnglishLogoSpelling.test.tsx
@@ -1,39 +1,26 @@
 import { render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import LogoSlider from '@/components/LogoSlider';
 import Logo from '@/components/shared/Logo';
 
-let mockLocale = 'ko';
+describe('English site logo', () => {
+  it('renders the shared image logo with an explicit English accessible label', () => {
+    render(<Logo alt="Ockhwadang" />);
 
-vi.mock('next-intl', () => ({
-  useLocale: () => mockLocale,
-}));
-
-afterEach(() => {
-  mockLocale = 'ko';
-});
-
-describe('English logo spelling', () => {
-  it('renders the English header wordmark as Ockhwadang', () => {
-    mockLocale = 'en';
-
-    render(<Logo />);
-
-    expect(screen.getByText('Ockhwadang')).toBeInTheDocument();
-    expect(screen.getByLabelText('Ockhwadang')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Ockhwadang' })).toHaveAttribute('src', '/logo-okhwadang.png');
+    expect(screen.queryByText('Ockhwadang')).not.toBeInTheDocument();
     expect(screen.queryByText('Okhwadang')).not.toBeInTheDocument();
   });
 
-  it('renders the English hero overlay wordmark as Ockhwadang', () => {
-    mockLocale = 'en';
-
+  it('renders the shared image logo for the decorative hero overlay', () => {
     render(<LogoSlider />);
 
-    expect(screen.getByText('Ockhwadang')).toBeInTheDocument();
+    expect(screen.getByRole('presentation', { hidden: true })).toHaveAttribute('src', '/logo-okhwadang.png');
+    expect(screen.queryByText('Ockhwadang')).not.toBeInTheDocument();
     expect(screen.queryByText('Okhwadang')).not.toBeInTheDocument();
   });
 
-  it('keeps the Korean image logo unchanged', () => {
+  it('keeps the Korean image logo default unchanged', () => {
     render(<Logo />);
 
     expect(screen.getByRole('img', { name: '옥화당' })).toHaveAttribute('src', '/logo-okhwadang.png');

--- a/src/components/header/MobileMenu.tsx
+++ b/src/components/header/MobileMenu.tsx
@@ -35,6 +35,7 @@ interface MobileMenuHeaderProps {
 
 function MobileMenuHeader({ onClose }: MobileMenuHeaderProps) {
   const tNav = useTranslations('navigation');
+  const tHeader = useTranslations('header');
   return (
     <div className="flex items-center px-4 h-14 shrink-0">
       <button
@@ -46,7 +47,7 @@ function MobileMenuHeader({ onClose }: MobileMenuHeaderProps) {
         <X className="h-5 w-5" />
       </button>
       <Link href="/" onClick={onClose} className="shrink-0">
-        <Logo variant="header" />
+        <Logo variant="header" alt={tHeader('okhwadang')} />
       </Link>
     </div>
   );

--- a/src/components/shared/Logo.tsx
+++ b/src/components/shared/Logo.tsx
@@ -1,41 +1,25 @@
 'use client';
 
 import Image from 'next/image';
-import { useLocale } from 'next-intl';
-import { cn } from '@/components/ui/utils';
 
 interface LogoProps {
   variant?: 'hero' | 'header';
   className?: string;
+  alt?: string;
+  priority?: boolean;
 }
 
-export default function Logo({ variant = 'header', className }: LogoProps) {
-  const locale = useLocale();
+export default function Logo({ variant = 'header', className, alt = '옥화당', priority = true }: LogoProps) {
   const size = variant === 'hero' ? { width: 200, height: 56 } : { width: 140, height: 40 };
-
-  if (locale === 'en') {
-    return (
-      <span
-        className={cn(
-          'font-display text-xl font-semibold tracking-tight text-foreground',
-          variant === 'hero' && 'text-3xl text-white',
-          className,
-        )}
-        aria-label="Ockhwadang"
-      >
-        Ockhwadang
-      </span>
-    );
-  }
 
   return (
     <Image
       src="/logo-okhwadang.png"
-      alt="옥화당"
+      alt={alt}
       {...size}
       style={{ height: 'auto' }}
       className={`object-contain ${variant === 'hero' ? 'brightness-0 invert' : ''} ${className ?? ''}`}
-      priority
+      priority={priority}
     />
   );
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -87,7 +87,8 @@
     "languageSelector": "Select Language",
     "languageList": "Language list",
     "menuBackTo": "Back to {title} menu",
-    "openSubmenu": "Open {label} submenu"
+    "openSubmenu": "Open {label} submenu",
+    "okhwadang": "Ockhwadang"
   },
   "footer": {
     "customerService": "Customer Service",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -87,7 +87,8 @@
     "languageSelector": "언어 선택",
     "languageList": "언어 목록",
     "menuBackTo": "{title} 메뉴로 돌아가기",
-    "openSubmenu": "{label} 하위 메뉴 열기"
+    "openSubmenu": "{label} 하위 메뉴 열기",
+    "okhwadang": "옥화당"
   },
   "footer": {
     "customerService": "고객센터",


### PR DESCRIPTION
## Summary
- Remove the English-only text wordmark branch from the shared Logo component
- Reuse the shared image Logo in the hero overlay LogoSlider
- Update logo regression tests so English pages assert the existing image logo instead of text

Closes #1105

## Verification
- `npx vitest run src/components/__tests__/EnglishLogoSpelling.test.tsx --reporter=verbose`
- `bash scripts/codex-project-guard.sh && npm run build && npm run test:run`
- `cd backend && npm run build && npm run test`
- `curl http://localhost:3000/api/health`
- `curl -I http://localhost:5173/en`
- `curl -I http://localhost:5173/ko`
- `curl -I http://localhost:5173/logo-okhwadang.png`
