### PR TITLE
Align checkout gateway env/CSP contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 BACKEND_URL=http://localhost:3000
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=   # Stripe publishable key (for global locale)
+# Checkout contract: match backend CHECKOUT_ENABLED_GATEWAYS. `bank_transfer` is always added for ko locale.
+NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS=naverpay,paypal,eximbay
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=   # Stripe publishable key (required when PAYMENT_GATEWAY=stripe)
 NEXT_PUBLIC_KAKAO_CLIENT_ID=  # REQUIRED — Kakao JavaScript/REST app key used to build OAuth authorize URL
 NEXT_PUBLIC_KAKAO_REDIRECT_URI=http://localhost:5173/auth/kakao/callback  # REQUIRED — must match Kakao Developers redirect URI
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,24 +56,26 @@ SENTRY_TRACES_SAMPLE_RATE=0.1
 # Redis/ElastiCache 연결 불필요.
 # ─────────────────────────────────────────────
 PAYMENT_GATEWAY=mock  # REQUIRED — 'mock' is blocked in production. Options: mock, toss, stripe, inicis, naverpay, paypal, eximbay
-TOSS_SECRET_KEY=   # Toss Payments secret key (for ko locale, default 국내 PG)
-TOSS_CLIENT_KEY=   # Toss Payments client key (for ko locale)
-STRIPE_SECRET_KEY=   # Stripe secret key (for global locale)
-STRIPE_WEBHOOK_SECRET=   # Stripe webhook signing secret
+# Checkout contract: keep this list in sync with frontend NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS. `bank_transfer` is always added for ko locale.
+CHECKOUT_ENABLED_GATEWAYS=naverpay,paypal,eximbay
+TOSS_SECRET_KEY=   # Toss Payments secret key (required when PAYMENT_GATEWAY=toss)
+TOSS_CLIENT_KEY=   # Toss Payments client key (required when PAYMENT_GATEWAY=toss)
+STRIPE_SECRET_KEY=   # Stripe secret key (required when PAYMENT_GATEWAY=stripe)
+STRIPE_WEBHOOK_SECRET=   # Stripe webhook signing secret (required when PAYMENT_GATEWAY=stripe)
 # KG Inicis (#721 국내 PG)
 INICIS_MID=
 INICIS_SIGN_KEY=
 INICIS_API_KEY=
 INICIS_CLIENT_KEY=
 # NaverPay (#721 국내 PG)
-NAVERPAY_PARTNER_ID=  # REQUIRED in production checkout
-NAVERPAY_CLIENT_ID=  # REQUIRED in production checkout
-NAVERPAY_CLIENT_SECRET=  # REQUIRED in production checkout
-NAVERPAY_CHAIN_ID=  # REQUIRED in production checkout
+NAVERPAY_PARTNER_ID=  # REQUIRED when checkout contract enables naverpay
+NAVERPAY_CLIENT_ID=  # REQUIRED when checkout contract enables naverpay
+NAVERPAY_CLIENT_SECRET=  # REQUIRED when checkout contract enables naverpay
+NAVERPAY_CHAIN_ID=  # REQUIRED when checkout contract enables naverpay
 # Eximbay (hosted international card checkout; card PAN/CVC stays in PG page)
-EXIMBAY_MERCHANT_ID=  # REQUIRED in production checkout when eximbay is enabled
-EXIMBAY_API_KEY=  # REQUIRED in production checkout when eximbay is enabled
-EXIMBAY_SECRET_KEY=  # REQUIRED in production checkout when eximbay is enabled
+EXIMBAY_MERCHANT_ID=  # REQUIRED when checkout contract enables eximbay
+EXIMBAY_API_KEY=  # REQUIRED when checkout contract enables eximbay
+EXIMBAY_SECRET_KEY=  # REQUIRED when checkout contract enables eximbay
 EXIMBAY_WEBHOOK_SECRET=
 EXIMBAY_API_BASE_URL=https://api-test.eximbay.com
 EXIMBAY_JS_SDK_URL=https://api-test.eximbay.com/v1/javascriptSDK.js
@@ -121,8 +123,8 @@ RESEND_API_KEY=  # REQUIRED (when NOTIFICATION_PROVIDER=resend)
 EMAIL_FROM=no-reply@okhwadang.com
 
 # PayPal (global checkout)
-PAYPAL_CLIENT_ID=  # REQUIRED in production checkout
-PAYPAL_CLIENT_SECRET=  # REQUIRED in production checkout
+PAYPAL_CLIENT_ID=  # REQUIRED when checkout contract enables paypal
+PAYPAL_CLIENT_SECRET=  # REQUIRED when checkout contract enables paypal
 PAYPAL_WEBHOOK_ID=
 PAYPAL_API_BASE_URL=
 PAYPAL_KRW_PER_USD=1350

--- a/backend/src/config/__tests__/env-validator.spec.ts
+++ b/backend/src/config/__tests__/env-validator.spec.ts
@@ -2,7 +2,6 @@ import {
   validateEnv,
   assertEnv,
   REQUIRED_PROD_ENV_KEYS,
-  CHECKOUT_PROD_ENV_KEYS,
   getRequiredCheckoutEnvKeys,
 } from '../env-validator';
 
