### PR TITLE
test: lock SSR product URL contract

### DIFF
--- a/src/lib/__tests__/api-server-contract.test.ts
+++ b/src/lib/__tests__/api-server-contract.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchAnnouncementBars, fetchPage, fetchSettingsMap } from '@/lib/api-server';
+import { fetchAnnouncementBars, fetchPage, fetchProduct, fetchSettingsMap } from '@/lib/api-server';
 
 const ORIGINAL_BACKEND_URL = process.env.BACKEND_URL;
 const ORIGINAL_CI = process.env.CI;
@@ -55,6 +55,22 @@ describe('api-server backend URL contract', () => {
 
     expect(fetchMock).toHaveBeenCalledWith('https://backend.example/api/pages/home?locale=en', {
       next: { revalidate: 300, tags: ['cms', 'page:home'] },
+    });
+  });
+
+  it('builds product SSR URLs from the same backend contract', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 42, name: 'Tea' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchProduct(42, 'en');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://backend.example/api/products/42?locale=en', {
+      next: { revalidate: 60, tags: ['catalog', 'product'] },
     });
   });
 


### PR DESCRIPTION
## Summary
- add explicit SSR product URL coverage alongside the existing settings/page contract tests
- keep issue #1113's shared BACKEND_URL + /api contract locked across settings, pages, and products

## Verification
- npx vitest run src/lib/__tests__/api-server-contract.test.ts src/lib/__tests__/backend-url.test.ts src/__tests__/middleware.test.ts src/__tests__/middleware-backend-fallback.test.ts src/__tests__/middleware-proxy.test.ts
- npx eslint src/lib/__tests__/api-server-contract.test.ts

Closes #1113