### PR TITLE
infra: lock BACKEND_URL proxy and SSR contract

### DIFF
--- a/docs/infrastructure/DEPLOYMENT.md
+++ b/docs/infrastructure/DEPLOYMENT.md
@@ -3,16 +3,19 @@
 ## 도메인
 
 - **운영 도메인**: `https://ockhwadang.com` (Cloudflare DNS → Vercel, HTTPS는 Vercel/Cloudflare가 처리)
-- **API 경로**: 브라우저는 `ockhwadang.com/api/*`만 호출. Next.js middleware(`src/middleware.ts`)가 Vercel Edge에서 `BACKEND_URL`로 런타임 프록시. Vercel Edge는 IP 직접 fetch를 금지하므로 반드시 도메인(`api.ockhwadang.com`) 경유.
+- **브라우저 API 경로**: 브라우저/CSR fetch는 `https://ockhwadang.com/api/*`만 호출한다.
+- **SSR/Edge 백엔드 원점**: `BACKEND_URL`은 **반드시 origin만** 넣는다. canonical 값은 `http://api.ockhwadang.com`이며 `/api` suffix를 붙이지 않는다.
+- **프록시 계약**: Next.js middleware(`src/middleware.ts`)와 SSR helper(`src/lib/api-server.ts`, `src/app/[locale]/layout.tsx`)가 같은 `BACKEND_URL + /api/*` 규칙을 공유한다.
 - **CDN 서브도메인**: `https://cdn.ockhwadang.com` → CloudFront → S3 `okhwadang-assets`
+
 ### Cloudflare DNS TXT 레코드
 
 운영 저장소에는 Cloudflare DNS IaC가 없으므로, 아래 값이 **운영 콘솔에서 유지되어야 하는 source of truth** 다.
 
-| Host | Type | Value | 목적 |
-| --- | --- | --- | --- |
-| `@` | `TXT` | `v=spf1 include:_spf.resend.com ~all` | `EMAIL_FROM=@ockhwadang.com` 발신 도메인 SPF |
-| `_dmarc` | `TXT` | `v=DMARC1; p=none; adkim=s; aspf=s; pct=100` | DMARC 초기 모니터링 정책 |
+| Host     | Type  | Value                                        | 목적                                         |
+| -------- | ----- | -------------------------------------------- | -------------------------------------------- |
+| `@`      | `TXT` | `v=spf1 include:_spf.resend.com ~all`        | `EMAIL_FROM=@ockhwadang.com` 발신 도메인 SPF |
+| `_dmarc` | `TXT` | `v=DMARC1; p=none; adkim=s; aspf=s; pct=100` | DMARC 초기 모니터링 정책                     |
 
 > ⚠️ 서비스 장애 가능성: SPF 값을 교체하면서 실제 발송 provider(include)를 빠뜨리면 정상 메일도 softfail/hardfail 될 수 있다.
 > ⚠️ 서비스 장애 가능성: DMARC를 `quarantine` 또는 `reject`로 바로 올리면 SPF/DKIM 정렬이 안 된 정상 메일이 스팸 처리되거나 반송될 수 있다. 우선 `p=none`으로 검증 후 단계적으로 강화한다.
@@ -34,6 +37,23 @@ nslookup -type=TXT _dmarc.ockhwadang.com
 
 5. 결과에 SPF/DMARC 문자열이 그대로 보이면 반영 완료다. 메일 provider가 늘어나면 `~all` 앞에 해당 provider `include:` 또는 `ip4:` 를 추가한 뒤 다시 검증한다.
 
+## 프록시·SSR smoke test
+
+배포 직후 또는 `BACKEND_URL`/Cloudflare/Nginx 변경 직후 아래 순서로 확인한다.
+
+1. **프록시 헬스 체크** — `curl -i https://ockhwadang.com/api/health`
+   - 기대값: `200 OK`, `status=ok`, `db.status=connected`
+2. **직접 백엔드 헬스 체크** — `curl -i http://api.ockhwadang.com/api/health`
+   - 기대값: 프록시와 같은 health payload
+3. **SSR 경로 확인** — 브라우저 DevTools 또는 `curl -I https://ockhwadang.com/ko`
+   - 기대값: 홈 SSR 응답이 200이고, 서버 컴포넌트 fetch가 `BACKEND_URL + /api/*` 계약으로만 동작
+4. **사용자 보호 라우트 확인** — 로그아웃 상태에서 `https://ockhwadang.com/ko/checkout` 또는 `/ko/my`
+   - 기대값: `/ko/login?redirect=...` 로 redirect
+5. **관리자 보호 라우트 확인** — 로그인한 관리자 세션으로 `https://ockhwadang.com/ko/admin`
+   - 기대값: 200 응답 또는 관리자 화면 진입, 비관리자 세션은 `/ko/` 로 redirect
+
+> 로컬/프리뷰/운영 모두 동일하게 `BACKEND_URL`은 origin만 넣고, 앱 코드가 `/api/*`를 붙인다. 코드가 `/api/api/*` 또는 origin path 누락으로 동작하면 회귀다.
+
 ## 상품 이미지 캐시 정책
 
 - 신규 업로드 S3 객체는 `Cache-Control: public, max-age=31536000, immutable` 메타데이터를 붙인다.
