### PR TITLE
Handle home CMS integrity failures and shell degraded mode

### DIFF
--- a/docs/infrastructure/DEPLOYMENT.md
+++ b/docs/infrastructure/DEPLOYMENT.md
@@ -209,6 +209,17 @@ curl https://api.ockhwadang.com/api/health
 
 정상 응답은 `status=ok`와 `db.status=connected`를 포함한다. 스토리지(S3) 확인이 실패해도 DB 상태와 분리되어 `storage=disconnected` / `storageReason`으로 표시되며, DB 연결 실패만 `db.status=disconnected`와 503 응답으로 배포 smoke test를 실패시킨다.
 
+### CMS / settings 정합성 스모크 체크
+```bash
+curl -s https://api.ockhwadang.com/api/pages/home?locale=ko | jq '{slug, blockCount: (.blocks | length)}'
+curl -s https://api.ockhwadang.com/api/settings/map?locale=ko | jq '{business_company_name, business_ceo, business_address, business_registration_number, business_mail_order_number, mobile_bottom_nav_visible}'
+```
+
+- `/api/health` 가 503 이거나 `db.status=disconnected` 면 런타임/인프라 장애다.
+- `/api/pages/home` 가 404 이거나 `blockCount=0` 이면 홈 CMS 데이터 정합성 문제다.
+- `/api/settings/map` 에서 필수 사업자 정보 키(`business_company_name`, `business_ceo`, `business_address`, `business_registration_number`, `business_mail_order_number`)가 비어 있으면 셸은 i18n 기본값으로 degraded mode fallback 한다.
+- 홈 CMS 데이터를 복구해야 하면 `scripts/run-seed.sh` 실행 또는 어드민에서 slug=`home` 페이지 블록을 재게시한 뒤 다시 확인한다.
+
 ---
 
 ## Nginx 설정 (EC2)