@@ -17,12 +16,15 @@ const makeFullEnv = (): NodeJS.ProcessEnv => ({
   NOTIFICATION_PROVIDER: 'resend',
   RESEND_API_KEY: 're_abc123',
   PAYMENT_GATEWAY: 'toss',
+  CHECKOUT_ENABLED_GATEWAYS: 'naverpay,paypal,eximbay',
   STORAGE_PROVIDER: 's3',
   AWS_S3_BUCKET_NAME: 'okhwadang-assets',
   AWS_REGION: 'ap-northeast-2',
   KAKAO_CLIENT_ID: 'kakao-client',
   KAKAO_CLIENT_SECRET: 'kakao-secret',
   KAKAO_REDIRECT_URI: 'https://ockhwadang.com/auth/kakao/callback',
+  TOSS_SECRET_KEY: 'toss-secret',
+  TOSS_CLIENT_KEY: 'toss-client',
   NAVERPAY_PARTNER_ID: 'naver-partner',
   NAVERPAY_CLIENT_ID: 'naver-client',
   NAVERPAY_CLIENT_SECRET: 'naver-secret',
@@ -56,13 +58,37 @@ describe('validateEnv', () => {
     expect(errorKeys).toContain('NAVERPAY_CHAIN_ID');
   });
 
-  it('CHECKOUT_ENABLED_GATEWAYS가 없으면 PAYMENT_GATEWAY provider 키만 필수로 검증한다', () => {
+  it('CHECKOUT_ENABLED_GATEWAYS가 없으면 기본 checkout 계약 키를 검증한다', () => {
     const env = makeFullEnv();
-    env.PAYMENT_GATEWAY = 'paypal';
+    delete env.CHECKOUT_ENABLED_GATEWAYS;
     delete env.NAVERPAY_CHAIN_ID;
 
-    expect(getRequiredCheckoutEnvKeys(env)).toEqual(['PAYPAL_CLIENT_ID', 'PAYPAL_CLIENT_SECRET']);
-    expect(validateEnv(env).map((e) => e.key)).not.toContain('NAVERPAY_CHAIN_ID');
+    expect(getRequiredCheckoutEnvKeys(env)).toEqual([
+      'NAVERPAY_PARTNER_ID',
+      'NAVERPAY_CLIENT_ID',
+      'NAVERPAY_CLIENT_SECRET',
+      'NAVERPAY_CHAIN_ID',
+      'PAYPAL_CLIENT_ID',
+      'PAYPAL_CLIENT_SECRET',
+      'EXIMBAY_MERCHANT_ID',
+      'EXIMBAY_API_KEY',
+      'EXIMBAY_SECRET_KEY',
+      'TOSS_SECRET_KEY',
+      'TOSS_CLIENT_KEY',
+    ]);
+    expect(validateEnv(env).map((e) => e.key)).toContain('NAVERPAY_CHAIN_ID');
+  });
+
+  it('hidden PAYMENT_GATEWAY=stripe flow adds only stripe backend keys on top of the checkout contract', () => {
+    const env = makeFullEnv();
+    env.PAYMENT_GATEWAY = 'stripe';
+    delete env.STRIPE_SECRET_KEY;
+    delete env.STRIPE_WEBHOOK_SECRET;
+
+    expect(getRequiredCheckoutEnvKeys(env)).toContain('STRIPE_SECRET_KEY');
+    expect(getRequiredCheckoutEnvKeys(env)).toContain('STRIPE_WEBHOOK_SECRET');
+    expect(validateEnv(env).map((e) => e.key)).toContain('STRIPE_SECRET_KEY');
+    expect(validateEnv(env).map((e) => e.key)).toContain('STRIPE_WEBHOOK_SECRET');
   });
 
   it('누락된 키가 있으면 해당 키 에러 반환', () => {
@@ -110,14 +136,17 @@ describe('validateEnv', () => {
     expect(errorKeys).toContain('JWT_SECRET');
   });
 
-  it('REQUIRED_PROD_ENV_KEYS에 있는 모든 키를 검증', () => {
-    const env: NodeJS.ProcessEnv = { NODE_ENV: 'production', CHECKOUT_ENABLED_GATEWAYS: 'naverpay,paypal,eximbay' };
+  it('REQUIRED_PROD_ENV_KEYS와 활성 checkout 계약 키를 모두 검증한다', () => {
+    const env: NodeJS.ProcessEnv = {
+      NODE_ENV: 'production',
+      CHECKOUT_ENABLED_GATEWAYS: 'naverpay,paypal,eximbay',
+    };
     const errors = validateEnv(env);
-    // NODE_ENV는 있으므로 나머지 키들이 모두 에러로 나와야 함
-    const missing = [...REQUIRED_PROD_ENV_KEYS, ...CHECKOUT_PROD_ENV_KEYS].filter(
+    const missing = [...REQUIRED_PROD_ENV_KEYS, ...getRequiredCheckoutEnvKeys(env)].filter(
       (k) => k !== 'NODE_ENV',
     );
     const errorKeys = errors.map((e) => e.key);
+
     for (const key of missing) {
       expect(errorKeys).toContain(key);
     }

--- a/backend/src/config/checkout-gateway-contract.ts
+++ b/backend/src/config/checkout-gateway-contract.ts
@@ -1,0 +1,225 @@
+export type CheckoutGatewayName = 'naverpay' | 'bank_transfer' | 'paypal' | 'eximbay';
+export type CheckoutRuntimeGatewayName = CheckoutGatewayName | 'toss' | 'stripe';
+export type CheckoutCspDirective =
+  'style-src' | 'script-src' | 'img-src' | 'connect-src' | 'child-src' | 'frame-src';
+
+export const DEFAULT_CHECKOUT_ENABLED_GATEWAYS = [
+  'naverpay',
+  'bank_transfer',
+  'paypal',
+  'eximbay',
+] as const satisfies readonly CheckoutGatewayName[];
+
+export const CHECKOUT_GATEWAY_ORDER_BY_LOCALE = {
+  ko: ['naverpay', 'bank_transfer', 'paypal', 'eximbay'],
+  default: ['paypal', 'eximbay'],
+} as const satisfies Record<'ko' | 'default', readonly CheckoutGatewayName[]>;
+
+export type CheckoutEnvTarget = 'backend' | 'frontend';
+
+export const CHECKOUT_GATEWAY_ENV_KEYS = {
+  bank_transfer: { backend: [], frontend: [] },
+  naverpay: {
+    backend: [
+      'NAVERPAY_PARTNER_ID',
+      'NAVERPAY_CLIENT_ID',
+      'NAVERPAY_CLIENT_SECRET',
+      'NAVERPAY_CHAIN_ID',
+    ],
+    frontend: [],
+  },
+  paypal: {
+    backend: ['PAYPAL_CLIENT_ID', 'PAYPAL_CLIENT_SECRET'],
+    frontend: [],
+  },
+  eximbay: {
+    backend: ['EXIMBAY_MERCHANT_ID', 'EXIMBAY_API_KEY', 'EXIMBAY_SECRET_KEY'],
+    frontend: [],
+  },
+  toss: {
+    backend: ['TOSS_SECRET_KEY', 'TOSS_CLIENT_KEY'],
+    frontend: [],
+  },
+  stripe: {
+    backend: ['STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET'],
+    frontend: ['NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY'],
+  },
+} as const satisfies Record<
+  CheckoutRuntimeGatewayName,
+  Record<CheckoutEnvTarget, readonly string[]>
+>;
+
+export const CHECKOUT_GATEWAY_CSP_SOURCES = {
+  bank_transfer: {},
+  naverpay: {
+    'script-src': ['https://nsp.pay.naver.com'],
+    'connect-src': [
+      'https://nsp.pay.naver.com',
+      'https://pay.naver.com',
+      'https://m.pay.naver.com',
+      'https://test-pay.naver.com',
+      'https://test-m.pay.naver.com',
+    ],
+    'child-src': [
+      'https://pay.naver.com',
+      'https://m.pay.naver.com',
+      'https://test-pay.naver.com',
+      'https://test-m.pay.naver.com',
+    ],
+    'frame-src': [
+      'https://pay.naver.com',
+      'https://m.pay.naver.com',
+      'https://test-pay.naver.com',
+      'https://test-m.pay.naver.com',
+    ],
+  },
+  paypal: {
+    'style-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+    'script-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+    'img-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+    'connect-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+    'child-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+    'frame-src': ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'],
+  },
+  eximbay: {
+    'script-src': [
+      'https://api-test.eximbay.com',
+      'https://api.eximbay.com',
+      'https://pgonline-test.eximbay.com',
+      'https://pgonline.eximbay.com',
+    ],
+    'connect-src': [
+      'https://api-test.eximbay.com',
+      'https://api.eximbay.com',
+      'https://pgonline-test.eximbay.com',
+      'https://pgonline.eximbay.com',
+    ],
+    'child-src': [
+      'https://api-test.eximbay.com',
+      'https://api.eximbay.com',
+      'https://pgonline-test.eximbay.com',
+      'https://pgonline.eximbay.com',
+    ],
+    'frame-src': [
+      'https://api-test.eximbay.com',
+      'https://api.eximbay.com',
+      'https://pgonline-test.eximbay.com',
+      'https://pgonline.eximbay.com',
+    ],
+  },
+  toss: {
+    'script-src': ['https://js.tosspayments.com', 'https://js.sandbox.tosspayments.com'],
+  },
+  stripe: {
+    'script-src': ['https://js.stripe.com', 'https://*.js.stripe.com'],
+    'connect-src': ['https://api.stripe.com'],
+    'child-src': ['https://js.stripe.com', 'https://*.js.stripe.com', 'https://hooks.stripe.com'],
+    'frame-src': ['https://js.stripe.com', 'https://*.js.stripe.com', 'https://hooks.stripe.com'],
+  },
+} as const satisfies Record<
+  CheckoutRuntimeGatewayName,
+  Partial<Record<CheckoutCspDirective, readonly string[]>>
+>;
+
+export function isCheckoutGatewayName(value: string): value is CheckoutGatewayName {
+  return (
+    value === 'naverpay' || value === 'bank_transfer' || value === 'paypal' || value === 'eximbay'
+  );
+}
+
+export function isCheckoutRuntimeGatewayName(value: string): value is CheckoutRuntimeGatewayName {
+  return (
+    value === 'naverpay' ||
+    value === 'bank_transfer' ||
+    value === 'paypal' ||
+    value === 'eximbay' ||
+    value === 'toss' ||
+    value === 'stripe'
+  );
+}
+
+function parseCheckoutRuntimeGateways(
+  value: string | undefined,
+  predicate: (candidate: string) => candidate is CheckoutRuntimeGatewayName,
+): CheckoutRuntimeGatewayName[] {
+  if (!value || value.trim() === '') return [];
+
+  const gateways = value
+    .split(',')
+    .map((candidate) => candidate.trim().toLowerCase())
+    .filter(predicate);
+
+  return [...new Set(gateways)];
+}
+
+export function getEnabledCheckoutGateways(
+  configuredGateways: string | undefined,
+): CheckoutGatewayName[] {
+  const explicitGateways = parseCheckoutRuntimeGateways(configuredGateways, isCheckoutGatewayName);
+  if (explicitGateways.length === 0) {
+    return [...DEFAULT_CHECKOUT_ENABLED_GATEWAYS];
+  }
+
+  return [...new Set([...explicitGateways, 'bank_transfer'])] as CheckoutGatewayName[];
+}
+
+export function getCheckoutGatewayOrder(locale: string): readonly CheckoutGatewayName[] {
+  return locale === 'ko'
+    ? CHECKOUT_GATEWAY_ORDER_BY_LOCALE.ko
+    : CHECKOUT_GATEWAY_ORDER_BY_LOCALE.default;
+}
+
+export function getAvailableCheckoutGateways(
+  locale: string,
+  configuredGateways: string | undefined,
+): CheckoutGatewayName[] {
+  const enabledGateways = getEnabledCheckoutGateways(configuredGateways);
+  return getCheckoutGatewayOrder(locale).filter((gateway) => enabledGateways.includes(gateway));
+}
+
+export function getContractRuntimeGateways(env: NodeJS.ProcessEnv): CheckoutRuntimeGatewayName[] {
+  const gateways = getEnabledCheckoutGateways(env.CHECKOUT_ENABLED_GATEWAYS);
+  const paymentGateway = (env.PAYMENT_GATEWAY ?? '').trim().toLowerCase();
+
+  if (
+    isCheckoutRuntimeGatewayName(paymentGateway) &&
+    !gateways.includes(paymentGateway as CheckoutGatewayName)
+  ) {
+    return [...gateways, paymentGateway];
+  }
+
+  return gateways;
+}
+
+export function getRequiredCheckoutContractEnvKeys(
+  env: NodeJS.ProcessEnv,
+  target: CheckoutEnvTarget = 'backend',
+): string[] {
+  return [
+    ...new Set(
+      getContractRuntimeGateways(env).flatMap(
+        (gateway) => CHECKOUT_GATEWAY_ENV_KEYS[gateway][target],
+      ),
+    ),
+  ];
+}
+
+export function getCheckoutCspSources(
+  env: NodeJS.ProcessEnv,
+): Partial<Record<CheckoutCspDirective, string[]>> {
+  const sourcesByDirective: Partial<Record<CheckoutCspDirective, string[]>> = {};
+
+  for (const gateway of getContractRuntimeGateways(env)) {
+    const gatewaySources = CHECKOUT_GATEWAY_CSP_SOURCES[gateway] as Partial<
+      Record<CheckoutCspDirective, readonly string[]>
+    >;
+
+    for (const directive of Object.keys(gatewaySources) as CheckoutCspDirective[]) {
+      const existing = sourcesByDirective[directive] ?? [];
+      const next = gatewaySources[directive] ?? [];
+      sourcesByDirective[directive] = [...new Set([...existing, ...next])];
+    }
+  }
+
+  return sourcesByDirective;
+}

--- a/backend/src/config/env-validator.ts
+++ b/backend/src/config/env-validator.ts
@@ -1,3 +1,8 @@
+import {
+  CHECKOUT_GATEWAY_ENV_KEYS,
+  getRequiredCheckoutContractEnvKeys,
+} from './checkout-gateway-contract';
+
 /**
  * 프로덕션 환경에서 NestJS bootstrap 전 필수 env 키 검증.
  *
@@ -22,54 +27,20 @@ export const REQUIRED_PROD_ENV_KEYS = [
   'KAKAO_REDIRECT_URI',
 ] as const;
 
-export const CHECKOUT_PROVIDER_ENV_KEYS = {
-  naverpay: [
-    'NAVERPAY_PARTNER_ID',
-    'NAVERPAY_CLIENT_ID',
-    'NAVERPAY_CLIENT_SECRET',
-    'NAVERPAY_CHAIN_ID',
-  ],
-  paypal: [
-    'PAYPAL_CLIENT_ID',
-    'PAYPAL_CLIENT_SECRET',
-  ],
-  eximbay: [
-    'EXIMBAY_MERCHANT_ID',
-    'EXIMBAY_API_KEY',
-    'EXIMBAY_SECRET_KEY',
-  ],
-} as const;
-
 export const CHECKOUT_PROD_ENV_KEYS = [
-  ...CHECKOUT_PROVIDER_ENV_KEYS.naverpay,
-  ...CHECKOUT_PROVIDER_ENV_KEYS.paypal,
-  ...CHECKOUT_PROVIDER_ENV_KEYS.eximbay,
+  ...CHECKOUT_GATEWAY_ENV_KEYS.naverpay.backend,
+  ...CHECKOUT_GATEWAY_ENV_KEYS.paypal.backend,
+  ...CHECKOUT_GATEWAY_ENV_KEYS.eximbay.backend,
+  ...CHECKOUT_GATEWAY_ENV_KEYS.toss.backend,
+  ...CHECKOUT_GATEWAY_ENV_KEYS.stripe.backend,
 ] as const;
 
-type CheckoutProvider = keyof typeof CHECKOUT_PROVIDER_ENV_KEYS;
-
-function isCheckoutProvider(value: string): value is CheckoutProvider {
-  return value === 'naverpay' || value === 'paypal' || value === 'eximbay';
-}
-
-function getEnabledCheckoutProviders(env: NodeJS.ProcessEnv): CheckoutProvider[] {
-  const configured = env.CHECKOUT_ENABLED_GATEWAYS ?? env.PAYMENT_GATEWAY ?? '';
-  const providers = configured
-    .split(',')
-    .map((value) => value.trim().toLowerCase())
-    .filter(isCheckoutProvider);
-  return [...new Set(providers)];
-}
+export type RequiredEnvKey =
+  (typeof REQUIRED_PROD_ENV_KEYS)[number] | (typeof CHECKOUT_PROD_ENV_KEYS)[number];
 
 export function getRequiredCheckoutEnvKeys(env: NodeJS.ProcessEnv): RequiredEnvKey[] {
-  return getEnabledCheckoutProviders(env).flatMap((provider) => [
-    ...CHECKOUT_PROVIDER_ENV_KEYS[provider],
-  ]);
+  return getRequiredCheckoutContractEnvKeys(env) as RequiredEnvKey[];
 }
-
-export type RequiredEnvKey =
-  | (typeof REQUIRED_PROD_ENV_KEYS)[number]
-  | (typeof CHECKOUT_PROD_ENV_KEYS)[number];
 
 export interface EnvValidationError {
   key: string;
@@ -135,7 +106,7 @@ export function assertEnv(env: NodeJS.ProcessEnv = process.env): void {
   write('    2. 로컬에서 원격 동기화: bash scripts/remote-env-sync.sh push');
   write('    3. 키 목록 검증: bash scripts/remote-env-sync.sh verify');
   write(
-    '    4. CHECKOUT_ENABLED_GATEWAYS 또는 PAYMENT_GATEWAY로 활성화한 결제수단의 키만 필수입니다.',
+    '    4. CHECKOUT_ENABLED_GATEWAYS와 NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS를 같은 계약으로 유지하고, 해당 결제수단 키만 채웁니다.',
   );
   write(line.trimEnd());
   write('');

--- a/backend/src/modules/payments/__tests__/payments.module.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.module.spec.ts
@@ -8,9 +8,7 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
         NODE_ENV: 'production',
         PAYMENT_GATEWAY: 'mock',
       }),
-    ).toThrow(
-      'Mock payment gateway는 프로덕션에서 사용할 수 없습니다',
-    );
+    ).toThrow('Mock payment gateway는 프로덕션에서 사용할 수 없습니다');
   });
 
   it('NODE_ENV=production, PAYMENT_GATEWAY 미설정 → 시작 실패', () => {
@@ -18,9 +16,7 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
       createPaymentConfig({
         NODE_ENV: 'production',
       }),
-    ).toThrow(
-      'Mock payment gateway는 프로덕션에서 사용할 수 없습니다',
-    );
+    ).toThrow('Mock payment gateway는 프로덕션에서 사용할 수 없습니다');
   });
 
   it('NODE_ENV=development, PAYMENT_GATEWAY=mock → 정상 동작', () => {
@@ -80,17 +76,43 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
 describe('locale gateway policy — express payments first and country-specific visibility', () => {
   it('ko → naverpay default, bank transfer, paypal, eximbay card fallback', () => {
     expect(resolveGatewayByLocale('ko')).toBe('naverpay');
-    expect(getAvailableGatewaysByLocale('ko')).toEqual(['naverpay', 'bank_transfer', 'paypal', 'eximbay']);
+    expect(getAvailableGatewaysByLocale('ko')).toEqual([
+      'naverpay',
+      'bank_transfer',
+      'paypal',
+      'eximbay',
+    ]);
   });
-
 
   it('ko keeps bank transfer even when external gateways are configured by env', () => {
     const previous = process.env.CHECKOUT_ENABLED_GATEWAYS;
     process.env.CHECKOUT_ENABLED_GATEWAYS = 'naverpay,paypal,eximbay';
 
     try {
-      expect(getAvailableGatewaysByLocale('ko')).toEqual(['naverpay', 'bank_transfer', 'paypal', 'eximbay']);
+      expect(getAvailableGatewaysByLocale('ko')).toEqual([
+        'naverpay',
+        'bank_transfer',
+        'paypal',
+        'eximbay',
+      ]);
       expect(getAvailableGatewaysByLocale('en')).toEqual(['paypal', 'eximbay']);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CHECKOUT_ENABLED_GATEWAYS;
+      } else {
+        process.env.CHECKOUT_ENABLED_GATEWAYS = previous;
+      }
+    }
+  });
+
+  it('explicit checkout contract can narrow locales without touching backend code', () => {
+    const previous = process.env.CHECKOUT_ENABLED_GATEWAYS;
+    process.env.CHECKOUT_ENABLED_GATEWAYS = 'paypal';
+
+    try {
+      expect(getAvailableGatewaysByLocale('ko')).toEqual(['bank_transfer', 'paypal']);
+      expect(resolveGatewayByLocale('ko')).toBe('bank_transfer');
+      expect(getAvailableGatewaysByLocale('en')).toEqual(['paypal']);
     } finally {
       if (previous === undefined) {
         delete process.env.CHECKOUT_ENABLED_GATEWAYS;

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -18,17 +18,18 @@ import { KGInicisPaymentAdapter } from './adapters/inicis.adapter';
 import { NaverPayPaymentAdapter } from './adapters/naverpay.adapter';
 import { PayPalPaymentAdapter } from './adapters/paypal.adapter';
 import { EximbayPaymentAdapter } from './adapters/eximbay.adapter';
+import { PAYMENT_CONFIG, PaymentConfig, paymentConfigProvider } from '../../config/payment.config';
 import {
-  PAYMENT_CONFIG,
-  PaymentConfig,
-  paymentConfigProvider,
-} from '../../config/payment.config';
+  getAvailableCheckoutGateways,
+  isCheckoutGatewayName as isSharedCheckoutGatewayName,
+  type CheckoutGatewayName,
+} from '../../config/checkout-gateway-contract';
 
 export function resolvePaymentGateway(config: PaymentConfig): string {
   return config.gateway;
 }
 
-export type CheckoutGatewayName = 'naverpay' | 'bank_transfer' | 'eximbay' | 'paypal';
+export { type CheckoutGatewayName } from '../../config/checkout-gateway-contract';
 
 /**
  * 국가/로케일 기반 결제 게이트웨이 노출 정책 (#1066)
@@ -37,24 +38,8 @@ export type CheckoutGatewayName = 'naverpay' | 'bank_transfer' | 'eximbay' | 'pa
  * - ko/KR: 네이버페이 기본, 무통장입금, PayPal, Eximbay 카드
  * - 글로벌: PayPal 기본, Eximbay 카드 (네이버페이 숨김)
  */
-function getEnabledCheckoutGateways(env: NodeJS.ProcessEnv = process.env): CheckoutGatewayName[] {
-  const configured = env.CHECKOUT_ENABLED_GATEWAYS;
-  if (!configured || configured.trim() === '') return ['naverpay', 'bank_transfer', 'eximbay', 'paypal'];
-
-  const gateways = configured
-    .split(',')
-    .map((value) => value.trim().toLowerCase())
-    .filter(isCheckoutGatewayName);
-
-  return [...new Set([...gateways, 'bank_transfer' as const])];
-}
-
 export function getAvailableGatewaysByLocale(locale: string): CheckoutGatewayName[] {
-  const localeOrder: CheckoutGatewayName[] = locale === 'ko'
-    ? ['naverpay', 'bank_transfer', 'paypal', 'eximbay']
-    : ['paypal', 'eximbay'];
-  const enabled = getEnabledCheckoutGateways();
-  return localeOrder.filter((gateway) => enabled.includes(gateway));
+  return getAvailableCheckoutGateways(locale, process.env.CHECKOUT_ENABLED_GATEWAYS);
 }
 
 export function resolveGatewayByLocale(locale: string): CheckoutGatewayName {
@@ -62,7 +47,7 @@ export function resolveGatewayByLocale(locale: string): CheckoutGatewayName {
 }
 
 export function isCheckoutGatewayName(value: string): value is CheckoutGatewayName {
-  return value === 'naverpay' || value === 'bank_transfer' || value === 'eximbay' || value === 'paypal';
+  return isSharedCheckoutGatewayName(value);
 }
 
 const gatewayProviders = [
@@ -120,9 +105,16 @@ const gatewayProviders = [
 ];
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment, PaymentWebhookEvent, Refund, Shipping, Order, PointHistory]), OrderEventsModule],
+  imports: [
+    TypeOrmModule.forFeature([Payment, PaymentWebhookEvent, Refund, Shipping, Order, PointHistory]),
+    OrderEventsModule,
+  ],
   controllers: [PaymentsController, AdminOrderRefundsController, AdminPaymentWebhooksController],
-  providers: [...gatewayProviders, PaymentsService, { provide: 'PaymentsService', useExisting: PaymentsService }],
+  providers: [
+    ...gatewayProviders,
+    PaymentsService,
+    { provide: 'PaymentsService', useExisting: PaymentsService },
+  ],
   exports: [PaymentsService, 'PaymentsService'],
 })
 export class PaymentsModule {}

--- a/docs/infrastructure/DEPLOYMENT.md
+++ b/docs/infrastructure/DEPLOYMENT.md
@@ -16,8 +16,12 @@
 - 프론트 `next/image` 최적화 캐시는 `next.config.ts`의 `images.minimumCacheTTL`로 최소 1일을 유지한다. 신규 S3 이미지처럼 origin `Cache-Control`이 더 길면 최적화 이미지 변형도 더 긴 upstream TTL을 따를 수 있으므로, 변경된 이미지는 반드시 새 URL로 교체한다.
 
 ### Vercel 환경변수
+
 - `BACKEND_URL=http://api.ockhwadang.com` (Cloudflare Proxied → EC2 Nginx :80 → NestJS :3000, HTTP)
 - `SITE_URL=https://ockhwadang.com`
+- `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS=naverpay,paypal,eximbay` (frontend-visible checkout contract; `bank_transfer`는 ko 로케일에 자동 추가)
+- EC2 `CHECKOUT_ENABLED_GATEWAYS=naverpay,paypal,eximbay` (backend checkout contract; 프론트와 반드시 동일 목록 유지)
+- `PAYMENT_GATEWAY=stripe|toss` 를 숨김 플로우로 유지하면 해당 PG의 env 키와 CSP 허용 목록도 함께 살아난다.
 
 ## 배포 구조
 
@@ -41,10 +45,12 @@
 ## 백엔드 (AWS EC2 t3.small)
 
 ### 배포 방식
+
 - `main` 브랜치 push 시 GitHub Actions → OIDC 인증 → SSM으로 EC2 명령어 실행
 - 배포 시작 시 `npm run build` 후 `dist/main.js` 존재 여부와 `npm run preflight:prod` DB 연결 사전 점검을 통과해야 `migration:run:prod` 및 PM2 재시작을 진행
 
 ### 서버 구성
+
 - Amazon Linux 2023
 - PM2로 프로세스 관리
 - Nginx (HTTP → HTTPS 리다이렉트)
@@ -84,8 +90,9 @@ permissions:
 자세한 내용은 [`docs/infrastructure/GITHUB_ACTIONS_OIDC.md`](./GITHUB_ACTIONS_OIDC.md)를 참조하세요.
 
 ### GitHub Secrets 설정
-| Secret | 설명 |
-|---|---|
+
+| Secret     | 설명                                   |
+| ---------- | -------------------------------------- |
 | `EC2_HOST` | EC2 인스턴스 퍼블릭 IP (`3.38.168.41`) |
 
 > **SSH_PRIVATE_KEY, EC2_USER 등 불필요** - OIDC가 대신 처리
@@ -97,12 +104,15 @@ permissions:
 ## 데이터베이스 마이그레이션
 
 ### 배포 시 자동 실행
+
 배포 스크립트에 포함되어 있어 별도 실행 불필요:
+
 ```bash
 npm run migration:run:prod   # dist/database/migrations/*.js 적용
 ```
 
 ### 로컬에서 원격 DB 직접 접근 (SSH 터널)
+
 ```bash
 bash scripts/start-local.sh   # SSH 터널 포함 전체 스택 기동
 LOCAL_DATABASE_URL=mysql://root:__REDACTED_ROOT_PW__@127.0.0.1:3307/commerce npm run migration:run
@@ -113,6 +123,7 @@ LOCAL_DATABASE_URL=mysql://root:__REDACTED_ROOT_PW__@127.0.0.1:3307/commerce npm
 ## 모니터링
 
 ### PM2 대시보드
+
 ```bash
 pm2 status          # 프로세스 상태 확인
 pm2 logs commerce   # 실시간 로그
@@ -142,6 +153,7 @@ pm2 save
 ```
 
 ### 헬스 체크 수동 확인
+
 ```bash
 curl https://api.ockhwadang.com/api/health
 ```
@@ -211,9 +223,11 @@ sudo systemctl enable --now nginx
 ### EC2 — PM2 프로세스 비정상 종료
 
 #### 증상
+
 배포 후 `pm2 status`에서 프로세스가 `errored` 상태.
 
 #### 해결
+
 ```bash
 pm2 logs commerce --lines 50   # 에러 로그 확인
 pm2 restart ecosystem.config.js --env production --update-env  # 재시작
@@ -227,10 +241,12 @@ pm2 restart ecosystem.config.js --env production --update-env  # 재시작
 ### Lightsail MySQL 연결 실패
 
 #### 증상
+
 NestJS 기동 후 `Unable to connect to the database` 또는
 `ERROR 1045 Access denied for user 'okhwadang_app'@'<ip>'`.
 
 #### 확인 사항
+
 1. Lightsail DB 상태가 `available`인지 (`aws lightsail get-relational-database`)
 2. VPC peering이 `active`인지, EC2 route table에 `172.26.0.0/16` 경로가 있는지
 3. EC2에서 endpoint로 접속 시 나가는 소스 IP 확인:
@@ -247,9 +263,11 @@ NestJS 기동 후 `Unable to connect to the database` 또는
 ### Nginx 502 Bad Gateway
 
 #### 원인
+
 NestJS(PM2)가 실행되지 않은 상태에서 Nginx가 프록시 시도.
 
 #### 해결
+
 ```bash
 pm2 status                     # commerce 프로세스 확인
 pm2 start ecosystem.config.js --env production  # 프로세스 없으면 시작

--- a/docs/infrastructure/ENVIRONMENT_VARIABLES.md
+++ b/docs/infrastructure/ENVIRONMENT_VARIABLES.md
@@ -6,6 +6,9 @@
 | ------------- | ----------------------- | ------------------------------------------------------------------------------------ |
 | `BACKEND_URL` | `http://localhost:3000` | NestJS 백엔드 URL (`src/middleware.ts` 런타임 프록시와 서버 컴포넌트 fetch에서 사용) |
 
+| `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS` | `naverpay,paypal,eximbay` | 프론트 체크아웃 노출 계약. `bank_transfer`는 ko 로케일에 자동 추가되며 backend `CHECKOUT_ENABLED_GATEWAYS`와 동일해야 함 |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | — | Stripe publishable key (`PAYMENT_GATEWAY=stripe` 숨김 플로우 유지 시 필수) |
+
 ---
 
 ## Vercel Functions (프록시)
@@ -63,24 +66,27 @@
 
 ### 결제
 
-| 변수                                 | 기본값 | 설명                                                                                         |
-| ------------------------------------ | ------ | -------------------------------------------------------------------------------------------- |
-| `PAYMENT_GATEWAY`                    | `mock` | PG 어댑터 선택 (`mock`/`toss`/`stripe`/`inicis`/`naverpay`/`paypal`/`eximbay`). `mock`은 프로덕션 차단 |
-| `TOSS_SECRET_KEY`                    | —      | 토스페이먼츠 시크릿 키                                                                       |
-| `TOSS_CLIENT_KEY`                    | —      | 토스페이먼츠 클라이언트 키                                                                   |
-| `STRIPE_SECRET_KEY`                  | —      | Stripe 시크릿 키                                                                             |
-| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | —      | Stripe 공개 키                                                                               |
-| `STRIPE_WEBHOOK_SECRET`              | —      | Stripe 웹훅 서명 키                                                                          |
-| `EXIMBAY_MERCHANT_ID`                | —      | Eximbay merchant ID (프로덕션 체크아웃 필수)                                                  |
-| `EXIMBAY_API_KEY`                    | —      | Eximbay Payment Preparation/Verify API key (프로덕션 체크아웃 필수)                           |
-| `EXIMBAY_SECRET_KEY`                 | —      | Eximbay API secret key (프로덕션 체크아웃 필수)                                                |
-| `EXIMBAY_WEBHOOK_SECRET`             | —      | Eximbay webhook HMAC secret                                                                   |
-| `EXIMBAY_API_BASE_URL`               | `https://api-test.eximbay.com` | Eximbay API base URL (production 계약 후 교체)                                    |
-| `EXIMBAY_JS_SDK_URL`                 | `https://api-test.eximbay.com/v1/javascriptSDK.js` | Eximbay hosted payment page SDK URL                            |
-| `EXIMBAY_CURRENCY`                   | `KRW`  | Eximbay 결제 통화 (`USD` 사용 시 `EXIMBAY_KRW_PER_USD`로 환산)                                |
-| `EXIMBAY_LANG`                       | locale 기반 | Eximbay 결제창 언어 강제 override (`KR`/`EN`)                                             |
-| `EXIMBAY_SHOP_NAME`                  | `Okhwadang` | Eximbay 결제창 상점명                                                                    |
-| `EXIMBAY_KRW_PER_USD`                | `1350` | Eximbay USD 결제를 위한 KRW→USD 환산 기준                                                     |
+> 체크아웃 단일 계약: `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS`와 backend `CHECKOUT_ENABLED_GATEWAYS`를 같은 값으로 유지합니다. `bank_transfer`는 ko 로케일에서 자동 추가되며, `PAYMENT_GATEWAY=stripe|toss` 같은 숨김 플로우는 별도 backend 키/CSP까지 함께 유지해야 합니다.
+
+| 변수                                 | 기본값                                             | 설명                                                                                                                       |
+| ------------------------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `PAYMENT_GATEWAY`                    | `mock`                                             | PG 어댑터 선택 (`mock`/`toss`/`stripe`/`inicis`/`naverpay`/`paypal`/`eximbay`). `mock`은 프로덕션 차단                     |
+| `CHECKOUT_ENABLED_GATEWAYS`          | `naverpay,paypal,eximbay`                          | 활성 체크아웃 계약. 프론트 `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS`와 동일하게 유지 (`bank_transfer`는 ko 로케일 자동 추가) |
+| `TOSS_SECRET_KEY`                    | —                                                  | 토스페이먼츠 시크릿 키                                                                                                     |
+| `TOSS_CLIENT_KEY`                    | —                                                  | 토스페이먼츠 클라이언트 키                                                                                                 |
+| `STRIPE_SECRET_KEY`                  | —                                                  | Stripe 시크릿 키                                                                                                           |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | —                                                  | Stripe 공개 키                                                                                                             |
+| `STRIPE_WEBHOOK_SECRET`              | —                                                  | Stripe 웹훅 서명 키                                                                                                        |
+| `EXIMBAY_MERCHANT_ID`                | —                                                  | Eximbay merchant ID (프로덕션 체크아웃 필수)                                                                               |
+| `EXIMBAY_API_KEY`                    | —                                                  | Eximbay Payment Preparation/Verify API key (프로덕션 체크아웃 필수)                                                        |
+| `EXIMBAY_SECRET_KEY`                 | —                                                  | Eximbay API secret key (프로덕션 체크아웃 필수)                                                                            |
+| `EXIMBAY_WEBHOOK_SECRET`             | —                                                  | Eximbay webhook HMAC secret                                                                                                |
+| `EXIMBAY_API_BASE_URL`               | `https://api-test.eximbay.com`                     | Eximbay API base URL (production 계약 후 교체)                                                                             |
+| `EXIMBAY_JS_SDK_URL`                 | `https://api-test.eximbay.com/v1/javascriptSDK.js` | Eximbay hosted payment page SDK URL                                                                                        |
+| `EXIMBAY_CURRENCY`                   | `KRW`                                              | Eximbay 결제 통화 (`USD` 사용 시 `EXIMBAY_KRW_PER_USD`로 환산)                                                             |
+| `EXIMBAY_LANG`                       | locale 기반                                        | Eximbay 결제창 언어 강제 override (`KR`/`EN`)                                                                              |
+| `EXIMBAY_SHOP_NAME`                  | `Okhwadang`                                        | Eximbay 결제창 상점명                                                                                                      |
+| `EXIMBAY_KRW_PER_USD`                | `1350`                                             | Eximbay USD 결제를 위한 KRW→USD 환산 기준                                                                                  |
 
 ### 스토리지
 

--- a/docs/qa/checkout-payment-e2e.md
+++ b/docs/qa/checkout-payment-e2e.md
@@ -7,13 +7,13 @@ This checklist is the launch fallback when automated browser E2E cannot safely r
 - Local stack is running with `bash scripts/start-local.sh` or the target staging environment is healthy.
 - Backend health returns 200: `curl http://localhost:3000/api/health`.
 - Frontend responds: `curl -I http://localhost:5173/ko`.
-- `CHECKOUT_ENABLED_GATEWAYS` / `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS` match the provider(s) being tested.
+- `CHECKOUT_ENABLED_GATEWAYS` / `NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS` are identical for the scenario under test (`bank_transfer` is auto-added for `ko`).
 - Enabled provider credentials exist only in local/staging env files or secret stores.
 - Test product has enough stock and a non-free-shipping address is available.
 
 ## Success path per enabled provider
 
-Run once for each enabled production provider: NaverPay, PayPal, Toss, Stripe, or Mock.
+Run once for each gateway named in `CHECKOUT_ENABLED_GATEWAYS`, plus any hidden `PAYMENT_GATEWAY=stripe|toss` flow that is intentionally kept alive.
 
 1. Log in as a test customer.
 2. Add one product to cart with quantity that produces a non-zero shipping fee.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,69 @@
 import type { NextConfig } from 'next';
 import createBundleAnalyzer from '@next/bundle-analyzer';
 import createNextIntlPlugin from 'next-intl/plugin';
+import {
+  getCheckoutCspSources,
+  type CheckoutCspDirective,
+} from './backend/src/config/checkout-gateway-contract';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 const withBundleAnalyzer = createBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 });
+
+function appendDirectiveSources(base: readonly string[], extra: readonly string[] = []): string {
+  return [...new Set([...base, ...extra])].join(' ');
+}
+
+export function buildCheckoutContentSecurityPolicy(env: NodeJS.ProcessEnv = process.env): string {
+  const checkoutSources = getCheckoutCspSources(env);
+  const directive = (name: CheckoutCspDirective, base: readonly string[]) =>
+    `${name} ${appendDirectiveSources(base, checkoutSources[name])}`;
+
+  return (
+    [
+      "default-src 'self'",
+      directive('style-src', ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com']),
+      directive('script-src', [
+        "'self'",
+        "'unsafe-inline'",
+        'https://static.cloudflareinsights.com',
+        'https://www.googletagmanager.com',
+        'https://www.google-analytics.com',
+      ]),
+      "object-src 'none'",
+      "base-uri 'self'",
+      directive('img-src', [
+        "'self'",
+        'data:',
+        'https://images.unsplash.com',
+        'https://*.amazonaws.com',
+        'https://*.cloudfront.net',
+        'https://cdn.ockhwadang.com',
+        'https://ockhwadang.com',
+        'https://i.pinimg.com',
+        'https://m.cbw.co.kr',
+        'https://gdimg.gmarket.co.kr',
+        'https://cdn-optimized.imweb.me',
+        'https://shop-phinf.pstatic.net',
+        'https://www.google.co.kr',
+      ]),
+      "font-src 'self' https://fonts.gstatic.com",
+      directive('connect-src', [
+        "'self'",
+        'https://fonts.googleapis.com',
+        'https://fonts.gstatic.com',
+        'https://cloudflareinsights.com',
+        'https://www.google-analytics.com',
+        'https://analytics.google.com',
+        'https://www.google.com',
+        'https://region1.google-analytics.com',
+      ]),
+      directive('child-src', ["'self'"]),
+      directive('frame-src', ["'self'"]),
+    ].join('; ') + ';'
+  );
+}
 
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: false,
@@ -30,29 +88,26 @@ const nextConfig: NextConfig = {
     return [];
   },
   async headers() {
-    return [{
-      source: '/(.*)',
-      headers: [
-        { key: 'X-Frame-Options', value: 'DENY' },
-        { key: 'X-Content-Type-Options', value: 'nosniff' },
-        { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-        { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
-        { key: 'Cross-Origin-Opener-Policy', value: 'same-origin-allow-popups' },
-        { key: 'Content-Security-Policy', value: [
-          "default-src 'self'",
-          "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com",
-          "script-src 'self' 'unsafe-inline' https://js.tosspayments.com https://js.sandbox.tosspayments.com https://static.cloudflareinsights.com https://www.googletagmanager.com https://www.google-analytics.com https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com https://nsp.pay.naver.com https://api-test.eximbay.com https://api.eximbay.com https://pgonline-test.eximbay.com https://pgonline.eximbay.com https://js.stripe.com https://*.js.stripe.com",
-          "object-src 'none'",
-          "base-uri 'self'",
-          "img-src 'self' data: https://images.unsplash.com https://*.amazonaws.com https://*.cloudfront.net https://cdn.ockhwadang.com https://ockhwadang.com https://i.pinimg.com https://m.cbw.co.kr https://gdimg.gmarket.co.kr https://cdn-optimized.imweb.me https://shop-phinf.pstatic.net https://www.google.co.kr https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com",
-          "font-src 'self' https://fonts.gstatic.com",
-          "connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com https://www.google-analytics.com https://analytics.google.com https://www.google.com https://region1.google-analytics.com https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com https://nsp.pay.naver.com https://pay.naver.com https://m.pay.naver.com https://test-pay.naver.com https://test-m.pay.naver.com https://api-test.eximbay.com https://api.eximbay.com https://pgonline-test.eximbay.com https://pgonline.eximbay.com https://api.stripe.com",
-          "child-src 'self' https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com https://pay.naver.com https://m.pay.naver.com https://test-pay.naver.com https://test-m.pay.naver.com https://api-test.eximbay.com https://api.eximbay.com https://pgonline-test.eximbay.com https://pgonline.eximbay.com https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com",
-          "frame-src 'self' https://*.paypal.com https://*.paypalobjects.com https://*.venmo.com https://pay.naver.com https://m.pay.naver.com https://test-pay.naver.com https://test-m.pay.naver.com https://api-test.eximbay.com https://api.eximbay.com https://pgonline-test.eximbay.com https://pgonline.eximbay.com https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com",
-        ].join('; ') + ';' },
-        { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
-      ],
-    }];
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin-allow-popups' },
+          {
+            key: 'Content-Security-Policy',
+            value: buildCheckoutContentSecurityPolicy(process.env),
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/src/__tests__/next-config-csp.test.ts
+++ b/src/__tests__/next-config-csp.test.ts
@@ -1,72 +1,71 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import nextConfig, { buildCheckoutContentSecurityPolicy } from '../../next.config';
 
-function getCspDirective(source: string, directive: string): string {
-  const cspLine = source
-    .split('\n')
-    .find((line) => line.trim().startsWith(`"${directive} `));
+function getCspDirective(csp: string, directive: string): string {
+  const prefix = `${directive} `;
+  const line = csp.split('; ').find((entry) => entry.startsWith(prefix));
 
-  expect(cspLine).toBeDefined();
-  return cspLine ?? '';
+  expect(line).toBeDefined();
+  return line ?? '';
 }
 
 describe('Next.js CSP headers', () => {
-  it('allows Google Analytics gtag script, collection endpoints, and audience image beacon', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const imgSrc = getCspDirective(source, 'img-src');
+  it('keeps COOP popup isolation on every response header set', async () => {
+    const headers = await nextConfig.headers?.();
+    const rootHeaders = headers?.find((entry) => entry.source === '/(.*)')?.headers ?? [];
 
-    expect(source).toContain('https://www.googletagmanager.com');
-    expect(source).toContain('https://www.google-analytics.com');
-    expect(source).toContain('https://analytics.google.com');
-    expect(source).toContain('https://www.google.com');
-    expect(source).toContain('https://region1.google-analytics.com');
+    expect(rootHeaders).toContainEqual({
+      key: 'Cross-Origin-Opener-Policy',
+      value: 'same-origin-allow-popups',
+    });
+  });
+
+  it('allows Google Analytics gtag script, collection endpoints, and audience image beacon', () => {
+    const csp = buildCheckoutContentSecurityPolicy({});
+    const imgSrc = getCspDirective(csp, 'img-src');
+
+    expect(csp).toContain('https://www.googletagmanager.com');
+    expect(csp).toContain('https://www.google-analytics.com');
+    expect(csp).toContain('https://analytics.google.com');
+    expect(csp).toContain('https://www.google.com');
+    expect(csp).toContain('https://region1.google-analytics.com');
     expect(imgSrc).toContain('https://www.google.co.kr');
   });
 
-  it('allows documented PayPal checkout SDK sources and popup isolation', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
+  it('includes PayPal, NaverPay, and Eximbay origins for the default checkout contract', () => {
+    const csp = buildCheckoutContentSecurityPolicy({});
+    const scriptSrc = getCspDirective(csp, 'script-src');
+    const connectSrc = getCspDirective(csp, 'connect-src');
+    const frameSrc = getCspDirective(csp, 'frame-src');
 
-    expect(source).toContain("Cross-Origin-Opener-Policy', value: 'same-origin-allow-popups");
-    expect(source).toContain('https://*.paypal.com');
-    expect(source).toContain('https://*.paypalobjects.com');
-    expect(source).toContain('https://*.venmo.com');
-    expect(source).toContain('child-src');
-    expect(source).toContain('frame-src');
-  });
-
-  it('allows NaverPay SDK and payment page origins in checkout CSP directives', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const scriptSrc = getCspDirective(source, 'script-src');
-    const connectSrc = getCspDirective(source, 'connect-src');
-    const frameSrc = getCspDirective(source, 'frame-src');
+    ['https://*.paypal.com', 'https://*.paypalobjects.com', 'https://*.venmo.com'].forEach(
+      (origin) => {
+        expect(csp).toContain(origin);
+      },
+    );
 
     expect(scriptSrc).toContain('https://nsp.pay.naver.com');
-
     [
-      'https://nsp.pay.naver.com',
       'https://pay.naver.com',
       'https://m.pay.naver.com',
       'https://test-pay.naver.com',
       'https://test-m.pay.naver.com',
     ].forEach((origin) => {
       expect(connectSrc).toContain(origin);
+      expect(frameSrc).toContain(origin);
     });
 
-    [
-      'https://pay.naver.com',
-      'https://m.pay.naver.com',
-      'https://test-pay.naver.com',
-      'https://test-m.pay.naver.com',
-    ].forEach((origin) => {
+    ['https://api-test.eximbay.com', 'https://api.eximbay.com'].forEach((origin) => {
+      expect(scriptSrc).toContain(origin);
+      expect(connectSrc).toContain(origin);
       expect(frameSrc).toContain(origin);
     });
   });
 
-  it('allows Stripe.js, Stripe API, and 3DS frame origins in checkout CSP directives', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const scriptSrc = getCspDirective(source, 'script-src');
-    const connectSrc = getCspDirective(source, 'connect-src');
-    const frameSrc = getCspDirective(source, 'frame-src');
+  it('adds Stripe sources when PAYMENT_GATEWAY=stripe keeps a hidden flow alive', () => {
+    const csp = buildCheckoutContentSecurityPolicy({ PAYMENT_GATEWAY: 'stripe' });
+    const scriptSrc = getCspDirective(csp, 'script-src');
+    const connectSrc = getCspDirective(csp, 'connect-src');
+    const frameSrc = getCspDirective(csp, 'frame-src');
 
     ['https://js.stripe.com', 'https://*.js.stripe.com'].forEach((origin) => {
       expect(scriptSrc).toContain(origin);
@@ -77,29 +76,22 @@ describe('Next.js CSP headers', () => {
     expect(frameSrc).toContain('https://hooks.stripe.com');
   });
 
-  it('allows Eximbay hosted payment SDK/API/frame origins in checkout CSP directives', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const scriptSrc = getCspDirective(source, 'script-src');
-    const connectSrc = getCspDirective(source, 'connect-src');
-    const frameSrc = getCspDirective(source, 'frame-src');
+  it('drops NaverPay and Eximbay sources when checkout contract only enables paypal', () => {
+    const csp = buildCheckoutContentSecurityPolicy({ CHECKOUT_ENABLED_GATEWAYS: 'paypal' });
+    const scriptSrc = getCspDirective(csp, 'script-src');
+    const connectSrc = getCspDirective(csp, 'connect-src');
+    const frameSrc = getCspDirective(csp, 'frame-src');
 
-    ['https://api-test.eximbay.com', 'https://api.eximbay.com'].forEach((origin) => {
-      expect(scriptSrc).toContain(origin);
-      expect(connectSrc).toContain(origin);
-      expect(frameSrc).toContain(origin);
-    });
-
-    ['https://pgonline-test.eximbay.com', 'https://pgonline.eximbay.com'].forEach((origin) => {
-      expect(connectSrc).toContain(origin);
-      expect(frameSrc).toContain(origin);
-    });
+    expect(csp).toContain('https://*.paypal.com');
+    expect(scriptSrc).not.toContain('https://nsp.pay.naver.com');
+    expect(connectSrc).not.toContain('https://pay.naver.com');
+    expect(frameSrc).not.toContain('https://api.eximbay.com');
   });
 
-  it('allows SmartStore product images from the exact Naver image origin', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-    const imgSrc = getCspDirective(source, 'img-src');
+  it('keeps SmartStore product images on the exact Naver image origin', () => {
+    const csp = buildCheckoutContentSecurityPolicy({});
+    const imgSrc = getCspDirective(csp, 'img-src');
 
-    expect(source).toContain("{ protocol: 'https', hostname: 'shop-phinf.pstatic.net' }");
     expect(imgSrc).toContain('https://shop-phinf.pstatic.net');
     expect(imgSrc).not.toContain('https://*.pstatic.net');
   });
@@ -107,8 +99,6 @@ describe('Next.js CSP headers', () => {
 
 describe('Next.js image cache policy', () => {
   it('keeps optimized remote product images cached beyond the default TTL', () => {
-    const source = readFileSync(join(process.cwd(), 'next.config.ts'), 'utf8');
-
-    expect(source).toContain('minimumCacheTTL: 86400');
+    expect(nextConfig.images?.minimumCacheTTL).toBe(86400);
   });
 });

--- a/src/constants/checkoutPaymentMethods.ts
+++ b/src/constants/checkoutPaymentMethods.ts
@@ -1,5 +1,9 @@
 import type { Locale } from '@/i18n/routing';
 import type { CheckoutGatewayName } from '@/lib/api';
+import {
+  getAvailableCheckoutGateways,
+  getEnabledCheckoutGateways as getSharedEnabledCheckoutGateways,
+} from '../../backend/src/config/checkout-gateway-contract';
 
 export type CheckoutPaymentCountry = 'KR' | 'GLOBAL';
 
@@ -8,25 +12,8 @@ export const CHECKOUT_PAYMENT_COUNTRY_BY_LOCALE = {
   en: 'GLOBAL',
 } as const satisfies Record<Locale, CheckoutPaymentCountry>;
 
-export const CHECKOUT_PAYMENT_METHODS_BY_COUNTRY = {
-  KR: ['naverpay', 'bank_transfer', 'paypal', 'eximbay'],
-  GLOBAL: ['paypal', 'eximbay'],
-} as const satisfies Record<CheckoutPaymentCountry, readonly CheckoutGatewayName[]>;
-
-function isCheckoutGatewayName(value: string): value is CheckoutGatewayName {
-  return value === 'naverpay' || value === 'bank_transfer' || value === 'eximbay' || value === 'paypal';
-}
-
 export function getEnabledCheckoutGateways(): CheckoutGatewayName[] {
-  const configured = process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS;
-  if (!configured || configured.trim() === '') return ['naverpay', 'bank_transfer', 'eximbay', 'paypal'];
-
-  const gateways = configured
-    .split(',')
-    .map((value) => value.trim().toLowerCase())
-    .filter(isCheckoutGatewayName);
-
-  return [...new Set([...gateways, 'bank_transfer' as const])];
+  return getSharedEnabledCheckoutGateways(process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS);
 }
 
 export function getCheckoutPaymentCountry(locale: Locale): CheckoutPaymentCountry {
@@ -34,9 +21,7 @@ export function getCheckoutPaymentCountry(locale: Locale): CheckoutPaymentCountr
 }
 
 export function getGatewayOptionsByLocale(locale: Locale): CheckoutGatewayName[] {
-  const enabled = getEnabledCheckoutGateways();
-  const country = getCheckoutPaymentCountry(locale);
-  return CHECKOUT_PAYMENT_METHODS_BY_COUNTRY[country].filter((gateway) => enabled.includes(gateway));
+  return getAvailableCheckoutGateways(locale, process.env.NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS);
 }
 
 export function getDefaultCheckoutGateway(locale: Locale): CheckoutGatewayName {


### PR DESCRIPTION
## Summary
- extract checkout gateway exposure, env-key, and CSP-domain rules into one shared contract source
- drive frontend locale exposure, backend env validation, and Next.js CSP generation from that contract
- document the mirrored CHECKOUT_ENABLED_GATEWAYS / NEXT_PUBLIC_CHECKOUT_ENABLED_GATEWAYS knobs and update checkout QA guidance

## Verification
- npm run test:run -- src/__tests__/next-config-csp.test.ts src/components/shared/checkout/__tests__/PaymentMethodSelector.test.tsx
- cd backend && npm test -- --runInBand config/__tests__/env-validator.spec.ts modules/payments/__tests__/payments.module.spec.ts
- npm run lint
- cd backend && npm run lint
- npm run build
- cd backend && npm run build
- bash scripts/start-local.sh
- curl -s http://localhost:3000/api/health
- curl -I http://localhost:5173/ko

Closes #1110