### PR TITLE
fix: #1110 unify checkout gateway exposure, env, and CSP contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 BACKEND_URL=http://localhost:3000
+# Checkout exposure single source: backend/src/config/checkout-gateway-contract.ts
+NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS=naverpay,paypal,eximbay  # Optional — bank_transfer is always shown for ko checkout
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=   # Stripe publishable key (for global locale)
 NEXT_PUBLIC_KAKAO_CLIENT_ID=  # REQUIRED — Kakao JavaScript/REST app key used to build OAuth authorize URL
 NEXT_PUBLIC_KAKAO_REDIRECT_URI=http://localhost:5173/auth/kakao/callback  # REQUIRED — must match Kakao Developers redirect URI

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,6 +56,8 @@ SENTRY_TRACES_SAMPLE_RATE=0.1
 # Redis/ElastiCache 연결 불필요.
 # ─────────────────────────────────────────────
 PAYMENT_GATEWAY=mock  # REQUIRED — 'mock' is blocked in production. Options: mock, toss, stripe, inicis, naverpay, paypal, eximbay
+# Checkout exposure single source: backend/src/config/checkout-gateway-contract.ts
+CHECKOUT_ENABLED_GATEWAYS=naverpay,paypal,eximbay  # Optional — if unset, checkout exposure falls back to locale defaults; bank_transfer stays enabled for ko
 TOSS_SECRET_KEY=   # Toss Payments secret key (for ko locale, default 국내 PG)
 TOSS_CLIENT_KEY=   # Toss Payments client key (for ko locale)
 STRIPE_SECRET_KEY=   # Stripe secret key (for global locale)

--- a/backend/src/config/checkout-gateway-contract.ts
+++ b/backend/src/config/checkout-gateway-contract.ts
@@ -1,0 +1,187 @@
+export type CheckoutGatewayName = 'naverpay' | 'bank_transfer' | 'eximbay' | 'paypal';
+export type CheckoutLocale = 'ko' | 'en';
+export type CheckoutGatewayCspDirective =
+  | 'style-src'
+  | 'script-src'
+  | 'img-src'
+  | 'connect-src'
+  | 'child-src'
+  | 'frame-src';
+
+interface CheckoutGatewayContract {
+  requiredEnvKeys: readonly string[];
+  csp: Partial<Record<CheckoutGatewayCspDirective, readonly string[]>>;
+}
+
+export const DEFAULT_CHECKOUT_GATEWAYS = ['naverpay', 'bank_transfer', 'paypal', 'eximbay'] as const satisfies readonly CheckoutGatewayName[];
+
+export const CHECKOUT_GATEWAY_ORDER_BY_LOCALE = {
+  ko: DEFAULT_CHECKOUT_GATEWAYS,
+  en: ['paypal', 'eximbay'],
+} as const satisfies Record<CheckoutLocale, readonly CheckoutGatewayName[]>;
+
+export const CHECKOUT_GATEWAY_CONTRACT = {
+  naverpay: {
+    requiredEnvKeys: [
+      'NAVERPAY_PARTNER_ID',
+      'NAVERPAY_CLIENT_ID',
+      'NAVERPAY_CLIENT_SECRET',
+      'NAVERPAY_CHAIN_ID',
+    ],
+    csp: {
+      'script-src': ['https://nsp.pay.naver.com'],
+      'connect-src': [
+        'https://nsp.pay.naver.com',
+        'https://pay.naver.com',
+        'https://m.pay.naver.com',
+        'https://test-pay.naver.com',
+        'https://test-m.pay.naver.com',
+      ],
+      'child-src': [
+        'https://pay.naver.com',
+        'https://m.pay.naver.com',
+        'https://test-pay.naver.com',
+        'https://test-m.pay.naver.com',
+      ],
+      'frame-src': [
+        'https://pay.naver.com',
+        'https://m.pay.naver.com',
+        'https://test-pay.naver.com',
+        'https://test-m.pay.naver.com',
+      ],
+    },
+  },
+  bank_transfer: {
+    requiredEnvKeys: [],
+    csp: {},
+  },
+  paypal: {
+    requiredEnvKeys: ['PAYPAL_CLIENT_ID', 'PAYPAL_CLIENT_SECRET'],
+    csp: {
+      'style-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+      'script-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+      'img-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+      'connect-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+      'child-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+      'frame-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+    },
+  },
+  eximbay: {
+    requiredEnvKeys: ['EXIMBAY_MERCHANT_ID', 'EXIMBAY_API_KEY', 'EXIMBAY_SECRET_KEY'],
+    csp: {
+      'script-src': ['https://api-test.eximbay.com', 'https://api.eximbay.com'],
+      'connect-src': [
+        'https://api-test.eximbay.com',
+        'https://api.eximbay.com',
+        'https://pgonline-test.eximbay.com',
+        'https://pgonline.eximbay.com',
+      ],
+      'child-src': [
+        'https://api-test.eximbay.com',
+        'https://api.eximbay.com',
+        'https://pgonline-test.eximbay.com',
+        'https://pgonline.eximbay.com',
+      ],
+      'frame-src': [
+        'https://api-test.eximbay.com',
+        'https://api.eximbay.com',
+        'https://pgonline-test.eximbay.com',
+        'https://pgonline.eximbay.com',
+      ],
+    },
+  },
+} as const satisfies Record<CheckoutGatewayName, CheckoutGatewayContract>;
+
+export const CHECKOUT_GATEWAY_CHANGE_FILES = [
+  'backend/src/config/checkout-gateway-contract.ts',
+  'src/constants/checkoutPaymentMethods.ts',
+  'backend/src/modules/payments/payments.module.ts',
+  'backend/src/config/env-validator.ts',
+  'next.config.ts',
+  '.env.example',
+  'backend/.env.example',
+  'docs/infrastructure/ENVIRONMENT_VARIABLES.md',
+  'docs/infrastructure/DEPLOYMENT.md',
+  'docs/qa/checkout-payment-e2e.md',
+] as const;
+
+export function isCheckoutGatewayName(value: string): value is CheckoutGatewayName {
+  return value === 'naverpay' || value === 'bank_transfer' || value === 'eximbay' || value === 'paypal';
+}
+
+export function parseConfiguredCheckoutGateways(configured: string | undefined | null): CheckoutGatewayName[] {
+  const gateways = (configured ?? '')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(isCheckoutGatewayName);
+
+  if (gateways.length === 0) {
+    return [];
+  }
+
+  return [...new Set([...gateways, 'bank_transfer' as const])];
+}
+
+export function getEnabledCheckoutGateways(
+  configured: string | undefined | null,
+  fallback: readonly CheckoutGatewayName[] = DEFAULT_CHECKOUT_GATEWAYS,
+): CheckoutGatewayName[] {
+  const parsed = parseConfiguredCheckoutGateways(configured);
+  return parsed.length > 0 ? parsed : [...fallback];
+}
+
+function resolveCheckoutLocale(locale: string): CheckoutLocale {
+  return locale === 'ko' ? 'ko' : 'en';
+}
+
+export function getCheckoutGatewayOptions(
+  locale: string,
+  configured: string | undefined | null,
+  fallback: readonly CheckoutGatewayName[] = DEFAULT_CHECKOUT_GATEWAYS,
+): CheckoutGatewayName[] {
+  const enabled = getEnabledCheckoutGateways(configured, fallback);
+  const localeOrder = CHECKOUT_GATEWAY_ORDER_BY_LOCALE[resolveCheckoutLocale(locale)];
+  return localeOrder.filter((gateway) => enabled.includes(gateway));
+}
+
+export function getDefaultCheckoutGateway(
+  locale: string,
+  configured: string | undefined | null,
+  fallback: readonly CheckoutGatewayName[] = DEFAULT_CHECKOUT_GATEWAYS,
+): CheckoutGatewayName {
+  return getCheckoutGatewayOptions(locale, configured, fallback)[0] ?? 'paypal';
+}
+
+export function getRequiredCheckoutEnvKeys(configured: string | undefined | null): string[] {
+  return getEnabledCheckoutGateways(configured, []).flatMap((gateway) => CHECKOUT_GATEWAY_CONTRACT[gateway].requiredEnvKeys);
+}
+
+export function getCheckoutGatewayCspSources(enabledGateways: readonly CheckoutGatewayName[]): Record<CheckoutGatewayCspDirective, string[]> {
+  const sources: Record<CheckoutGatewayCspDirective, string[]> = {
+    'style-src': [],
+    'script-src': [],
+    'img-src': [],
+    'connect-src': [],
+    'child-src': [],
+    'frame-src': [],
+  };
+
+  for (const gateway of enabledGateways) {
+    for (const [directive, values] of Object.entries(CHECKOUT_GATEWAY_CONTRACT[gateway].csp) as [CheckoutGatewayCspDirective, readonly string[]][]) {
+      for (const value of values) {
+        if (!sources[directive].includes(value)) {
+          sources[directive].push(value);
+        }
+      }
+    }
+  }
+
+  return sources;
+}
+
+export function getConfiguredCheckoutGatewayCspSources(
+  configured: string | undefined | null,
+  fallback: readonly CheckoutGatewayName[] = DEFAULT_CHECKOUT_GATEWAYS,
+): Record<CheckoutGatewayCspDirective, string[]> {
+  return getCheckoutGatewayCspSources(getEnabledCheckoutGateways(configured, fallback));
+}