--- a/src/app/[locale]/(routes)/__tests__/error.test.tsx
+++ b/src/app/[locale]/(routes)/__tests__/error.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ErrorPage from '../error';
+import { createHomeCmsIntegrityError } from '../home-integrity';
+
+vi.mock('@/utils/clientLocale', () => ({
+  getClientLocale: () => 'ko',
+}));
+
+describe('storefront route error boundary', () => {
+  it('renders a CMS-specific checklist for missing home page content', () => {
+    render(<ErrorPage error={createHomeCmsIntegrityError('ko')} reset={vi.fn()} />);
+
+    expect(screen.getByText('홈 CMS 콘텐츠를 확인해 주세요.')).toBeInTheDocument();
+    expect(screen.getByText(/slug=home 페이지가 게시 상태인지 확인하세요/)).toBeInTheDocument();
+    expect(screen.getByText(/page_blocks가 1개 이상인지 확인하세요/)).toBeInTheDocument();
+  });
+
+  it('falls back to the generic error UI for non-CMS runtime errors', () => {
+    render(<ErrorPage error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(screen.getByText('데이터를 불러오지 못했습니다')).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/(routes)/error.tsx
+++ b/src/app/[locale]/(routes)/error.tsx
@@ -1,6 +1,54 @@
 'use client';
+
 import ErrorFallback from '@/components/shared/ErrorFallback';
+import { localMessage } from '@/utils/localMessages';
+import { isHomeCmsIntegrityError } from './home-integrity';
+
+function HomeCmsIntegrityFallback({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-xl rounded-lg border border-amber-200 bg-amber-50 p-6 text-left shadow-sm">
+        <div className="space-y-2">
+          <p className="text-base font-semibold text-amber-950">
+            {localMessage('home.integrityError.title')}
+          </p>
+          <p className="text-sm text-amber-900">
+            {localMessage('home.integrityError.description')}
+          </p>
+        </div>
+        <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-amber-950">
+          <li>{localMessage('home.integrityError.checkPage')}</li>
+          <li>{localMessage('home.integrityError.checkBlocks')}</li>
+          <li>{localMessage('home.integrityError.checkSeed')}</li>
+        </ul>
+        <div className="mt-4 rounded-md bg-background/80 p-3 text-xs text-muted-foreground">
+          <p className="font-medium text-foreground">
+            {localMessage('home.integrityError.errorLabel')}
+          </p>
+          <p className="mt-1 break-words">{error.message}</p>
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-4 inline-flex items-center gap-2 rounded bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-80"
+        >
+          {localMessage('ui.retry')}
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  if (isHomeCmsIntegrityError(error)) {
+    return <HomeCmsIntegrityFallback error={error} reset={reset} />;
+  }
+
   return <ErrorFallback error={error} onRetry={reset} />;
 }

--- a/src/app/[locale]/(routes)/home-integrity.ts
+++ b/src/app/[locale]/(routes)/home-integrity.ts
@@ -1,0 +1,11 @@
+export const HOME_CMS_INTEGRITY_ERROR_PREFIX = '[home-cms-integrity]';
+
+export function createHomeCmsIntegrityError(locale: string): Error {
+  return new Error(
+    `${HOME_CMS_INTEGRITY_ERROR_PREFIX} slug='home' page is missing or has no blocks (locale=${locale}). Run scripts/run-seed.sh or republish the CMS page blocks.`,
+  );
+}
+
+export function isHomeCmsIntegrityError(error: Error): boolean {
+  return error.message.includes(HOME_CMS_INTEGRITY_ERROR_PREFIX);
+}

--- a/src/app/[locale]/(routes)/page.tsx
+++ b/src/app/[locale]/(routes)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import BlockRenderer from '@/components/shared/blocks/BlockRenderer';
+import { createHomeCmsIntegrityError } from './home-integrity';
 import { fetchPage } from '@/lib/api-server';
 import { isLocale } from '@/i18n/routing';
 
@@ -54,10 +55,7 @@ export default async function Home({
 
   // 홈은 반드시 DB 에서 렌더. 폴백 금지 — 상단 주석 참조.
   if (!homePage?.blocks?.length) {
-    throw new Error(
-      `[home] DB 에 slug='home' 페이지가 없거나 블록이 비어있습니다 (locale=${locale}). ` +
-        `시드 데이터를 확인하세요: scripts/run-seed.sh`,
-    );
+    throw createHomeCmsIntegrityError(locale);
   }
 
   const blocks = homePage.blocks;

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import AnnouncementBar from '@/components/shared/layout/AnnouncementBar';
 import Providers from '@/components/Providers';
 import { isLocale, routing } from '@/i18n/routing';
 import { fetchSettingsMap as fetchBackendSettingsMap } from '@/lib/api-server';
+import { resolveFooterBusinessInfo, resolveMobileBottomNavVisible } from '@/lib/shell-settings';
 import { getThemeStyle } from '@/lib/theme-style';
 
 const SITE_URL = process.env.SITE_URL ?? 'https://shop-okhwadang.com';
@@ -54,7 +55,6 @@ async function getSettingsMap(locale?: string): Promise<Record<string, string> |
     return null;
   }
 }
-
 export default async function LocaleLayout({
   children,
   params,
@@ -76,26 +76,9 @@ export default async function LocaleLayout({
     getTranslations('navigation'),
   ]);
 
-  const themeStyle = await getThemeStyle(settingsMap);
-
-  const mobileBottomNavVisible = settingsMap?.mobile_bottom_nav_visible === 'true';
-
-  const businessInfo = settingsMap
-    ? {
-        companyName: settingsMap.business_company_name ?? '',
-        ceo: settingsMap.business_ceo ?? '',
-        address: settingsMap.business_address ?? '',
-        bizNo: settingsMap.business_registration_number ?? '',
-        mailOrderNo: settingsMap.business_mail_order_number ?? '',
-        phone: settingsMap.business_phone ?? '',
-        email: settingsMap.business_email ?? '',
-        hours: settingsMap.business_hours ?? '',
-        lunchTime: settingsMap.business_lunch_time ?? '',
-        holidays: settingsMap.business_holidays ?? '',
-        privacyOfficer: settingsMap.business_privacy_officer ?? '',
-        infoUrl: settingsMap.business_info_url ?? '',
-      }
-    : undefined;
+  const themeStyle = getThemeStyle(settingsMap);
+  const mobileBottomNavVisible = resolveMobileBottomNavVisible(settingsMap);
+  const businessInfo = resolveFooterBusinessInfo(settingsMap);
 
   // SSR 단계에서 data-theme 기본값을 light로 설정 — hydration mismatch 방지.
   // ko 로케일은 클라이언트의 FOUC 스크립트가 localStorage 사용자 선호를 즉시 반영한다.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,7 +4,7 @@ import { usePathname } from 'next/navigation';
 import { Toaster } from 'sonner';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import type { FooterBusinessInfo } from '@/components/Footer';
+import type { FooterBusinessInfo } from '@/lib/shell-settings';
 import MobileBottomNavWrapper from '@/components/MobileBottomNavWrapper';
 import { MobileNavProvider } from '@/contexts/MobileNavContext';
 import RecentlyViewedWidget from '@/components/RecentlyViewedWidget';

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 import { Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { useNavigation } from '@/hooks/useNavigation';
+import type { FooterBusinessInfo } from '@/lib/shell-settings';
+
 import type { NavigationItem } from '@/lib/api';
 
 const InstagramIcon = ({ size = 18 }: { size?: number }) => (
@@ -57,21 +59,6 @@ function renderNavLinks(items: NavigationItem[]) {
       {item.label}
     </Link>
   ));
-}
-
-export interface FooterBusinessInfo {
-  companyName: string;
-  ceo: string;
-  address: string;
-  bizNo: string;
-  mailOrderNo: string;
-  phone: string;
-  email: string;
-  hours: string;
-  lunchTime: string;
-  holidays: string;
-  privacyOfficer: string;
-  infoUrl: string;
 }
 
 interface FooterProps {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1515,7 +1515,15 @@
         "subtitle": "Compose a quiet ritual with Yixing teapots and tea ware of your own.",
         "ctaText": "View Journal"
       }
-    ]
+    ],
+    "integrityError": {
+      "title": "Check the home CMS content.",
+      "description": "This is likely a slug=home page or block integrity problem, not a generic runtime outage.",
+      "checkPage": "Confirm the slug=home page is published in Admin > Pages.",
+      "checkBlocks": "Confirm the home page has at least one page_blocks entry.",
+      "checkSeed": "If recovery is needed, run scripts/run-seed.sh or republish the CMS page blocks before retrying.",
+      "errorLabel": "Original error"
+    }
   },
   "journalCategories": {
     "culture": "Tea Culture",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1515,7 +1515,15 @@
         "subtitle": "자사호와 다구로 꾸미는 나만의 다석, 고요한 시간의 시작.",
         "ctaText": "저널 보기"
       }
-    ]
+    ],
+    "integrityError": {
+      "title": "홈 CMS 콘텐츠를 확인해 주세요.",
+      "description": "런타임 장애가 아니라 slug=home 페이지 또는 블록 정합성 문제일 가능성이 큽니다.",
+      "checkPage": "관리자 > 페이지에서 slug=home 페이지가 게시 상태인지 확인하세요.",
+      "checkBlocks": "home 페이지의 page_blocks가 1개 이상인지 확인하세요.",
+      "checkSeed": "복구가 필요하면 scripts/run-seed.sh 실행 또는 CMS 페이지 블록 재게시 후 다시 시도하세요.",
+      "errorLabel": "원본 오류"
+    }
   },
   "journalCategories": {
     "culture": "다문화",

--- a/src/lib/__tests__/api-server.test.ts
+++ b/src/lib/__tests__/api-server.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchPage } from '../api-server';
+
+describe('fetchPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns null only when the CMS page is actually missing', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: vi.fn().mockResolvedValue({ message: 'not found' }),
+    } as unknown as Response);
+
+    await expect(fetchPage('home', 'ko')).resolves.toBeNull();
+  });
+
+  it('rethrows non-404 backend failures so route errors can distinguish runtime issues', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ message: 'backend exploded' }),
+    } as unknown as Response);
+
+    await expect(fetchPage('home', 'ko')).rejects.toThrow('backend exploded');
+  });
+});

