### PR TITLE
Handle home CMS integrity failures and shell degraded mode

### DIFF
--- a/src/app/[locale]/(routes)/__tests__/error.test.tsx
+++ b/src/app/[locale]/(routes)/__tests__/error.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ErrorPage from '../error';
+import { createHomePageContentError } from '@/lib/storefront-diagnostics';
+
+vi.mock('@/utils/clientLocale', () => ({
+  getClientLocale: () => 'ko',
+}));
+
+describe('storefront route error boundary', () => {
+  it('renders a CMS-specific message for missing home page content', () => {
+    render(<ErrorPage error={createHomePageContentError('ko')} reset={vi.fn()} />);
+
+    expect(screen.getByText('홈 CMS 콘텐츠가 비어 있습니다')).toBeInTheDocument();
+    expect(screen.getByText(/slug='home' 페이지와 블록 게시 상태를 확인하세요/)).toBeInTheDocument();
+    expect(screen.getAllByText(/scripts\/run-seed\.sh/).length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the generic error UI for non-CMS runtime errors', () => {
+    render(<ErrorPage error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(screen.getByText('데이터를 불러오지 못했습니다')).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/(routes)/error.tsx
+++ b/src/app/[locale]/(routes)/error.tsx
@@ -1,6 +1,49 @@
 'use client';
+
 import ErrorFallback from '@/components/shared/ErrorFallback';
+import { localMessage } from '@/utils/localMessages';
+import { isHomePageContentError } from '@/lib/storefront-diagnostics';
+
+function HomeCmsIntegrityFallback({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-xl rounded-lg border border-amber-200 bg-amber-50 p-6 text-left shadow-sm">
+        <div className="space-y-2">
+          <p className="text-base font-semibold text-amber-950">
+            {localMessage('ui.homeCmsMissingTitle')}
+          </p>
+          <p className="text-sm text-amber-900">
+            {localMessage('ui.homeCmsMissingDescription')}
+          </p>
+        </div>
+        <p className="mt-4 text-sm text-amber-950">
+          {localMessage('ui.homeCmsMissingRecoveryHint')}
+        </p>
+        <div className="mt-4 rounded-md bg-background/80 p-3 text-xs text-muted-foreground">
+          <p className="mt-1 break-words">{error.message}</p>
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-4 inline-flex items-center gap-2 rounded bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-80"
+        >
+          {localMessage('ui.retry')}
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  if (isHomePageContentError(error)) {
+    return <HomeCmsIntegrityFallback error={error} reset={reset} />;
+  }
+
   return <ErrorFallback error={error} onRetry={reset} />;
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -55,7 +55,6 @@ async function getStorefrontShellSnapshot(locale: string) {
     return buildStorefrontShellSnapshot(null, { fetchFailed: true });
   }
 }
-
 export default async function LocaleLayout({
   children,
   params,

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,7 +4,7 @@ import { usePathname } from 'next/navigation';
 import { Toaster } from 'sonner';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import type { FooterBusinessInfo } from '@/components/Footer';
+import type { StorefrontBusinessInfo as FooterBusinessInfo } from '@/lib/storefront-shell';
 import MobileBottomNavWrapper from '@/components/MobileBottomNavWrapper';
 import { MobileNavProvider } from '@/contexts/MobileNavContext';
 import RecentlyViewedWidget from '@/components/RecentlyViewedWidget';

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 import { Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { useNavigation } from '@/hooks/useNavigation';
+import type { StorefrontBusinessInfo as FooterBusinessInfo } from '@/lib/storefront-shell';
+
 import type { NavigationItem } from '@/lib/api';
 
 const InstagramIcon = ({ size = 18 }: { size?: number }) => (
@@ -57,21 +59,6 @@ function renderNavLinks(items: NavigationItem[]) {
       {item.label}
     </Link>
   ));
-}
-
-export interface FooterBusinessInfo {
-  companyName: string;
-  ceo: string;
-  address: string;
-  bizNo: string;
-  mailOrderNo: string;
-  phone: string;
-  email: string;
-  hours: string;
-  lunchTime: string;
-  holidays: string;
-  privacyOfficer: string;
-  infoUrl: string;
 }
 
 interface FooterProps {

--- a/src/lib/__tests__/api-server.test.ts
+++ b/src/lib/__tests__/api-server.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchPage } from '../api-server';
+
+describe('fetchPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns null only when the CMS page is actually missing', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: vi.fn().mockResolvedValue({ message: 'not found' }),
+    } as unknown as Response);
+
+    await expect(fetchPage('home', 'ko')).resolves.toBeNull();
+  });
+
+  it('rethrows non-404 backend failures so route errors can distinguish runtime issues', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ message: 'backend exploded' }),
+    } as unknown as Response);
+
+    await expect(fetchPage('home', 'ko')).rejects.toThrow('backend exploded');
+  });
+});