--- a/backend/src/config/env-validator.ts
+++ b/backend/src/config/env-validator.ts
@@ -4,6 +4,10 @@
  * backend/.env.example에 # REQUIRED 주석이 붙은 키 목록과 동기화할 것.
  * 누락 시 명확한 에러 메시지 출력 후 프로세스 종료.
  */
+import {
+  CHECKOUT_GATEWAY_CONTRACT,
+  getRequiredCheckoutEnvKeys as getRequiredCheckoutEnvKeysFromContract,
+} from './checkout-gateway-contract';
 
 export const REQUIRED_PROD_ENV_KEYS = [
   'NODE_ENV',
@@ -23,21 +27,9 @@ export const REQUIRED_PROD_ENV_KEYS = [
 ] as const;
 
 export const CHECKOUT_PROVIDER_ENV_KEYS = {
-  naverpay: [
-    'NAVERPAY_PARTNER_ID',
-    'NAVERPAY_CLIENT_ID',
-    'NAVERPAY_CLIENT_SECRET',
-    'NAVERPAY_CHAIN_ID',
-  ],
-  paypal: [
-    'PAYPAL_CLIENT_ID',
-    'PAYPAL_CLIENT_SECRET',
-  ],
-  eximbay: [
-    'EXIMBAY_MERCHANT_ID',
-    'EXIMBAY_API_KEY',
-    'EXIMBAY_SECRET_KEY',
-  ],
+  naverpay: [...CHECKOUT_GATEWAY_CONTRACT.naverpay.requiredEnvKeys],
+  paypal: [...CHECKOUT_GATEWAY_CONTRACT.paypal.requiredEnvKeys],
+  eximbay: [...CHECKOUT_GATEWAY_CONTRACT.eximbay.requiredEnvKeys],
 } as const;
 
 export const CHECKOUT_PROD_ENV_KEYS = [
@@ -46,25 +38,10 @@ export const CHECKOUT_PROD_ENV_KEYS = [
   ...CHECKOUT_PROVIDER_ENV_KEYS.eximbay,
 ] as const;
 
-type CheckoutProvider = keyof typeof CHECKOUT_PROVIDER_ENV_KEYS;
-
-function isCheckoutProvider(value: string): value is CheckoutProvider {
-  return value === 'naverpay' || value === 'paypal' || value === 'eximbay';
-}
-
-function getEnabledCheckoutProviders(env: NodeJS.ProcessEnv): CheckoutProvider[] {
-  const configured = env.CHECKOUT_ENABLED_GATEWAYS ?? env.PAYMENT_GATEWAY ?? '';
-  const providers = configured
-    .split(',')
-    .map((value) => value.trim().toLowerCase())
-    .filter(isCheckoutProvider);
-  return [...new Set(providers)];
-}
-
 export function getRequiredCheckoutEnvKeys(env: NodeJS.ProcessEnv): RequiredEnvKey[] {
-  return getEnabledCheckoutProviders(env).flatMap((provider) => [
-    ...CHECKOUT_PROVIDER_ENV_KEYS[provider],
-  ]);
+  return getRequiredCheckoutEnvKeysFromContract(
+    env.CHECKOUT_ENABLED_GATEWAYS ?? env.PAYMENT_GATEWAY,
+  ) as RequiredEnvKey[];
 }
 
 export type RequiredEnvKey =

--- a/backend/src/modules/payments/__tests__/payments.module.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.module.spec.ts
@@ -90,6 +90,23 @@ describe('locale gateway policy — express payments first and country-specific 
     expect(getAvailableGatewaysByLocale('en', env)).toEqual(['paypal', 'eximbay']);
   });
 
+  it('ko hides disabled express gateways when only paypal is enabled', () => {
+    const previous = process.env.CHECKOUT_ENABLED_GATEWAYS;
+    process.env.CHECKOUT_ENABLED_GATEWAYS = 'paypal';
+
+    try {
+      expect(resolveGatewayByLocale('ko')).toBe('bank_transfer');
+      expect(getAvailableGatewaysByLocale('ko')).toEqual(['bank_transfer', 'paypal']);
+      expect(getAvailableGatewaysByLocale('en')).toEqual(['paypal']);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CHECKOUT_ENABLED_GATEWAYS;
+      } else {
+        process.env.CHECKOUT_ENABLED_GATEWAYS = previous;
+      }
+    }
+  });
+
   it('en and other locales → paypal default, eximbay card, no naverpay', () => {
     expect(resolveGatewayByLocale('en')).toBe('paypal');
     expect(resolveGatewayByLocale('ja')).toBe('paypal');

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -12,6 +12,27 @@ import { PaymentsController } from './payments.controller';
 import { AdminOrderRefundsController } from './admin-order-refunds.controller';
 import { AdminPaymentWebhooksController } from './admin-payment-webhooks.controller';
 import { gatewayProviders } from './payment-gateway.provider';
+import {
+  getCheckoutGatewayOptions,
+  getDefaultCheckoutGateway,
+  isCheckoutGatewayName,
+  type CheckoutGatewayName,
+} from '../../config/checkout-gateway-contract';
+
+/**
+ * 국가/로케일 기반 결제 게이트웨이 노출 정책 (#1066, #1110)
+ *
+ * 단일 소스: backend/src/config/checkout-gateway-contract.ts
+ */
+export function getAvailableGatewaysByLocale(locale: string): CheckoutGatewayName[] {
+  return getCheckoutGatewayOptions(locale, process.env.CHECKOUT_ENABLED_GATEWAYS);
+}
+
+export function resolveGatewayByLocale(locale: string): CheckoutGatewayName {
+  return getDefaultCheckoutGateway(locale, process.env.CHECKOUT_ENABLED_GATEWAYS);
+}
+
+export { isCheckoutGatewayName };
 
 @Module({
   imports: [TypeOrmModule.forFeature([Payment, PaymentWebhookEvent, Refund, Shipping, Order, PointHistory]), OrderEventsModule],

--- a/docs/infrastructure/DEPLOYMENT.md
+++ b/docs/infrastructure/DEPLOYMENT.md
@@ -69,6 +69,8 @@ nslookup -type=TXT _dmarc.ockhwadang.com
 - 백엔드/EC2 `.env.production` `BACKEND_URL=https://api.ockhwadang.com/api` (결제 webhook/status_url, 업로드 절대 URL 생성에 사용)
 - `api.ockhwadang.com` 은 Cloudflare **Proxied + SSL/TLS mode `Full (strict)`** 로 유지하고, EC2 nginx 443에는 Cloudflare Origin CA 또는 동등한 서버 인증서를 설치한다.
 - `SITE_URL=https://ockhwadang.com`
+- `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS=naverpay,paypal,eximbay`
+- `CHECKOUT_ENABLED_GATEWAYS=naverpay,paypal,eximbay` (프론트와 동일하게 유지; 단일 소스는 `backend/src/config/checkout-gateway-contract.ts`)
 
 ## 배포 구조
 

--- a/docs/infrastructure/ENVIRONMENT_VARIABLES.md
+++ b/docs/infrastructure/ENVIRONMENT_VARIABLES.md
@@ -6,6 +6,7 @@
 | ------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `BACKEND_URL` | `http://localhost:3000` | Next.js middleware 프록시와 SSR fetch가 공유하는 **백엔드 origin**. canonical contract는 `origin only` 이며 앱 코드가 `/api/*` 를 붙인다. 예: 로컬 `http://localhost:3000`, 운영 `https://api.ockhwadang.com` |
 | `SITE_URL`    | `http://localhost:5173` | canonical 프론트엔드 origin. 메타데이터/redirect/배포 smoke test 기준 URL                                                                                                                                    |
+| `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS` | `naverpay,paypal,eximbay` | 체크아웃 노출 계약. `backend/src/config/checkout-gateway-contract.ts` 기준으로 로케일별 결제수단 노출과 CSP를 함께 관리 |
 
 ### 프록시 계약 메모
 
@@ -72,24 +73,41 @@
 
 ### 결제
 
-| 변수                                 | 기본값                                             | 설명                                                                                                   |
-| ------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `PAYMENT_GATEWAY`                    | `mock`                                             | PG 어댑터 선택 (`mock`/`toss`/`stripe`/`inicis`/`naverpay`/`paypal`/`eximbay`). `mock`은 프로덕션 차단 |
-| `TOSS_SECRET_KEY`                    | —                                                  | 토스페이먼츠 시크릿 키                                                                                 |
-| `TOSS_CLIENT_KEY`                    | —                                                  | 토스페이먼츠 클라이언트 키                                                                             |
-| `STRIPE_SECRET_KEY`                  | —                                                  | Stripe 시크릿 키                                                                                       |
-| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | —                                                  | Stripe 공개 키                                                                                         |
-| `STRIPE_WEBHOOK_SECRET`              | —                                                  | Stripe 웹훅 서명 키                                                                                    |
-| `EXIMBAY_MERCHANT_ID`                | —                                                  | Eximbay merchant ID (프로덕션 체크아웃 필수)                                                           |
-| `EXIMBAY_API_KEY`                    | —                                                  | Eximbay Payment Preparation/Verify API key (프로덕션 체크아웃 필수)                                    |
-| `EXIMBAY_SECRET_KEY`                 | —                                                  | Eximbay API secret key (프로덕션 체크아웃 필수)                                                        |
-| `EXIMBAY_WEBHOOK_SECRET`             | —                                                  | Eximbay webhook HMAC secret                                                                            |
-| `EXIMBAY_API_BASE_URL`               | `https://api-test.eximbay.com`                     | Eximbay API base URL (production 계약 후 교체)                                                         |
-| `EXIMBAY_JS_SDK_URL`                 | `https://api-test.eximbay.com/v1/javascriptSDK.js` | Eximbay hosted payment page SDK URL                                                                    |
-| `EXIMBAY_CURRENCY`                   | `KRW`                                              | Eximbay 결제 통화 (`USD` 사용 시 `EXIMBAY_KRW_PER_USD`로 환산)                                         |
-| `EXIMBAY_LANG`                       | locale 기반                                        | Eximbay 결제창 언어 강제 override (`KR`/`EN`)                                                          |
-| `EXIMBAY_SHOP_NAME`                  | `Okhwadang`                                        | Eximbay 결제창 상점명                                                                                  |
-| `EXIMBAY_KRW_PER_USD`                | `1350`                                             | Eximbay USD 결제를 위한 KRW→USD 환산 기준                                                              |
+체크아웃 노출 계약의 단일 소스는 `backend/src/config/checkout-gateway-contract.ts`입니다. 게이트웨이 추가/제거 시 아래 변수와 `next.config.ts` CSP가 함께 갱신됩니다.
+
+| 변수 | 기본값 | 설명 |
+| --- | --- | --- |
+| `CHECKOUT_ENABLED_GATEWAYS` | `naverpay,paypal,eximbay` | 백엔드 체크아웃 노출 계약. 쉼표 구분. `bank_transfer`는 `ko` 체크아웃에서 항상 유지 |
+| `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS` | `naverpay,paypal,eximbay` | 프론트 체크아웃 노출 계약. Vercel 빌드 시 CSP 허용 목록도 이 값 기준으로 계산 |
+| `PAYMENT_GATEWAY` | `mock` | 백엔드 기본 PG 어댑터 (`mock`/`toss`/`stripe`/`inicis`/`naverpay`/`paypal`/`eximbay`). `mock`은 프로덕션 차단 |
+| `NAVERPAY_PARTNER_ID` | — | NaverPay partner ID (프로덕션 체크아웃 필수) |
+| `NAVERPAY_CLIENT_ID` | — | NaverPay client ID (프로덕션 체크아웃 필수) |
+| `NAVERPAY_CLIENT_SECRET` | — | NaverPay client secret (프로덕션 체크아웃 필수) |
+| `NAVERPAY_CHAIN_ID` | — | NaverPay chain ID (프로덕션 체크아웃 필수) |
+| `PAYPAL_CLIENT_ID` | — | PayPal REST API client ID (프로덕션 체크아웃 필수) |
+| `PAYPAL_CLIENT_SECRET` | — | PayPal REST API client secret (프로덕션 체크아웃 필수) |
+| `PAYPAL_WEBHOOK_ID` | — | PayPal webhook signature verification ID |
+| `PAYPAL_API_BASE_URL` | sandbox/prod default | PayPal REST API base URL override |
+| `PAYPAL_KRW_PER_USD` | `1350` | PayPal USD 결제를 위한 KRW→USD 환산 기준 |
+| `EXIMBAY_MERCHANT_ID` | — | Eximbay merchant ID (프로덕션 체크아웃 필수) |
+| `EXIMBAY_API_KEY` | — | Eximbay Payment Preparation/Verify API key (프로덕션 체크아웃 필수) |
+| `EXIMBAY_SECRET_KEY` | — | Eximbay API secret key (프로덕션 체크아웃 필수) |
+| `EXIMBAY_WEBHOOK_SECRET` | — | Eximbay webhook HMAC secret |
+| `EXIMBAY_API_BASE_URL` | `https://api-test.eximbay.com` | Eximbay API base URL (production 계약 후 교체) |
+| `EXIMBAY_JS_SDK_URL` | `https://api-test.eximbay.com/v1/javascriptSDK.js` | Eximbay hosted payment page SDK URL |
+| `EXIMBAY_CURRENCY` | `KRW` | Eximbay 결제 통화 (`USD` 사용 시 `EXIMBAY_KRW_PER_USD`로 환산) |
+| `EXIMBAY_LANG` | locale 기반 | Eximbay 결제창 언어 강제 override (`KR`/`EN`) |
+| `EXIMBAY_SHOP_NAME` | `Okhwadang` | Eximbay 결제창 상점명 |
+| `EXIMBAY_KRW_PER_USD` | `1350` | Eximbay USD 결제를 위한 KRW→USD 환산 기준 |
+| `TOSS_SECRET_KEY` | — | Toss adapter 시크릿 키 (기본 어댑터/레거시 결제 재시도용) |
+| `TOSS_CLIENT_KEY` | — | Toss adapter 클라이언트 키 |
+| `STRIPE_SECRET_KEY` | — | Stripe adapter 시크릿 키 |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | — | Stripe 공개 키 |
+| `STRIPE_WEBHOOK_SECRET` | — | Stripe 웹훅 서명 키 |
+| `INICIS_MID` | — | KG Inicis MID |
+| `INICIS_SIGN_KEY` | — | KG Inicis sign key |
+| `INICIS_API_KEY` | — | KG Inicis API key |
+| `INICIS_CLIENT_KEY` | — | KG Inicis client key |
 
 ### 스토리지
 
@@ -156,30 +174,3 @@ backend/.env.example      # 키 목록 (커밋 O, 값 없음)
 ```
 
 > **`.env` 파일은 절대 커밋하지 않습니다.** `.env.example`에 키 목록만 기록합니다.
-
-| `NAVERPAY_PARTNER_ID` | — | NaverPay partner ID (프로덕션 체크아웃 필수) |
-| `NAVERPAY_CLIENT_ID` | — | NaverPay client ID (프로덕션 체크아웃 필수) |
-| `NAVERPAY_CLIENT_SECRET` | — | NaverPay client secret (프로덕션 체크아웃 필수) |
-| `NAVERPAY_CHAIN_ID` | — | NaverPay chain ID (프로덕션 체크아웃 필수) |
-| `NAVER_COMMERCE_APP_ID` | — | 네이버 커머스API 애플리케이션 ID (스마트스토어 상품 동기화용) |
-| `NAVER_COMMERCE_APP_SECRET` | — | 네이버 커머스API 애플리케이션 시크릿. 실제 값은 secret/env에만 보관 |
-| `NAVER_COMMERCE_API_BASE_URL` | `https://api.commerce.naver.com/external` | 네이버 커머스API 호스트 override (테스트/장애 대응용) |
-| `NAVER_COMMERCE_MAX_SYNC_PRODUCTS` | `500` | 네이버 커머스API 동기화에서 한 번에 목록 조회/상세 조회할 최대 상품 수 |
-| `NAVER_COMMERCE_DETAIL_REQUEST_DELAY_MS` | `700` | 네이버 상품 상세 API 연속 호출 사이 대기 시간(ms). 4개 이상 조회 시 요청 제한을 피하기 위한 throttle |
-| `NAVER_COMMERCE_RETRY_ATTEMPTS` | `3` | 네이버 API 429/503 등 일시 제한 응답 재시도 횟수 |
-| `NAVER_COMMERCE_RETRY_BASE_DELAY_MS` | `1000` | 네이버 API 일시 제한 응답 재시도 지수 백오프 시작 대기 시간(ms) |
-| `PAYPAL_CLIENT_ID` | — | PayPal REST API client ID (프로덕션 체크아웃 필수) |
-| `PAYPAL_CLIENT_SECRET` | — | PayPal REST API client secret (프로덕션 체크아웃 필수) |
-| `PAYPAL_WEBHOOK_ID` | — | PayPal webhook signature verification ID |
-| `PAYPAL_API_BASE_URL` | sandbox/prod default | PayPal REST API base URL override |
-| `PAYPAL_KRW_PER_USD` | `1350` | PayPal USD 결제를 위한 KRW→USD 환산 기준 |
-| `EXIMBAY_MERCHANT_ID` | — | Eximbay merchant ID (프로덕션 체크아웃 필수) |
-| `EXIMBAY_API_KEY` | — | Eximbay API key (프로덕션 체크아웃 필수) |
-| `EXIMBAY_SECRET_KEY` | — | Eximbay API secret key (프로덕션 체크아웃 필수) |
-| `EXIMBAY_WEBHOOK_SECRET` | — | Eximbay webhook HMAC secret |
-| `EXIMBAY_API_BASE_URL` | `https://api-test.eximbay.com` | Eximbay API base URL |
-| `EXIMBAY_JS_SDK_URL` | `https://api-test.eximbay.com/v1/javascriptSDK.js` | Eximbay JS SDK URL |
-| `EXIMBAY_CURRENCY` | `KRW` | Eximbay 결제 통화 |
-| `EXIMBAY_LANG` | locale 기반 | Eximbay 결제창 언어 override |
-| `EXIMBAY_SHOP_NAME` | `Okhwadang` | Eximbay 결제창 상점명 |
-| `EXIMBAY_KRW_PER_USD` | `1350` | Eximbay USD 결제를 위한 KRW→USD 환산 기준 |

--- a/docs/qa/checkout-payment-e2e.md
+++ b/docs/qa/checkout-payment-e2e.md
@@ -8,12 +8,13 @@ This checklist is the launch fallback when automated browser E2E cannot safely r
 - Backend health returns 200: `curl http://localhost:3000/api/health`.
 - Frontend responds: `curl -I http://localhost:5173/ko`.
 - `CHECKOUT_ENABLED_GATEWAYS` / `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS` match the provider(s) being tested.
+- 계약 변경 전 `backend/src/config/checkout-gateway-contract.ts`와 `next.config.ts` generated CSP를 함께 검토한다.
 - Enabled provider credentials exist only in local/staging env files or secret stores.
 - Test product has enough stock and a non-free-shipping address is available.
 
 ## Success path per enabled provider
 
-Run once for each enabled production provider: NaverPay, PayPal, Toss, Stripe, or Mock.
+Run once for each enabled checkout provider: NaverPay, PayPal, Eximbay, or bank transfer. Toss/Stripe legacy retry flows are separate adapter checks, not the locale-exposed checkout contract.
 
 1. Log in as a test customer.
 2. Add one product to cart with quantity that produces a non-zero shipping fee.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,64 @@
 import type { NextConfig } from 'next';
 import createBundleAnalyzer from '@next/bundle-analyzer';
 import createNextIntlPlugin from 'next-intl/plugin';
+import { getConfiguredCheckoutGatewayCspSources } from './src/lib/checkout-gateway-contract';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 const withBundleAnalyzer = createBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 });
+
+const enabledCheckoutGatewaySources = getConfiguredCheckoutGatewayCspSources(
+  process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS ?? process.env.CHECKOUT_ENABLED_GATEWAYS,
+);
+
+const legacyPaymentSdkSources = {
+  'script-src': ['https://js.tosspayments.com', 'https://js.sandbox.tosspayments.com', 'https://js.stripe.com', 'https://*.js.stripe.com'],
+  'connect-src': ['https://api.stripe.com'],
+  'child-src': ['https://js.stripe.com', 'https://*.js.stripe.com', 'https://hooks.stripe.com'],
+  'frame-src': ['https://js.stripe.com', 'https://*.js.stripe.com', 'https://hooks.stripe.com'],
+} as const;
+
+function mergeSources(...groups: readonly (readonly string[])[]): string[] {
+  return [...new Set(groups.flat())];
+}
+
+const contentSecurityPolicyDirectives: Array<[string, string[]]> = [
+  ["default-src", ["'self'"]],
+  ["style-src", mergeSources(["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'], enabledCheckoutGatewaySources['style-src'])],
+  [
+    "script-src",
+    mergeSources(
+      ["'self'", "'unsafe-inline'", 'https://static.cloudflareinsights.com', 'https://www.googletagmanager.com', 'https://www.google-analytics.com'],
+      legacyPaymentSdkSources['script-src'],
+      enabledCheckoutGatewaySources['script-src'],
+    ),
+  ],
+  ["object-src", ["'none'"]],
+  ["base-uri", ["'self'"]],
+  [
+    "img-src",
+    mergeSources(
+      ["'self'", 'data:', 'https://images.unsplash.com', 'https://*.amazonaws.com', 'https://*.cloudfront.net', 'https://cdn.ockhwadang.com', 'https://ockhwadang.com', 'https://i.pinimg.com', 'https://m.cbw.co.kr', 'https://gdimg.gmarket.co.kr', 'https://cdn-optimized.imweb.me', 'https://shop-phinf.pstatic.net', 'https://www.google.co.kr'],
+      enabledCheckoutGatewaySources['img-src'],
+    ),
+  ],
+  ["font-src", ["'self'", 'https://fonts.gstatic.com']],
+  [
+    "connect-src",
+    mergeSources(
+      ["'self'", 'https://fonts.googleapis.com', 'https://fonts.gstatic.com', 'https://cloudflareinsights.com', 'https://www.google-analytics.com', 'https://analytics.google.com', 'https://www.google.com', 'https://region1.google-analytics.com'],
+      legacyPaymentSdkSources['connect-src'],
+      enabledCheckoutGatewaySources['connect-src'],
+    ),
+  ],
+  ["child-src", mergeSources(["'self'"], legacyPaymentSdkSources['child-src'], enabledCheckoutGatewaySources['child-src'])],
+  ["frame-src", mergeSources(["'self'"], legacyPaymentSdkSources['frame-src'], enabledCheckoutGatewaySources['frame-src'])],
+];
+
+const contentSecurityPolicy = contentSecurityPolicyDirectives
+  .map(([directive, sources]) => `${directive} ${sources.join(' ')}`)
+  .join('; ') + ';';
 
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: false,
@@ -38,18 +91,7 @@ const nextConfig: NextConfig = {
         { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
         { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
         { key: 'Cross-Origin-Opener-Policy', value: 'same-origin-allow-popups' },
-        { key: 'Content-Security-Policy', value: [
-          "default-src 'self'",
-          "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com",
-          "script-src 'self' 'unsafe-inline' https://js.tosspayments.com https://js.sandbox.tosspayments.com https://static.cloudflareinsights.com https://www.googletagmanager.com https://www.google-analytics.com https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com https://nsp.pay.naver.com https://api-test.eximbay.com https://api.eximbay.com https://pgonline-test.eximbay.com https://pgonline.eximbay.com https://js.stripe.com https://*.js.stripe.com",
-          "object-src 'none'",
-          "base-uri 'self'",
-          "img-src 'self' data: https://images.unsplash.com https://*.amazonaws.com https://*.cloudfront.net https://cdn.ockhwadang.com https://ockhwadang.com https://i.pinimg.com https://m.cbw.co.kr https://gdimg.gmarket.co.kr https://cdn-optimized.imweb.me https://shop-phinf.pstatic.net https://www.google.co.kr https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com",
-          "font-src 'self' https://fonts.gstatic.com",
-          "connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com https://www.google-analytics.com https://analytics.google.com https://www.google.com https://region1.google-analytics.com https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com https://nsp.pay.naver.com https://pay.naver.com https://m.pay.naver.com https://test-pay.naver.com https://test-m.pay.naver.com https://api-test.eximbay.com https://api.eximbay.com https://pgonline-test.eximbay.com https://pgonline.eximbay.com https://api.stripe.com",
-          "child-src 'self' https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com https://pay.naver.com https://m.pay.naver.com https://test-pay.naver.com https://test-m.pay.naver.com https://api-test.eximbay.com https://api.eximbay.com https://pgonline-test.eximbay.com https://pgonline.eximbay.com https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com",
-          "frame-src 'self' https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com https://pay.naver.com https://m.pay.naver.com https://test-pay.naver.com https://test-m.pay.naver.com https://api-test.eximbay.com https://api.eximbay.com https://pgonline-test.eximbay.com https://pgonline.eximbay.com https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com",
-        ].join('; ') + ';' },
+        { key: 'Content-Security-Policy', value: contentSecurityPolicy },
         { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
       ],
     }];

--- a/src/__tests__/next-config-csp.test.ts
+++ b/src/__tests__/next-config-csp.test.ts
@@ -1,114 +1,123 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import type { NextConfig } from 'next';
+import { describe, expect, it, vi } from 'vitest';
+import { getConfiguredCheckoutGatewayCspSources } from '@/lib/checkout-gateway-contract';
 
-function getCspDirective(source: string, directive: string): string {
-  const cspLine = source
-    .split('\n')
-    .find((line) => line.trim().startsWith(`"${directive} `));
+type CheckoutEnvOverrides = Partial<
+  Record<'NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS' | 'CHECKOUT_ENABLED_GATEWAYS', string | undefined>
+>;
 
-  expect(cspLine).toBeDefined();
-  return cspLine ?? '';
+function parseCspDirectives(headerValue: string): Record<string, string> {
+  return Object.fromEntries(
+    headerValue
+      .split(';')
+      .map((segment) => segment.trim())
+      .filter(Boolean)
+      .map((segment) => {
+        const [directive] = segment.split(' ', 1);
+        return [directive, segment];
+      }),
+  );
+}
+
+async function loadNextConfigSnapshot(envOverrides: CheckoutEnvOverrides = {}) {
+  const previousPublic = process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
+  const previousBackend = process.env.CHECKOUT_ENABLED_GATEWAYS;
+
+  if ('NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS' in envOverrides) {
+    const value = envOverrides.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
+    if (value === undefined) delete process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
+    else process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS = value;
+  } else {
+    delete process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
+  }
+
+  if ('CHECKOUT_ENABLED_GATEWAYS' in envOverrides) {
+    const value = envOverrides.CHECKOUT_ENABLED_GATEWAYS;
+    if (value === undefined) delete process.env.CHECKOUT_ENABLED_GATEWAYS;
+    else process.env.CHECKOUT_ENABLED_GATEWAYS = value;
+  } else {
+    delete process.env.CHECKOUT_ENABLED_GATEWAYS;
+  }
+
+  try {
+    vi.resetModules();
+    const nextConfig = (await import('../../next.config')).default as NextConfig;
+    const headers = await nextConfig.headers?.();
+    const contentSecurityPolicy = headers?.[0]?.headers.find((header) => header.key === 'Content-Security-Policy')?.value ?? '';
+
+    return {
+      nextConfig,
+      headers,
+      directives: parseCspDirectives(contentSecurityPolicy),
+    };
+  } finally {
+    if (previousPublic === undefined) delete process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
+    else process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS = previousPublic;
+
+    if (previousBackend === undefined) delete process.env.CHECKOUT_ENABLED_GATEWAYS;
+    else process.env.CHECKOUT_ENABLED_GATEWAYS = previousBackend;
+
+    vi.resetModules();
+  }
 }
 
 describe('Next.js CSP headers', () => {
-  it('allows Google Analytics gtag script, collection endpoints, and audience image beacon', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const imgSrc = getCspDirective(source, 'img-src');
+  it('allows Google Analytics gtag script, collection endpoints, and audience image beacon', async () => {
+    const { directives } = await loadNextConfigSnapshot();
 
-    expect(source).toContain('https://www.googletagmanager.com');
-    expect(source).toContain('https://www.google-analytics.com');
-    expect(source).toContain('https://analytics.google.com');
-    expect(source).toContain('https://www.google.com');
-    expect(source).toContain('https://region1.google-analytics.com');
-    expect(imgSrc).toContain('https://www.google.co.kr');
+    expect(directives['script-src']).toContain('https://www.googletagmanager.com');
+    expect(directives['script-src']).toContain('https://www.google-analytics.com');
+    expect(directives['connect-src']).toContain('https://analytics.google.com');
+    expect(directives['connect-src']).toContain('https://www.google.com');
+    expect(directives['connect-src']).toContain('https://region1.google-analytics.com');
+    expect(directives['img-src']).toContain('https://www.google.co.kr');
   });
 
-  it('allows documented PayPal checkout SDK sources and popup isolation', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
+  it('uses the shared checkout gateway contract sources by default', async () => {
+    const { directives } = await loadNextConfigSnapshot();
+    const expectedSources = getConfiguredCheckoutGatewayCspSources(undefined);
 
-    expect(source).toContain("Cross-Origin-Opener-Policy', value: 'same-origin-allow-popups");
-    expect(source).toContain('https://*.paypal.com');
-    expect(source).toContain('https://*.paypalobjects.com');
-    expect(source).toContain('https://*.venmo.com');
-    expect(source).toContain('child-src');
-    expect(source).toContain('frame-src');
+    for (const [directive, origins] of Object.entries(expectedSources)) {
+      for (const origin of origins) {
+        expect(directives[directive]).toContain(origin);
+      }
+    }
   });
 
-  it('allows NaverPay SDK and payment page origins in checkout CSP directives', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const scriptSrc = getCspDirective(source, 'script-src');
-    const connectSrc = getCspDirective(source, 'connect-src');
-    const frameSrc = getCspDirective(source, 'frame-src');
+  it('keeps PayPal popup isolation enabled', async () => {
+    const { headers } = await loadNextConfigSnapshot();
+    const coop = headers?.[0]?.headers.find((header) => header.key === 'Cross-Origin-Opener-Policy')?.value;
 
-    expect(scriptSrc).toContain('https://nsp.pay.naver.com');
-
-    [
-      'https://nsp.pay.naver.com',
-      'https://pay.naver.com',
-      'https://m.pay.naver.com',
-      'https://test-pay.naver.com',
-      'https://test-m.pay.naver.com',
-    ].forEach((origin) => {
-      expect(connectSrc).toContain(origin);
-    });
-
-    [
-      'https://pay.naver.com',
-      'https://m.pay.naver.com',
-      'https://test-pay.naver.com',
-      'https://test-m.pay.naver.com',
-    ].forEach((origin) => {
-      expect(frameSrc).toContain(origin);
-    });
+    expect(coop).toBe('same-origin-allow-popups');
   });
 
-  it('allows Stripe.js, Stripe API, and 3DS frame origins in checkout CSP directives', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const scriptSrc = getCspDirective(source, 'script-src');
-    const connectSrc = getCspDirective(source, 'connect-src');
-    const frameSrc = getCspDirective(source, 'frame-src');
-
-    ['https://js.stripe.com', 'https://*.js.stripe.com'].forEach((origin) => {
-      expect(scriptSrc).toContain(origin);
-      expect(frameSrc).toContain(origin);
+  it('prunes disabled checkout gateway CSP origins when only paypal is enabled', async () => {
+    const { directives } = await loadNextConfigSnapshot({
+      NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS: 'paypal',
+      CHECKOUT_ENABLED_GATEWAYS: 'paypal',
     });
 
-    expect(connectSrc).toContain('https://api.stripe.com');
-    expect(frameSrc).toContain('https://hooks.stripe.com');
+    expect(directives['style-src']).toContain('https://*.paypal.com');
+    expect(directives['connect-src']).toContain('https://*.paypal.com');
+    expect(directives['script-src']).not.toContain('https://nsp.pay.naver.com');
+    expect(directives['connect-src']).not.toContain('https://pay.naver.com');
+    expect(directives['connect-src']).not.toContain('https://api-test.eximbay.com');
+    expect(directives['frame-src']).not.toContain('https://pgonline.eximbay.com');
   });
 
-  it('allows Eximbay hosted payment SDK/API/frame origins in checkout CSP directives', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const scriptSrc = getCspDirective(source, 'script-src');
-    const connectSrc = getCspDirective(source, 'connect-src');
-    const frameSrc = getCspDirective(source, 'frame-src');
+  it('allows SmartStore product images from the exact Naver image origin', async () => {
+    const { nextConfig, directives } = await loadNextConfigSnapshot();
 
-    ['https://api-test.eximbay.com', 'https://api.eximbay.com'].forEach((origin) => {
-      expect(scriptSrc).toContain(origin);
-      expect(connectSrc).toContain(origin);
-      expect(frameSrc).toContain(origin);
-    });
-
-    ['https://pgonline-test.eximbay.com', 'https://pgonline.eximbay.com'].forEach((origin) => {
-      expect(connectSrc).toContain(origin);
-      expect(frameSrc).toContain(origin);
-    });
-  });
-
-  it('allows SmartStore product images from the exact Naver image origin', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const imgSrc = getCspDirective(source, 'img-src');
-
-    expect(source).toContain("{ protocol: 'https', hostname: 'shop-phinf.pstatic.net' }");
-    expect(imgSrc).toContain('https://shop-phinf.pstatic.net');
-    expect(imgSrc).not.toContain('https://*.pstatic.net');
+    expect(nextConfig.images?.remotePatterns).toContainEqual({ protocol: 'https', hostname: 'shop-phinf.pstatic.net' });
+    expect(directives['img-src']).toContain('https://shop-phinf.pstatic.net');
+    expect(directives['img-src']).not.toContain('https://*.pstatic.net');
   });
 });
 
 describe('Next.js image cache policy', () => {
-  it('keeps optimized remote product images cached beyond the default TTL', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
+  it('keeps optimized remote product images cached beyond the default TTL', async () => {
+    const { nextConfig } = await loadNextConfigSnapshot();
 
-    expect(source).toContain('minimumCacheTTL: 86400');
+    expect(nextConfig.images?.minimumCacheTTL).toBe(86400);
   });
 });

--- a/src/components/shared/checkout/__tests__/PaymentMethodSelector.test.tsx
+++ b/src/components/shared/checkout/__tests__/PaymentMethodSelector.test.tsx
@@ -115,4 +115,33 @@ describe('PaymentMethodSelector', () => {
     expect(screen.queryByRole('radio', { name: /네이버페이|Naver Pay/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('radio', { name: /무통장입금|Bank transfer/ })).not.toBeInTheDocument();
   });
+
+  it('NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS로 비활성 게이트웨이를 숨긴다', () => {
+    const previous = process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
+    process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS = 'paypal';
+
+    try {
+      const options = getGatewayOptionsByLocale('ko');
+
+      render(
+        <PaymentMethodSelector
+          gatewayOptions={options}
+          selectedGateway={getDefaultCheckoutGateway('ko')}
+          onSelect={vi.fn()}
+        />,
+      );
+
+      expect(options).toEqual(['bank_transfer', 'paypal']);
+      expect(screen.getByRole('radio', { name: /무통장입금/ })).toBeChecked();
+      expect(screen.getByRole('radio', { name: /PayPal/ })).toBeInTheDocument();
+      expect(screen.queryByRole('radio', { name: /네이버페이|Naver Pay/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('radio', { name: /Credit card/ })).not.toBeInTheDocument();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
+      } else {
+        process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS = previous;
+      }
+    }
+  });
 });

--- a/src/constants/checkoutPaymentMethods.ts
+++ b/src/constants/checkoutPaymentMethods.ts
@@ -1,5 +1,11 @@
 import type { Locale } from '@/i18n/routing';
 import type { CheckoutGatewayName } from '@/lib/api';
+import {
+  CHECKOUT_GATEWAY_ORDER_BY_LOCALE,
+  getDefaultCheckoutGateway as getDefaultCheckoutGatewayFromContract,
+  getEnabledCheckoutGateways as getEnabledCheckoutGatewaysFromContract,
+  getCheckoutGatewayOptions as getCheckoutGatewayOptionsFromContract,
+} from '@/lib/checkout-gateway-contract';
 
 export type CheckoutPaymentCountry = 'KR' | 'GLOBAL';
 
@@ -9,24 +15,12 @@ export const CHECKOUT_PAYMENT_COUNTRY_BY_LOCALE = {
 } as const satisfies Record<Locale, CheckoutPaymentCountry>;
 
 export const CHECKOUT_PAYMENT_METHODS_BY_COUNTRY = {
-  KR: ['naverpay', 'bank_transfer', 'paypal', 'eximbay'],
-  GLOBAL: ['paypal', 'eximbay'],
+  KR: CHECKOUT_GATEWAY_ORDER_BY_LOCALE.ko,
+  GLOBAL: CHECKOUT_GATEWAY_ORDER_BY_LOCALE.en,
 } as const satisfies Record<CheckoutPaymentCountry, readonly CheckoutGatewayName[]>;
 
-function isCheckoutGatewayName(value: string): value is CheckoutGatewayName {
-  return value === 'naverpay' || value === 'bank_transfer' || value === 'eximbay' || value === 'paypal';
-}
-
 export function getEnabledCheckoutGateways(): CheckoutGatewayName[] {
-  const configured = process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
-  if (!configured || configured.trim() === '') return ['naverpay', 'bank_transfer', 'eximbay', 'paypal'];
-
-  const gateways = configured
-    .split(',')
-    .map((value) => value.trim().toLowerCase())
-    .filter(isCheckoutGatewayName);
-
-  return [...new Set([...gateways, 'bank_transfer' as const])];
+  return getEnabledCheckoutGatewaysFromContract(process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS) as CheckoutGatewayName[];
 }
 
 export function getCheckoutPaymentCountry(locale: Locale): CheckoutPaymentCountry {
@@ -34,11 +28,9 @@ export function getCheckoutPaymentCountry(locale: Locale): CheckoutPaymentCountr
 }
 
 export function getGatewayOptionsByLocale(locale: Locale): CheckoutGatewayName[] {
-  const enabled = getEnabledCheckoutGateways();
-  const country = getCheckoutPaymentCountry(locale);
-  return CHECKOUT_PAYMENT_METHODS_BY_COUNTRY[country].filter((gateway) => enabled.includes(gateway));
+  return getCheckoutGatewayOptionsFromContract(locale, process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS) as CheckoutGatewayName[];
 }
 
 export function getDefaultCheckoutGateway(locale: Locale): CheckoutGatewayName {
-  return getGatewayOptionsByLocale(locale)[0] ?? 'paypal';
+  return getDefaultCheckoutGatewayFromContract(locale, process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS) as CheckoutGatewayName;
 }

--- a/src/lib/checkout-gateway-contract.ts
+++ b/src/lib/checkout-gateway-contract.ts
@@ -1,0 +1,1 @@
+export * from '../../backend/src/config/checkout-gateway-contract';


### PR DESCRIPTION
## Summary
- consolidate the locale-exposed checkout gateway contract into `backend/src/config/checkout-gateway-contract.ts`
- derive frontend gateway options, backend env validation, and Next.js checkout CSP sources from the same contract
- document the paired `CHECKOUT_ENABLED_GATEWAYS` / `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS` workflow and add regression coverage

## Verification
- npm run typecheck
- npm run build
- npm run test:run -- src/__tests__/next-config-csp.test.ts src/components/shared/checkout/__tests__/PaymentMethodSelector.test.tsx
- cd backend && npm run build
- cd backend && npm test -- config/__tests__/env-validator.spec.ts modules/payments/__tests__/payments.module.spec.ts
- bash scripts/start-local.sh
- node fetch to http://127.0.0.1:3000/api/health returned 200

Closes #1110
