### PR TITLE
frontend: harden /my and /checkout middleware auth

### DIFF
--- a/src/__tests__/middleware-backend-fallback.test.ts
+++ b/src/__tests__/middleware-backend-fallback.test.ts
@@ -61,6 +61,22 @@ describe('middleware backend admin-role fallback', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('allows /checkout when JWT_PUBLIC_KEY is unavailable but backend /auth/me confirms the session', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ id: 9, role: 'user' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await middleware(makeRequest('/ko/checkout'));
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('redirects /admin when backend fallback returns a non-admin role', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 
 vi.mock('next-intl/middleware', () => ({
-  default: () => (req: { url: string }) => new Response(null, { status: 200, headers: { location: req.url } }),
+  default: () => (req: { url: string }) =>
+    new Response(null, { status: 200, headers: { location: req.url } }),
 }));
 vi.mock('@/i18n/routing', () => ({
   routing: { locales: ['ko', 'en'], defaultLocale: 'ko' },
 }));
-
 
 let testKeyPair: CryptoKeyPair;
 let testPublicKeyPem: string;
@@ -85,7 +85,11 @@ describe('middleware', () => {
   });
 
   it('passes through /admin when accessToken cookie has valid super_admin role', async () => {
-    const superAdminToken = await makeSignedToken({ sub: 2, role: 'super_admin', tokenType: 'access' });
+    const superAdminToken = await makeSignedToken({
+      sub: 2,
+      role: 'super_admin',
+      tokenType: 'access',
+    });
     const req = makeRequest('/admin', superAdminToken);
     const res = await middleware(req);
     expect(res.status).toBe(200);
@@ -130,6 +134,31 @@ describe('middleware', () => {
 
   it('redirects /checkout to /login when no accessToken cookie', async () => {
     const req = makeRequest('/checkout');
+    const res = await middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/login');
+    expect(location).toContain('redirect=%2Fcheckout');
+  });
+
+  it('redirects /my to /login when accessToken cookie has a forged signature', async () => {
+    const forgedUserToken = makeForgedToken({ sub: 5, role: 'user', tokenType: 'access' });
+    const req = makeRequest('/my', forgedUserToken);
+    const res = await middleware(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toContain('/login');
+    expect(location).toContain('redirect=%2Fmy');
+  });
+
+  it('redirects /checkout to /login when accessToken cookie is expired', async () => {
+    const expiredToken = await makeSignedToken({
+      sub: 6,
+      role: 'user',
+      tokenType: 'access',
+      exp: Math.floor(Date.now() / 1000) - 60,
+    });
+    const req = makeRequest('/checkout', expiredToken);
     const res = await middleware(req);
     expect(res.status).toBe(307);
     const location = res.headers.get('location');
@@ -183,7 +212,6 @@ describe('middleware', () => {
     expect(localeCookie?.httpOnly).toBe(true);
     expect(localeCookie?.secure).toBe(false);
   });
-
 
   it('redirects locale-prefixed /ko/admin to /ko/login with full path in redirect', async () => {
     const req = makeRequest('/ko/admin');

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,8 +48,28 @@ function withLocaleCookie(
 }
 
 const ADMIN_ROLES = new Set(['admin', 'super_admin']);
+const MEMBER_PROTECTED_PREFIXES = ['/my', '/checkout'] as const;
 
-type AdminRoleCheckResult = 'admin' | 'not-admin' | 'unverified';
+type JwtSessionCheckResult =
+  { status: 'valid'; role: string | null } | { status: 'invalid' | 'unverified' };
+
+function isMemberProtectedPath(pathnameWithoutLocale: string): boolean {
+  return MEMBER_PROTECTED_PREFIXES.some((prefix) => pathnameWithoutLocale.startsWith(prefix));
+}
+
+function redirectToLogin(
+  request: NextRequest,
+  localePrefix: string,
+  redirectTarget: string,
+): NextResponse {
+  const loginUrl = new URL(`${localePrefix}/login`, request.url);
+  loginUrl.searchParams.set('redirect', redirectTarget);
+  return NextResponse.redirect(loginUrl);
+}
+
+function redirectToLocaleHome(request: NextRequest, localePrefix: string): NextResponse {
+  return NextResponse.redirect(new URL(`${localePrefix}/`, request.url));
+}
 
 export function resetPublicKeyCache(): void {
   testPublicKey = null;
@@ -100,6 +120,10 @@ async function getPublicKey(): Promise<CryptoKey | null> {
 function hasConfiguredPublicKey(): boolean {
   return Boolean(testPublicKey ?? process.env.JWT_PUBLIC_KEY);
 }
+function isExpiredJwtPayload(payload: Record<string, unknown>): boolean {
+  const exp = payload.exp;
+  return typeof exp === 'number' && exp * 1000 <= Date.now();
+}
 
 async function verifyRS256(token: string): Promise<Record<string, unknown> | null> {
   try {
@@ -134,19 +158,32 @@ async function verifyRS256(token: string): Promise<Record<string, unknown> | nul
   }
 }
 
-async function hasAdminRoleByJwt(token: string): Promise<AdminRoleCheckResult> {
+async function getJwtSessionCheck(token: string): Promise<JwtSessionCheckResult> {
   const payload = await verifyRS256(token);
-  if (!payload) return 'unverified';
-  return typeof payload.role === 'string' && ADMIN_ROLES.has(payload.role) ? 'admin' : 'not-admin';
+  if (!payload) return { status: 'unverified' };
+
+  if (
+    (typeof payload.tokenType === 'string' && payload.tokenType !== 'access') ||
+    isExpiredJwtPayload(payload)
+  ) {
+    return { status: 'invalid' };
+  }
+
+  return {
+    status: 'valid',
+    role: typeof payload.role === 'string' ? payload.role : null,
+  };
 }
 
 function getBackendAuthMeUrl(): string | null {
   return buildConfiguredBackendApiUrl('/auth/me');
 }
 
-async function hasAdminRoleByBackend(cookieHeader: string | null): Promise<boolean> {
+async function fetchAuthenticatedProfile(
+  cookieHeader: string | null,
+): Promise<{ role?: unknown } | null> {
   const url = getBackendAuthMeUrl();
-  if (!url || !cookieHeader) return false;
+  if (!url || !cookieHeader) return null;
 
   try {
     const response = await fetch(url, {
@@ -154,25 +191,37 @@ async function hasAdminRoleByBackend(cookieHeader: string | null): Promise<boole
       cache: 'no-store',
     });
 
-    if (!response.ok) return false;
-
-    const profile = (await response.json()) as { role?: unknown };
-    return typeof profile.role === 'string' && ADMIN_ROLES.has(profile.role);
+    if (!response.ok) return null;
+    return (await response.json()) as { role?: unknown };
   } catch {
-    return false;
+    return null;
   }
 }
 
-async function hasAdminRole(token: string, cookieHeader: string | null): Promise<boolean> {
-  const jwtResult = await hasAdminRoleByJwt(token);
-  if (jwtResult === 'admin') return true;
-  if (jwtResult === 'not-admin' || hasConfiguredPublicKey()) return false;
+async function hasAuthenticatedSession(
+  token: string,
+  cookieHeader: string | null,
+): Promise<boolean> {
+  const jwtResult = await getJwtSessionCheck(token);
+  if (jwtResult.status === 'valid') return true;
+  if (jwtResult.status === 'invalid' || hasConfiguredPublicKey()) return false;
 
   // In local/Vercel deployments the Edge middleware may not have JWT_PUBLIC_KEY,
   // while the backend still has the private/public key pair and can validate the
   // httpOnly cookie. Fall back to the backend profile endpoint only when local
   // verification is impossible, not when a configured key rejects the token.
-  return hasAdminRoleByBackend(cookieHeader);
+  return Boolean(await fetchAuthenticatedProfile(cookieHeader));
+}
+
+async function hasAdminRole(token: string, cookieHeader: string | null): Promise<boolean> {
+  const jwtResult = await getJwtSessionCheck(token);
+  if (jwtResult.status === 'valid') {
+    return Boolean(jwtResult.role && ADMIN_ROLES.has(jwtResult.role));
+  }
+  if (jwtResult.status === 'invalid' || hasConfiguredPublicKey()) return false;
+
+  const profile = await fetchAuthenticatedProfile(cookieHeader);
+  return typeof profile?.role === 'string' && ADMIN_ROLES.has(profile.role);
 }
 
 export async function middleware(request: NextRequest) {
@@ -182,6 +231,8 @@ export async function middleware(request: NextRequest) {
   const localeMatch = pathname.match(localePattern);
   const localePrefix = localeMatch ? `/${localeMatch[1]}` : '';
   const pathnameWithoutLocale = localeMatch ? localeMatch[2] || '/' : pathname;
+  const redirectTarget = pathname + request.nextUrl.search;
+  const cookieHeader = request.headers.get('cookie');
   const finalizeResponse = (response: Response) =>
     withLocaleCookie(request, response, localePrefix, pathnameWithoutLocale);
 
@@ -191,20 +242,16 @@ export async function middleware(request: NextRequest) {
 
   if (pathnameWithoutLocale.startsWith('/admin')) {
     if (!token) {
-      const loginUrl = new URL(`${localePrefix}/login`, request.url);
-      loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
-      return finalizeResponse(NextResponse.redirect(loginUrl));
+      return finalizeResponse(redirectToLogin(request, localePrefix, redirectTarget));
     }
-    if (!(await hasAdminRole(token, request.headers.get('cookie')))) {
-      return finalizeResponse(NextResponse.redirect(new URL(`${localePrefix}/`, request.url)));
+    if (!(await hasAdminRole(token, cookieHeader))) {
+      return finalizeResponse(redirectToLocaleHome(request, localePrefix));
     }
   }
 
-  if (pathnameWithoutLocale.startsWith('/my') || pathnameWithoutLocale.startsWith('/checkout')) {
-    if (!token) {
-      const loginUrl = new URL(`${localePrefix}/login`, request.url);
-      loginUrl.searchParams.set('redirect', pathname + request.nextUrl.search);
-      return finalizeResponse(NextResponse.redirect(loginUrl));
+  if (isMemberProtectedPath(pathnameWithoutLocale)) {
+    if (!token || !(await hasAuthenticatedSession(token, cookieHeader))) {
+      return finalizeResponse(redirectToLogin(request, localePrefix, redirectTarget));
     }
   }
 


### PR DESCRIPTION
## Summary\n- reject forged, expired, and non-access tokens before protected member routes render\n- share backend /auth/me fallback between member and admin routes only when Edge cannot verify locally\n- split middleware redirect and session helpers and lock the behavior with regression tests\n\n## Verification\n- npx vitest run src/__tests__/middleware.test.ts src/__tests__/middleware-backend-fallback.test.ts src/__tests__/middleware-proxy.test.ts src/lib/__tests__/backend-url.test.ts src/lib/__tests__/api-server-contract.test.ts\n- npx eslint src/middleware.ts src/__tests__/middleware.test.ts src/__tests__/middleware-backend-fallback.test.ts src/__tests__/middleware-proxy.test.ts src/lib/backend-url.ts src/lib/api-server.ts src/lib/__tests__/backend-url.test.ts src/lib/__tests__/api-server-contract.test.ts src/app/[locale]/layout.tsx\n\nCloses #1111