@@ -44,7 +64,8 @@ nslookup -type=TXT _dmarc.ockhwadang.com
 - 프론트 `next/image` 최적화 캐시는 `next.config.ts`의 `images.minimumCacheTTL`로 최소 1일을 유지한다. 신규 S3 이미지처럼 origin `Cache-Control`이 더 길면 최적화 이미지 변형도 더 긴 upstream TTL을 따를 수 있으므로, 변경된 이미지는 반드시 새 URL로 교체한다.
 
 ### Vercel 환경변수
-- `BACKEND_URL=http://api.ockhwadang.com` (Cloudflare Proxied → EC2 Nginx :80 → NestJS :3000, HTTP)
+
+- `BACKEND_URL=http://api.ockhwadang.com` (Cloudflare Proxied → EC2 Nginx :80 → NestJS :3000, **origin only — `/api` suffix 금지**)
 - `SITE_URL=https://ockhwadang.com`
 
 ## 배포 구조
@@ -54,8 +75,8 @@ nslookup -type=TXT _dmarc.ockhwadang.com
     │
     ├── HTTPS ──→ Cloudflare ──→ Vercel CDN (Next.js SSR, ockhwadang.com)
     │                 │
-    │                 └── /api/* rewrites ──→ api.ockhwadang.com → AWS EC2 t3.small (NestJS :3000)
-    │                                              │
+    │                 └── middleware + SSR fetch ──→ BACKEND_URL + /api/* ──→ api.ockhwadang.com → AWS EC2 t3.small (NestJS :3000)
+    │                                                                                 │
     │                                              └── MySQL ──→ AWS Lightsail MySQL :3306
     │                                                 (캐시는 백엔드 프로세스 내 in-memory)
     └──────────────────────────────────────────────────────────────────────────────────────────
@@ -69,10 +90,12 @@ nslookup -type=TXT _dmarc.ockhwadang.com
 ## 백엔드 (AWS EC2 t3.small)
 
 ### 배포 방식
+
 - `main` 브랜치 push 시 GitHub Actions → OIDC 인증 → SSM으로 EC2 명령어 실행
 - 배포 시작 시 `npm run build` 후 `dist/main.js` 존재 여부와 `npm run preflight:prod` DB 연결 사전 점검을 통과해야 `migration:run:prod` 및 PM2 재시작을 진행
 
 ### 서버 구성
+
 - Amazon Linux 2023
 - PM2로 프로세스 관리
 - Nginx (HTTP → HTTPS 리다이렉트)
@@ -112,8 +135,9 @@ permissions:
 자세한 내용은 [`docs/infrastructure/GITHUB_ACTIONS_OIDC.md`](./GITHUB_ACTIONS_OIDC.md)를 참조하세요.
 
 ### GitHub Secrets 설정
-| Secret | 설명 |
-|---|---|
+
+| Secret     | 설명                                   |
+| ---------- | -------------------------------------- |
 | `EC2_HOST` | EC2 인스턴스 퍼블릭 IP (`3.38.168.41`) |
 
 > **SSH_PRIVATE_KEY, EC2_USER 등 불필요** - OIDC가 대신 처리
@@ -125,12 +149,15 @@ permissions:
 ## 데이터베이스 마이그레이션
 
 ### 배포 시 자동 실행
+
 배포 스크립트에 포함되어 있어 별도 실행 불필요:
+
 ```bash
 npm run migration:run:prod   # dist/database/migrations/*.js 적용
 ```
 
 ### 로컬에서 원격 DB 직접 접근 (SSH 터널)
+
 ```bash
 bash scripts/start-local.sh   # SSH 터널 포함 전체 스택 기동
 LOCAL_DATABASE_URL=mysql://root:__REDACTED_ROOT_PW__@127.0.0.1:3307/commerce npm run migration:run
@@ -141,6 +168,7 @@ LOCAL_DATABASE_URL=mysql://root:__REDACTED_ROOT_PW__@127.0.0.1:3307/commerce npm
 ## 모니터링
 
 ### PM2 대시보드
+
 ```bash
 pm2 status          # 프로세스 상태 확인
 pm2 logs commerce   # 실시간 로그
@@ -170,6 +198,7 @@ pm2 save
 ```
 
 ### 헬스 체크 수동 확인
+
 ```bash
 curl https://api.ockhwadang.com/api/health
 ```
@@ -239,9 +268,11 @@ sudo systemctl enable --now nginx
 ### EC2 — PM2 프로세스 비정상 종료
 
 #### 증상
+
 배포 후 `pm2 status`에서 프로세스가 `errored` 상태.
 
 #### 해결
+
 ```bash
 pm2 logs commerce --lines 50   # 에러 로그 확인
 pm2 restart ecosystem.config.js --env production --update-env  # 재시작
@@ -255,10 +286,12 @@ pm2 restart ecosystem.config.js --env production --update-env  # 재시작
 ### Lightsail MySQL 연결 실패
 
 #### 증상
+
 NestJS 기동 후 `Unable to connect to the database` 또는
 `ERROR 1045 Access denied for user 'okhwadang_app'@'<ip>'`.
 
 #### 확인 사항
+
 1. Lightsail DB 상태가 `available`인지 (`aws lightsail get-relational-database`)
 2. VPC peering이 `active`인지, EC2 route table에 `172.26.0.0/16` 경로가 있는지
 3. EC2에서 endpoint로 접속 시 나가는 소스 IP 확인:
@@ -275,9 +308,11 @@ NestJS 기동 후 `Unable to connect to the database` 또는
 ### Nginx 502 Bad Gateway
 
 #### 원인
+
 NestJS(PM2)가 실행되지 않은 상태에서 Nginx가 프록시 시도.
 
 #### 해결
+
 ```bash
 pm2 status                     # commerce 프로세스 확인
 pm2 start ecosystem.config.js --env production  # 프로세스 없으면 시작

--- a/docs/infrastructure/ENVIRONMENT_VARIABLES.md
+++ b/docs/infrastructure/ENVIRONMENT_VARIABLES.md
@@ -1,20 +1,19 @@
 # Environment Variables
 
-## 프론트엔드 (Next.js)
+## 프론트엔드 / Vercel 런타임
 
-| 변수          | 기본값                  | 설명                                                                                 |
-| ------------- | ----------------------- | ------------------------------------------------------------------------------------ |
-| `BACKEND_URL` | `http://localhost:3000` | NestJS 백엔드 URL (`src/middleware.ts` 런타임 프록시와 서버 컴포넌트 fetch에서 사용) |
+| 변수          | 기본값                  | 설명                                                                                                                                                                                                         |
+| ------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `BACKEND_URL` | `http://localhost:3000` | Next.js middleware 프록시와 SSR fetch가 공유하는 **백엔드 origin**. canonical contract는 `origin only` 이며 앱 코드가 `/api/*` 를 붙인다. 예: 로컬 `http://localhost:3000`, 운영 `http://api.ockhwadang.com` |
+| `SITE_URL`    | `http://localhost:5173` | canonical 프론트엔드 origin. 메타데이터/redirect/배포 smoke test 기준 URL                                                                                                                                    |
+
+### 프록시 계약 메모
+
+- 브라우저/CSR은 항상 `/api/*` 만 호출한다.
+- middleware(`src/middleware.ts`)와 SSR helper(`src/lib/api-server.ts`, `src/app/[locale]/layout.tsx`)가 같은 `BACKEND_URL + /api/*` 규칙을 사용한다.
+- `BACKEND_URL`에 `/api` 를 붙여 넣는 구성이 남아 있어도 코드가 정규화하지만, 문서/환경은 **반드시 origin only** 로 정렬한다.
 
 ---
-
-## Vercel Functions (프록시)
-
-| 변수                 | 기본값                 | 설명                  |
-| -------------------- | ---------------------- | --------------------- |
-| `BACKEND_URL`        | `http://<EC2_IP>:3000` | 백엔드 서버 URL       |
-| `BACKEND_TIMEOUT_MS` | `10000`                | 프록시 타임아웃 (ms)  |
-| `LOG_PROXY_REQUESTS` | `true`                 | 프록시 요청 로깅 여부 |
 
 ---
 
@@ -63,24 +62,24 @@
 
 ### 결제
 
-| 변수                                 | 기본값 | 설명                                                                                         |
-| ------------------------------------ | ------ | -------------------------------------------------------------------------------------------- |
-| `PAYMENT_GATEWAY`                    | `mock` | PG 어댑터 선택 (`mock`/`toss`/`stripe`/`inicis`/`naverpay`/`paypal`/`eximbay`). `mock`은 프로덕션 차단 |
-| `TOSS_SECRET_KEY`                    | —      | 토스페이먼츠 시크릿 키                                                                       |
-| `TOSS_CLIENT_KEY`                    | —      | 토스페이먼츠 클라이언트 키                                                                   |
-| `STRIPE_SECRET_KEY`                  | —      | Stripe 시크릿 키                                                                             |
-| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | —      | Stripe 공개 키                                                                               |
-| `STRIPE_WEBHOOK_SECRET`              | —      | Stripe 웹훅 서명 키                                                                          |
-| `EXIMBAY_MERCHANT_ID`                | —      | Eximbay merchant ID (프로덕션 체크아웃 필수)                                                  |
-| `EXIMBAY_API_KEY`                    | —      | Eximbay Payment Preparation/Verify API key (프로덕션 체크아웃 필수)                           |
-| `EXIMBAY_SECRET_KEY`                 | —      | Eximbay API secret key (프로덕션 체크아웃 필수)                                                |
-| `EXIMBAY_WEBHOOK_SECRET`             | —      | Eximbay webhook HMAC secret                                                                   |
-| `EXIMBAY_API_BASE_URL`               | `https://api-test.eximbay.com` | Eximbay API base URL (production 계약 후 교체)                                    |
-| `EXIMBAY_JS_SDK_URL`                 | `https://api-test.eximbay.com/v1/javascriptSDK.js` | Eximbay hosted payment page SDK URL                            |
-| `EXIMBAY_CURRENCY`                   | `KRW`  | Eximbay 결제 통화 (`USD` 사용 시 `EXIMBAY_KRW_PER_USD`로 환산)                                |
-| `EXIMBAY_LANG`                       | locale 기반 | Eximbay 결제창 언어 강제 override (`KR`/`EN`)                                             |
-| `EXIMBAY_SHOP_NAME`                  | `Okhwadang` | Eximbay 결제창 상점명                                                                    |
-| `EXIMBAY_KRW_PER_USD`                | `1350` | Eximbay USD 결제를 위한 KRW→USD 환산 기준                                                     |
+| 변수                                 | 기본값                                             | 설명                                                                                                   |
+| ------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `PAYMENT_GATEWAY`                    | `mock`                                             | PG 어댑터 선택 (`mock`/`toss`/`stripe`/`inicis`/`naverpay`/`paypal`/`eximbay`). `mock`은 프로덕션 차단 |
+| `TOSS_SECRET_KEY`                    | —                                                  | 토스페이먼츠 시크릿 키                                                                                 |
+| `TOSS_CLIENT_KEY`                    | —                                                  | 토스페이먼츠 클라이언트 키                                                                             |
+| `STRIPE_SECRET_KEY`                  | —                                                  | Stripe 시크릿 키                                                                                       |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | —                                                  | Stripe 공개 키                                                                                         |
+| `STRIPE_WEBHOOK_SECRET`              | —                                                  | Stripe 웹훅 서명 키                                                                                    |
+| `EXIMBAY_MERCHANT_ID`                | —                                                  | Eximbay merchant ID (프로덕션 체크아웃 필수)                                                           |
+| `EXIMBAY_API_KEY`                    | —                                                  | Eximbay Payment Preparation/Verify API key (프로덕션 체크아웃 필수)                                    |
+| `EXIMBAY_SECRET_KEY`                 | —                                                  | Eximbay API secret key (프로덕션 체크아웃 필수)                                                        |
+| `EXIMBAY_WEBHOOK_SECRET`             | —                                                  | Eximbay webhook HMAC secret                                                                            |
+| `EXIMBAY_API_BASE_URL`               | `https://api-test.eximbay.com`                     | Eximbay API base URL (production 계약 후 교체)                                                         |
+| `EXIMBAY_JS_SDK_URL`                 | `https://api-test.eximbay.com/v1/javascriptSDK.js` | Eximbay hosted payment page SDK URL                                                                    |
+| `EXIMBAY_CURRENCY`                   | `KRW`                                              | Eximbay 결제 통화 (`USD` 사용 시 `EXIMBAY_KRW_PER_USD`로 환산)                                         |
+| `EXIMBAY_LANG`                       | locale 기반                                        | Eximbay 결제창 언어 강제 override (`KR`/`EN`)                                                          |
+| `EXIMBAY_SHOP_NAME`                  | `Okhwadang`                                        | Eximbay 결제창 상점명                                                                                  |
+| `EXIMBAY_KRW_PER_USD`                | `1350`                                             | Eximbay USD 결제를 위한 KRW→USD 환산 기준                                                              |
 
 ### 스토리지
 
@@ -94,10 +93,10 @@
 
 ### 알림 (이메일)
 
-| 변수                    | 기본값                   | 설명                                                              |
-| ----------------------- | ------------------------ | ----------------------------------------------------------------- |
-| `NOTIFICATION_PROVIDER` | `mock`                   | 이메일 어댑터 (`mock`/`resend`/`ses`). 프로덕션에서는 `mock` 금지 |
-| `RESEND_API_KEY`        | —                        | Resend API 키 (`NOTIFICATION_PROVIDER=resend` 시 필수)            |
+| 변수                    | 기본값                    | 설명                                                                                   |
+| ----------------------- | ------------------------- | -------------------------------------------------------------------------------------- |
+| `NOTIFICATION_PROVIDER` | `mock`                    | 이메일 어댑터 (`mock`/`resend`/`ses`). 프로덕션에서는 `mock` 금지                      |
+| `RESEND_API_KEY`        | —                         | Resend API 키 (`NOTIFICATION_PROVIDER=resend` 시 필수)                                 |
 | `EMAIL_FROM`            | `no-reply@ockhwadang.com` | 발신자 이메일 주소. 운영 DNS(`ockhwadang.com`)의 SPF/DMARC 정책과 동일 도메인으로 유지 |
 
 ### Cache

--- a/src/__tests__/middleware-proxy.test.ts
+++ b/src/__tests__/middleware-proxy.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('next-intl/middleware', () => ({
+  default: () => () => new Response(null, { status: 200 }),
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  routing: { locales: ['ko', 'en'], defaultLocale: 'ko' },
+}));
+
+import { middleware } from '@/middleware';
+
+const ORIGINAL_BACKEND_URL = process.env.BACKEND_URL;
+
+function makeRequest(pathname: string): NextRequest {
+  return new NextRequest(`https://ockhwadang.com${pathname}`, {
+    headers: { cookie: 'accessToken=opaque-token; refreshToken=refresh-token' },
+  });
+}
+
+describe('middleware /api proxy contract', () => {
+  beforeEach(() => {
+    process.env.BACKEND_URL = 'https://backend.example/api/';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (ORIGINAL_BACKEND_URL === undefined) {
+      delete process.env.BACKEND_URL;
+    } else {
+      process.env.BACKEND_URL = ORIGINAL_BACKEND_URL;
+    }
+  });
+
+  it('proxies locale-prefixed /api requests through the canonical backend origin', async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe('https://backend.example/api/health?full=1');
+      expect(init?.method).toBe('GET');
+      return new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await middleware(makeRequest('/ko/api/health?full=1'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-proxy-by')).toBe('Next.js Middleware');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import AppShell from '@/components/AppShell';
 import AnnouncementBar from '@/components/shared/layout/AnnouncementBar';
 import Providers from '@/components/Providers';
 import { isLocale, routing } from '@/i18n/routing';
+import { buildBackendApiUrl } from '@/lib/backend-url';
 import { getThemeStyle } from '@/lib/theme-style';
 
 const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
@@ -46,14 +47,11 @@ export async function generateMetadata({
 
 const GOOGLE_TAG_ID = 'G-ENSHH2TBSY';
 
-const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
-
 async function getSettingsMap(locale?: string): Promise<Record<string, string> | null> {
   try {
-    const url = locale && locale !== 'ko'
-      ? `${BACKEND_URL}/api/settings/map?locale=${locale}`
-      : `${BACKEND_URL}/api/settings/map`;
-    const res = await fetch(url, {
+    const search =
+      locale && locale !== 'ko' ? `?${new URLSearchParams({ locale }).toString()}` : '';
+    const res = await fetch(buildBackendApiUrl('/settings/map', search), {
       cache: 'no-store',
     });
     if (!res.ok) return null;
@@ -116,7 +114,11 @@ export default async function LocaleLayout({
     <html lang={safeLocale} data-theme={initialTheme} suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: foucScript }} />
-        <Script async src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_TAG_ID}`} strategy="afterInteractive" />
+        <Script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_TAG_ID}`}
+          strategy="afterInteractive"
+        />
         <Script id="google-tag" strategy="afterInteractive">
           {`
             window.dataLayer = window.dataLayer || [];

--- a/src/lib/__tests__/api-server-contract.test.ts
+++ b/src/lib/__tests__/api-server-contract.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchPage, fetchSettingsMap } from '@/lib/api-server';
+
+const ORIGINAL_BACKEND_URL = process.env.BACKEND_URL;
+const ORIGINAL_CI = process.env.CI;
+
+describe('api-server backend URL contract', () => {
+  beforeEach(() => {
+    process.env.BACKEND_URL = 'https://backend.example/api/';
+    delete process.env.CI;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (ORIGINAL_BACKEND_URL === undefined) {
+      delete process.env.BACKEND_URL;
+    } else {
+      process.env.BACKEND_URL = ORIGINAL_BACKEND_URL;
+    }
+    if (ORIGINAL_CI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = ORIGINAL_CI;
+    }
+  });
+
+  it('builds the settings map SSR URL from the canonical backend origin', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ mobile_bottom_nav_visible: 'true' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchSettingsMap('en');
+
+    expect(result).toEqual({ mobile_bottom_nav_visible: 'true' });
+    expect(fetchMock).toHaveBeenCalledWith('https://backend.example/api/settings/map?locale=en', {
+      next: { revalidate: 300, tags: ['settings', 'theme'] },
+    });
+  });
+
+  it('builds CMS page SSR URLs from the same backend contract', async () => {
+    const page = { id: 1, slug: 'home', title: 'Home', blocks: [] };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(page), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchPage('home', 'en');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://backend.example/api/pages/home?locale=en', {
+      next: { revalidate: 300, tags: ['cms', 'page:home'] },
+    });
+  });
+});

--- a/src/lib/__tests__/backend-url.test.ts
+++ b/src/lib/__tests__/backend-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBackendApiUrl,
+  buildConfiguredBackendApiUrl,
+  getBackendOrigin,
+  getConfiguredBackendOrigin,
+  normalizeBackendOrigin,
+} from '@/lib/backend-url';
+
+describe('backend URL contract', () => {
+  it('normalizes trailing slashes and a legacy /api suffix to the backend origin', () => {
+    expect(normalizeBackendOrigin('https://backend.example/api/')).toBe('https://backend.example');
+    expect(normalizeBackendOrigin('https://backend.example/')).toBe('https://backend.example');
+  });
+
+  it('builds backend API URLs from either the canonical origin or a legacy /api env value', () => {
+    expect(buildBackendApiUrl('/health', '?full=1', 'https://backend.example')).toBe(
+      'https://backend.example/api/health?full=1',
+    );
+    expect(buildBackendApiUrl('/health', '?full=1', 'https://backend.example/api/')).toBe(
+      'https://backend.example/api/health?full=1',
+    );
+  });
+
+  it('falls back to localhost only for non-required SSR callers', () => {
+    expect(getBackendOrigin('')).toBe('http://localhost:3000');
+    expect(getConfiguredBackendOrigin('')).toBeNull();
+    expect(buildConfiguredBackendApiUrl('/health', '', '')).toBeNull();
+  });
+});

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,8 +1,17 @@
 import { cache } from 'react';
-import type { ProductListResponse, ProductSort, Category, ProductDetail, Page, SiteSetting, Journal, AttributeType, AttributeValueOption } from '@/lib/api';
+import type {
+  ProductListResponse,
+  ProductSort,
+  Category,
+  ProductDetail,
+  Page,
+  SiteSetting,
+  Journal,
+  AttributeType,
+  AttributeValueOption,
+} from '@/lib/api';
 import { toAttributeFilterOptions, type AttributeFilterGroup } from '@/lib/attributeFilterOptions';
-
-const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3000';
+import { buildBackendApiUrl } from '@/lib/backend-url';
 
 class BackendHttpError extends Error {
   constructor(
@@ -13,8 +22,6 @@ class BackendHttpError extends Error {
     this.name = 'BackendHttpError';
   }
 }
-
-
 
 interface BackendFetchPolicy {
   revalidate?: number;
@@ -34,7 +41,7 @@ async function fetchFromBackend<T>(
   params?: Record<string, string | number | undefined>,
   policy?: BackendFetchPolicy,
 ): Promise<T> {
-  let url = `${BACKEND_URL}/api${endpoint}`;
+  let url = buildBackendApiUrl(endpoint);
 
   if (params) {
     const searchParams = new URLSearchParams();
@@ -50,7 +57,10 @@ async function fetchFromBackend<T>(
   }
 
   const shouldUseCachePolicy = Boolean(policy) && process.env.CI !== 'true';
-  const response = await fetch(url, shouldUseCachePolicy ? { next: policy } : { cache: 'no-store' });
+  const response = await fetch(
+    url,
+    shouldUseCachePolicy ? { next: policy } : { cache: 'no-store' },
+  );
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
@@ -80,37 +90,51 @@ export function fetchProducts(params?: {
 }
 
 export function fetchCategories(locale?: string) {
-  return fetchFromBackend<Category[]>('/categories', locale ? { locale } : undefined, CACHE_POLICIES.categories);
+  return fetchFromBackend<Category[]>(
+    '/categories',
+    locale ? { locale } : undefined,
+    CACHE_POLICIES.categories,
+  );
 }
 
-export const fetchProduct = cache(async (id: number, locale?: string): Promise<ProductDetail | null> => {
-  try {
-    return await fetchFromBackend<ProductDetail>(`/products/${id}`, locale ? { locale } : undefined, CACHE_POLICIES.product);
-  } catch (err) {
-    if (err instanceof BackendHttpError && err.status === 404) {
-      return null;
+export const fetchProduct = cache(
+  async (id: number, locale?: string): Promise<ProductDetail | null> => {
+    try {
+      return await fetchFromBackend<ProductDetail>(
+        `/products/${id}`,
+        locale ? { locale } : undefined,
+        CACHE_POLICIES.product,
+      );
+    } catch (err) {
+      if (err instanceof BackendHttpError && err.status === 404) {
+        return null;
+      }
+      throw err;
     }
-    throw err;
-  }
-});
+  },
+);
 
 export async function fetchPage(slug: string, locale?: string): Promise<Page | null> {
   try {
-    return await fetchFromBackend<Page>(`/pages/${slug}`, locale ? { locale } : undefined, { ...CACHE_POLICIES.cms, tags: [...CACHE_POLICIES.cms.tags, `page:${slug}`] });
+    return await fetchFromBackend<Page>(`/pages/${slug}`, locale ? { locale } : undefined, {
+      ...CACHE_POLICIES.cms,
+      tags: [...CACHE_POLICIES.cms.tags, `page:${slug}`],
+    });
   } catch {
     return null;
   }
 }
-
 
 export async function fetchJournal(slug: string, locale?: string): Promise<Journal | null> {
   try {
-    return await fetchFromBackend<Journal>(`/journals/${slug}`, locale ? { locale } : undefined, { ...CACHE_POLICIES.cms, tags: [...CACHE_POLICIES.cms.tags, `journal:${slug}`] });
+    return await fetchFromBackend<Journal>(`/journals/${slug}`, locale ? { locale } : undefined, {
+      ...CACHE_POLICIES.cms,
+      tags: [...CACHE_POLICIES.cms.tags, `journal:${slug}`],
+    });
   } catch {
     return null;
   }
 }
-
 
 export async function fetchCatalogFilterOptions(locale?: string): Promise<AttributeFilterGroup[]> {
   const types = await fetchFromBackend<AttributeType[]>(
@@ -137,16 +161,23 @@ export async function fetchCatalogFilterOptions(locale?: string): Promise<Attrib
     .filter((group) => group.options.length > 0);
 }
 
-
 export function fetchSettings(group?: string, locale?: string) {
   const params: Record<string, string | undefined> = {};
   if (group) params.group = group;
   if (locale) params.locale = locale;
-  return fetchFromBackend<SiteSetting[]>('/settings', Object.keys(params).length ? params : undefined, CACHE_POLICIES.settings);
+  return fetchFromBackend<SiteSetting[]>(
+    '/settings',
+    Object.keys(params).length ? params : undefined,
+    CACHE_POLICIES.settings,
+  );
 }
 
 export function fetchSettingsMap(locale?: string) {
-  return fetchFromBackend<Record<string, string>>('/settings/map', locale ? { locale } : undefined, CACHE_POLICIES.settings);
+  return fetchFromBackend<Record<string, string>>(
+    '/settings/map',
+    locale ? { locale } : undefined,
+    CACHE_POLICIES.settings,
+  );
 }
 
 export interface AnnouncementBarItem {
@@ -162,7 +193,11 @@ export interface AnnouncementBarItem {
 
 export async function fetchAnnouncementBars(locale?: string): Promise<AnnouncementBarItem[]> {
   try {
-    return await fetchFromBackend<AnnouncementBarItem[]>('/announcement-bars', locale ? { locale } : undefined, { revalidate: 60, tags: ['announcement-bars'] });
+    return await fetchFromBackend<AnnouncementBarItem[]>(
+      '/announcement-bars',
+      locale ? { locale } : undefined,
+      { revalidate: 60, tags: ['announcement-bars'] },
+    );
   } catch {
     return [];
   }

--- a/src/lib/backend-url.ts
+++ b/src/lib/backend-url.ts
@@ -1,0 +1,48 @@
+const DEFAULT_BACKEND_ORIGIN = 'http://localhost:3000';
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function stripApiSuffix(value: string): string {
+  return value.endsWith('/api') ? value.slice(0, -4) : value;
+}
+
+export function normalizeBackendOrigin(value: string): string {
+  return stripApiSuffix(stripTrailingSlash(value.trim()));
+}
+
+export function getBackendOrigin(raw = process.env.BACKEND_URL): string {
+  const configured = raw?.trim();
+  return normalizeBackendOrigin(configured || DEFAULT_BACKEND_ORIGIN);
+}
+
+export function getConfiguredBackendOrigin(raw = process.env.BACKEND_URL): string | null {
+  const configured = raw?.trim();
+  return configured ? normalizeBackendOrigin(configured) : null;
+}
+
+export function buildBackendApiUrl(
+  apiPath: string,
+  search = '',
+  raw = process.env.BACKEND_URL,
+): string {
+  const normalizedApiPath = apiPath.startsWith('/api')
+    ? apiPath
+    : `/api${apiPath.startsWith('/') ? apiPath : `/${apiPath}`}`;
+  return `${getBackendOrigin(raw)}${normalizedApiPath}${search}`;
+}
+
+export function buildConfiguredBackendApiUrl(
+  apiPath: string,
+  search = '',
+  raw = process.env.BACKEND_URL,
+): string | null {
+  const origin = getConfiguredBackendOrigin(raw);
+  if (!origin) return null;
+
+  const normalizedApiPath = apiPath.startsWith('/api')
+    ? apiPath
+    : `/api${apiPath.startsWith('/') ? apiPath : `/${apiPath}`}`;
+  return `${origin}${normalizedApiPath}${search}`;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import createMiddleware from 'next-intl/middleware';
 import { routing } from '@/i18n/routing';
+import { buildConfiguredBackendApiUrl } from '@/lib/backend-url';
 
 const intlMiddleware = createMiddleware(routing);
 
@@ -26,13 +27,14 @@ function withLocaleCookie(
     return response;
   }
 
-  const nextResponse = response instanceof NextResponse
-    ? response
-    : new NextResponse(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers,
-      });
+  const nextResponse =
+    response instanceof NextResponse
+      ? response
+      : new NextResponse(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
 
   nextResponse.cookies.set(LOCALE_COOKIE_NAME, localePrefix.slice(1), {
     path: '/',
@@ -112,9 +114,8 @@ async function verifyRS256(token: string): Promise<Record<string, unknown> | nul
     const key = await getPublicKey();
     if (!key) return null;
 
-    const signature = Uint8Array.from(
-      atob(parts[2].replace(/-/g, '+').replace(/_/g, '/')),
-      (c) => c.charCodeAt(0),
+    const signature = Uint8Array.from(atob(parts[2].replace(/-/g, '+').replace(/_/g, '/')), (c) =>
+      c.charCodeAt(0),
     ).buffer;
 
     const data = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
@@ -140,11 +141,7 @@ async function hasAdminRoleByJwt(token: string): Promise<AdminRoleCheckResult> {
 }
 
 function getBackendAuthMeUrl(): string | null {
-  const backendUrl = process.env.BACKEND_URL?.trim();
-  if (!backendUrl) return null;
-
-  const normalized = backendUrl.replace(/\/$/, '');
-  return normalized.endsWith('/api') ? `${normalized}/auth/me` : `${normalized}/api/auth/me`;
+  return buildConfiguredBackendApiUrl('/auth/me');
 }
 
 async function hasAdminRoleByBackend(cookieHeader: string | null): Promise<boolean> {
@@ -159,7 +156,7 @@ async function hasAdminRoleByBackend(cookieHeader: string | null): Promise<boole
 
     if (!response.ok) return false;
 
-    const profile = await response.json() as { role?: unknown };
+    const profile = (await response.json()) as { role?: unknown };
     return typeof profile.role === 'string' && ADMIN_ROLES.has(profile.role);
   } catch {
     return false;
@@ -184,8 +181,9 @@ export async function middleware(request: NextRequest) {
 
   const localeMatch = pathname.match(localePattern);
   const localePrefix = localeMatch ? `/${localeMatch[1]}` : '';
-  const pathnameWithoutLocale = localeMatch ? (localeMatch[2] || '/') : pathname;
-  const finalizeResponse = (response: Response) => withLocaleCookie(request, response, localePrefix, pathnameWithoutLocale);
+  const pathnameWithoutLocale = localeMatch ? localeMatch[2] || '/' : pathname;
+  const finalizeResponse = (response: Response) =>
+    withLocaleCookie(request, response, localePrefix, pathnameWithoutLocale);
 
   if (pathnameWithoutLocale === '/sitemap.xml' || pathnameWithoutLocale === '/robots.txt') {
     return finalizeResponse(NextResponse.next());
@@ -211,22 +209,15 @@ export async function middleware(request: NextRequest) {
   }
 
   if (pathnameWithoutLocale.startsWith('/api')) {
-    // Proxy to backend using runtime BACKEND_URL
-    const backendUrl = process.env.BACKEND_URL;
-
-    if (!backendUrl) {
-      return finalizeResponse(NextResponse.json(
-        { error: 'BACKEND_URL not configured' },
-        { status: 500 }
-      ));
-    }
-
-    const apiPath = pathname.startsWith('/api')
-      ? pathname
-      : pathname.replace(/^\/[a-z]{2}\/api/, '/api'); // handle /ko/api -> /api
+    // Proxy to backend using the canonical BACKEND_URL origin + /api/* contract.
 
     const search = new URL(request.url).search || request.nextUrl.search;
-    const url = `${backendUrl}${apiPath}${search}`;
+    const url = buildConfiguredBackendApiUrl(pathnameWithoutLocale, search);
+    if (!url) {
+      return finalizeResponse(
+        NextResponse.json({ error: 'BACKEND_URL not configured' }, { status: 500 }),
+      );
+    }
 
     // Forward request to backend
     const headers = new Headers();
@@ -266,15 +257,19 @@ export async function middleware(request: NextRequest) {
       }
       responseHeaders.set('X-Proxy-By', 'Next.js Middleware');
 
-      return finalizeResponse(new NextResponse(data, {
-        status: response.status,
-        headers: responseHeaders,
-      }));
+      return finalizeResponse(
+        new NextResponse(data, {
+          status: response.status,
+          headers: responseHeaders,
+        }),
+      );
     } catch (error) {
-      return finalizeResponse(NextResponse.json(
-        { error: 'Backend unreachable', details: String(error) },
-        { status: 502 }
-      ));
+      return finalizeResponse(
+        NextResponse.json(
+          { error: 'Backend unreachable', details: String(error) },
+          { status: 502 },
+        ),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary\n- normalize the frontend BACKEND_URL contract to an origin-only shared helper\n- route middleware proxy and SSR helpers through the same BACKEND_URL + /api builder\n- document deployment smoke checks and add regression tests for proxy/SSR URL construction\n\n## Verification\n- npx vitest run src/lib/__tests__/backend-url.test.ts src/__tests__/middleware-proxy.test.ts src/lib/__tests__/api-server-contract.test.ts src/__tests__/middleware-backend-fallback.test.ts src/__tests__/middleware.test.ts\n- npx eslint src/middleware.ts src/lib/backend-url.ts src/lib/api-server.ts src/app/[locale]/layout.tsx src/lib/__tests__/backend-url.test.ts src/__tests__/middleware-proxy.test.ts src/lib/__tests__/api-server-contract.test.ts\n\nCloses #1109