--- a/src/lib/__tests__/shell-settings.test.ts
+++ b/src/lib/__tests__/shell-settings.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getMissingRequiredShellBusinessInfoSettings,
+  resolveFooterBusinessInfo,
+  resolveMobileBottomNavVisible,
+} from '../shell-settings';
+
+describe('shell-settings helpers', () => {
+  it('returns partial footer business info without blank strings', () => {
+    const businessInfo = resolveFooterBusinessInfo({
+      business_company_name: '옥화당',
+      business_ceo: '  ',
+      business_email: 'support@example.com',
+      business_info_url: 'https://www.ftc.go.kr/example',
+    });
+
+    expect(businessInfo).toEqual({
+      companyName: '옥화당',
+      email: 'support@example.com',
+      infoUrl: 'https://www.ftc.go.kr/example',
+    });
+  });
+
+  it('tracks missing required legal footer settings separately from optional fields', () => {
+    const missingKeys = getMissingRequiredShellBusinessInfoSettings({
+      business_company_name: '옥화당',
+      business_ceo: '권준현',
+      business_phone: '010-0000-0000',
+    });
+
+    expect(missingKeys).toEqual([
+      'business_address',
+      'business_registration_number',
+      'business_mail_order_number',
+    ]);
+  });
+
+  it('keeps mobile bottom navigation hidden unless the setting is explicitly true', () => {
+    expect(resolveMobileBottomNavVisible({ mobile_bottom_nav_visible: 'true' })).toBe(true);
+    expect(resolveMobileBottomNavVisible({ mobile_bottom_nav_visible: 'false' })).toBe(false);
+    expect(resolveMobileBottomNavVisible(null)).toBe(false);
+  });
+});

