### PR TITLE
fix: #1134 홈페이지 남은 지연 경로 마무리

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -164,7 +164,9 @@ describe('Home page', () => {
   it('throws an operator-facing error when home CMS content is missing', async () => {
     mockFetchPage.mockResolvedValueOnce(null);
 
-    await expect(Home({ params: Promise.resolve({ locale: 'ko' }) })).rejects.toThrow(HOME_PAGE_CONTENT_ERROR_CODE);
+    await expect(Home({ params: Promise.resolve({ locale: 'ko' }) })).rejects.toMatchObject({
+      name: HOME_PAGE_CONTENT_ERROR_CODE,
+    });
   });
 
   it.each(['favicon.ico', 'robots.txt', 'sitemap.xml', 'logo.png'])(

--- a/src/app/[locale]/(routes)/__tests__/error.test.tsx
+++ b/src/app/[locale]/(routes)/__tests__/error.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import ErrorPage from '../error';
-import { createHomePageContentError } from '@/lib/storefront-diagnostics';
+import { HOME_PAGE_CONTENT_ERROR_CODE, createHomePageContentError } from '@/lib/storefront-diagnostics';
+
 
 vi.mock('@/utils/clientLocale', () => ({
   getClientLocale: () => 'ko',
@@ -16,6 +17,16 @@ describe('storefront route error boundary', () => {
     expect(screen.getAllByText(/scripts\/run-seed\.sh/).length).toBeGreaterThan(0);
   });
 
+
+  it('renders a CMS-specific message when the production-safe digest is present', () => {
+    const error = new Error('generic production error') as Error & { digest?: string };
+    error.digest = HOME_PAGE_CONTENT_ERROR_CODE;
+
+    render(<ErrorPage error={error} reset={vi.fn()} />);
+
+    expect(screen.getByText('홈 CMS 콘텐츠가 비어 있습니다')).toBeInTheDocument();
+    expect(screen.getByText(/slug='home' 페이지와 블록 게시 상태를 확인하세요/)).toBeInTheDocument();
+  });
   it('falls back to the generic error UI for non-CMS runtime errors', () => {
     render(<ErrorPage error={new Error('boom')} reset={vi.fn()} />);
 

--- a/src/app/[locale]/(routes)/error.tsx
+++ b/src/app/[locale]/(routes)/error.tsx
@@ -2,15 +2,16 @@
 
 import ErrorFallback from '@/components/shared/ErrorFallback';
 import { localMessage } from '@/utils/localMessages';
-import { isHomePageContentError } from '@/lib/storefront-diagnostics';
+import { HOME_PAGE_CONTENT_ERROR_CODE, isHomePageContentError } from '@/lib/storefront-diagnostics';
 
 function HomeCmsIntegrityFallback({
   error,
   reset,
 }: {
-  error: Error;
+  error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const homeCmsDetail = error.message || error.digest || HOME_PAGE_CONTENT_ERROR_CODE;
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="w-full max-w-xl rounded-lg border border-amber-200 bg-amber-50 p-6 text-left shadow-sm">
@@ -26,7 +27,7 @@ function HomeCmsIntegrityFallback({
           {localMessage('ui.homeCmsMissingRecoveryHint')}
         </p>
         <div className="mt-4 rounded-md bg-background/80 p-3 text-xs text-muted-foreground">
-          <p className="mt-1 break-words">{error.message}</p>
+          <p className="mt-1 break-words">{homeCmsDetail}</p>
         </div>
         <button
           type="button"
@@ -40,7 +41,7 @@ function HomeCmsIntegrityFallback({
   );
 }
 
-export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   if (isHomePageContentError(error)) {
     return <HomeCmsIntegrityFallback error={error} reset={reset} />;
   }

--- a/src/app/[locale]/(routes)/page.tsx
+++ b/src/app/[locale]/(routes)/page.tsx
@@ -2,9 +2,15 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import BlockRenderer from '@/components/shared/blocks/BlockRenderer';
-import type { CategoryNavContent, JournalPreviewContent, PageBlock, ProductGridContent } from '@/lib/api';
-import { createHomePageContentError } from '@/lib/storefront-diagnostics';
-import { fetchCategories, fetchJournals, fetchPage, fetchProducts } from '@/lib/api-server';
+import type {
+  CategoryNavContent,
+  JournalPreviewContent,
+  PageBlock,
+  ProductCarouselContent,
+  ProductGridContent,
+} from '@/lib/api';
+import { HOME_PAGE_CONTENT_ERROR_CODE, createHomePageContentError, getHomePageContentErrorDetail } from '@/lib/storefront-diagnostics';
+import { fetchCategories, fetchJournals, fetchPage, fetchProducts, fetchProductsBulk } from '@/lib/api-server';
 import { isLocale } from '@/i18n/routing';
 
 
@@ -42,29 +48,68 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+function HomeCmsIntegrityFallback({
+  title,
+  description,
+  recoveryHint,
+  detail,
+}: {
+  title: string;
+  description: string;
+  recoveryHint: string;
+  detail: string;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-xl rounded-lg border border-amber-200 bg-amber-50 p-6 text-left shadow-sm">
+        <div className="space-y-2">
+          <p className="text-base font-semibold text-amber-950">{title}</p>
+          <p className="text-sm text-amber-900">{description}</p>
+        </div>
+        <p className="mt-4 text-sm text-amber-950">{recoveryHint}</p>
+        <div className="mt-4 rounded-md bg-background/80 p-3 text-xs text-muted-foreground">
+          <p className="break-words">[{HOME_PAGE_CONTENT_ERROR_CODE}] {detail}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+async function prefetchProductBlock(
+  content: ProductGridContent | ProductCarouselContent,
+  locale: string,
+) {
+  if (Array.isArray(content.prefetched_products)) {
+    return content.prefetched_products;
+  }
+
+  if (Array.isArray(content.product_ids) && content.product_ids.length > 0) {
+    return fetchProductsBulk(content.product_ids.slice(0, content.limit), locale);
+  }
+
+  const products = await fetchProducts({
+    categoryId: content.category_id,
+    sort: content.sort,
+    limit: content.limit,
+    locale,
+  });
+
+  return products.items;
+}
+
 async function prefetchHomeBlocks(blocks: PageBlock[], locale: string): Promise<PageBlock[]> {
   return Promise.all(
     blocks.map(async (block) => {
       try {
-        if (block.type === 'product_grid') {
-          const content = block.content as unknown as ProductGridContent;
-
-          if (Array.isArray(content.prefetched_products) || Array.isArray(content.product_ids)) {
-            return block;
-          }
-
-          const products = await fetchProducts({
-            categoryId: content.category_id,
-            sort: content.sort,
-            limit: content.limit,
-            locale,
-          });
+        if (block.type === 'product_grid' || block.type === 'product_carousel') {
+          const content = block.content as unknown as ProductGridContent | ProductCarouselContent;
+          const prefetchedProducts = await prefetchProductBlock(content, locale);
 
           return {
             ...block,
             content: {
               ...content,
-              prefetched_products: products.items,
+              prefetched_products: prefetchedProducts,
             },
           } satisfies PageBlock;
         }
@@ -131,11 +176,25 @@ export default async function Home({
   if (!isLocale(locale)) {
     notFound();
   }
-  const homePage = await fetchPage('home', locale);
+  const [homePage, tUi] = await Promise.all([
+    fetchPage('home', locale),
+    getTranslations('ui'),
+  ]);
 
   // 홈은 반드시 DB 에서 렌더. 폴백 금지 — 상단 주석 참조.
   if (!homePage?.blocks?.length) {
-    throw createHomePageContentError(locale);
+    if (process.env.NODE_ENV !== 'production') {
+      throw createHomePageContentError(locale);
+    }
+
+    return (
+      <HomeCmsIntegrityFallback
+        title={tUi('homeCmsMissingTitle')}
+        description={tUi('homeCmsMissingDescription')}
+        recoveryHint={tUi('homeCmsMissingRecoveryHint')}
+        detail={getHomePageContentErrorDetail(locale)}
+      />
+    );
   }
 
   const blocks = await prefetchHomeBlocks(homePage.blocks, locale);

--- a/src/components/__tests__/HomePage.test.tsx
+++ b/src/components/__tests__/HomePage.test.tsx
@@ -2,8 +2,12 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import HeroBannerBlock from '@/components/shared/blocks/HeroBannerBlock';
 import ProductGridBlock from '@/components/shared/blocks/ProductGridBlock';
+import ProductCarouselBlock from '@/components/shared/blocks/ProductCarouselBlock';
 import CategoryNavBlock from '@/components/shared/blocks/CategoryNavBlock';
-import type { HeroBannerContent, ProductGridContent, CategoryNavContent, Product, Category } from '@/lib/api';
+import { productsApi } from '@/lib/api';
+import type { HeroBannerContent, ProductGridContent, ProductCarouselContent, CategoryNavContent, Product, Category } from '@/lib/api';
+
+
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -81,6 +85,7 @@ vi.mock('@/lib/api', async () => {
     productsApi: {
       getList: vi.fn().mockResolvedValue({ items: [] }),
       getById: vi.fn(),
+      getBulk: vi.fn().mockResolvedValue([]),
     },
     categoriesApi: {
       getTree: vi.fn().mockResolvedValue([]),
@@ -238,6 +243,26 @@ describe('ProductGridBlock', () => {
     };
     const { container } = render(<ProductGridBlock content={content} />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('ProductCarouselBlock', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders prefetched carousel products without client fetch', () => {
+    const content: ProductCarouselContent = {
+      title: '베스트 자사호',
+      template: 'default',
+      limit: 8,
+      prefetched_products: sampleProducts,
+    };
+
+    render(<ProductCarouselBlock content={content} />);
+
+    expect(screen.getByText('테스트 상품 1')).toBeInTheDocument();
+    expect(screen.getByText('테스트 상품 2')).toBeInTheDocument();
+    expect(vi.mocked(productsApi.getBulk)).not.toHaveBeenCalled();
+    expect(vi.mocked(productsApi.getList)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/shared/ErrorFallback.tsx
+++ b/src/components/shared/ErrorFallback.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { isHomePageContentError } from '@/lib/storefront-diagnostics';
+import { HOME_PAGE_CONTENT_ERROR_CODE, isHomePageContentError } from '@/lib/storefront-diagnostics';
 import { handleApiError } from '@/utils/error';
 import { localMessage } from '@/utils/localMessages';
 
@@ -17,8 +17,10 @@ export default function ErrorFallback({ error, onRetry }: ErrorFallbackProps) {
         recoveryHint: localMessage('ui.homeCmsMissingRecoveryHint'),
       }
     : null;
+
+  const homeCmsDetail = error.message || error.digest || HOME_PAGE_CONTENT_ERROR_CODE;
   const detailMessage = diagnostic
-    ? error.message
+    ? homeCmsDetail
     : handleApiError(error, localMessage('ui.unknownError'));
 
   return (

--- a/src/components/shared/blocks/ProductCarouselBlock.tsx
+++ b/src/components/shared/blocks/ProductCarouselBlock.tsx
@@ -23,7 +23,7 @@ export default function ProductCarouselBlock({ content }: Props) {
   const locale = params.locale as Locale;
   const t = useTranslations('product');
   const tCommon = useTranslations('common');
-  const { product_ids, category_id, sort, limit, template, title } = content;
+  const { product_ids, category_id, sort, limit, template, title, prefetched_products } = content;
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -33,7 +33,7 @@ export default function ProductCarouselBlock({ content }: Props) {
   const gap = 24;
 
   const { data: products, loading } = useBlockData<Product>({
-    prefetched: null,
+    prefetched: prefetched_products,
     fetch: async () => {
       if (product_ids && product_ids.length > 0) {
         return productsApi.getBulk(product_ids.slice(0, limit), locale);

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,5 +1,6 @@
 import { cache } from 'react';
 import type {
+  Product,
   ProductListResponse,
   ProductSort,
   Category,
@@ -34,6 +35,7 @@ async function fetchFromBackend<T>(
   endpoint: string,
   params?: Record<string, string | number | undefined>,
   policy?: BackendFetchPolicy,
+  init?: RequestInit,
 ): Promise<T> {
   let url = buildBackendApiUrl(endpoint);
 
@@ -51,10 +53,10 @@ async function fetchFromBackend<T>(
   }
 
   const shouldUseCachePolicy = Boolean(policy) && process.env.CI !== 'true';
-  const response = await fetch(
-    url,
-    shouldUseCachePolicy ? { next: policy } : { cache: 'no-store' },
-  );
+  const response = await fetch(url, {
+    ...init,
+    ...(shouldUseCachePolicy ? { next: policy } : { cache: 'no-store' }),
+  });
 
   if (!response.ok) {
     throw await createApiHttpError(response);
@@ -79,6 +81,19 @@ export function fetchProducts(params?: {
     '/products',
     params as Record<string, string | number | undefined>,
     CACHE_POLICIES.catalog,
+  );
+}
+
+export function fetchProductsBulk(ids: number[], locale?: string) {
+  return fetchFromBackend<Product[]>(
+    '/products/bulk',
+    locale ? { locale } : undefined,
+    CACHE_POLICIES.catalog,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids }),
+    },
   );
 }
 

--- a/src/lib/api/pages.ts
+++ b/src/lib/api/pages.ts
@@ -74,6 +74,8 @@ export interface ProductCarouselContent {
   limit: number;
   template: 'default' | 'large';
   title?: string;
+  /** 서버에서 미리 가져온 상품 데이터 (fallback용) */
+  prefetched_products?: Product[];
 }
 
 export interface CategoryNavContent {

--- a/src/lib/storefront-diagnostics.ts
+++ b/src/lib/storefront-diagnostics.ts
@@ -1,12 +1,34 @@
 export const HOME_PAGE_CONTENT_ERROR_CODE = 'CMS_HOME_PAGE_MISSING';
 
+type StorefrontDiagnosticError = Error & {
+  digest?: string;
+  cause?: unknown;
+};
+
+export function getHomePageContentErrorDetail(locale: string): string {
+  return `DB 에 slug='home' 페이지가 없거나 블록이 비어있습니다 (locale=${locale}). 시드 데이터를 확인하세요: scripts/run-seed.sh`;
+}
+
 export function createHomePageContentError(locale: string): Error {
-  return new Error(
-    `[${HOME_PAGE_CONTENT_ERROR_CODE}] DB 에 slug='home' 페이지가 없거나 블록이 비어있습니다 (locale=${locale}). ` +
-      '시드 데이터를 확인하세요: scripts/run-seed.sh',
+  const error = new Error(getHomePageContentErrorDetail(locale)) as StorefrontDiagnosticError;
+  error.name = HOME_PAGE_CONTENT_ERROR_CODE;
+  error.digest = HOME_PAGE_CONTENT_ERROR_CODE;
+  error.cause = { code: HOME_PAGE_CONTENT_ERROR_CODE, locale };
+  return error;
+}
+
+function hasHomePageContentErrorCode(value: unknown): boolean {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && 'code' in value
+      && (value as { code?: unknown }).code === HOME_PAGE_CONTENT_ERROR_CODE,
   );
 }
 
 export function isHomePageContentError(error: Error): boolean {
-  return error.message.includes(`[${HOME_PAGE_CONTENT_ERROR_CODE}]`);
+  const diagnosticError = error as StorefrontDiagnosticError;
+  return diagnosticError.name === HOME_PAGE_CONTENT_ERROR_CODE
+    || diagnosticError.digest === HOME_PAGE_CONTENT_ERROR_CODE
+    || hasHomePageContentErrorCode(diagnosticError.cause);
 }


### PR DESCRIPTION
## Summary
- prefetch the remaining homepage product block shapes, including curated product grids and product carousels
- make the home CMS-missing operator guidance production-stable instead of depending on server error message text
- add regression tests for the follow-up coverage

## Verification
- [x] bash scripts/codex-project-guard.sh
- [x] npm run build && npm run test:run
- [x] cd backend && npm run build && npm run test
- [x] bash scripts/start-local.sh
- [x] http://localhost:3000/api/health
- [x] http://localhost:5173/en
- [x] http://localhost:5173/ko

Closes #1134
