### PR TITLE
refactor: unify SSR and CSR API error contracts

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,7 +7,7 @@ import AppShell from '@/components/AppShell';
 import AnnouncementBar from '@/components/shared/layout/AnnouncementBar';
 import Providers from '@/components/Providers';
 import { isLocale, routing } from '@/i18n/routing';
-import { buildBackendApiUrl } from '@/lib/backend-url';
+import { fetchSettingsMap as fetchBackendSettingsMap } from '@/lib/api-server';
 import { getThemeStyle } from '@/lib/theme-style';
 
 const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
@@ -49,13 +49,7 @@ const GOOGLE_TAG_ID = 'G-ENSHH2TBSY';
 
 async function getSettingsMap(locale?: string): Promise<Record<string, string> | null> {
   try {
-    const search =
-      locale && locale !== 'ko' ? `?${new URLSearchParams({ locale }).toString()}` : '';
-    const res = await fetch(buildBackendApiUrl('/settings/map', search), {
-      cache: 'no-store',
-    });
-    if (!res.ok) return null;
-    return res.json();
+    return await fetchBackendSettingsMap(locale);
   } catch {
     return null;
   }

--- a/src/lib/__tests__/api-error.test.ts
+++ b/src/lib/__tests__/api-error.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ApiHttpError,
+  createApiHttpError,
+  isEmptyApiResponse,
+  normalizeApiErrorMessage,
+} from '@/lib/api-error';
+
+describe('shared API error contract', () => {
+  it('normalizes array-based validation messages into one string', () => {
+    expect(normalizeApiErrorMessage(['필수입니다.', '형식이 올바르지 않습니다.'], 400)).toBe(
+      '필수입니다., 형식이 올바르지 않습니다.',
+    );
+  });
+
+  it('maps backend Forbidden responses to the shared Korean message', () => {
+    expect(normalizeApiErrorMessage('Forbidden', 403)).toBe('접근 권한이 없습니다.');
+  });
+
+  it('builds typed HTTP errors from response payloads', async () => {
+    const error = await createApiHttpError(
+      new Response(JSON.stringify({ message: '설정을 불러오지 못했습니다.' }), { status: 500 }),
+    );
+
+    expect(error).toBeInstanceOf(ApiHttpError);
+    expect(error.message).toBe('설정을 불러오지 못했습니다.');
+    expect(error.status).toBe(500);
+  });
+
+  it('detects empty API responses consistently', () => {
+    expect(isEmptyApiResponse(new Response(null, { status: 204 }))).toBe(true);
+    expect(
+      isEmptyApiResponse(
+        new Response(JSON.stringify({ ok: true }), { headers: { 'content-length': '0' } }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/lib/__tests__/api-interceptor.test.ts
+++ b/src/lib/__tests__/api-interceptor.test.ts
@@ -96,4 +96,14 @@ describe('ApiClient 401 interceptor', () => {
 
     await expect(apiClient.get('/products/99')).rejects.toThrow('잘못된 요청입니다.');
   });
+
+  it('배열형 에러 메시지는 CSR에서도 같은 문자열 규칙으로 합쳐진다', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(400, { message: ['필수입니다.', '형식이 올바르지 않습니다.'] }),
+    );
+
+    await expect(apiClient.get('/products/99')).rejects.toThrow(
+      '필수입니다., 형식이 올바르지 않습니다.',
+    );
+  });
 });

--- a/src/lib/__tests__/api-server-contract.test.ts
+++ b/src/lib/__tests__/api-server-contract.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchPage, fetchSettingsMap } from '@/lib/api-server';
+import { fetchAnnouncementBars, fetchPage, fetchSettingsMap } from '@/lib/api-server';
 
 const ORIGINAL_BACKEND_URL = process.env.BACKEND_URL;
 const ORIGINAL_CI = process.env.CI;
@@ -56,5 +56,41 @@ describe('api-server backend URL contract', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://backend.example/api/pages/home?locale=en', {
       next: { revalidate: 300, tags: ['cms', 'page:home'] },
     });
+  });
+
+  it('returns null for CMS pages only when the backend responds with 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Not Found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchPage('missing', 'en')).resolves.toBeNull();
+  });
+
+  it('re-throws non-404 CMS page failures instead of hiding them as null', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: '설정 동기화 실패' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchPage('home', 'en')).rejects.toThrow('설정 동기화 실패');
+  });
+
+  it('keeps degraded mode only for non-critical announcement bars', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'temporarily unavailable' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchAnnouncementBars('en')).resolves.toEqual([]);
   });
 });

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,47 @@
+const DEFAULT_API_ERROR_MESSAGE = '오류가 발생했습니다.';
+
+export class ApiHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'ApiHttpError';
+  }
+}
+
+export function normalizeApiErrorMessage(
+  rawMessage: unknown,
+  status: number,
+  fallbackMessage = DEFAULT_API_ERROR_MESSAGE,
+): string {
+  const message = Array.isArray(rawMessage)
+    ? rawMessage.join(', ')
+    : typeof rawMessage === 'string' && rawMessage.trim()
+      ? rawMessage
+      : fallbackMessage;
+
+  if (status === 403 && message === 'Forbidden') {
+    return '접근 권한이 없습니다.';
+  }
+
+  return message;
+}
+
+export async function createApiHttpError(
+  response: Pick<Response, 'json' | 'status'>,
+  fallbackMessage = DEFAULT_API_ERROR_MESSAGE,
+): Promise<ApiHttpError> {
+  const payload = (await response.json().catch(() => ({ message: fallbackMessage }))) as {
+    message?: unknown;
+  };
+
+  return new ApiHttpError(
+    normalizeApiErrorMessage(payload.message, response.status, fallbackMessage),
+    response.status,
+  );
+}
+
+export function isEmptyApiResponse(response: Pick<Response, 'status' | 'headers'>): boolean {
+  return response.status === 204 || response.headers.get('content-length') === '0';
+}

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -11,17 +11,8 @@ import type {
   AttributeValueOption,
 } from '@/lib/api';
 import { toAttributeFilterOptions, type AttributeFilterGroup } from '@/lib/attributeFilterOptions';