--- a/src/lib/__tests__/storefront-shell.test.ts
+++ b/src/lib/__tests__/storefront-shell.test.ts
@@ -6,6 +6,11 @@ describe('buildStorefrontShellSnapshot', () => {
     const snapshot = buildStorefrontShellSnapshot({
       mobile_bottom_nav_visible: 'true',
       business_company_name: '옥화당',
+      business_ceo: '권준현',
+      business_address: '서울특별시 강남구 역삼로 114',
+      business_registration_number: '131-72-05631',
+      business_mail_order_number: '2026-서울강남-01632',
+      business_email: 'support@example.com',
       color_primary: '#123456',
     });
 
@@ -13,7 +18,14 @@ describe('buildStorefrontShellSnapshot', () => {
     expect(snapshot.issue).toBeUndefined();
     expect(snapshot.mobileBottomNavVisible).toBe(true);
     expect(snapshot.themeStyle).toContain('--db-color-primary: #123456');
-    expect(snapshot.businessInfo?.companyName).toBe('옥화당');
+    expect(snapshot.businessInfo).toEqual({
+      companyName: '옥화당',
+      ceo: '권준현',
+      address: '서울특별시 강남구 역삼로 114',
+      bizNo: '131-72-05631',
+      mailOrderNo: '2026-서울강남-01632',
+      email: 'support@example.com',
+    });
   });
 
   it('marks the shell degraded when the settings fetch fails', () => {
@@ -25,14 +37,27 @@ describe('buildStorefrontShellSnapshot', () => {
     expect(snapshot.businessInfo).toBeUndefined();
   });
 
-  it('marks the shell degraded when required settings are missing', () => {
+  it('marks the shell degraded when required settings are missing but keeps partial business info', () => {
     const snapshot = buildStorefrontShellSnapshot({
       business_company_name: '옥화당',
+      business_phone: '010-0000-0000',
+      business_email: 'support@example.com',
+      business_ceo: '  ',
     });
 
     expect(snapshot.mode).toBe('degraded');
     expect(snapshot.issue).toBe('missing_required_settings');
-    expect(snapshot.missingRequiredKeys).toEqual(['mobile_bottom_nav_visible']);
-    expect(snapshot.businessInfo?.companyName).toBe('옥화당');
+    expect(snapshot.missingRequiredKeys).toEqual([
+      'mobile_bottom_nav_visible',
+      'business_ceo',
+      'business_address',
+      'business_registration_number',
+      'business_mail_order_number',
+    ]);
+    expect(snapshot.businessInfo).toEqual({
+      companyName: '옥화당',
+      phone: '010-0000-0000',
+      email: 'support@example.com',
+    });
   });
 });

--- a/src/lib/storefront-shell.ts
+++ b/src/lib/storefront-shell.ts
@@ -1,22 +1,29 @@
 import { getThemeStyle } from '@/lib/theme-style';
 
-const REQUIRED_STOREFRONT_SETTING_KEYS = ['mobile_bottom_nav_visible'] as const;
+const REQUIRED_STOREFRONT_SETTING_KEYS = [
+  'mobile_bottom_nav_visible',
+  'business_company_name',
+  'business_ceo',
+  'business_address',
+  'business_registration_number',
+  'business_mail_order_number',
+] as const;
 
 export type StorefrontShellIssue = 'settings_fetch_failed' | 'missing_required_settings';
 
 export interface StorefrontBusinessInfo {
-  companyName: string;
-  ceo: string;
-  address: string;
-  bizNo: string;
-  mailOrderNo: string;
-  phone: string;
-  email: string;
-  hours: string;
-  lunchTime: string;
-  holidays: string;
-  privacyOfficer: string;
-  infoUrl: string;
+  companyName?: string;
+  ceo?: string;
+  address?: string;
+  bizNo?: string;
+  mailOrderNo?: string;
+  phone?: string;
+  email?: string;
+  hours?: string;
+  lunchTime?: string;
+  holidays?: string;
+  privacyOfficer?: string;
+  infoUrl?: string;
 }
 
 export interface StorefrontShellSnapshot {
@@ -36,20 +43,30 @@ function hasSettingValue(settingsMap: Record<string, string> | null, key: string
 function buildBusinessInfo(settingsMap: Record<string, string> | null): StorefrontBusinessInfo | undefined {
   if (!settingsMap) return undefined;
 
-  return {
-    companyName: settingsMap.business_company_name ?? '',
-    ceo: settingsMap.business_ceo ?? '',
-    address: settingsMap.business_address ?? '',
-    bizNo: settingsMap.business_registration_number ?? '',
-    mailOrderNo: settingsMap.business_mail_order_number ?? '',
-    phone: settingsMap.business_phone ?? '',
-    email: settingsMap.business_email ?? '',
-    hours: settingsMap.business_hours ?? '',
-    lunchTime: settingsMap.business_lunch_time ?? '',
-    holidays: settingsMap.business_holidays ?? '',
-    privacyOfficer: settingsMap.business_privacy_officer ?? '',
-    infoUrl: settingsMap.business_info_url ?? '',
-  };
+  const businessInfo: StorefrontBusinessInfo = {};
+  const fieldMap = {
+    companyName: 'business_company_name',
+    ceo: 'business_ceo',
+    address: 'business_address',
+    bizNo: 'business_registration_number',
+    mailOrderNo: 'business_mail_order_number',
+    phone: 'business_phone',
+    email: 'business_email',
+    hours: 'business_hours',
+    lunchTime: 'business_lunch_time',
+    holidays: 'business_holidays',
+    privacyOfficer: 'business_privacy_officer',
+    infoUrl: 'business_info_url',
+  } as const satisfies Record<keyof StorefrontBusinessInfo, string>;
+
+  for (const [field, key] of Object.entries(fieldMap)) {
+    const value = settingsMap[key]?.trim();
+    if (value) {
+      businessInfo[field as keyof StorefrontBusinessInfo] = value;
+    }
+  }
+
+  return Object.keys(businessInfo).length > 0 ? businessInfo : undefined;
 }
 
 export function buildStorefrontShellSnapshot(


### PR DESCRIPTION
## Summary
- keep home CMS integrity failures distinct from generic runtime fetch failures and show an operator-friendly error state
- harden storefront degraded mode by treating required business/legal settings separately from optional fields and preserving partial business info safely
- add focused verification for the storefront shell snapshot and CMS error handling, plus deployment runbook guidance

## Verification
- npx vitest run 'src/lib/__tests__/api-server.test.ts' 'src/lib/__tests__/storefront-shell.test.ts' 'src/app/[locale]/(routes)/__tests__/error.test.tsx' 'src/components/__tests__/Footer.test.tsx' 'src/components/__tests__/AppShell.test.tsx' 'src/components/shared/layout/__tests__/AnnouncementBar.test.tsx' 'src/__tests__/App.test.tsx'
- npm run build
- bash scripts/start-local.sh

Closes #1112