### PR TITLE
fix: #1117 NEXT_LOCALE 쿠키 보안 속성 강화

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -7,62 +7,6 @@ vi.mock('@/i18n/routing', () => ({
   routing: { locales: ['ko', 'en'], defaultLocale: 'ko' },
 }));
 
-vi.mock('@/middleware', () => {
-  const mockHasAdminRole = (token: string) => {
-    if (token.includes('FORGED')) return Promise.resolve(false);
-    try {
-      const parts = token.split('.');
-      if (parts.length !== 3) return Promise.resolve(false);
-      const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
-      return Promise.resolve(payload.role === 'admin' || payload.role === 'super_admin');
-    } catch {
-      return Promise.resolve(false);
-    }
-  };
-
-  const localePattern = new RegExp(`^/(ko|en)(/.*)?$`);
-
-  return {
-    __esModule: true,
-    mockHasAdminRole,
-    middleware: (req: { url: string; cookies: { get: (name: string) => { value: string } | undefined } }) => {
-      const url = new URL(req.url);
-      const pathname = url.pathname;
-      const token = req.cookies.get('accessToken')?.value;
-      const search = url.search;
-
-      const localeMatch = pathname.match(localePattern);
-      const localePrefix = localeMatch ? `/${localeMatch[1]}` : '';
-      const pathnameWithoutLocale = localeMatch ? (localeMatch[2] || '/') : pathname;
-
-      if (pathnameWithoutLocale.startsWith('/admin')) {
-        if (!token) {
-          return new Response(null, { status: 307, headers: { location: `${localePrefix}/login?redirect=${encodeURIComponent(pathname + search)}` } });
-        }
-        return mockHasAdminRole(token).then((isAdmin) => {
-          if (!isAdmin) {
-            return new Response(null, { status: 307, headers: { location: `${localePrefix}/` } });
-          }
-          return new Response(null, { status: 200 });
-        });
-      }
-
-      if (pathnameWithoutLocale.startsWith('/my') || pathnameWithoutLocale.startsWith('/checkout')) {
-        if (!token) {
-          return new Response(null, { status: 307, headers: { location: `${localePrefix}/login?redirect=${encodeURIComponent(pathname + search)}` } });
-        }
-      }
-
-      if (pathnameWithoutLocale.startsWith('/api')) {
-        return new Response(null, { status: 200 });
-      }
-
-      return new Response(null, { status: 200 });
-    },
-    resetPublicKeyCache: () => {},
-    setTestPublicKey: () => {},
-  };
-});
 
 let testKeyPair: CryptoKeyPair;
 let testPublicKeyPem: string;
@@ -107,15 +51,15 @@ function makeForgedToken(payload: Record<string, unknown>): string {
 }
 
 import { middleware, resetPublicKeyCache, setTestPublicKey } from '@/middleware';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 beforeEach(() => {
   resetPublicKeyCache();
   setTestPublicKey(testPublicKeyPem);
 });
 