+import { ApiHttpError, createApiHttpError } from '@/lib/api-error';
 import { buildBackendApiUrl } from '@/lib/backend-url';
-
-class BackendHttpError extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-  ) {
-    super(message);
-    this.name = 'BackendHttpError';
-  }
-}
 
 interface BackendFetchPolicy {
   revalidate?: number;
@@ -63,8 +54,7 @@ async function fetchFromBackend<T>(
   );
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
-    throw new BackendHttpError(error.message || `HTTP ${response.status}`, response.status);
+    throw await createApiHttpError(response);
   }
 
   return response.json() as Promise<T>;
@@ -106,7 +96,7 @@ export const fetchProduct = cache(
         CACHE_POLICIES.product,
       );
     } catch (err) {
-      if (err instanceof BackendHttpError && err.status === 404) {
+      if (err instanceof ApiHttpError && err.status === 404) {
         return null;
       }
       throw err;
@@ -114,26 +104,30 @@ export const fetchProduct = cache(
   },
 );
 
-export async function fetchPage(slug: string, locale?: string): Promise<Page | null> {
+async function fetchCmsResourceOrNullOn404<T>(
+  endpoint: string,
+  locale: string | undefined,
+  cacheTag: string,
+): Promise<T | null> {
   try {
-    return await fetchFromBackend<Page>(`/pages/${slug}`, locale ? { locale } : undefined, {
+    return await fetchFromBackend<T>(endpoint, locale ? { locale } : undefined, {
       ...CACHE_POLICIES.cms,
-      tags: [...CACHE_POLICIES.cms.tags, `page:${slug}`],
+      tags: [...CACHE_POLICIES.cms.tags, cacheTag],
     });
-  } catch {
-    return null;
+  } catch (err) {
+    if (err instanceof ApiHttpError && err.status === 404) {
+      return null;
+    }
+    throw err;
   }
 }
 
+export async function fetchPage(slug: string, locale?: string): Promise<Page | null> {
+  return fetchCmsResourceOrNullOn404<Page>(`/pages/${slug}`, locale, `page:${slug}`);
+}
+
 export async function fetchJournal(slug: string, locale?: string): Promise<Journal | null> {
-  try {
-    return await fetchFromBackend<Journal>(`/journals/${slug}`, locale ? { locale } : undefined, {
-      ...CACHE_POLICIES.cms,
-      tags: [...CACHE_POLICIES.cms.tags, `journal:${slug}`],
-    });
-  } catch {
-    return null;
-  }
+  return fetchCmsResourceOrNullOn404<Journal>(`/journals/${slug}`, locale, `journal:${slug}`);
 }
 
 export async function fetchCatalogFilterOptions(locale?: string): Promise<AttributeFilterGroup[]> {
@@ -193,6 +187,7 @@ export interface AnnouncementBarItem {
 
 export async function fetchAnnouncementBars(locale?: string): Promise<AnnouncementBarItem[]> {
   try {
+    // Announcement bars are non-critical chrome; degrade to [] when the backend is unavailable.
     return await fetchFromBackend<AnnouncementBarItem[]>(
       '/announcement-bars',
       locale ? { locale } : undefined,

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -3,6 +3,7 @@ import {
   GLOBAL_LOADING_END_EVENT,
   GLOBAL_LOADING_START_EVENT,
 } from '@/constants/global-loading';
+import { createApiHttpError, isEmptyApiResponse } from '@/lib/api-error';
 
 const API_BASE = '/api';
 
@@ -91,7 +92,9 @@ class ApiClient {
 
     const { headers: optionHeaders, ...restFetchOptions } = fetchOptions ?? {};
     const isFormData = restFetchOptions.body instanceof FormData;
-    const defaultHeaders: Record<string, string> = isFormData ? {} : { 'Content-Type': 'application/json' };
+    const defaultHeaders: Record<string, string> = isFormData
+      ? {}
+      : { 'Content-Type': 'application/json' };
     emitGlobalLoadingEvent(GLOBAL_LOADING_START_EVENT);
 
     try {
@@ -106,8 +109,7 @@ class ApiClient {
 
       if (response.status === 401) {
         if (AUTH_SKIP_REFRESH.has(endpoint)) {
-          const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
-          throw new Error(error.message || `HTTP ${response.status}`);
+          throw await createApiHttpError(response);
         }
         await _ensureTokenRefreshed();
         // Retry original request after token refresh
@@ -120,35 +122,19 @@ class ApiClient {
           },
         });
         if (!retryResponse.ok) {
-          const error = await retryResponse.json().catch(() => ({ message: '오류가 발생했습니다.' }));
-          throw new Error(error.message || `HTTP ${retryResponse.status}`);
+          throw await createApiHttpError(retryResponse);
         }
-        if (retryResponse.status === 204 || retryResponse.headers.get('content-length') === '0') {
+        if (isEmptyApiResponse(retryResponse)) {
           return undefined as T;
         }
         return retryResponse.json() as Promise<T>;
       }
 
-      if (response.status === 403) {
-        const error = await response.json().catch(() => ({ message: '접근 권한이 없습니다.' }));
-        const message = Array.isArray(error.message)
-          ? error.message.join(', ')
-          : (error.message || '접근 권한이 없습니다.');
-        if (message === 'Forbidden') {
-          throw new Error('접근 권한이 없습니다.');
-        }
-        throw new Error(message);
-      }
-
       if (!response.ok) {
-        const error = await response.json().catch(() => ({ message: '오류가 발생했습니다.' }));
-        const message = Array.isArray(error.message)
-          ? error.message.join(', ')
-          : (error.message || `HTTP ${response.status}`);
-        throw new Error(message);
+        throw await createApiHttpError(response);
       }
 
-      if (response.status === 204 || response.headers.get('content-length') === '0') {
+      if (isEmptyApiResponse(response)) {
         return undefined as T;
       }
       return response.json() as Promise<T>;


### PR DESCRIPTION
## Summary\n- move CSR and SSR error parsing onto one shared API helper\n- stop treating CMS page and journal backend failures as null unless the backend returned 404\n- route layout settings fetches through the shared SSR helper and lock degraded-mode boundaries with regression tests\n\n## Verification\n- npx vitest run src/lib/__tests__/api-error.test.ts src/lib/__tests__/api-interceptor.test.ts src/lib/__tests__/api-server-contract.test.ts src/lib/__tests__/backend-url.test.ts src/__tests__/middleware-proxy.test.ts\n- npx eslint src/lib/api-error.ts src/lib/api/core.ts src/lib/api-server.ts src/app/[locale]/layout.tsx src/lib/__tests__/api-error.test.ts src/lib/__tests__/api-interceptor.test.ts src/lib/__tests__/api-server-contract.test.ts src/lib/backend-url.ts src/lib/__tests__/backend-url.test.ts src/__tests__/middleware-proxy.test.ts\n\nCloses #1113