### PR TITLE
Handle CMS degraded mode and shell integrity for #1112

### DIFF
--- a/docs/infrastructure/DEPLOYMENT.md
+++ b/docs/infrastructure/DEPLOYMENT.md
@@ -209,6 +209,27 @@ curl https://api.ockhwadang.com/api/health
 
 정상 응답은 `status=ok`와 `db.status=connected`를 포함한다. 스토리지(S3) 확인이 실패해도 DB 상태와 분리되어 `storage=disconnected` / `storageReason`으로 표시되며, DB 연결 실패만 `db.status=disconnected`와 503 응답으로 배포 smoke test를 실패시킨다.
 
+### CMS / settings degraded mode 점검
+
+배포 직후 홈 CMS 또는 settings API 이상 여부를 아래 순서로 바로 구분한다.
+
+1. 공개 홈(`/` 또는 `/en`)을 열어 다음 두 증상을 확인한다.
+   - 홈이 에러 화면으로 전환되고 `slug='home'` / `scripts/run-seed.sh` 문구가 보이면 **CMS 콘텐츠 결손**이다.
+   - 상단에 degraded mode 배너가 보이면 **settings API 또는 필수 설정 키 누락**이다.
+2. settings API 응답 확인:
+   ```bash
+   curl https://api.ockhwadang.com/api/settings/map | jq '.mobile_bottom_nav_visible'
+   ```
+   - 200 응답 + 문자열 값이면 필수 셸 설정은 정상이다.
+   - 5xx/timeout/null 이면 프런트는 degraded mode 로 동작한다.
+3. 홈 CMS 정합성 확인:
+   ```bash
+   curl https://api.ockhwadang.com/api/pages/home | jq '.blocks | length'
+   ```
+   - 1 이상이면 홈 블록이 존재한다.
+   - 0, `null`, 404 이면 `pages.slug=home` 또는 `page_blocks` 시드/게시 상태를 복구해야 한다.
+4. 로컬/스테이징에서 시드 복구가 필요하면 `bash scripts/run-seed.sh` 후 다시 2~3번을 반복한다.
+
 ---
 
 ## Nginx 설정 (EC2)

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { HOME_PAGE_CONTENT_ERROR_CODE } from '@/lib/storefront-diagnostics';
 import Home from '@/app/[locale]/(routes)/page';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 
