### PR TITLE
docs: #1108 require TLS on the Vercel→EC2 origin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | 스토리지 | AWS S3 + CloudFront | 이미지/미디어 CDN |
 | 인프라 | Docker Compose | 로컬 MySQL 관리 |
 | FE 배포 | Vercel Pro | Next.js SSR 자동 배포 |
-| BE 배포 | AWS EC2 t3.small + PM2 | Nginx (HTTP), HTTPS는 Cloudflare/Vercel 종료 |
+| BE 배포 | AWS EC2 t3.small + PM2 | Nginx (TLS 443 origin) + Cloudflare Full/Strict |
 | DB 호스팅 | AWS Lightsail MySQL | 7일 자동 백업 |
 | 테스트 | Vitest (FE) + Jest E2E (BE) | |
 | Node.js | 22.x | .nvmrc로 고정 |

--- a/docs/infrastructure/DEPLOYMENT.md
+++ b/docs/infrastructure/DEPLOYMENT.md
@@ -2,8 +2,8 @@
 
 ## 도메인
 
-- **운영 도메인**: `https://ockhwadang.com` (Cloudflare DNS → Vercel, HTTPS는 Vercel/Cloudflare가 처리)
-- **API 경로**: 브라우저는 `ockhwadang.com/api/*`만 호출. Next.js middleware(`src/middleware.ts`)가 Vercel Edge에서 `BACKEND_URL`로 런타임 프록시. Vercel Edge는 IP 직접 fetch를 금지하므로 반드시 도메인(`api.ockhwadang.com`) 경유.
+- **운영 도메인**: `https://ockhwadang.com` (Cloudflare DNS → Vercel, 브라우저 진입부터 HTTPS 고정)
+- **API 경로**: 브라우저는 `ockhwadang.com/api/*`만 호출. Next.js middleware(`src/middleware.ts`)가 Vercel Edge에서 `BACKEND_URL=https://api.ockhwadang.com` 로 런타임 프록시하며, `api.ockhwadang.com` 은 Cloudflare Proxied + `Full (strict)` 로 EC2 origin 443에 연결한다. Vercel Edge는 IP 직접 fetch를 금지하므로 반드시 도메인 경유.
 - **CDN 서브도메인**: `https://cdn.ockhwadang.com` → CloudFront → S3 `okhwadang-assets`
 ### Cloudflare DNS TXT 레코드
 
@@ -43,8 +43,10 @@ nslookup -type=TXT _dmarc.ockhwadang.com
 - 기존 S3 객체에는 신규 코드가 소급 적용되지 않는다. 기존 상품 이미지까지 같은 정책을 적용해야 하면 AWS 콘솔/CLI로 객체 메타데이터를 일괄 교체하거나 관리자에서 이미지를 재업로드한다.
 - 프론트 `next/image` 최적화 캐시는 `next.config.ts`의 `images.minimumCacheTTL`로 최소 1일을 유지한다. 신규 S3 이미지처럼 origin `Cache-Control`이 더 길면 최적화 이미지 변형도 더 긴 upstream TTL을 따를 수 있으므로, 변경된 이미지는 반드시 새 URL로 교체한다.
 
-### Vercel 환경변수
-- `BACKEND_URL=http://api.ockhwadang.com` (Cloudflare Proxied → EC2 Nginx :80 → NestJS :3000, HTTP)
+### 운영 origin URL
+- 프론트/Vercel `BACKEND_URL=https://api.ockhwadang.com`
+- 백엔드/EC2 `.env.production` `BACKEND_URL=https://api.ockhwadang.com/api` (결제 webhook/status_url, 업로드 절대 URL 생성에 사용)
+- `api.ockhwadang.com` 은 Cloudflare **Proxied + SSL/TLS mode `Full (strict)`** 로 유지하고, EC2 nginx 443에는 Cloudflare Origin CA 또는 동등한 서버 인증서를 설치한다.
 - `SITE_URL=https://ockhwadang.com`
 
 ## 배포 구조
@@ -54,10 +56,12 @@ nslookup -type=TXT _dmarc.ockhwadang.com
     │
     ├── HTTPS ──→ Cloudflare ──→ Vercel CDN (Next.js SSR, ockhwadang.com)
     │                 │