-function makeRequest(pathname: string, token?: string): NextRequest {
-  const url = `http://localhost${pathname}`;
+function makeRequest(pathname: string, token?: string, baseUrl = 'http://localhost'): NextRequest {
+  const url = `${baseUrl}${pathname}`;
   const req = new NextRequest(url);
   if (token) {
     req.cookies.set('accessToken', token);
@@ -218,6 +162,28 @@ describe('middleware', () => {
       expect(res.status).toBe(200);
     }
   });
+
+  it('sets NEXT_LOCALE with HttpOnly, SameSite and Secure on https locale-prefixed pages', async () => {
+    const req = makeRequest('/ko/products/1', undefined, 'https://ockhwadang.com');
+    const res = await middleware(req);
+    const localeCookie = (res as NextResponse).cookies.get('NEXT_LOCALE');
+
+    expect(localeCookie?.value).toBe('ko');
+    expect(localeCookie?.httpOnly).toBe(true);
+    expect(localeCookie?.sameSite).toBe('lax');
+    expect(localeCookie?.secure).toBe(true);
+  });
+
+  it('does not force Secure on plain-http localhost locale-prefixed pages', async () => {
+    const req = makeRequest('/ko/products/1');
+    const res = await middleware(req);
+    const localeCookie = (res as NextResponse).cookies.get('NEXT_LOCALE');
+
+    expect(localeCookie?.value).toBe('ko');
+    expect(localeCookie?.httpOnly).toBe(true);
+    expect(localeCookie?.secure).toBe(false);
+  });
+
 
   it('redirects locale-prefixed /ko/admin to /ko/login with full path in redirect', async () => {
     const req = makeRequest('/ko/admin');

--- a/src/components/__tests__/LanguageSelector.integration.test.tsx
+++ b/src/components/__tests__/LanguageSelector.integration.test.tsx
@@ -20,7 +20,7 @@ vi.mock('next-intl', () => ({
   },
 }));
 
-vi.mock('@/i18n/navigation', () => ({
+vi.mock('next/navigation', () => ({
   useRouter: () => ({
     replace: replaceMock,
   }),
@@ -32,7 +32,6 @@ describe('LanguageSelector integration', () => {
     replaceMock.mockClear();
     historyBackSpy = vi.spyOn(window.history, 'back').mockImplementation(() => undefined);
     window.history.replaceState({}, '', 'http://localhost:3000/ko?search=1');
-    document.cookie = 'NEXT_LOCALE=; max-age=0; path=/';
   });
 
   afterEach(() => {
@@ -51,9 +50,8 @@ describe('LanguageSelector integration', () => {
     await user.click(screen.getByRole('button', { name: 'English' }));
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith('/?search=1', { locale: 'en' });
+      expect(replaceMock).toHaveBeenCalledWith('/en?search=1');
     });
     expect(historyBackSpy).not.toHaveBeenCalled();
-    expect(document.cookie).toContain('NEXT_LOCALE=en');
   });
 });

--- a/src/components/__tests__/LanguageSelector.test.tsx
+++ b/src/components/__tests__/LanguageSelector.test.tsx
@@ -32,7 +32,7 @@ vi.mock('next-intl', () => ({
   },
 }));
 
-vi.mock('@/i18n/navigation', () => ({
+vi.mock('next/navigation', () => ({
   useRouter: () => ({
     replace: replaceMock,
   }),
@@ -42,7 +42,6 @@ beforeEach(() => {
   mockLocale = 'ko';
   replaceMock = vi.fn();
   window.history.replaceState({}, '', 'http://localhost:3000/ko');
-  document.cookie = 'NEXT_LOCALE=; max-age=0; path=/';
 });
 
 afterEach(() => {
@@ -73,12 +72,12 @@ describe('LanguageSelector', () => {
     expect(screen.queryByText('中文')).not.toBeInTheDocument();
   });
 
-  it('selecting a different language navigates to the same internal path with locale option and closes dropdown', async () => {
+  it('selecting a different language navigates to the locale-prefixed path and closes dropdown', async () => {
     const user = userEvent.setup();
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
     await user.click(screen.getByText('English'));
-    expect(replaceMock).toHaveBeenCalledWith('/', { locale: 'en' });
+    expect(replaceMock).toHaveBeenCalledWith('/en');
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
@@ -88,7 +87,7 @@ describe('LanguageSelector', () => {
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
     await user.click(screen.getByText('English'));
-    expect(replaceMock).toHaveBeenCalledWith('/products/123#details', { locale: 'en' });
+    expect(replaceMock).toHaveBeenCalledWith('/en/products/123#details');
   });
 
   it('selecting current locale does not navigate', async () => {
@@ -99,12 +98,13 @@ describe('LanguageSelector', () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it('sets NEXT_LOCALE cookie on language change', async () => {
+  it('removes the language query state when switching locale', async () => {
+    window.history.replaceState({}, '', 'http://localhost:3000/ko/products?language=1&search=tea');
     const user = userEvent.setup();
     render(<LanguageSelector />);
     await user.click(screen.getByRole('button', { name: '언어 선택' }));
     await user.click(screen.getByText('English'));
-    expect(document.cookie).toContain('NEXT_LOCALE=en');
+    expect(replaceMock).toHaveBeenCalledWith('/en/products?search=tea');
   });
 
   it('closes dropdown on Escape key', async () => {
@@ -153,7 +153,7 @@ describe('LanguageSelector', () => {
     const user = userEvent.setup();
     render(<LanguageSelector variant="inline" />);
     await user.click(screen.getByRole('button', { name: 'English' }));
-    expect(replaceMock).toHaveBeenCalledWith('/', { locale: 'en' });
+    expect(replaceMock).toHaveBeenCalledWith('/en');
   });
 
   it('inline variant does not navigate when clicking current locale', async () => {

--- a/src/components/shared/LanguageSelector.tsx
+++ b/src/components/shared/LanguageSelector.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect, useTransition } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { useRouter } from '@/i18n/navigation';
+import { useRouter } from 'next/navigation';
 import { Globe } from 'lucide-react';
 import { cn } from '@/components/ui/utils';
 import { useUrlModal } from '@/hooks/useUrlModal';
@@ -47,14 +47,23 @@ function getInternalHref(): string {
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
+function getLocalizedHref(locale: Locale): string {
+  const href = getInternalHref();
+  if (href === '/') return `/${locale}`;
+  if (href.startsWith('/?') || href.startsWith('/#')) return `/${locale}${href.slice(1)}`;
+  return `/${locale}${href}`;
+}
+
 function switchLocale(
   locale: Locale,
   currentLocale: Locale,
-  onNavigate: (href: string, options: { locale: Locale }) => void,
+  onNavigate: (href: string) => void,
 ) {
   if (locale === currentLocale) return;
-  document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
-  onNavigate(getInternalHref(), { locale });
+  // Service risk: `next-intl` locale navigation syncs NEXT_LOCALE via `document.cookie`,
+  // which cannot enforce HttpOnly. Keep this URL builder aligned if routing gains
+  // localized pathnames or domain-based locale routing, or language switches can break.
+  onNavigate(getLocalizedHref(locale));
 }
 
 /** 모바일 사이드바용 — 세그먼트 버튼, 드롭다운 없음 */
@@ -76,7 +85,7 @@ function InlineLanguageSelector({ className }: { className?: string }) {
               type="button"
               onClick={() => {
                 startTransition(() => {
-                  switchLocale(option.locale, currentLocale, (href, options) => router.replace(href, options));
+                  switchLocale(option.locale, currentLocale, (href) => router.replace(href));
                 });
               }}
               aria-pressed={isSelected}
@@ -112,7 +121,7 @@ function DropdownLanguageSelector({ className, compact = false }: { className?: 
   const handleSelect = (locale: Locale) => {
     setIsOpen(false, 'replace');
     startTransition(() => {
-      switchLocale(locale, currentLocale, (href, options) => router.replace(href, options));
+      switchLocale(locale, currentLocale, (href) => router.replace(href));
     });
   };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,44 @@ import { routing } from '@/i18n/routing';
 const intlMiddleware = createMiddleware(routing);
 
 const localePattern = new RegExp(`^/(${routing.locales.join('|')})(/.*)?$`);
+const LOCALE_COOKIE_NAME = 'NEXT_LOCALE';
+const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+function shouldUseSecureLocaleCookie(request: NextRequest): boolean {
+  const forwardedProto = request.headers.get('x-forwarded-proto');
+  // Service risk: forcing `Secure` on plain HTTP breaks locale persistence in local/dev.
+  // Keep this tied to real HTTPS so production is hardened without making localhost fail.
+  return request.nextUrl.protocol === 'https:' || forwardedProto === 'https';
+}
+
+function withLocaleCookie(
+  request: NextRequest,
+  response: Response,
+  localePrefix: string,
+  pathnameWithoutLocale: string,
+): Response {
+  if (!localePrefix || pathnameWithoutLocale.startsWith('/api')) {
+    return response;
+  }
+
+  const nextResponse = response instanceof NextResponse
+    ? response
+    : new NextResponse(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+
+  nextResponse.cookies.set(LOCALE_COOKIE_NAME, localePrefix.slice(1), {
+    path: '/',
+    maxAge: LOCALE_COOKIE_MAX_AGE,
+    sameSite: 'lax',
+    secure: shouldUseSecureLocaleCookie(request),
+    httpOnly: true,
+  });
+
+  return nextResponse;
+}
 
 const ADMIN_ROLES = new Set(['admin', 'super_admin']);
 
@@ -147,19 +185,20 @@ export async function middleware(request: NextRequest) {
   const localeMatch = pathname.match(localePattern);
   const localePrefix = localeMatch ? `/${localeMatch[1]}` : '';
   const pathnameWithoutLocale = localeMatch ? (localeMatch[2] || '/') : pathname;
+  const finalizeResponse = (response: Response) => withLocaleCookie(request, response, localePrefix, pathnameWithoutLocale);
 
   if (pathnameWithoutLocale === '/sitemap.xml' || pathnameWithoutLocale === '/robots.txt') {
-    return NextResponse.next();
+    return finalizeResponse(NextResponse.next());
   }
 
   if (pathnameWithoutLocale.startsWith('/admin')) {
     if (!token) {
       const loginUrl = new URL(`${localePrefix}/login`, request.url);
       loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
-      return NextResponse.redirect(loginUrl);
+      return finalizeResponse(NextResponse.redirect(loginUrl));
     }
     if (!(await hasAdminRole(token, request.headers.get('cookie')))) {
-      return NextResponse.redirect(new URL(`${localePrefix}/`, request.url));
+      return finalizeResponse(NextResponse.redirect(new URL(`${localePrefix}/`, request.url)));
     }
   }
 
@@ -167,7 +206,7 @@ export async function middleware(request: NextRequest) {
     if (!token) {
       const loginUrl = new URL(`${localePrefix}/login`, request.url);
       loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
-      return NextResponse.redirect(loginUrl);
+      return finalizeResponse(NextResponse.redirect(loginUrl));
     }
   }
 
@@ -176,10 +215,10 @@ export async function middleware(request: NextRequest) {
     const backendUrl = process.env.BACKEND_URL;
 
     if (!backendUrl) {
-      return NextResponse.json(
+      return finalizeResponse(NextResponse.json(
         { error: 'BACKEND_URL not configured' },
         { status: 500 }
-      );
+      ));
     }
 
     const apiPath = pathname.startsWith('/api')
@@ -227,19 +266,19 @@ export async function middleware(request: NextRequest) {
       }
       responseHeaders.set('X-Proxy-By', 'Next.js Middleware');
 
-      return new NextResponse(data, {
+      return finalizeResponse(new NextResponse(data, {
         status: response.status,
         headers: responseHeaders,
-      });
+      }));
     } catch (error) {
-      return NextResponse.json(
+      return finalizeResponse(NextResponse.json(
         { error: 'Backend unreachable', details: String(error) },
         { status: 502 }
-      );
+      ));
     }
   }
 
-  return intlMiddleware(request);
+  return finalizeResponse(intlMiddleware(request));
 }
 
 export const config = {


### PR DESCRIPTION
## 요약
- `NEXT_LOCALE`를 클라이언트 `document.cookie` 쓰기에서 제거했습니다
- middleware 에서 `HttpOnly`, `SameSite=Lax`, `Secure(HTTPS)`로 locale 쿠키를 설정합니다
- 언어 전환 경로와 middleware 회귀 테스트를 갱신했습니다

## 변경 이유
운영 점검에서 `NEXT_LOCALE` 쿠키가 `Secure`, `HttpOnly` 없이 내려가는 것이 확인됐고,
기존 구현은 클라이언트 쓰기 경로 때문에 `HttpOnly`를 만족시킬 수 없었습니다.

## 검증
- `npx vitest run src/__tests__/middleware.test.ts src/components/__tests__/LanguageSelector.test.tsx src/components/__tests__/LanguageSelector.integration.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `bash scripts/start-local.sh`

## 리스크
- locale pathnames/domain routing을 나중에 확장하면 `LanguageSelector`의 URL 조합 로직을 같이 갱신해야 합니다.
- localhost HTTP 개발 환경은 locale 유지가 깨지지 않도록 `Secure`를 강제하지 않습니다.

Closes #1117