@@ -158,6 +159,12 @@ describe('Home page', () => {
     render(jsx);
     expect(screen.getByText('지금 바로 쇼핑하세요')).toBeInTheDocument();
     expect(mockFetchPage).toHaveBeenCalledWith('home', 'ko');
+  });
+
+  it('throws an operator-facing error when home CMS content is missing', async () => {
+    mockFetchPage.mockResolvedValueOnce(null);
+
+    await expect(Home({ params: Promise.resolve({ locale: 'ko' }) })).rejects.toThrow(HOME_PAGE_CONTENT_ERROR_CODE);
   });
 
   it.each(['favicon.ico', 'robots.txt', 'sitemap.xml', 'logo.png'])(

--- a/src/app/[locale]/(routes)/page.tsx
+++ b/src/app/[locale]/(routes)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import BlockRenderer from '@/components/shared/blocks/BlockRenderer';
+import { createHomePageContentError } from '@/lib/storefront-diagnostics';
 import { fetchPage } from '@/lib/api-server';
 import { isLocale } from '@/i18n/routing';
 
@@ -54,10 +55,7 @@ export default async function Home({
 
   // 홈은 반드시 DB 에서 렌더. 폴백 금지 — 상단 주석 참조.
   if (!homePage?.blocks?.length) {
-    throw new Error(
-      `[home] DB 에 slug='home' 페이지가 없거나 블록이 비어있습니다 (locale=${locale}). ` +
-        `시드 데이터를 확인하세요: scripts/run-seed.sh`,
-    );
+    throw createHomePageContentError(locale);
   }
 
   const blocks = homePage.blocks;

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,8 +7,8 @@ import AppShell from '@/components/AppShell';
 import AnnouncementBar from '@/components/shared/layout/AnnouncementBar';
 import Providers from '@/components/Providers';
 import { isLocale, routing } from '@/i18n/routing';
-import { fetchSettingsMap as fetchBackendSettingsMap } from '@/lib/api-server';
-import { getThemeStyle } from '@/lib/theme-style';
+import { fetchSettingsMap } from '@/lib/api-server';
+import { buildStorefrontShellSnapshot } from '@/lib/storefront-shell';
 
 const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
 
@@ -47,11 +47,12 @@ export async function generateMetadata({
 
 const GOOGLE_TAG_ID = 'G-ENSHH2TBSY';
 
-async function getSettingsMap(locale?: string): Promise<Record<string, string> | null> {
+async function getStorefrontShellSnapshot(locale: string) {
   try {
-    return await fetchBackendSettingsMap(locale);
+    const settingsMap = await fetchSettingsMap(locale);
+    return buildStorefrontShellSnapshot(settingsMap);
   } catch {
-    return null;
+    return buildStorefrontShellSnapshot(null, { fetchFailed: true });
   }
 }
 
@@ -70,32 +71,28 @@ export default async function LocaleLayout({
 
   setRequestLocale(safeLocale);
 
-  const [messages, settingsMap, tNav] = await Promise.all([
+  const [messages, shellSnapshot, tNav, tUi] = await Promise.all([
     getMessages(),
-    getSettingsMap(safeLocale),
+    getStorefrontShellSnapshot(safeLocale),
     getTranslations('navigation'),
+    getTranslations('ui'),
   ]);
 
-  const themeStyle = await getThemeStyle(settingsMap);
-
-  const mobileBottomNavVisible = settingsMap?.mobile_bottom_nav_visible === 'true';
-
-  const businessInfo = settingsMap
-    ? {
-        companyName: settingsMap.business_company_name ?? '',
-        ceo: settingsMap.business_ceo ?? '',
-        address: settingsMap.business_address ?? '',
-        bizNo: settingsMap.business_registration_number ?? '',
-        mailOrderNo: settingsMap.business_mail_order_number ?? '',
-        phone: settingsMap.business_phone ?? '',
-        email: settingsMap.business_email ?? '',
-        hours: settingsMap.business_hours ?? '',
-        lunchTime: settingsMap.business_lunch_time ?? '',
-        holidays: settingsMap.business_holidays ?? '',
-        privacyOfficer: settingsMap.business_privacy_officer ?? '',
-        infoUrl: settingsMap.business_info_url ?? '',
-      }
-    : undefined;
+  const degradedNotice = shellSnapshot.mode === 'degraded'
+    ? (
+      <div data-testid="storefront-shell-degraded-notice" className="border-b border-amber-200 bg-amber-50 text-amber-950">
+        <div className="layout-container py-3">
+          <p className="text-sm font-medium">{tUi('storefrontShellDegradedTitle')}</p>
+          <p className="mt-1 text-xs md:text-sm">
+            {shellSnapshot.issue === 'missing_required_settings'
+              ? tUi('storefrontShellMissingRequiredSettings', { keys: shellSnapshot.missingRequiredKeys.join(', ') })
+              : tUi('storefrontShellFetchFailedDescription')}
+          </p>
+          <p className="mt-1 text-xs text-amber-800">{tUi('storefrontShellRecoveryHint')}</p>
+        </div>
+      </div>
+    )
+    : null;
 
   // SSR 단계에서 data-theme 기본값을 light로 설정 — hydration mismatch 방지.
   // ko 로케일은 클라이언트의 FOUC 스크립트가 localStorage 사용자 선호를 즉시 반영한다.
@@ -121,7 +118,7 @@ export default async function LocaleLayout({
             gtag('config', '${GOOGLE_TAG_ID}');
           `}
         </Script>
-        {themeStyle ? <style>{themeStyle}</style> : null}
+        {shellSnapshot.themeStyle ? <style>{shellSnapshot.themeStyle}</style> : null}
       </head>
       <body>
         <a
@@ -134,9 +131,14 @@ export default async function LocaleLayout({
           <Providers locale={safeLocale}>
             <AppShell
               locale={safeLocale}
-              mobileBottomNavVisible={mobileBottomNavVisible}
-              announcementBar={<AnnouncementBar locale={safeLocale} />}
-              businessInfo={businessInfo}
+              mobileBottomNavVisible={shellSnapshot.mobileBottomNavVisible}
+              announcementBar={
+                <>
+                  {degradedNotice}
+                  <AnnouncementBar locale={safeLocale} />
+                </>
+              }
+              businessInfo={shellSnapshot.businessInfo}
             >
               {children}
             </AppShell>

--- a/src/components/shared/ErrorFallback.tsx
+++ b/src/components/shared/ErrorFallback.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { isHomePageContentError } from '@/lib/storefront-diagnostics';
 import { handleApiError } from '@/utils/error';
 import { localMessage } from '@/utils/localMessages';
 
@@ -9,12 +10,31 @@ interface ErrorFallbackProps {
 }
 
 export default function ErrorFallback({ error, onRetry }: ErrorFallbackProps) {
+  const diagnostic = isHomePageContentError(error)
+    ? {
+        title: localMessage('ui.homeCmsMissingTitle'),
+        description: localMessage('ui.homeCmsMissingDescription'),
+        recoveryHint: localMessage('ui.homeCmsMissingRecoveryHint'),
+      }
+    : null;
+  const detailMessage = diagnostic
+    ? error.message
+    : handleApiError(error, localMessage('ui.unknownError'));
+
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="text-center max-w-md">
         <div className="rounded-lg border border-red-200 bg-red-50 p-6 mb-6">
-          <p className="text-sm text-red-600 mb-2">{localMessage('ui.dataLoadError')}</p>
-          <p className="text-xs text-red-500/70">{handleApiError(error, localMessage('ui.unknownError'))}</p>
+          <p className="text-sm font-medium text-red-700 mb-2">
+            {diagnostic?.title ?? localMessage('ui.dataLoadError')}
+          </p>
+          {diagnostic ? (
+            <>
+              <p className="text-sm text-red-700/90 mb-1">{diagnostic.description}</p>
+              <p className="text-xs text-red-600 mb-2">{diagnostic.recoveryHint}</p>
+            </>
+          ) : null}
+          <p className="text-xs text-red-500/70">{detailMessage}</p>
         </div>
         <button
           onClick={onRetry}

--- a/src/components/shared/__tests__/ErrorFallback.test.tsx
+++ b/src/components/shared/__tests__/ErrorFallback.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import ErrorFallback from '../ErrorFallback';
+import { createHomePageContentError } from '@/lib/storefront-diagnostics';
+
+describe('ErrorFallback', () => {
+  beforeEach(() => {
+    document.documentElement.lang = 'ko';
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('shows targeted CMS guidance for missing home content', () => {
+    render(
+      <ErrorFallback
+        error={createHomePageContentError('ko')}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('홈 CMS 콘텐츠가 비어 있습니다')).toBeInTheDocument();
+    expect(screen.getByText("slug='home' 페이지와 블록 게시 상태를 확인하세요.")).toBeInTheDocument();
+    expect(screen.getAllByText(/scripts\/run-seed\.sh/)).toHaveLength(2);
+  });
+});

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1878,7 +1878,14 @@
     "unknownError": "An unknown error occurred.",
     "retry": "Try again",
     "blockError": "Unable to display this block ({type})",
-    "unknownBlock": "Unknown block type: {type}"
+    "unknownBlock": "Unknown block type: {type}",
+    "homeCmsMissingTitle": "Home CMS content is missing",
+    "homeCmsMissingDescription": "Check the published slug='home' page and its page blocks.",
+    "homeCmsMissingRecoveryHint": "For local or staging, restore seed data with scripts/run-seed.sh. In production, inspect pages/page_blocks integrity first.",
+    "storefrontShellDegradedTitle": "Some storefront settings could not be loaded, so the shell is running in degraded mode.",
+    "storefrontShellFetchFailedDescription": "The settings API did not respond, so theme, business info, and mobile navigation are using degraded defaults.",
+    "storefrontShellMissingRequiredSettings": "Required setting keys are missing: {keys}",
+    "storefrontShellRecoveryHint": "Check the admin settings screen and the /api/settings/map response."
   },
   "newsletter": {
     "emailPlaceholder": "Enter your email",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1878,7 +1878,14 @@
     "unknownError": "알 수 없는 오류가 발생했습니다.",
     "retry": "다시 시도",
     "blockError": "블록을 표시할 수 없습니다 ({type})",
-    "unknownBlock": "알 수 없는 블록 타입: {type}"
+    "unknownBlock": "알 수 없는 블록 타입: {type}",
+    "homeCmsMissingTitle": "홈 CMS 콘텐츠가 비어 있습니다",
+    "homeCmsMissingDescription": "slug='home' 페이지와 블록 게시 상태를 확인하세요.",
+    "homeCmsMissingRecoveryHint": "로컬/스테이징은 scripts/run-seed.sh 로 시드를 복구하고, 운영은 pages/page_blocks 정합성을 점검하세요.",
+    "storefrontShellDegradedTitle": "일부 운영 설정을 불러오지 못해 기본 셸로 표시 중입니다.",
+    "storefrontShellFetchFailedDescription": "settings API 응답이 없어 테마·사업자 정보·하단 네비게이션을 degraded mode 로 처리했습니다.",
+    "storefrontShellMissingRequiredSettings": "필수 설정 키가 누락되었습니다: {keys}",
+    "storefrontShellRecoveryHint": "관리자 설정 화면과 /api/settings/map 응답을 확인하세요."
   },
   "newsletter": {
     "emailPlaceholder": "이메일을 입력하세요",

--- a/src/lib/__tests__/storefront-shell.test.ts
+++ b/src/lib/__tests__/storefront-shell.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { buildStorefrontShellSnapshot } from '../storefront-shell';
+
+describe('buildStorefrontShellSnapshot', () => {
+  it('keeps the storefront shell ready when required settings exist', () => {
+    const snapshot = buildStorefrontShellSnapshot({
+      mobile_bottom_nav_visible: 'true',
+      business_company_name: '옥화당',
+      color_primary: '#123456',
+    });
+
+    expect(snapshot.mode).toBe('ready');
+    expect(snapshot.issue).toBeUndefined();
+    expect(snapshot.mobileBottomNavVisible).toBe(true);
+    expect(snapshot.themeStyle).toContain('--db-color-primary: #123456');
+    expect(snapshot.businessInfo?.companyName).toBe('옥화당');
+  });
+
+  it('marks the shell degraded when the settings fetch fails', () => {
+    const snapshot = buildStorefrontShellSnapshot(null, { fetchFailed: true });
+
+    expect(snapshot.mode).toBe('degraded');
+    expect(snapshot.issue).toBe('settings_fetch_failed');
+    expect(snapshot.mobileBottomNavVisible).toBe(false);
+    expect(snapshot.businessInfo).toBeUndefined();
+  });
+
+  it('marks the shell degraded when required settings are missing', () => {
+    const snapshot = buildStorefrontShellSnapshot({
+      business_company_name: '옥화당',
+    });
+
+    expect(snapshot.mode).toBe('degraded');
+    expect(snapshot.issue).toBe('missing_required_settings');
+    expect(snapshot.missingRequiredKeys).toEqual(['mobile_bottom_nav_visible']);
+    expect(snapshot.businessInfo?.companyName).toBe('옥화당');
+  });
+});

--- a/src/lib/storefront-diagnostics.ts
+++ b/src/lib/storefront-diagnostics.ts
@@ -1,0 +1,12 @@
+export const HOME_PAGE_CONTENT_ERROR_CODE = 'CMS_HOME_PAGE_MISSING';
+
+export function createHomePageContentError(locale: string): Error {
+  return new Error(
+    `[${HOME_PAGE_CONTENT_ERROR_CODE}] DB 에 slug='home' 페이지가 없거나 블록이 비어있습니다 (locale=${locale}). ` +
+      '시드 데이터를 확인하세요: scripts/run-seed.sh',
+  );
+}
+
+export function isHomePageContentError(error: Error): boolean {
+  return error.message.includes(`[${HOME_PAGE_CONTENT_ERROR_CODE}]`);
+}

--- a/src/lib/storefront-shell.ts
+++ b/src/lib/storefront-shell.ts
@@ -1,0 +1,74 @@
+import { getThemeStyle } from '@/lib/theme-style';
+
+const REQUIRED_STOREFRONT_SETTING_KEYS = ['mobile_bottom_nav_visible'] as const;
+
+export type StorefrontShellIssue = 'settings_fetch_failed' | 'missing_required_settings';
+
+export interface StorefrontBusinessInfo {
+  companyName: string;
+  ceo: string;
+  address: string;
+  bizNo: string;
+  mailOrderNo: string;
+  phone: string;
+  email: string;
+  hours: string;
+  lunchTime: string;
+  holidays: string;
+  privacyOfficer: string;
+  infoUrl: string;
+}
+
+export interface StorefrontShellSnapshot {
+  mode: 'ready' | 'degraded';
+  issue?: StorefrontShellIssue;
+  missingRequiredKeys: string[];
+  mobileBottomNavVisible: boolean;
+  themeStyle: string;
+  businessInfo?: StorefrontBusinessInfo;
+}
+
+function hasSettingValue(settingsMap: Record<string, string> | null, key: string): boolean {
+  const value = settingsMap?.[key];
+  return typeof value === 'string' ? value.trim().length > 0 : value != null;
+}
+
+function buildBusinessInfo(settingsMap: Record<string, string> | null): StorefrontBusinessInfo | undefined {
+  if (!settingsMap) return undefined;
+
+  return {
+    companyName: settingsMap.business_company_name ?? '',
+    ceo: settingsMap.business_ceo ?? '',
+    address: settingsMap.business_address ?? '',
+    bizNo: settingsMap.business_registration_number ?? '',
+    mailOrderNo: settingsMap.business_mail_order_number ?? '',
+    phone: settingsMap.business_phone ?? '',
+    email: settingsMap.business_email ?? '',
+    hours: settingsMap.business_hours ?? '',
+    lunchTime: settingsMap.business_lunch_time ?? '',
+    holidays: settingsMap.business_holidays ?? '',
+    privacyOfficer: settingsMap.business_privacy_officer ?? '',
+    infoUrl: settingsMap.business_info_url ?? '',
+  };
+}
+
+export function buildStorefrontShellSnapshot(
+  settingsMap: Record<string, string> | null,
+  options?: { fetchFailed?: boolean },
+): StorefrontShellSnapshot {
+  const missingRequiredKeys = REQUIRED_STOREFRONT_SETTING_KEYS.filter((key) => !hasSettingValue(settingsMap, key));
+  const issue = options?.fetchFailed
+    ? 'settings_fetch_failed'
+    : missingRequiredKeys.length > 0
+      ? 'missing_required_settings'
+      : undefined;
+
+  return {
+    mode: issue ? 'degraded' : 'ready',
+    issue,
+    missingRequiredKeys: [...missingRequiredKeys],
+    mobileBottomNavVisible: settingsMap?.mobile_bottom_nav_visible === 'true',
+    themeStyle: getThemeStyle(settingsMap),
+    businessInfo: buildBusinessInfo(settingsMap),
+  };
+}


### PR DESCRIPTION
## Summary
- classify required storefront settings separately from optional shell settings and surface degraded-mode diagnostics in the public shell
- turn missing `home` CMS content into an explicit operator-facing failure with focused tests
- document a short deployment runbook for distinguishing settings API failures from CMS seed/content gaps

## Verification
- npm run lint
- npm run typecheck
- npm run test:run
- npx vitest run ./src/components/shared/__tests__/ErrorFallback.test.tsx
- npx vitest run ./src/lib/__tests__/storefront-shell.test.ts
- npx vitest run src/__tests__/App.test.tsx

## Notes
- `npm run build` still fails in this worktree because `/ko/admin/settings/business` prerender reaches an unavailable backend settings API; that existing environment/runtime dependency is unchanged here.

Closes #1112