--- a/src/lib/shell-settings.ts
+++ b/src/lib/shell-settings.ts
@@ -1,0 +1,79 @@
+export interface FooterBusinessInfo {
+  companyName?: string;
+  ceo?: string;
+  address?: string;
+  bizNo?: string;
+  mailOrderNo?: string;
+  phone?: string;
+  email?: string;
+  hours?: string;
+  lunchTime?: string;
+  holidays?: string;
+  privacyOfficer?: string;
+  infoUrl?: string;
+}
+
+const BUSINESS_INFO_SETTING_KEYS = {
+  companyName: 'business_company_name',
+  ceo: 'business_ceo',
+  address: 'business_address',
+  bizNo: 'business_registration_number',
+  mailOrderNo: 'business_mail_order_number',
+  phone: 'business_phone',
+  email: 'business_email',
+  hours: 'business_hours',
+  lunchTime: 'business_lunch_time',
+  holidays: 'business_holidays',
+  privacyOfficer: 'business_privacy_officer',
+  infoUrl: 'business_info_url',
+} as const satisfies Record<keyof FooterBusinessInfo, string>;
+
+export const REQUIRED_SHELL_BUSINESS_INFO_SETTINGS = [
+  'business_company_name',
+  'business_ceo',
+  'business_address',
+  'business_registration_number',
+  'business_mail_order_number',
+] as const;
+
+function readSettingValue(
+  settingsMap: Record<string, string> | null,
+  key: string,
+): string | undefined {
+  const value = settingsMap?.[key];
+  if (typeof value !== 'string') return undefined;
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function getMissingRequiredShellBusinessInfoSettings(
+  settingsMap: Record<string, string> | null,
+): string[] {
+  return REQUIRED_SHELL_BUSINESS_INFO_SETTINGS.filter(
+    (key) => !readSettingValue(settingsMap, key),
+  );
+}
+
+export function resolveFooterBusinessInfo(
+  settingsMap: Record<string, string> | null,
+): FooterBusinessInfo | undefined {
+  if (!settingsMap) return undefined;
+
+  const businessInfo: FooterBusinessInfo = {};
+
+  for (const [field, settingKey] of Object.entries(BUSINESS_INFO_SETTING_KEYS)) {
+    const value = readSettingValue(settingsMap, settingKey);
+    if (value) {
+      businessInfo[field as keyof FooterBusinessInfo] = value;
+    }
+  }
+
+  return Object.keys(businessInfo).length > 0 ? businessInfo : undefined;
+}
+
+export function resolveMobileBottomNavVisible(
+  settingsMap: Record<string, string> | null,
+): boolean {
+  return readSettingValue(settingsMap, 'mobile_bottom_nav_visible') === 'true';
+}


### PR DESCRIPTION
## Summary
- distinguish missing home CMS content from non-404 backend/runtime failures
- keep storefront shell business info on fallback-safe partial settings and add operator-focused home error messaging
- document CMS/settings smoke checks and add focused tests for the new contracts

## Verification
- npx vitest run 'src/lib/__tests__/api-server.test.ts' 'src/lib/__tests__/shell-settings.test.ts' 'src/app/[locale]/(routes)/__tests__/error.test.tsx' 'src/components/__tests__/Footer.test.tsx' 'src/components/__tests__/AppShell.test.tsx' 'src/components/shared/layout/__tests__/AnnouncementBar.test.tsx' 'src/__tests__/App.test.tsx'
- npm run build
- bash scripts/start-local.sh

Closes #1112