-    │                 └── /api/* rewrites ──→ api.ockhwadang.com → AWS EC2 t3.small (NestJS :3000)
+    │                 └── /api/* rewrites ──→ HTTPS api.ockhwadang.com (Cloudflare Proxied)
     │                                              │
-    │                                              └── MySQL ──→ AWS Lightsail MySQL :3306
-    │                                                 (캐시는 백엔드 프로세스 내 in-memory)
+    │                                              └── HTTPS :443 ──→ AWS EC2 t3.small (Nginx → NestJS :3000)
+    │                                                                  │
+    │                                                                  └── MySQL ──→ AWS Lightsail MySQL :3306
+    │                                                                     (캐시는 백엔드 프로세스 내 in-memory)
     └──────────────────────────────────────────────────────────────────────────────────────────
 ```
 
@@ -75,7 +79,7 @@ nslookup -type=TXT _dmarc.ockhwadang.com
 ### 서버 구성
 - Amazon Linux 2023
 - PM2로 프로세스 관리
-- Nginx (HTTP → HTTPS 리다이렉트)
+- Nginx (443 TLS origin + 80 → 443 redirect)
 
 ### OIDC + SSM 배포 (현재 방식)
 
@@ -180,17 +184,27 @@ curl https://api.ockhwadang.com/api/health
 
 ## Nginx 설정 (EC2)
 
-HTTPS는 Vercel(Cloudflare)에서 종료되고, EC2 nginx는 **HTTP 80 → NestJS :3000** 리버스 프록시만 담당. SSL/certbot 불필요.
+EC2 nginx는 `api.ockhwadang.com` origin에서 TLS를 종료하고, 복호화된 요청만 `127.0.0.1:3000` NestJS로 전달한다. Cloudflare는 `Full (strict)` 모드여야 하며, 443 인증서는 Cloudflare Origin CA 또는 동등한 서버 인증서를 사용한다.
 
 ```bash
 sudo dnf install -y nginx
-sudo cp infra/nginx/commerce.conf /etc/nginx/conf.d/commerce.conf
+sudo install -d -m 700 /etc/ssl/cloudflare
+# origin.crt / origin.key 는 Cloudflare Origin CA(또는 동등한 서버 인증서)로 별도 배치
+sudo cp "$(git rev-parse --show-toplevel)/infra/nginx/commerce.conf" /etc/nginx/conf.d/commerce.conf
 sudo nginx -t
 sudo systemctl enable --now nginx
 ```
 
-> ⚠️ EC2 보안그룹은 80 포트를 0.0.0.0/0 에 허용해야 한다. (Vercel egress IP가 동적이라 IP 화이트리스트는 비현실적)
-> Vercel ↔ EC2 구간은 평문이므로, 민감 데이터가 많아지면 추후 Cloudflare Tunnel 또는 Origin Cert 도입을 검토.
+> ⚠️ EC2 보안그룹은 443만 Cloudflare IP range에서 허용한다. 80은 steady-state 에서 닫고, HTTP → HTTPS redirect 또는 인증서 발급 검증이 꼭 필요할 때만 임시로 연다.
+> ⚠️ 운영 전환 후 `http://api.ockhwadang.com` 직접 응답이 남아 있으면 안 된다. 허용되는 결과는 `301/308` HTTPS redirect 또는 명시적 차단뿐이다.
+
+### 전환 후 smoke check
+
+1. `curl -sS https://api.ockhwadang.com/api/health | jq '.status, .db.status'`
+2. `curl -I http://api.ockhwadang.com/api/health` → `301/308` redirect 또는 연결 거부
+3. 브라우저 DevTools Network 에서 로그인 후 `GET /api/auth/me` 가 HTTPS 로만 호출되고, 응답 `Set-Cookie` 에 `Secure; HttpOnly; SameSite=Strict` 가 유지되는지 확인
+4. 주문/결제 smoke: `POST /api/orders` 와 `POST /api/payments/prepare` 가 HTTPS 로만 성공하고, PG webhook/status URL 이 `https://api.ockhwadang.com/api/...` 로 남아 있는지 확인
+5. 관리자 smoke: `PUT /api/admin/settings` 저장이 HTTPS 로 2xx 응답하는지 확인
 
 자세한 설정은 [`infra/nginx/commerce.conf`](infra/nginx/commerce.conf)를 참조하세요.
 

--- a/docs/infrastructure/EC2_INITIAL_SETUP.md
+++ b/docs/infrastructure/EC2_INITIAL_SETUP.md
@@ -100,7 +100,7 @@ nano .env.production
 ```env
 NODE_ENV=production
 PORT=3000
-BACKEND_URL=http://3.38.168.41:3000
+BACKEND_URL=https://api.ockhwadang.com/api
 
 DB_SYNCHRONIZE=false
 DB_SSL_ENABLED=false
@@ -170,30 +170,19 @@ pm2 startup
 
 ## 9. Nginx 설정
 
-```bash
-sudo nano /etc/nginx/conf.d/commerce.conf
-```
-
-```nginx
-server {
-    listen 80;
-    server_name 3.38.168.41;
-
-    location / {
-        proxy_pass http://127.0.0.1:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-}
-```
+EC2 origin은 `api.ockhwadang.com` 443에서 TLS를 받고 `127.0.0.1:3000` 으로만 전달한다. Cloudflare는 `Full (strict)` 로 맞추고, Origin CA 인증서(또는 동등한 서버 인증서)를 `/etc/ssl/cloudflare/origin.crt`, `/etc/ssl/cloudflare/origin.key` 에 배치한다.
 
 ```bash
+sudo dnf install -y nginx
+# origin.crt / origin.key 는 Cloudflare Origin CA(또는 동등한 서버 인증서)로 별도 배치
+sudo install -d -m 700 /etc/ssl/cloudflare
+sudo cp "$(git rev-parse --show-toplevel)/infra/nginx/commerce.conf" /etc/nginx/conf.d/commerce.conf
 sudo nginx -t
 sudo systemctl start nginx
 sudo systemctl enable nginx
 ```
+
+> `infra/nginx/commerce.conf` 는 `80 → 443` redirect 와 `443 ssl → 127.0.0.1:3000` 프록시를 함께 정의한다.
 
 ---
 
@@ -201,7 +190,8 @@ sudo systemctl enable nginx
 
 ```bash
 curl http://localhost:3000/api/health
-curl http://3.38.168.41:3000/api/health
+curl https://api.ockhwadang.com/api/health
+curl -I http://api.ockhwadang.com/api/health
 ```
 
 ---

--- a/docs/infrastructure/ENVIRONMENT_VARIABLES.md
+++ b/docs/infrastructure/ENVIRONMENT_VARIABLES.md
@@ -4,7 +4,7 @@
 
 | 변수          | 기본값                  | 설명                                                                                 |
 | ------------- | ----------------------- | ------------------------------------------------------------------------------------ |
-| `BACKEND_URL` | `http://localhost:3000` | NestJS 백엔드 URL (`src/middleware.ts` 런타임 프록시와 서버 컴포넌트 fetch에서 사용) |
+| `BACKEND_URL` | `http://localhost:3000` | NestJS 백엔드 URL (`src/middleware.ts` 런타임 프록시와 서버 컴포넌트 fetch에서 사용). 운영 Vercel 값은 `https://api.ockhwadang.com` |
 
 ---
 
@@ -12,7 +12,7 @@
 
 | 변수                 | 기본값                 | 설명                  |
 | -------------------- | ---------------------- | --------------------- |
-| `BACKEND_URL`        | `http://<EC2_IP>:3000` | 백엔드 서버 URL       |
+| `BACKEND_URL`        | `https://api.ockhwadang.com` | 백엔드 origin URL (Cloudflare Proxied + Full (strict)) |
 | `BACKEND_TIMEOUT_MS` | `10000`                | 프록시 타임아웃 (ms)  |
 | `LOG_PROXY_REQUESTS` | `true`                 | 프록시 요청 로깅 여부 |
 
@@ -26,6 +26,7 @@
 | ---------- | ------------- | ----------------------------- |
 | `NODE_ENV` | `development` | 환경 (development/production) |
 | `PORT`     | `3000`        | 서버 포트                     |
+| `BACKEND_URL` | `https://api.ockhwadang.com/api` | 백엔드 외부 기준 URL (결제 webhook/status_url, 업로드 절대 URL 생성에 사용). 프로덕션은 HTTPS만 허용 |
 
 ### 데이터베이스
 

--- a/docs/infrastructure/GITHUB_ACTIONS_OIDC.md
+++ b/docs/infrastructure/GITHUB_ACTIONS_OIDC.md
@@ -231,7 +231,7 @@ ssh -i ~/okhwadang-ec2-key.pem ec2-user@3.38.168.41
 sudo tee /app/shop-okhwadang/backend/.env.production > /dev/null << 'EOF'
 NODE_ENV=production
 PORT=3000
-BACKEND_URL=http://3.38.168.41:3000
+BACKEND_URL=https://api.ockhwadang.com/api
 DB_SYNCHRONIZE=false
 DB_SSL_ENABLED=false
 DATABASE_URL=mysql://user:password@<lightsail-private-ip>:3306/commerce

--- a/docs/infrastructure/SECURITY_GROUPS.md
+++ b/docs/infrastructure/SECURITY_GROUPS.md
@@ -8,8 +8,8 @@ This document describes the security group rules for the shop-okhwadang AWS infr
 
 | Port | Protocol | Source | Description |
 |------|----------|--------|-------------|
-| 80 | TCP | 0.0.0.0/0 | HTTP - Vercel middleware가 `api.ockhwadang.com`(Cloudflare Proxied)으로 `/api/*` 프록시. Vercel Edge는 도메인 fetch만 허용하므로 서브도메인 경유 필수 |
-| 443 | TCP | Cloudflare IPv4 ranges | HTTPS (optional, Cloudflare Full/Strict 모드 사용 시) |
+| 80 | TCP | BLOCKED (steady state) | HTTP - 기본 차단. 필요 시 일시적으로만 열어 301/308 redirect 또는 인증서 발급 검증에 사용 |
+| 443 | TCP | Cloudflare IPv4/IPv6 ranges | HTTPS - `api.ockhwadang.com` origin. Cloudflare Proxied + Full (strict) 유지 |
 | 22 | TCP | <admin-ip>/32 | SSH - Admin access only (restrict to known IPs) |
 | 3000 | TCP | BLOCKED | Application port - Nginx proxy only |
 
@@ -45,17 +45,19 @@ EC2 (Private IP) ---:3306---> Lightsail MySQL
                     -------------------------------
                     |  Vercel (Next.js SSR/Edge)   |
                     |  middleware: /api/* proxy    |
-                    |  BACKEND_URL = http://api.ockhwadang.com |
+                    |  BACKEND_URL = https://api.ockhwadang.com |
                     -------------------------------
                               |
-                    -------------------------------
-                    | Cloudflare (api.ockhwadang.com, Proxied) |
-                    -------------------------------
+                    -----------------------------------------------
+                    | Cloudflare (api.ockhwadang.com, Proxied)   |
+                    | SSL/TLS mode = Full (strict)               |
+                    -----------------------------------------------
                               |
-                    -------------------------------
-                    |   EC2 (Nginx :80 → :3000)    |
-                    |   Port 3000 BLOCKED 외부에서   |
-                    -------------------------------
+                    -----------------------------------------------
+                    | EC2 (Nginx :443 TLS → :3000)               |
+                    | Port 80 blocked/redirect only              |
+                    | Port 3000 blocked externally               |
+                    -----------------------------------------------
                               |
                     -------------------------------
                     |       Lightsail MySQL        |
@@ -66,6 +68,8 @@ EC2 (Private IP) ---:3306---> Lightsail MySQL
 ## Security Best Practices
 
 1. **SSH Access**: Restrict to known admin IP addresses only
-2. **Application Port**: Port 3000 must remain blocked - all traffic goes through Nginx
-3. **Database**: Never expose MySQL to public internet
-4. **Monitoring**: Enable VPC Flow Logs to track rejected traffic
+2. **Origin TLS**: Keep Cloudflare `api.ockhwadang.com` in `Full (strict)` and install an origin certificate on EC2 nginx 443
+3. **HTTP Port 80**: Keep closed in steady state; open only temporarily for redirect/certificate validation if absolutely required
+4. **Application Port**: Port 3000 must remain blocked - all traffic goes through Nginx
+5. **Database**: Never expose MySQL to public internet
+6. **Monitoring**: Enable VPC Flow Logs to track rejected traffic

--- a/infra/nginx/commerce.conf
+++ b/infra/nginx/commerce.conf
@@ -1,6 +1,7 @@
-# Reverse proxy to NestJS :3000
-# HTTPS는 Vercel(ockhwadang.com)에서 종료되고, /api/* 는 next.config.ts rewrites로
-# Vercel 서버측에서 EC2(이 nginx)로 평문 프록시된다. 외부에 직접 노출되지 않음.
+# TLS reverse proxy to NestJS :3000
+# Cloudflare(api.ockhwadang.com, Proxied) must stay in Full (strict) mode and
+# connect to this origin over HTTPS. Install a Cloudflare Origin CA certificate
+# or an equivalent server certificate at the paths below.
 upstream commerce_backend {
     server 127.0.0.1:3000;
     keepalive 64;
@@ -8,7 +9,21 @@ upstream commerce_backend {
 
 server {
     listen 80 default_server;
-    server_name _;
+    server_name api.ockhwadang.com;
+
+    return 301 https://api.ockhwadang.com$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name api.ockhwadang.com;
+
+    ssl_certificate /etc/ssl/cloudflare/origin.crt;
+    ssl_certificate_key /etc/ssl/cloudflare/origin.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_prefer_server_ciphers off;
 
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -34,7 +49,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache_bypass $http_upgrade;
     }
 }


### PR DESCRIPTION
## 요약
- 운영 문서를 Vercel → Cloudflare → EC2 origin 전체를 HTTPS/Full (strict) 전제로 다시 정렬했습니다.
- 프론트/Vercel 및 백엔드/EC2 `BACKEND_URL` 운영값 예시를 HTTPS 기준으로 통일했습니다.
- 샘플 nginx 설정을 80→443 redirect + 443 TLS origin 프록시로 바꾸고, smoke/보안그룹 절차를 함께 갱신했습니다.

## 검증
- git diff --check
- docker run --rm -v <temp-conf>:/etc/nginx/conf.d:ro -v <temp-ssl>:/etc/ssl/cloudflare:ro nginx:1.29-alpine nginx -t

## 비고
- 실제 Cloudflare SSL/TLS 모드 전환, Origin CA 배치, 운영 smoke 는 콘솔/서버 작업이 필요합니다.

Closes #1108