### PR TITLE
#1137 비회원 구매기능

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -92,6 +92,56 @@ import { ContextualLogger } from './common/logging/contextual-logger.service';
           return `forgot-password:${req.ip}`;
         },
       },
+      {
+        name: 'guestCreate',
+        ttl: Number(process.env.THROTTLE_GUEST_CREATE_TTL ?? 60000),
+        limit: Number(process.env.THROTTLE_GUEST_CREATE_LIMIT ?? 3),
+        skipIf: (context) => {
+          const req = context.switchToHttp().getRequest<{ method?: string; originalUrl?: string }>();
+          const originalUrl = String(req.originalUrl ?? '');
+          return !(req.method === 'POST' && (originalUrl === '/api/guest/orders' || originalUrl.startsWith('/api/guest/orders?')));
+        },
+        getTracker: (req) => {
+          const rawEmail =
+            typeof req.body === 'object' && req.body !== null && 'guestEmail' in req.body
+              ? req.body.guestEmail
+              : undefined;
+
+          if (typeof rawEmail === 'string') {
+            const normalizedEmail = rawEmail.trim().toLowerCase();
+            if (normalizedEmail.length > 0) {
+              return `guest-create:${normalizedEmail}`;
+            }
+          }
+
+          return `guest-create:${req.ip}`;
+        },
+      },
+      {
+        name: 'guestLookup',
+        ttl: Number(process.env.THROTTLE_GUEST_LOOKUP_TTL ?? 60000),
+        limit: Number(process.env.THROTTLE_GUEST_LOOKUP_LIMIT ?? 5),
+        skipIf: (context) => {
+          const req = context.switchToHttp().getRequest<{ method?: string; originalUrl?: string }>();
+          const originalUrl = String(req.originalUrl ?? '');
+          return !(req.method === 'POST' && (originalUrl === '/api/guest/orders/lookup' || originalUrl.startsWith('/api/guest/orders/lookup?')));
+        },
+        getTracker: (req) => {
+          const rawEmail =
+            typeof req.body === 'object' && req.body !== null && 'email' in req.body
+              ? req.body.email
+              : undefined;
+
+          if (typeof rawEmail === 'string') {
+            const normalizedEmail = rawEmail.trim().toLowerCase();
+            if (normalizedEmail.length > 0) {
+              return `guest-lookup:${normalizedEmail}`;
+            }
+          }
+
+          return `guest-lookup:${req.ip}`;
+        },
+      },
     ]),
     CacheModule,
     ScheduleModule.forRoot(),

--- a/backend/src/database/__tests__/guest-checkout-migration.spec.ts
+++ b/backend/src/database/__tests__/guest-checkout-migration.spec.ts
@@ -1,0 +1,214 @@
+import { QueryRunner } from 'typeorm';
+import { AddGuestCheckoutSchema1786600000000 } from '../migrations/1786600000000-AddGuestCheckoutSchema';
+
+describe('guest checkout migration', () => {
+  type SchemaState = {
+    tables: Set<string>;
+    columns: Set<string>;
+    indexes: Set<string>;
+    foreignKeys: Set<string>;
+  };
+
+  function createQueryRunner() {
+    const executed: string[] = [];
+    const state: SchemaState = {
+      tables: new Set(['orders', 'policy_consents']),
+      columns: new Set([
+        'orders.id',
+        'orders.user_id',
+        'orders.order_number',
+        'policy_consents.id',
+        'policy_consents.user_id',
+      ]),
+      indexes: new Set(['orders.IDX_a922b820eeef29ac1c6800e826', 'policy_consents.IDX_policy_consents_user']),
+      foreignKeys: new Set([
+        'orders.FK_a922b820eeef29ac1c6800e826a',
+        'policy_consents.FK_policy_consents_user',
+      ]),
+    };
+
+    const query = jest.fn(async (sql: string, params?: unknown[]) => {
+      executed.push(sql);
+
+      if (sql.includes('INFORMATION_SCHEMA.TABLES')) {
+        const tableName = String(params?.[0]);
+        return [{ cnt: state.tables.has(tableName) ? '1' : '0' }];
+      }
+
+      if (sql.includes('INFORMATION_SCHEMA.COLUMNS')) {
+        const tableName = String(params?.[0]);
+        const columnName = String(params?.[1]);
+        return [{ cnt: state.columns.has(`${tableName}.${columnName}`) ? '1' : '0' }];
+      }
+
+      if (sql.includes('INFORMATION_SCHEMA.STATISTICS')) {
+        const tableName = String(params?.[0]);
+        const indexName = String(params?.[1]);
+        return [{ cnt: state.indexes.has(`${tableName}.${indexName}`) ? '1' : '0' }];
+      }
+
+      if (sql.includes('INFORMATION_SCHEMA.TABLE_CONSTRAINTS')) {
+        const tableName = String(params?.[0]);
+        const constraintName = String(params?.[1]);
+        return [{ cnt: state.foreignKeys.has(`${tableName}.${constraintName}`) ? '1' : '0' }];
+      }
+
+      if (sql.startsWith('ALTER TABLE `orders` ADD COLUMN `guest_email_normalized`')) {
+        state.columns.add('orders.guest_email_normalized');
+      }
+
+      if (sql.startsWith('ALTER TABLE `orders` ADD COLUMN `order_locale`')) {
+        state.columns.add('orders.order_locale');
+      }
+
+      if (sql.startsWith('ALTER TABLE `orders` DROP FOREIGN KEY')) {
+        state.foreignKeys.delete('orders.FK_a922b820eeef29ac1c6800e826a');
+      }
+
+      if (sql.startsWith('ALTER TABLE `orders` ADD CONSTRAINT `FK_a922b820eeef29ac1c6800e826a`')) {
+        state.foreignKeys.add('orders.FK_a922b820eeef29ac1c6800e826a');
+      }
+
+      if (sql.startsWith('ALTER TABLE `policy_consents` DROP FOREIGN KEY')) {
+        state.foreignKeys.delete('policy_consents.FK_policy_consents_user');
+      }
+
+      if (sql.startsWith('ALTER TABLE `policy_consents` ADD CONSTRAINT `FK_policy_consents_user`')) {
+        state.foreignKeys.add('policy_consents.FK_policy_consents_user');
+      }
+
+      if (sql.startsWith('CREATE TABLE `guest_order_access`')) {
+        state.tables.add('guest_order_access');
+        state.columns.add('guest_order_access.id');
+        state.columns.add('guest_order_access.order_id');
+        state.columns.add('guest_order_access.token_digest');
+        state.columns.add('guest_order_access.expires_at');
+        state.columns.add('guest_order_access.superseded_at');
+        state.columns.add('guest_order_access.superseded_by_id');
+        state.columns.add('guest_order_access.created_at');
+        state.indexes.add('guest_order_access.IDX_guest_order_access_order_id');
+        state.indexes.add('guest_order_access.IDX_guest_order_access_token_digest');
+        state.indexes.add('guest_order_access.IDX_guest_order_access_expires_at');
+        state.indexes.add('guest_order_access.IDX_guest_order_access_superseded_by_id');
+      }
+
+      if (sql.startsWith('ALTER TABLE `guest_order_access` ADD CONSTRAINT `FK_guest_order_access_order_id`')) {
+        state.foreignKeys.add('guest_order_access.FK_guest_order_access_order_id');
+      }
+
+      if (sql.startsWith('ALTER TABLE `guest_order_access` ADD CONSTRAINT `FK_guest_order_access_superseded_by_id`')) {
+        state.foreignKeys.add('guest_order_access.FK_guest_order_access_superseded_by_id');
+      }
+
+      return [];
+    });
+
+    return {
+      queryRunner: { query } as unknown as QueryRunner,
+      executed,
+      state,
+    };
+  }
+
+  it('applies the stage-31 schema changes in the locked migration order', async () => {
+    const { queryRunner, executed } = createQueryRunner();
+
+    await new AddGuestCheckoutSchema1786600000000().up(queryRunner);
+
+    expect(executed).toEqual(
+      expect.arrayContaining([
+        'ALTER TABLE `orders` ADD COLUMN `guest_email_normalized` varchar(255) NULL AFTER `user_id`',
+        "ALTER TABLE `orders` ADD COLUMN `order_locale` enum('ko', 'en') NULL AFTER `order_number`",
+        "UPDATE `orders` SET `order_locale` = 'ko' WHERE `order_locale` IS NULL",
+        'ALTER TABLE `orders` DROP FOREIGN KEY `FK_a922b820eeef29ac1c6800e826a`',
+        'ALTER TABLE `orders` MODIFY COLUMN `user_id` bigint NULL',
+        'ALTER TABLE `orders` ADD CONSTRAINT `FK_a922b820eeef29ac1c6800e826a` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE NO ACTION',
+        'ALTER TABLE `policy_consents` DROP FOREIGN KEY `FK_policy_consents_user`',
+        'ALTER TABLE `policy_consents` MODIFY COLUMN `user_id` bigint NULL',
+        'ALTER TABLE `policy_consents` ADD CONSTRAINT `FK_policy_consents_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION',
+        'CREATE TABLE `guest_order_access` (`id` bigint NOT NULL AUTO_INCREMENT, `order_id` bigint NOT NULL, `token_digest` varchar(64) NOT NULL, `expires_at` datetime NOT NULL, `superseded_at` datetime NULL, `superseded_by_id` bigint NULL, `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), INDEX `IDX_guest_order_access_order_id` (`order_id`), UNIQUE INDEX `IDX_guest_order_access_token_digest` (`token_digest`), INDEX `IDX_guest_order_access_expires_at` (`expires_at`), INDEX `IDX_guest_order_access_superseded_by_id` (`superseded_by_id`), PRIMARY KEY (`id`)) ENGINE=InnoDB',
+        'ALTER TABLE `guest_order_access` ADD CONSTRAINT `FK_guest_order_access_order_id` FOREIGN KEY (`order_id`) REFERENCES `orders`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION',
+        'ALTER TABLE `guest_order_access` ADD CONSTRAINT `FK_guest_order_access_superseded_by_id` FOREIGN KEY (`superseded_by_id`) REFERENCES `guest_order_access`(`id`) ON DELETE SET NULL ON UPDATE NO ACTION',
+        "ALTER TABLE `orders` MODIFY COLUMN `order_locale` enum('ko', 'en') NOT NULL",
+      ]),
+    );
+
+    const guestEmailIndex = executed.indexOf(
+      'ALTER TABLE `orders` ADD COLUMN `guest_email_normalized` varchar(255) NULL AFTER `user_id`',
+    );
+    const orderLocaleIndex = executed.indexOf(
+      "ALTER TABLE `orders` ADD COLUMN `order_locale` enum('ko', 'en') NULL AFTER `order_number`",
+    );
+    const backfillIndex = executed.indexOf(
+      "UPDATE `orders` SET `order_locale` = 'ko' WHERE `order_locale` IS NULL",
+    );
+    const ordersDropFkIndex = executed.indexOf(
+      'ALTER TABLE `orders` DROP FOREIGN KEY `FK_a922b820eeef29ac1c6800e826a`',
+    );
+    const ordersNullableIndex = executed.indexOf('ALTER TABLE `orders` MODIFY COLUMN `user_id` bigint NULL');
+    const ordersAddFkIndex = executed.indexOf(
+      'ALTER TABLE `orders` ADD CONSTRAINT `FK_a922b820eeef29ac1c6800e826a` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE NO ACTION',
+    );
+    const policyDropFkIndex = executed.indexOf(
+      'ALTER TABLE `policy_consents` DROP FOREIGN KEY `FK_policy_consents_user`',
+    );
+    const policyNullableIndex = executed.indexOf(
+      'ALTER TABLE `policy_consents` MODIFY COLUMN `user_id` bigint NULL',
+    );
+    const policyAddFkIndex = executed.indexOf(
+      'ALTER TABLE `policy_consents` ADD CONSTRAINT `FK_policy_consents_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION',
+    );
+    const guestTableIndex = executed.findIndex((sql) => sql.startsWith('CREATE TABLE `guest_order_access`'));
+    const orderLocaleNotNullIndex = executed.indexOf(
+      "ALTER TABLE `orders` MODIFY COLUMN `order_locale` enum('ko', 'en') NOT NULL",
+    );
+
+    expect(guestEmailIndex).toBeGreaterThan(-1);
+    expect(orderLocaleIndex).toBeGreaterThan(guestEmailIndex);
+    expect(backfillIndex).toBeGreaterThan(orderLocaleIndex);
+    expect(ordersDropFkIndex).toBeGreaterThan(backfillIndex);
+    expect(ordersNullableIndex).toBeGreaterThan(ordersDropFkIndex);
+    expect(ordersAddFkIndex).toBeGreaterThan(ordersNullableIndex);
+    expect(policyDropFkIndex).toBeGreaterThan(ordersAddFkIndex);
+    expect(policyNullableIndex).toBeGreaterThan(policyDropFkIndex);
+    expect(policyAddFkIndex).toBeGreaterThan(policyNullableIndex);
+    expect(guestTableIndex).toBeGreaterThan(policyAddFkIndex);
+    expect(orderLocaleNotNullIndex).toBeGreaterThan(guestTableIndex);
+  });
+
+  it('preserves the locked foreign-key semantics and guest access storage shape', async () => {
+    const { queryRunner, state, executed } = createQueryRunner();
+
+    await new AddGuestCheckoutSchema1786600000000().up(queryRunner);
+
+    expect(state.foreignKeys.has('orders.FK_a922b820eeef29ac1c6800e826a')).toBe(true);
+    expect(state.foreignKeys.has('policy_consents.FK_policy_consents_user')).toBe(true);
+    expect(state.foreignKeys.has('guest_order_access.FK_guest_order_access_order_id')).toBe(true);
+    expect(state.foreignKeys.has('guest_order_access.FK_guest_order_access_superseded_by_id')).toBe(true);
+    expect(state.indexes.has('guest_order_access.IDX_guest_order_access_token_digest')).toBe(true);
+    expect(state.columns.has('orders.guest_email_normalized')).toBe(true);
+    expect(state.columns.has('orders.order_locale')).toBe(true);
+
+    expect(
+      executed.some((sql) =>
+        sql.includes('`policy_consents` ADD CONSTRAINT `FK_policy_consents_user`')
+        && sql.includes('ON DELETE CASCADE'),
+      ),
+    ).toBe(true);
+    expect(
+      executed.some((sql) =>
+        sql.includes('`orders` ADD CONSTRAINT `FK_a922b820eeef29ac1c6800e826a`')
+        && sql.includes('ON DELETE RESTRICT'),
+      ),
+    ).toBe(true);
+    expect(
+      executed.some((sql) =>
+        sql.startsWith('CREATE TABLE `guest_order_access`')
+        && sql.includes('`token_digest` varchar(64) NOT NULL')
+        && sql.includes('`expires_at` datetime NOT NULL')
+        && sql.includes('`superseded_at` datetime NULL')
+        && sql.includes('`superseded_by_id` bigint NULL'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/backend/src/database/migrations/1786600000000-AddGuestCheckoutSchema.ts
+++ b/backend/src/database/migrations/1786600000000-AddGuestCheckoutSchema.ts
@@ -1,0 +1,180 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGuestCheckoutSchema1786600000000 implements MigrationInterface {
+  name = 'AddGuestCheckoutSchema1786600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await this.columnExists(queryRunner, 'orders', 'guest_email_normalized'))) {
+      await queryRunner.query(
+        "ALTER TABLE `orders` ADD COLUMN `guest_email_normalized` varchar(255) NULL AFTER `user_id`",
+      );
+    }
+
+    if (!(await this.columnExists(queryRunner, 'orders', 'order_locale'))) {
+      await queryRunner.query(
+        "ALTER TABLE `orders` ADD COLUMN `order_locale` enum('ko', 'en') NULL AFTER `order_number`",
+      );
+    }
+
+    await queryRunner.query("UPDATE `orders` SET `order_locale` = 'ko' WHERE `order_locale` IS NULL");
+
+    if (await this.foreignKeyExists(queryRunner, 'orders', 'FK_a922b820eeef29ac1c6800e826a')) {
+      await queryRunner.query(
+        'ALTER TABLE `orders` DROP FOREIGN KEY `FK_a922b820eeef29ac1c6800e826a`',
+      );
+    }
+
+    await queryRunner.query('ALTER TABLE `orders` MODIFY COLUMN `user_id` bigint NULL');
+
+    if (!(await this.indexExists(queryRunner, 'orders', 'IDX_a922b820eeef29ac1c6800e826'))) {
+      await queryRunner.query('CREATE INDEX `IDX_a922b820eeef29ac1c6800e826` ON `orders` (`user_id`)');
+    }
+
+    if (!(await this.foreignKeyExists(queryRunner, 'orders', 'FK_a922b820eeef29ac1c6800e826a'))) {
+      await queryRunner.query(
+        'ALTER TABLE `orders` ADD CONSTRAINT `FK_a922b820eeef29ac1c6800e826a` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE NO ACTION',
+      );
+    }
+
+    if (await this.foreignKeyExists(queryRunner, 'policy_consents', 'FK_policy_consents_user')) {
+      await queryRunner.query(
+        'ALTER TABLE `policy_consents` DROP FOREIGN KEY `FK_policy_consents_user`',
+      );
+    }
+
+    await queryRunner.query('ALTER TABLE `policy_consents` MODIFY COLUMN `user_id` bigint NULL');
+
+    if (!(await this.indexExists(queryRunner, 'policy_consents', 'IDX_policy_consents_user'))) {
+      await queryRunner.query(
+        'CREATE INDEX `IDX_policy_consents_user` ON `policy_consents` (`user_id`)',
+      );
+    }
+
+    if (!(await this.foreignKeyExists(queryRunner, 'policy_consents', 'FK_policy_consents_user'))) {
+      await queryRunner.query(
+        'ALTER TABLE `policy_consents` ADD CONSTRAINT `FK_policy_consents_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION',
+      );
+    }
+
+    if (!(await this.tableExists(queryRunner, 'guest_order_access'))) {
+      await queryRunner.query(
+        'CREATE TABLE `guest_order_access` (`id` bigint NOT NULL AUTO_INCREMENT, `order_id` bigint NOT NULL, `token_digest` varchar(64) NOT NULL, `expires_at` datetime NOT NULL, `superseded_at` datetime NULL, `superseded_by_id` bigint NULL, `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), INDEX `IDX_guest_order_access_order_id` (`order_id`), UNIQUE INDEX `IDX_guest_order_access_token_digest` (`token_digest`), INDEX `IDX_guest_order_access_expires_at` (`expires_at`), INDEX `IDX_guest_order_access_superseded_by_id` (`superseded_by_id`), PRIMARY KEY (`id`)) ENGINE=InnoDB',
+      );
+      await queryRunner.query(
+        'ALTER TABLE `guest_order_access` ADD CONSTRAINT `FK_guest_order_access_order_id` FOREIGN KEY (`order_id`) REFERENCES `orders`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION',
+      );
+      await queryRunner.query(
+        'ALTER TABLE `guest_order_access` ADD CONSTRAINT `FK_guest_order_access_superseded_by_id` FOREIGN KEY (`superseded_by_id`) REFERENCES `guest_order_access`(`id`) ON DELETE SET NULL ON UPDATE NO ACTION',
+      );
+    }
+
+    await queryRunner.query("ALTER TABLE `orders` MODIFY COLUMN `order_locale` enum('ko', 'en') NOT NULL");
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (await this.tableExists(queryRunner, 'guest_order_access')) {
+      if (await this.foreignKeyExists(queryRunner, 'guest_order_access', 'FK_guest_order_access_superseded_by_id')) {
+        await queryRunner.query(
+          'ALTER TABLE `guest_order_access` DROP FOREIGN KEY `FK_guest_order_access_superseded_by_id`',
+        );
+      }
+      if (await this.foreignKeyExists(queryRunner, 'guest_order_access', 'FK_guest_order_access_order_id')) {
+        await queryRunner.query(
+          'ALTER TABLE `guest_order_access` DROP FOREIGN KEY `FK_guest_order_access_order_id`',
+        );
+      }
+      await queryRunner.query('DROP TABLE `guest_order_access`');
+    }
+
+    await this.ensureRollbackSafe(queryRunner, 'policy_consents', '`user_id` IS NULL', 'policy_consents.user_id');
+    if (await this.foreignKeyExists(queryRunner, 'policy_consents', 'FK_policy_consents_user')) {
+      await queryRunner.query(
+        'ALTER TABLE `policy_consents` DROP FOREIGN KEY `FK_policy_consents_user`',
+      );
+    }
+    await queryRunner.query('ALTER TABLE `policy_consents` MODIFY COLUMN `user_id` bigint NOT NULL');
+    if (!(await this.foreignKeyExists(queryRunner, 'policy_consents', 'FK_policy_consents_user'))) {
+      await queryRunner.query(
+        'ALTER TABLE `policy_consents` ADD CONSTRAINT `FK_policy_consents_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION',
+      );
+    }
+
+    await this.ensureRollbackSafe(queryRunner, 'orders', '`user_id` IS NULL', 'orders.user_id');
+    if (await this.foreignKeyExists(queryRunner, 'orders', 'FK_a922b820eeef29ac1c6800e826a')) {
+      await queryRunner.query(
+        'ALTER TABLE `orders` DROP FOREIGN KEY `FK_a922b820eeef29ac1c6800e826a`',
+      );
+    }
+    await queryRunner.query('ALTER TABLE `orders` MODIFY COLUMN `user_id` bigint NOT NULL');
+    if (!(await this.foreignKeyExists(queryRunner, 'orders', 'FK_a922b820eeef29ac1c6800e826a'))) {
+      await queryRunner.query(
+        'ALTER TABLE `orders` ADD CONSTRAINT `FK_a922b820eeef29ac1c6800e826a` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE NO ACTION',
+      );
+    }
+
+    if (await this.columnExists(queryRunner, 'orders', 'order_locale')) {
+      await queryRunner.query('ALTER TABLE `orders` DROP COLUMN `order_locale`');
+    }
+    if (await this.columnExists(queryRunner, 'orders', 'guest_email_normalized')) {
+      await queryRunner.query('ALTER TABLE `orders` DROP COLUMN `guest_email_normalized`');
+    }
+  }
+
+  private async ensureRollbackSafe(
+    queryRunner: QueryRunner,
+    tableName: string,
+    predicate: string,
+    label: string,
+  ): Promise<void> {
+    const rows = (await queryRunner.query(
+      `SELECT COUNT(*) AS cnt FROM \`${tableName}\` WHERE ${predicate}`,
+    )) as Array<{ cnt: string }>;
+    if (Number(rows[0]?.cnt ?? 0) > 0) {
+      throw new Error(`Cannot rollback guest checkout schema while ${label} contains NULL rows.`);
+    }
+  }
+
+  private async tableExists(queryRunner: QueryRunner, tableName: string): Promise<boolean> {
+    const rows = (await queryRunner.query(
+      'SELECT COUNT(*) AS cnt FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+      [tableName],
+    )) as Array<{ cnt: string }>;
+    return Number(rows[0]?.cnt ?? 0) > 0;
+  }
+
+  private async columnExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+  ): Promise<boolean> {
+    const rows = (await queryRunner.query(
+      'SELECT COUNT(*) AS cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?',
+      [tableName, columnName],
+    )) as Array<{ cnt: string }>;
+    return Number(rows[0]?.cnt ?? 0) > 0;
+  }
+
+  private async indexExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    indexName: string,
+  ): Promise<boolean> {
+    const rows = (await queryRunner.query(
+      'SELECT COUNT(*) AS cnt FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?',
+      [tableName, indexName],
+    )) as Array<{ cnt: string }>;
+    return Number(rows[0]?.cnt ?? 0) > 0;
+  }
+
+  private async foreignKeyExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    constraintName: string,
+  ): Promise<boolean> {
+    const rows = (await queryRunner.query(
+      'SELECT COUNT(*) AS cnt FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_NAME = ? AND CONSTRAINT_TYPE = \'FOREIGN KEY\'',
+      [tableName, constraintName],
+    )) as Array<{ cnt: string }>;
+    return Number(rows[0]?.cnt ?? 0) > 0;
+  }
+}

--- a/backend/src/modules/admin/admin-export.service.ts
+++ b/backend/src/modules/admin/admin-export.service.ts
@@ -67,15 +67,15 @@ export class AdminExportService {
       format,
       filenamePrefix: 'orders',
       sheetName: '주문',
-      headerRow: ['ID', '주문번호', '상태', '수령인', '전화번호', '우편번호', '주소', '총금액', '할인금액', '배송비', '회원이메일', '생성일'],
-      columns: ['id', 'orderNumber', 'status', 'recipientName', 'recipientPhone', 'zipcode', 'address', 'totalAmount', 'discountAmount', 'shippingFee', 'userEmail', 'createdAt'],
+      headerRow: ['ID', '주문번호', '고객유형', '상태', '수령인', '전화번호', '우편번호', '주소', '총금액', '할인금액', '배송비', '회원이메일', '생성일'],
+      columns: ['id', 'orderNumber', 'customerType', 'status', 'recipientName', 'recipientPhone', 'zipcode', 'address', 'totalAmount', 'discountAmount', 'shippingFee', 'userEmail', 'createdAt'],
       queryBuilder: qb,
       mapRow: (order) => this.mapOrderRow(order, isMask),
     });
 
     this.logger.log(`Orders exported: format=${format}, mask=${isMask}`);
-  }
 
+  }
   async exportMembers(query: ExportQueryDto, res: Response): Promise<void> {
     const isMask = query.mask === 'true';
     const format = query.format ?? 'csv';
@@ -194,11 +194,14 @@ export class AdminExportService {
 
   private mapOrderRow(order: Order, isMask: boolean): ExportRow {
     const phone = isMask ? maskPhone(order.recipientPhone) : order.recipientPhone;
-    const email = isMask && order.user?.email ? maskEmail(order.user.email) : (order.user?.email ?? '');
+    const customerType = this.getOrderCustomerType(order);
+    const rawEmail = order.user?.email ?? this.getGuestEmailNormalized(order) ?? '';
+    const email = isMask && rawEmail ? maskEmail(rawEmail) : rawEmail;
 
     return {
       id: order.id,
       orderNumber: order.orderNumber,
+      customerType,
       status: order.status,
       recipientName: order.recipientName,
       recipientPhone: phone,
@@ -210,6 +213,19 @@ export class AdminExportService {
       userEmail: email,
       createdAt: order.createdAt.toISOString(),
     };
+  }
+
+  private getOrderCustomerType(order: Order): 'member' | 'guest' {
+    return this.getOrderUserId(order) === null ? 'guest' : 'member';
+  }
+
+  private getOrderUserId(order: Order): number | null {
+    const userId = (order as Order & { userId?: number | null }).userId;
+    return userId == null ? null : Number(userId);
+  }
+
+  private getGuestEmailNormalized(order: Order): string | null {
+    return (order as Order & { guestEmailNormalized?: string | null }).guestEmailNormalized ?? null;
   }
 
   private mapMemberRow(user: User, isMask: boolean): ExportRow {

--- a/backend/src/modules/admin/admin-orders.service.ts
+++ b/backend/src/modules/admin/admin-orders.service.ts
@@ -19,7 +19,7 @@ import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
 import { assertOrderStatusTransition } from '../orders/policies/order-status-transition.policy';
 import { MessageNotificationService } from '../notification/message-notification.service';
 import { NotificationService } from '../notification/notification.service';
-import { buildOrderEmailItems, buildOrderUrl } from '../notification/order-email-context';
+import { buildGuestOrderLookupUrl, buildOrderEmailItems, buildOrderUrl } from '../notification/order-email-context';
 
 @Injectable()
 export class AdminOrdersService {
@@ -56,7 +56,7 @@ export class AdminOrdersService {
 
     if (query.keyword) {
       qb.andWhere(
-        '(order.orderNumber LIKE :kw OR order.recipientName LIKE :kw OR user.email LIKE :kw)',
+        '(order.orderNumber LIKE :kw OR order.recipientName LIKE :kw OR user.email LIKE :kw OR order.guest_email_normalized LIKE :kw)',
         { kw: `%${query.keyword}%` },
       );
     }
@@ -69,7 +69,11 @@ export class AdminOrdersService {
       qb.andWhere('order.createdAt <= :endDate', { endDate: `${query.endDate} 23:59:59` });
     }
 
-    return paginate(qb, { page, limit });
+    const result = await paginate(qb, { page, limit });
+    return {
+      ...result,
+      items: result.items.map((order) => this.decorateOrder(order)),
+    };
   }
 
   async updateStatus(orderId: number, nextStatus: OrderStatus): Promise<Order | null> {
@@ -112,20 +116,28 @@ export class AdminOrdersService {
     });
 
     if (nextStatus === OrderStatus.DELIVERED) {
-      void this.messageNotificationService?.sendShippingDelivered(orderId);
+      if (this.isGuestOrder(order)) {
+        void this.sendDeliveredNotification(orderId, order);
+      } else {
+        void this.messageNotificationService?.sendShippingDelivered(orderId);
+      }
     }
 
     if (nextStatus === OrderStatus.COMPLETED) {
-      const completedAmount = Number(order.totalAmount) - Number(order.discountAmount ?? 0);
-      void this.membershipService.incrementAccumulatedAmount(order.userId, completedAmount)
-        .catch((err) => this.logger.warn(`Failed to increment tier amount for user ${order.userId}: ${String(err)}`));
+      const userId = this.getOrderUserId(order);
+      if (userId !== null) {
+        const completedAmount = Number(order.totalAmount) - Number(order.discountAmount ?? 0);
+        void this.membershipService.incrementAccumulatedAmount(userId, completedAmount)
+          .catch((err) => this.logger.warn(`Failed to increment tier amount for user ${userId}: ${String(err)}`));
+      }
     }
     this.logger.log(`Order #${orderId} status changed: ${currentStatus} → ${nextStatus}`);
 
-    return this.orderRepository.findOne({
+    const updatedOrder = await this.orderRepository.findOne({
       where: { id: orderId },
       relations: ['items', 'user'],
     });
+    return updatedOrder ? this.decorateOrder(updatedOrder) : null;
   }
 
 
@@ -198,10 +210,11 @@ export class AdminOrdersService {
 
     void this.sendCancellationNotifications(orderId, orderForNotification, trimmedReason);
 
-    return this.orderRepository.findOne({
+    const updatedOrder = await this.orderRepository.findOne({
       where: { id: orderId },
       relations: ['items', 'user'],
     });
+    return updatedOrder ? this.decorateOrder(updatedOrder) : null;
   }
 
   private assertPaymentStateAllowsCancellation(status: OrderStatus, payment: Payment | null): void {
@@ -243,15 +256,23 @@ export class AdminOrdersService {
   }
 
   private async sendCancellationNotifications(orderId: number, order: Order, reason: string): Promise<void> {
+    const locale = this.getOrderLocale(order);
+    const email = order.user?.email ?? this.getGuestEmailNormalized(order);
+
+    if (!email) {
+      return;
+    }
+
     await Promise.all([
-      this.notificationService.sendOrderCancelled(order.user?.email ?? '', {
+      this.notificationService.sendOrderCancelled(email, {
         recipientName: order.recipientName,
         orderNumber: order.orderNumber,
         reason,
-        orderItems: buildOrderEmailItems(order, 'ko'),
-        orderUrl: buildOrderUrl(orderId, 'ko'),
+        locale,
+        orderItems: buildOrderEmailItems(order, locale),
+        orderUrl: this.resolveOrderUrl(orderId, order),
       }),
-      this.messageNotificationService.sendOrderCancelled(orderId, reason),
+      ...(this.isGuestOrder(order) ? [] : [this.messageNotificationService.sendOrderCancelled(orderId, reason)]),
     ]).catch((err) => {
       this.logger.warn(`Failed to send cancellation notification for order ${orderId}: ${String(err)}`);
     });
@@ -292,18 +313,19 @@ export class AdminOrdersService {
   }
 
   private async restorePoints(manager: EntityManager, order: Order): Promise<void> {
-    if (!order.pointsUsed || order.pointsUsed <= 0) {
+    const userId = this.getOrderUserId(order);
+    if (userId === null || !order.pointsUsed || order.pointsUsed <= 0) {
       return;
     }
 
     const currentBalance = await this.pointsService.getRunningBalanceInTx(
       manager,
-      order.userId,
+      userId,
     );
     const restoredBalance = currentBalance + order.pointsUsed;
 
     await manager.save(PointHistory, {
-      userId: order.userId,
+      userId,
       type: 'admin_adjust',
       amount: order.pointsUsed,
       balance: restoredBalance,
@@ -313,7 +335,7 @@ export class AdminOrdersService {
   }
 
   async registerShipping(orderId: number, dto: RegisterShippingDto): Promise<Shipping | null> {
-    await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.', ['items', 'user']);
 
     const existing = await this.shippingRepository.findOne({ where: { orderId } });
     if (existing && existing.trackingNumber) {
@@ -337,8 +359,89 @@ export class AdminOrdersService {
     }
 
     this.logger.log(`Shipping registered for order #${orderId}: ${dto.carrier} ${dto.trackingNumber}`);
-    void this.messageNotificationService?.sendShippingStarted(orderId);
+    void this.sendShippingStartedNotification(orderId, order, dto.carrier, dto.trackingNumber);
 
     return this.shippingRepository.findOne({ where: { orderId } });
+  }
+
+  private decorateOrder(order: Order): Order {
+    const customerType = this.isGuestOrder(order) ? 'guest' : 'member';
+    return Object.assign(order, {
+      customerType,
+      guestEmailNormalized: this.getGuestEmailNormalized(order),
+      user: customerType === 'guest' ? null : (order.user ?? null),
+    });
+  }
+
+  private async sendDeliveredNotification(orderId: number, order: Order): Promise<void> {
+    const shipping = await this.shippingRepository.findOne({ where: { orderId } });
+    const email = this.getGuestEmailNormalized(order);
+    const locale = this.getOrderLocale(order);
+
+    if (!email || !shipping?.trackingNumber) {
+      return;
+    }
+
+    await this.notificationService.sendShippingUpdate(email, {
+      recipientName: order.recipientName,
+      orderNumber: order.orderNumber,
+      carrier: shipping.carrier ?? 'unknown',
+      trackingNumber: shipping.trackingNumber,
+      locale,
+      orderItems: buildOrderEmailItems(order, locale),
+      orderUrl: buildGuestOrderLookupUrl(locale),
+    });
+  }
+
+  private async sendShippingStartedNotification(
+    orderId: number,
+    order: Order,
+    carrier: string,
+    trackingNumber: string,
+  ): Promise<void> {
+    if (this.isGuestOrder(order)) {
+      const email = this.getGuestEmailNormalized(order);
+      const locale = this.getOrderLocale(order);
+      if (!email) {
+        return;
+      }
+
+      await this.notificationService.sendShippingUpdate(email, {
+        recipientName: order.recipientName,
+        orderNumber: order.orderNumber,
+        carrier,
+        trackingNumber,
+        locale,
+        orderItems: buildOrderEmailItems(order, locale),
+        orderUrl: buildGuestOrderLookupUrl(locale),
+      });
+      return;
+    }
+
+    void this.messageNotificationService?.sendShippingStarted(orderId);
+  }
+
+  private isGuestOrder(order: Order): boolean {
+    return this.getOrderUserId(order) === null;
+  }
+
+  private getOrderUserId(order: Order): number | null {
+    const userId = (order as Order & { userId?: number | null }).userId;
+    return userId == null ? null : Number(userId);
+  }
+
+  private getGuestEmailNormalized(order: Order): string | null {
+    return (order as Order & { guestEmailNormalized?: string | null }).guestEmailNormalized ?? null;
+  }
+
+  private getOrderLocale(order: Order): 'ko' | 'en' {
+    return (order as Order & { orderLocale?: 'ko' | 'en' }).orderLocale ?? 'ko';
+  }
+
+  private resolveOrderUrl(orderId: number, order: Order): string | undefined {
+    const locale = this.getOrderLocale(order);
+    return this.isGuestOrder(order)
+      ? buildGuestOrderLookupUrl(locale)
+      : buildOrderUrl(orderId, locale);
   }
 }

--- a/backend/src/modules/coupons/__tests__/coupon-rules.service.spec.ts
+++ b/backend/src/modules/coupons/__tests__/coupon-rules.service.spec.ts
@@ -276,10 +276,12 @@ describe('CouponRulesService', () => {
       expect(mockCouponsService.issueCouponsForUser).toHaveBeenCalledWith(100, [10]);
     });
 
-    it('첫 구매 이벤트(isFirstPurchase=true) 만 FIRST_PURCHASE 규칙을 적용한다', async () => {
-      let orderHandler: Handler<{ userId: number; isFirstPurchase: boolean }> | undefined;
+    it('첫 구매 이벤트는 member/customerType 가 맞는 경우에만 FIRST_PURCHASE 규칙을 적용한다', async () => {
+      let orderHandler:
+        | Handler<{ userId: number | null; isFirstPurchase: boolean; customerType: 'member' | 'guest' }>
+        | undefined;
       mockOrderEvents.onOrderCompleted.mockImplementation(
-        (cb: Handler<{ userId: number; isFirstPurchase: boolean }>) => {
+        (cb: Handler<{ userId: number | null; isFirstPurchase: boolean; customerType: 'member' | 'guest' }>) => {
           orderHandler = cb;
         },
       );
@@ -291,12 +293,12 @@ describe('CouponRulesService', () => {
       service.onModuleInit();
       expect(orderHandler).toBeDefined();
 
-      // 두 번째 이상 구매면 FIRST_PURCHASE 규칙은 적용되지 않는다.
-      await orderHandler!({ userId: 200, isFirstPurchase: false });
+      await orderHandler!({ userId: 200, isFirstPurchase: false, customerType: 'member' });
+      await orderHandler!({ userId: null, isFirstPurchase: true, customerType: 'guest' });
+      await orderHandler!({ userId: 200, isFirstPurchase: true, customerType: 'guest' });
       expect(mockCouponsService.issueCouponsForUser).not.toHaveBeenCalled();
 
-      // 첫 구매면 적용된다.
-      await orderHandler!({ userId: 200, isFirstPurchase: true });
+      await orderHandler!({ userId: 200, isFirstPurchase: true, customerType: 'member' });
       expect(mockCouponsService.issueCouponsForUser).toHaveBeenCalledWith(200, [21]);
     });
 

--- a/backend/src/modules/coupons/coupon-rules.service.ts
+++ b/backend/src/modules/coupons/coupon-rules.service.ts
@@ -46,7 +46,7 @@ export class CouponRulesService implements OnModuleInit {
     });
 
     this.orderEvents.onOrderCompleted(async (event) => {
-      if (event.isFirstPurchase) {
+      if (event.customerType === 'member' && event.userId !== null && event.isFirstPurchase) {
         try {
           await this.applyRulesForUser(CouponRuleTrigger.FIRST_PURCHASE, event.userId);
         } catch (err) {

--- a/backend/src/modules/notification/notification-dispatch.helper.ts
+++ b/backend/src/modules/notification/notification-dispatch.helper.ts
@@ -5,50 +5,45 @@ import { User } from '../users/entities/user.entity';
 export type NotificationDispatchMode = 'await' | 'fire-and-forget';
 
 export interface NotificationDispatchRecipient {
-  id: number;
+  id?: number;
   email: string;
   name: string;
 }
 
+type NotificationDispatchTarget =
+  | { userId: number; recipient?: never }
+  | { userId?: never; recipient: NotificationDispatchRecipient };
+
 interface NotificationDispatchParams {
   event: string;
-  userId: number;
   resourceId: number | string;
   mode: NotificationDispatchMode;
   logger: Pick<Logger, 'warn'>;
   send: (recipient: NotificationDispatchRecipient) => Promise<void>;
 }
 
+type NotificationDispatchRequest = NotificationDispatchParams & NotificationDispatchTarget;
+
 @Injectable()
 export class NotificationDispatchHelper {
   constructor(private readonly dataSource: DataSource) {}
 
-  async dispatch(params: NotificationDispatchParams): Promise<void> {
+  async dispatch(params: NotificationDispatchRequest): Promise<void> {
     const {
       event,
-      userId,
       resourceId,
       mode,
       logger,
       send,
     } = params;
 
-    try {
-      const userRepository = this.dataSource.getRepository(User);
-      const user = await userRepository.findOne({
-        where: { id: userId },
-        select: { id: true, email: true, name: true },
-      });
+    const failureTarget = this.getFailureTarget(params);
 
-      if (!user?.email) {
+    try {
+      const recipient = await this.resolveRecipient(params);
+      if (!recipient?.email) {
         return;
       }
-
-      const recipient: NotificationDispatchRecipient = {
-        id: Number(user.id),
-        email: user.email,
-        name: user.name,
-      };
 
       const sendTask = send(recipient);
 
@@ -58,19 +53,68 @@ export class NotificationDispatchHelper {
       }
 
       void sendTask.catch((err) => {
-        logger.warn(this.buildFailureMessage(event, userId, resourceId, err));
+        logger.warn(this.buildFailureMessage(event, failureTarget, resourceId, err));
       });
     } catch (err) {
-      logger.warn(this.buildFailureMessage(event, userId, resourceId, err));
+      logger.warn(this.buildFailureMessage(event, failureTarget, resourceId, err));
     }
+  }
+
+  private getFailureTarget(params: NotificationDispatchRequest): string {
+    const userId = this.getUserTargetId(params);
+    if (userId !== null) {
+      return `userId=${userId}`;
+    }
+
+    return params.recipient?.email
+      ? `recipientEmail=${params.recipient.email}`
+      : 'recipient=unresolved';
+  }
+
+  private resolveRecipient(params: NotificationDispatchRequest): Promise<NotificationDispatchRecipient | null> {
+    const userId = this.getUserTargetId(params);
+    if (userId !== null) {
+      return this.resolveUserRecipient(userId);
+    }
+
+    return Promise.resolve(params.recipient ?? null);
+  }
+
+  private getUserTargetId(params: NotificationDispatchRequest): number | null {
+    const userId = (params as { userId?: unknown }).userId;
+    if (typeof userId === 'number' && Number.isFinite(userId)) {
+      return userId;
+    }
+    if (typeof userId === 'string' && /^\d+$/.test(userId)) {
+      return Number(userId);
+    }
+    return null;
+  }
+
+  private async resolveUserRecipient(userId: number): Promise<NotificationDispatchRecipient | null> {
+    const userRepository = this.dataSource.getRepository(User);
+    const user = await userRepository.findOne({
+      where: { id: userId },
+      select: { id: true, email: true, name: true },
+    });
+
+    if (!user?.email) {
+      return null;
+    }
+
+    return {
+      id: Number(user.id),
+      email: user.email,
+      name: user.name,
+    };
   }
 
   private buildFailureMessage(
     event: string,
-    userId: number,
+    target: string,
     resourceId: number | string,
     err: unknown,
   ): string {
-    return `[notification-dispatch] failed event=${event} userId=${userId} resourceId=${resourceId} error=${String(err)}`;
+    return `[notification-dispatch] failed event=${event} ${target} resourceId=${resourceId} error=${String(err)}`;
   }
 }

--- a/backend/src/modules/notification/order-email-context.ts
+++ b/backend/src/modules/notification/order-email-context.ts
@@ -19,6 +19,12 @@ export function buildOrderUrl(orderId: number, locale: 'ko' | 'en' = 'ko'): stri
   return `${baseUrl}/${locale}/my/orders/${orderId}`;
 }
 
+export function buildGuestOrderLookupUrl(locale: 'ko' | 'en' = 'ko'): string | undefined {
+  const baseUrl = normalizeFrontendUrl();
+  if (!baseUrl) return undefined;
+  return `${baseUrl}/${locale}/order/lookup`;
+}
+
 export function buildOrderEmailItems(
   orderOrItems: Pick<Order, 'items'> | OrderItem[] | null | undefined,
   locale: 'ko' | 'en' = 'ko',

--- a/backend/src/modules/orders/__tests__/create-order.dto.spec.ts
+++ b/backend/src/modules/orders/__tests__/create-order.dto.spec.ts
@@ -8,6 +8,7 @@ const validPayload = {
   recipientPhone: '010-1234-5678',
   zipcode: '12345',
   address: '서울특별시 강남구',
+  orderLocale: 'en',
 };
 
 describe('CreateOrderDto', () => {
@@ -24,6 +25,18 @@ describe('CreateOrderDto', () => {
 
     expect(errors).toHaveLength(0);
     expect(dto.marketingConsent).toBe(true);
+  });
+
+  it('accepts orderLocale under whitelist validation', async () => {
+    const dto = plainToInstance(CreateOrderDto, validPayload);
+
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    expect(errors).toHaveLength(0);
+    expect(dto.orderLocale).toBe('en');
   });
 
   it('still rejects unknown checkout payload fields', async () => {

--- a/backend/src/modules/orders/__tests__/guest-order-access.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/guest-order-access.service.spec.ts
@@ -1,0 +1,211 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { createHash } from 'crypto';
+import { DataSource, EntityManager } from 'typeorm';
+import { GuestOrderAccessService } from '../guest-order-access.service';
+import { GuestOrderAccess } from '../entities/guest-order-access.entity';
+import { Order, OrderStatus } from '../entities/order.entity';
+import { LookupGuestOrderDto } from '../dto/lookup-guest-order.dto';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 11,
+    userId: null,
+    guestEmailNormalized: 'guest@example.com',
+    orderNumber: 'ORD-20260722-ABCDE',
+    orderLocale: 'ko',
+    status: OrderStatus.PENDING,
+    totalAmount: 12000,
+    discountAmount: 0,
+    shippingFee: 0,
+    recipientName: '홍길동',
+    recipientPhone: '010-1234-5678',
+    zipcode: '12345',
+    address: '서울시 강남구',
+    addressDetail: null,
+    memo: null,
+    cancelReason: null,
+    cancelledAt: null,
+    pointsUsed: 0,
+    createdAt: new Date('2026-07-22T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-22T00:00:00.000Z'),
+    user: null,
+    items: [],
+    ...overrides,
+  } as Order;
+}
+
+function makeAccess(overrides: Partial<GuestOrderAccess> = {}): GuestOrderAccess {
+  return {
+    id: 21,
+    orderId: 11,
+    tokenDigest: createHash('sha256').update('seed-token').digest('hex'),
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    supersededAt: null,
+    supersededById: null,
+    createdAt: new Date('2026-07-22T00:00:00.000Z'),
+    order: makeOrder(),
+    supersededBy: null,
+    ...overrides,
+  } as GuestOrderAccess;
+}
+
+function makeOrderQueryBuilder(result: Order | null) {
+  return {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(result),
+  };
+}
+
+function makeAccessQueryBuilder(result: GuestOrderAccess | null) {
+  return {
+    setLock: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(result),
+  };
+}
+
+describe('GuestOrderAccessService', () => {
+  let service: GuestOrderAccessService;
+  let accessRepository: {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let orderRepository: {
+    createQueryBuilder: jest.Mock;
+  };
+  let dataSource: {
+    createQueryRunner: jest.Mock;
+  };
+
+  beforeEach(() => {
+    accessRepository = {
+      create: jest.fn((input) => ({ id: 99, ...input })),
+      save: jest.fn(async (input) => input),
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    orderRepository = {
+      createQueryBuilder: jest.fn(),
+    };
+
+    dataSource = {
+      createQueryRunner: jest.fn(),
+    };
+
+    service = new GuestOrderAccessService(
+      accessRepository as never,
+      orderRepository as never,
+      dataSource as unknown as DataSource,
+    );
+  });
+
+  it('issues a raw token once while persisting only its SHA-256 digest with 30-day expiry', async () => {
+    const issued = await service.issueAccessToken(11);
+
+    expect(issued.guestAccessToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(accessRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderId: 11,
+        tokenDigest: createHash('sha256').update(issued.guestAccessToken).digest('hex'),
+        supersededAt: null,
+        supersededById: null,
+      }),
+    );
+    expect(accessRepository.create.mock.calls[0][0].tokenDigest).not.toBe(issued.guestAccessToken);
+    expect(issued.guestAccessTokenExpiresAt.getTime() - Date.now()).toBeGreaterThan(29 * 24 * 60 * 60 * 1000);
+    expect(issued.guestAccessTokenExpiresAt.getTime() - Date.now()).toBeLessThanOrEqual(30 * 24 * 60 * 60 * 1000 + 5_000);
+  });
+
+  it('normalizes lookup email and order number before querying the guest order', async () => {
+    const order = makeOrder();
+    const qb = makeOrderQueryBuilder(order);
+    orderRepository.createQueryBuilder.mockReturnValue(qb);
+
+    const dto: LookupGuestOrderDto = {
+      orderNumber: '  ORD-20260722-ABCDE  ',
+      email: ' Guest@Example.com ',
+      locale: 'ko',
+    };
+
+    await expect(service.lookupOrderOrThrow(dto)).resolves.toBe(order);
+    expect(qb.where).toHaveBeenCalledWith('order.orderNumber = :orderNumber', {
+      orderNumber: 'ORD-20260722-ABCDE',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('order.guestEmailNormalized = :guestEmailNormalized', {
+      guestEmailNormalized: 'guest@example.com',
+    });
+  });
+
+  it('lookup issuance supersedes the current active token and returns a replacement token', async () => {
+    const order = makeOrder();
+    const activeAccess = makeAccess({ id: 31, orderId: order.id });
+    const lookupQb = makeOrderQueryBuilder(order);
+    const lockedOrderQb = makeOrderQueryBuilder(order);
+    const accessQb = makeAccessQueryBuilder(activeAccess);
+
+    orderRepository.createQueryBuilder
+      .mockReturnValueOnce(lookupQb)
+      .mockReturnValueOnce(lockedOrderQb);
+    accessRepository.createQueryBuilder.mockReturnValue(accessQb);
+
+    const manager = {
+      queryRunner: {},
+      getRepository: jest.fn((entity) => {
+        if (entity === GuestOrderAccess) return accessRepository;
+        if (entity === Order) return orderRepository;
+        throw new Error(`Unexpected repository request: ${String(entity)}`);
+      }),
+    } as unknown as EntityManager;
+
+    jest.spyOn(service, 'withOrderAccessLock').mockImplementation(async (_orderId, operation) => operation(manager));
+
+    const result = await service.lookupAndIssueAccessToken({
+      orderNumber: order.orderNumber,
+      email: 'Guest@Example.com',
+      locale: 'ko',
+    });
+
+    expect(result.order.id).toBe(order.id);
+    expect(result.guestAccessToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(activeAccess.supersededAt).toBeInstanceOf(Date);
+    expect(activeAccess.supersededById).toBe(99);
+    expect(accessRepository.save).toHaveBeenCalledWith(activeAccess);
+  });
+
+  it('rotates the current token and rejects the stale superseded token afterward', async () => {
+    const currentRawToken = 'a'.repeat(64);
+    const currentAccess = makeAccess({
+      id: 41,
+      orderId: 11,
+      tokenDigest: createHash('sha256').update(currentRawToken).digest('hex'),
+    });
+    const rotateQb = makeAccessQueryBuilder(currentAccess);
+    accessRepository.createQueryBuilder.mockReturnValue(rotateQb);
+
+    const manager = {
+      queryRunner: {},
+      getRepository: jest.fn((entity) => {
+        if (entity === GuestOrderAccess) return accessRepository;
+        throw new Error(`Unexpected repository request: ${String(entity)}`);
+      }),
+    } as unknown as EntityManager;
+
+    const rotated = await service.rotateAccessTokenForOrder(11, currentRawToken, manager);
+
+    expect(rotated.guestAccessToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(currentAccess.supersededAt).toBeInstanceOf(Date);
+    expect(currentAccess.supersededById).toBe(99);
+
+    accessRepository.findOne.mockResolvedValueOnce(currentAccess);
+    await expect(service.getValidAccessOrThrow(11, currentRawToken)).rejects.toThrow(UnauthorizedException);
+
+    accessRepository.findOne.mockResolvedValueOnce(rotated.access);
+    await expect(service.getValidAccessOrThrow(11, rotated.guestAccessToken)).resolves.toBe(rotated.access);
+  });
+});

--- a/backend/src/modules/orders/__tests__/guest-order-creation.workflow.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/guest-order-creation.workflow.service.spec.ts
@@ -1,0 +1,93 @@
+import { GuestOrderCreationWorkflowService } from '../guest-order-creation.workflow.service';
+import { CreateGuestOrderDto } from '../dto/create-guest-order.dto';
+import { OrderStatus } from '../entities/order.entity';
+
+describe('GuestOrderCreationWorkflowService', () => {
+  const dto: CreateGuestOrderDto = {
+    items: [{ productId: 1, quantity: 2 }],
+    guestEmail: '  Guest@Example.COM ',
+    recipientName: '홍길동',
+    recipientPhone: '010-1234-5678',
+    zipcode: '12345',
+    address: '서울특별시 강남구',
+    addressDetail: '101동 101호',
+    memo: '부재 시 문 앞',
+    orderLocale: 'en',
+    policyConsents: [{ slug: 'terms', version: 'v1', effectiveDate: '2026-07-22' }],
+    marketingConsent: true,
+  };
+
+  it('persists guest-safe order fields and reuses only identity-agnostic helpers', async () => {
+    const manager = { marker: 'tx-manager' };
+    const savedOrder = {
+      id: 321,
+      orderNumber: 'ORD-20260722-ABCDE',
+      status: OrderStatus.PENDING,
+    };
+    const orderItems = [{ productId: 1, quantity: 2, productName: '상품' }];
+    const shippingItemPolicies = [{ isFreeShipping: false }];
+
+    const sharedWorkflow = {
+      assertCreatePayload: jest.fn(),
+      validateAndReserveStock: jest.fn().mockResolvedValue({
+        orderItems,
+        subtotalAmount: 42000,
+        shippingItemPolicies,
+      }),
+      calculateShippingFee: jest.fn().mockResolvedValue(3000),
+      saveOrder: jest.fn().mockResolvedValue(savedOrder),
+      savePolicyConsent: jest.fn().mockResolvedValue(undefined),
+      saveOrderItems: jest.fn().mockResolvedValue(undefined),
+      ensureSufficientPoints: jest.fn(),
+      calculateDiscountAndShipping: jest.fn(),
+      applyCouponAndPoints: jest.fn(),
+      clearCartItems: jest.fn(),
+    };
+
+    const service = new GuestOrderCreationWorkflowService(sharedWorkflow as never);
+
+    const result = await service.runCreateOrderTransaction(manager as never, dto);
+
+    expect(sharedWorkflow.validateAndReserveStock).toHaveBeenCalledWith(manager, dto);
+    expect(sharedWorkflow.calculateShippingFee).toHaveBeenCalledWith(42000, dto.zipcode, shippingItemPolicies);
+    expect(sharedWorkflow.saveOrder).toHaveBeenCalledWith(manager, {
+      userId: null,
+      totalAmount: 45000,
+      discountAmount: 0,
+      shippingFee: 3000,
+      pointsUsed: 0,
+      guestEmailNormalized: 'guest@example.com',
+      orderLocale: 'en',
+      recipientName: dto.recipientName,
+      recipientPhone: dto.recipientPhone,
+      zipcode: dto.zipcode,
+      address: dto.address,
+      addressDetail: dto.addressDetail,
+      memo: dto.memo,
+    });
+    expect(sharedWorkflow.savePolicyConsent).toHaveBeenCalledWith(manager, null, savedOrder, dto);
+    expect(sharedWorkflow.saveOrderItems).toHaveBeenCalledWith(manager, orderItems, 321);
+    expect(sharedWorkflow.ensureSufficientPoints).not.toHaveBeenCalled();
+    expect(sharedWorkflow.calculateDiscountAndShipping).not.toHaveBeenCalled();
+    expect(sharedWorkflow.applyCouponAndPoints).not.toHaveBeenCalled();
+    expect(sharedWorkflow.clearCartItems).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      savedOrder,
+      totalPayable: 45000,
+      recipientName: dto.recipientName,
+      guestEmailNormalized: 'guest@example.com',
+      orderLocale: 'en',
+    });
+  });
+
+  it('delegates payload validation to the shared workflow preflight check', () => {
+    const sharedWorkflow = {
+      assertCreatePayload: jest.fn(),
+    };
+    const service = new GuestOrderCreationWorkflowService(sharedWorkflow as never);
+
+    service.assertCreatePayload(dto);
+
+    expect(sharedWorkflow.assertCreatePayload).toHaveBeenCalledWith(dto);
+  });
+});

--- a/backend/src/modules/orders/__tests__/guest-orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/guest-orders.service.spec.ts
@@ -122,16 +122,17 @@ describe('GuestOrdersService', () => {
       guestAccessToken: 'issued-token',
       guestAccessTokenExpiresAt,
     });
+    const txManager = {} as EntityManager;
     dataSource.transaction.mockImplementation(async (callback: (manager: EntityManager) => Promise<unknown>) =>
-      callback({} as EntityManager),
+      callback(txManager),
     );
     jest.spyOn(service, 'findOne').mockResolvedValue(localizedOrder);
 
     const result = await service.create(dto);
 
     expect(guestOrderCreationWorkflow.assertCreatePayload).toHaveBeenCalledWith(dto);
-    expect(guestOrderCreationWorkflow.runCreateOrderTransaction).toHaveBeenCalled();
-    expect(guestOrderAccessService.issueAccessToken).toHaveBeenCalledWith(19, expect.anything());
+    expect(guestOrderCreationWorkflow.runCreateOrderTransaction).toHaveBeenCalledWith(txManager, dto);
+    expect(guestOrderAccessService.issueAccessToken).toHaveBeenCalledWith(19, txManager);
     expect(orderPostCommitService.dispatchOrderCreated).toHaveBeenCalledWith(null, postCommit);
     expect(service.findOne).toHaveBeenCalledWith(19, 'en');
     expect(result).toEqual({

--- a/backend/src/modules/orders/__tests__/guest-orders.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/guest-orders.service.spec.ts
@@ -1,0 +1,221 @@
+import { NotFoundException } from '@nestjs/common';
+import { DataSource, EntityManager } from 'typeorm';
+import { GuestOrdersService } from '../guest-orders.service';
+import { Order } from '../entities/order.entity';
+import { GuestOrderCreationWorkflowService } from '../guest-order-creation.workflow.service';
+import { GuestOrderAccessService } from '../guest-order-access.service';
+import { OrderPostCommitService } from '../order-post-commit.service';
+import { CreateGuestOrderDto } from '../dto/create-guest-order.dto';
+import { LookupGuestOrderDto } from '../dto/lookup-guest-order.dto';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 11,
+    orderNumber: 'ORD-20260722-ABCDE',
+    userId: null,
+    orderLocale: 'ko',
+    items: [
+      {
+        productName: '기본 상품명',
+        optionName: '기본 옵션',
+        product: {
+          name: '기본 상품명',
+          nameEn: 'English Product',
+        },
+        option: {
+          name: '색상',
+          nameEn: 'Color',
+          value: '빨강',
+          valueEn: 'Red',
+        },
+      },
+    ],
+    ...overrides,
+  } as Order;
+}
+
+function makeOrderQueryBuilder(result: Order | null) {
+  return {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(result),
+  };
+}
+
+describe('GuestOrdersService', () => {
+  let service: GuestOrdersService;
+  let orderRepository: {
+    createQueryBuilder: jest.Mock;
+  };
+  let dataSource: {
+    transaction: jest.Mock;
+  };
+  let guestOrderCreationWorkflow: {
+    assertCreatePayload: jest.Mock;
+    runCreateOrderTransaction: jest.Mock;
+  };
+  let guestOrderAccessService: {
+    issueAccessToken: jest.Mock;
+    getOrderForAccessOrThrow: jest.Mock;
+    lookupAndIssueAccessToken: jest.Mock;
+  };
+  let orderPostCommitService: {
+    dispatchOrderCreated: jest.Mock;
+  };
+
+  beforeEach(() => {
+    orderRepository = {
+      createQueryBuilder: jest.fn(),
+    };
+
+    dataSource = {
+      transaction: jest.fn(),
+    };
+
+    guestOrderCreationWorkflow = {
+      assertCreatePayload: jest.fn(),
+      runCreateOrderTransaction: jest.fn(),
+    };
+
+    guestOrderAccessService = {
+      issueAccessToken: jest.fn(),
+      getOrderForAccessOrThrow: jest.fn(),
+      lookupAndIssueAccessToken: jest.fn(),
+    };
+
+    orderPostCommitService = {
+      dispatchOrderCreated: jest.fn().mockResolvedValue(undefined),
+    };
+
+    service = new GuestOrdersService(
+      orderRepository as never,
+      dataSource as unknown as DataSource,
+      guestOrderCreationWorkflow as unknown as GuestOrderCreationWorkflowService,
+      guestOrderAccessService as unknown as GuestOrderAccessService,
+      orderPostCommitService as unknown as OrderPostCommitService,
+    );
+  });
+
+  it('creates a guest order, issues a token, dispatches post-commit work, and returns the localized order view', async () => {
+    const dto: CreateGuestOrderDto = {
+      items: [{ productId: 5, quantity: 2 }],
+      guestEmail: 'guest@example.com',
+      recipientName: '게스트',
+      recipientPhone: '010-1111-2222',
+      zipcode: '12345',
+      address: '서울시 강남구',
+      addressDetail: '101호',
+      orderLocale: 'en',
+    };
+    const savedOrder = makeOrder({ id: 19, orderNumber: 'ORD-20260722-ZYXWV' });
+    const postCommit = {
+      savedOrder,
+      guestEmailNormalized: 'guest@example.com',
+      totalPayable: 48000,
+      recipientName: '게스트',
+    };
+    const guestAccessTokenExpiresAt = new Date('2026-08-21T00:00:00.000Z');
+    const localizedOrder = makeOrder({ id: 19, orderLocale: 'en' });
+
+    guestOrderCreationWorkflow.runCreateOrderTransaction.mockResolvedValue(postCommit);
+    guestOrderAccessService.issueAccessToken.mockResolvedValue({
+      guestAccessToken: 'issued-token',
+      guestAccessTokenExpiresAt,
+    });
+    dataSource.transaction.mockImplementation(async (callback: (manager: EntityManager) => Promise<unknown>) =>
+      callback({} as EntityManager),
+    );
+    jest.spyOn(service, 'findOne').mockResolvedValue(localizedOrder);
+
+    const result = await service.create(dto);
+
+    expect(guestOrderCreationWorkflow.assertCreatePayload).toHaveBeenCalledWith(dto);
+    expect(guestOrderCreationWorkflow.runCreateOrderTransaction).toHaveBeenCalled();
+    expect(guestOrderAccessService.issueAccessToken).toHaveBeenCalledWith(19, expect.anything());
+    expect(orderPostCommitService.dispatchOrderCreated).toHaveBeenCalledWith(null, postCommit);
+    expect(service.findOne).toHaveBeenCalledWith(19, 'en');
+    expect(result).toEqual({
+      order: localizedOrder,
+      guestAccessToken: 'issued-token',
+      guestAccessTokenExpiresAt,
+    });
+  });
+
+  it('delegates guest order detail access to the token access service', async () => {
+    const order = makeOrder();
+    guestOrderAccessService.getOrderForAccessOrThrow.mockResolvedValue(order);
+
+    await expect(service.getById(11, 'guest-token', 'ko')).resolves.toBe(order);
+    expect(guestOrderAccessService.getOrderForAccessOrThrow).toHaveBeenCalledWith(11, 'guest-token', 'ko');
+  });
+
+  it('delegates guest order lookup and token rotation to the access service', async () => {
+    const dto: LookupGuestOrderDto = {
+      orderNumber: 'ORD-20260722-ABCDE',
+      email: 'guest@example.com',
+      locale: 'en',
+    };
+    const order = makeOrder({ orderLocale: 'en' });
+    const guestAccessTokenExpiresAt = new Date('2026-08-21T00:00:00.000Z');
+    guestOrderAccessService.lookupAndIssueAccessToken.mockResolvedValue({
+      order,
+      guestAccessToken: 'rotated-token',
+      guestAccessTokenExpiresAt,
+    });
+
+    await expect(service.lookup(dto)).resolves.toEqual({
+      order,
+      guestAccessToken: 'rotated-token',
+      guestAccessTokenExpiresAt,
+    });
+    expect(guestOrderAccessService.lookupAndIssueAccessToken).toHaveBeenCalledWith(dto);
+  });
+
+  it('localizes product and option fields when english order detail is requested through the query-builder path', async () => {
+    const order = makeOrder();
+    const queryBuilder = makeOrderQueryBuilder(order);
+    orderRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+    const result = await service.findOne(11, 'en');
+
+    expect(queryBuilder.where).toHaveBeenCalledWith('order.id = :id', { id: 11 });
+    expect(result.items[0].product.name).toBe('English Product');
+    expect(result.items[0].productName).toBe('English Product');
+    expect(result.items[0].option?.name).toBe('Color');
+    expect(result.items[0].option?.value).toBe('Red');
+    expect(result.items[0].optionName).toBe('Color: Red');
+  });
+
+  it('uses the manager repository fallback and orderLocale when the caller omits locale', async () => {
+    const managerRepository = {
+      findOne: jest.fn().mockResolvedValue(makeOrder({ orderLocale: 'en' })),
+    };
+    const manager = {
+      getRepository: jest.fn().mockReturnValue(managerRepository),
+    } as unknown as EntityManager;
+
+    const result = await service.findOne(15, undefined, manager);
+
+    expect(managerRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 15 },
+      relations: ['items', 'items.product', 'items.option'],
+    });
+    expect(result.items[0].product.name).toBe('English Product');
+    expect(result.items[0].optionName).toBe('Color: Red');
+  });
+
+  it('returns the raw order object when locale is korean', async () => {
+    const order = makeOrder();
+    const queryBuilder = makeOrderQueryBuilder(order);
+    orderRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+    await expect(service.findOne(11, 'ko')).resolves.toBe(order);
+  });
+
+  it('throws when the order does not exist', async () => {
+    const queryBuilder = makeOrderQueryBuilder(null);
+    orderRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+    await expect(service.findOne(404, 'ko')).rejects.toThrow(NotFoundException);
+  });
+});

--- a/backend/src/modules/orders/__tests__/order-post-commit.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/order-post-commit.service.spec.ts
@@ -1,10 +1,5 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
 import { OrderPostCommitService } from '../order-post-commit.service';
 import { Order } from '../entities/order.entity';
-import { NotificationService } from '../../notification/notification.service';
-import { MessageNotificationService } from '../../notification/message-notification.service';
-import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import type { OrderPostCommitPayload } from '../order-creation.workflow.service';
 
 describe('OrderPostCommitService', () => {

--- a/backend/src/modules/orders/__tests__/order-post-commit.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/order-post-commit.service.spec.ts
@@ -1,0 +1,159 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { OrderPostCommitService } from '../order-post-commit.service';
+import { Order } from '../entities/order.entity';
+import { NotificationService } from '../../notification/notification.service';
+import { MessageNotificationService } from '../../notification/message-notification.service';
+import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
+import type { OrderPostCommitPayload } from '../order-creation.workflow.service';
+
+describe('OrderPostCommitService', () => {
+  let service: OrderPostCommitService;
+  const orderRepository = {
+    findOne: jest.fn(),
+  };
+  const notificationService = {
+    sendOrderConfirmed: jest.fn().mockResolvedValue(undefined),
+  };
+  const messageNotificationService = {
+    sendOrderCreated: jest.fn().mockResolvedValue(undefined),
+  };
+  const notificationDispatchHelper = {
+    dispatch: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const originalFrontendUrl = process.env.FRONTEND_URL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FRONTEND_URL = 'https://shop.example.com';
+
+    service = new OrderPostCommitService(
+      orderRepository as never,
+      notificationService as never,
+      messageNotificationService as never,
+      notificationDispatchHelper as never,
+    );
+  });
+
+  afterAll(() => {
+    process.env.FRONTEND_URL = originalFrontendUrl;
+  });
+
+  it('dispatches guest order-created notifications to the explicit recipient with locale-aware guest lookup CTA and no member message branch', async () => {
+    const payload: OrderPostCommitPayload = {
+      savedOrder: {
+        id: 41,
+        orderNumber: 'ORD-GUEST-41',
+        userId: null,
+      } as unknown as Order,
+      totalPayable: 54000,
+      recipientName: 'Guest Buyer',
+    };
+
+    orderRepository.findOne.mockResolvedValue({
+      id: 41,
+      orderNumber: 'ORD-GUEST-41',
+      userId: null,
+      guestEmailNormalized: 'guest@example.com',
+      orderLocale: 'en',
+      items: [
+        {
+          productId: 7,
+          productName: 'Tea Cup',
+          optionName: null,
+          quantity: 2,
+          price: 27000,
+        },
+      ],
+    } as unknown as Order);
+
+    await service.dispatchOrderCreated(null, payload);
+
+    expect(notificationDispatchHelper.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'order.confirmed',
+        resourceId: 41,
+        mode: 'fire-and-forget',
+        recipient: {
+          email: 'guest@example.com',
+          name: 'Guest Buyer',
+        },
+      }),
+    );
+    expect(messageNotificationService.sendOrderCreated).not.toHaveBeenCalled();
+
+    const dispatchArg = notificationDispatchHelper.dispatch.mock.calls[0][0] as {
+      send: (recipient: { email: string; name: string }) => Promise<void>;
+    };
+    await dispatchArg.send({ email: 'guest@example.com', name: 'Guest Buyer' });
+
+    expect(notificationService.sendOrderConfirmed).toHaveBeenCalledWith(
+      'guest@example.com',
+      expect.objectContaining({
+        recipientName: 'Guest Buyer',
+        orderNumber: 'ORD-GUEST-41',
+        totalAmount: 54000,
+        locale: 'en',
+        orderUrl: 'https://shop.example.com/en/order/lookup',
+      }),
+    );
+  });
+
+  it('keeps member order-created notifications on userId dispatch and member message notification branch', async () => {
+    const payload: OrderPostCommitPayload = {
+      savedOrder: {
+        id: 42,
+        orderNumber: 'ORD-MEMBER-42',
+        userId: 9,
+      } as unknown as Order,
+      totalPayable: 12000,
+      recipientName: 'Member Buyer',
+    };
+
+    orderRepository.findOne.mockResolvedValue({
+      id: 42,
+      orderNumber: 'ORD-MEMBER-42',
+      userId: 9,
+      orderLocale: 'ko',
+      items: [
+        {
+          productId: 3,
+          productName: 'Tea',
+          optionName: null,
+          quantity: 1,
+          price: 12000,
+        },
+      ],
+    } as unknown as Order);
+
+    await service.dispatchOrderCreated(9, payload);
+    await Promise.resolve();
+
+    expect(notificationDispatchHelper.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'order.confirmed',
+        resourceId: 42,
+        mode: 'fire-and-forget',
+        userId: 9,
+      }),
+    );
+    expect(messageNotificationService.sendOrderCreated).toHaveBeenCalledWith(42);
+
+    const dispatchArg = notificationDispatchHelper.dispatch.mock.calls[0][0] as {
+      send: (recipient: { email: string; name: string }) => Promise<void>;
+    };
+    await dispatchArg.send({ email: 'member@example.com', name: 'Member Buyer' });
+
+    expect(notificationService.sendOrderConfirmed).toHaveBeenCalledWith(
+      'member@example.com',
+      expect.objectContaining({
+        recipientName: 'Member Buyer',
+        orderNumber: 'ORD-MEMBER-42',
+        totalAmount: 12000,
+        locale: 'ko',
+        orderUrl: 'https://shop.example.com/ko/my/orders/42',
+      }),
+    );
+  });
+});

--- a/backend/src/modules/orders/__tests__/order-service-requests.service.spec.ts
+++ b/backend/src/modules/orders/__tests__/order-service-requests.service.spec.ts
@@ -16,7 +16,9 @@ import type { PaymentsService } from '../../payments/payments.service';
 import { Payment, PaymentStatus } from '../../payments/entities/payment.entity';
 import { UpdateOrderServiceRequestDto } from '../dto/update-order-service-request.dto';
 
-const makeOrder = (overrides: Partial<Order> = {}): Order => ({
+type MemberOrder = Order & { userId: number };
+
+const makeOrder = (overrides: Partial<Order> = {}): MemberOrder => ({
   id: 7,
   userId: 10,
   orderNumber: 'ORD-20260101-ABCDE',
@@ -35,10 +37,10 @@ const makeOrder = (overrides: Partial<Order> = {}): Order => ({
   updatedAt: new Date(),
   items: [],
   ...overrides,
-} as Order);
+}) as MemberOrder;
 
 const makeRequest = (
-  order: Order,
+  order: MemberOrder,
   overrides: Partial<OrderServiceRequest> = {},
 ): OrderServiceRequest => ({
   id: 55,
@@ -62,7 +64,7 @@ const makeRequest = (
   order,
   user: { id: order.userId, email: 'user@example.com', name: '홍길동' },
   ...overrides,
-} as unknown as OrderServiceRequest);
+}) as unknown as OrderServiceRequest;
 
 const makeRepository = () => ({
   findOne: jest.fn(),

--- a/backend/src/modules/orders/dto/create-guest-order.dto.ts
+++ b/backend/src/modules/orders/dto/create-guest-order.dto.ts
@@ -1,0 +1,81 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsEmail,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import { OrderItemDto, PolicyConsentSnapshotDto } from './create-order.dto';
+
+export class CreateGuestOrderDto {
+  @ApiProperty({ type: [OrderItemDto], description: '주문 상품 목록' })
+  @IsArray({ message: '주문 상품 목록은 배열이어야 합니다.' })
+  @ValidateNested({ each: true })
+  @Type(() => OrderItemDto)
+  items!: OrderItemDto[];
+
+  @ApiProperty({ example: 'guest@example.com', description: '비회원 주문 조회용 이메일 주소' })
+  @Transform(({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim() : value))
+  @IsEmail({}, { message: '올바른 이메일 형식을 입력해 주세요.' })
+  @IsNotEmpty({ message: '이메일을 입력해 주세요.' })
+  guestEmail!: string;
+
+  @ApiProperty({ example: '홍길동', description: '수령인 이름' })
+  @IsString({ message: '수령인 이름을 입력해 주세요.' })
+  @IsNotEmpty({ message: '수령인 이름을 입력해 주세요.' })
+  @MaxLength(100, { message: '수령인 이름은 최대 100자까지 입력 가능합니다.' })
+  recipientName!: string;
+
+  @ApiProperty({ example: '010-1234-5678', description: '수령인 연락처' })
+  @IsString({ message: '수령인 연락처를 입력해 주세요.' })
+  @IsNotEmpty({ message: '수령인 연락처를 입력해 주세요.' })
+  @MaxLength(20, { message: '수령인 연락처는 최대 20자까지 입력 가능합니다.' })
+  recipientPhone!: string;
+
+  @ApiProperty({ example: '12345', description: '우편번호' })
+  @IsString({ message: '우편번호를 입력해 주세요.' })
+  @IsNotEmpty({ message: '우편번호를 입력해 주세요.' })
+  @MaxLength(10, { message: '우편번호는 최대 10자까지 입력 가능합니다.' })
+  zipcode!: string;
+
+  @ApiProperty({ example: '서울특별시 강남구 테헤란로 123', description: '주소' })
+  @IsString({ message: '주소를 입력해 주세요.' })
+  @IsNotEmpty({ message: '주소를 입력해 주세요.' })
+  @MaxLength(255, { message: '주소는 최대 255자까지 입력 가능합니다.' })
+  address!: string;
+
+  @ApiProperty({ example: '101동 101호', description: '상세 주소', required: false })
+  @IsOptional()
+  @IsString({ message: '상세 주소는 문자열이어야 합니다.' })
+  @MaxLength(255, { message: '상세 주소는 최대 255자까지 입력 가능합니다.' })
+  addressDetail?: string | null;
+
+  @ApiProperty({ example: '부재 시 문 앞에 놓아주세요', description: '배송 메모', required: false })
+  @IsOptional()
+  @IsString({ message: '배송 메모는 문자열이어야 합니다.' })
+  @MaxLength(500, { message: '배송 메모는 최대 500자까지 입력 가능합니다.' })
+  memo?: string | null;
+
+  @ApiProperty({ example: 'ko', enum: ['ko', 'en'], description: '주문 생성 시점 로케일' })
+  @IsIn(['ko', 'en'], { message: '주문 로케일은 ko 또는 en이어야 합니다.' })
+  orderLocale!: 'ko' | 'en';
+
+  @ApiProperty({ type: [PolicyConsentSnapshotDto], description: '결제 동의 시점 정책 버전 스냅샷', required: false })
+  @IsOptional()
+  @IsArray({ message: '정책 동의 목록은 배열이어야 합니다.' })
+  @ValidateNested({ each: true })
+  @Type(() => PolicyConsentSnapshotDto)
+  policyConsents?: PolicyConsentSnapshotDto[];
+
+  @ApiProperty({ example: false, description: '마케팅 수신 동의 여부', required: false })
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => value === true || value === 'true')
+  @IsBoolean({ message: '마케팅 수신 동의 여부는 boolean이어야 합니다.' })
+  marketingConsent?: boolean;
+}

--- a/backend/src/modules/orders/dto/create-order.dto.ts
+++ b/backend/src/modules/orders/dto/create-order.dto.ts
@@ -2,9 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import {
   IsArray, IsInt, IsOptional, IsString, MaxLength, Min,
-  ValidateNested, ValidateIf, IsNotEmpty, IsBoolean,
+  ValidateNested, ValidateIf, IsNotEmpty, IsBoolean, IsIn,
 } from 'class-validator';
-
 export class OrderItemDto {
   @ApiProperty({ example: 1, description: '상품 ID' })
   @IsInt({ message: '상품 ID는 정수여야 합니다.' })
@@ -85,6 +84,11 @@ export class CreateOrderDto {
   @IsString({ message: '배송 메모는 문자열이어야 합니다.' })
   @MaxLength(500, { message: '배송 메모는 최대 500자까지 입력 가능합니다.' })
   memo?: string | null;
+
+  @ApiProperty({ example: 'ko', enum: ['ko', 'en'], description: '주문 생성 시점 로케일', required: false })
+  @IsOptional()
+  @IsIn(['ko', 'en'], { message: '주문 로케일은 ko 또는 en이어야 합니다.' })
+  orderLocale?: 'ko' | 'en';
 
   @ApiProperty({ example: 1000, description: '사용할 포인트', required: false })
   @IsOptional()

--- a/backend/src/modules/orders/dto/lookup-guest-order.dto.ts
+++ b/backend/src/modules/orders/dto/lookup-guest-order.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsEmail, IsIn, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class LookupGuestOrderDto {
+  @ApiProperty({ example: 'ORD-20260722-ABCDE', description: '주문 번호' })
+  @Transform(({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString({ message: '주문 번호는 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '주문 번호를 입력해 주세요.' })
+  @MaxLength(50, { message: '주문 번호는 최대 50자까지 입력 가능합니다.' })
+  orderNumber!: string;
+
+  @ApiProperty({ example: 'guest@example.com', description: '주문 시 사용한 이메일' })
+  @Transform(({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+  @IsEmail({}, { message: '이메일 형식이 올바르지 않습니다.' })
+  @MaxLength(255, { message: '이메일은 최대 255자까지 입력 가능합니다.' })
+  email!: string;
+
+  @ApiPropertyOptional({ example: 'ko', enum: ['ko', 'en'], description: '로케일 (ko/en)' })
+  @IsOptional()
+  @IsIn(['ko', 'en'], { message: '로케일은 ko 또는 en만 지원합니다.' })
+  locale?: 'ko' | 'en';
+}

--- a/backend/src/modules/orders/entities/guest-order-access.entity.ts
+++ b/backend/src/modules/orders/entities/guest-order-access.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Order } from './order.entity';
+
+@Entity('guest_order_access')
+@Index('IDX_guest_order_access_order_id', ['orderId'])
+@Index('IDX_guest_order_access_token_digest', ['tokenDigest'], { unique: true })
+@Index('IDX_guest_order_access_expires_at', ['expiresAt'])
+@Index('IDX_guest_order_access_superseded_by_id', ['supersededById'])
+export class GuestOrderAccess {
+  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
+  id!: number;
+
+  @Column({ name: 'order_id', type: 'bigint' })
+  orderId!: number;
+
+  @Column({ name: 'token_digest', type: 'varchar', length: 64 })
+  tokenDigest!: string;
+
+  @Column({ name: 'expires_at', type: 'datetime' })
+  expiresAt!: Date;
+
+  @Column({ name: 'superseded_at', type: 'datetime', nullable: true })
+  supersededAt!: Date | null;
+
+  @Column({ name: 'superseded_by_id', type: 'bigint', nullable: true })
+  supersededById!: number | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @ManyToOne(() => Order, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'order_id' })
+  order!: Order;
+
+  @ManyToOne(() => GuestOrderAccess, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'superseded_by_id' })
+  supersededBy!: GuestOrderAccess | null;
+}

--- a/backend/src/modules/orders/entities/order.entity.ts
+++ b/backend/src/modules/orders/entities/order.entity.ts
@@ -1,6 +1,13 @@
 import {
-  Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn,
-  ManyToOne, OneToMany, JoinColumn, Index,
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  Index,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { OrderItem } from './order-item.entity';
@@ -25,11 +32,17 @@ export class Order {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id!: number;
 
-  @Column({ name: 'user_id', type: 'bigint' })
-  userId!: number;
+  @Column({ name: 'user_id', type: 'bigint', nullable: true })
+  userId!: number | null;
+
+  @Column({ name: 'guest_email_normalized', type: 'varchar', length: 255, nullable: true })
+  guestEmailNormalized!: string | null;
 
   @Column({ name: 'order_number', length: 50, unique: true })
   orderNumber!: string;
+
+  @Column({ name: 'order_locale', type: 'enum', enum: ['ko', 'en'] })
+  orderLocale!: 'ko' | 'en';
 
   @Column({ type: 'enum', enum: OrderStatus, default: OrderStatus.PENDING })
   status!: OrderStatus;
@@ -76,9 +89,9 @@ export class Order {
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt!: Date;
 
-  @ManyToOne(() => User, { onDelete: 'RESTRICT' })
+  @ManyToOne(() => User, { nullable: true, onDelete: 'RESTRICT' })
   @JoinColumn({ name: 'user_id' })
-  user!: User;
+  user!: User | null;
 
   @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })
   items!: OrderItem[];

--- a/backend/src/modules/orders/events/order-completed.event.ts
+++ b/backend/src/modules/orders/events/order-completed.event.ts
@@ -1,9 +1,10 @@
 export class OrderCompletedEvent {
   constructor(
-    public readonly userId: number,
+    public readonly userId: number | null,
     public readonly orderId: number,
     public readonly orderNumber: string,
     public readonly isFirstPurchase: boolean,
+    public readonly customerType: 'member' | 'guest',
   ) {}
 }
 

--- a/backend/src/modules/orders/guest-order-access.service.ts
+++ b/backend/src/modules/orders/guest-order-access.service.ts
@@ -1,0 +1,303 @@
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { createHash, randomBytes } from 'crypto';
+import { DataSource, EntityManager, QueryRunner, Repository } from 'typeorm';
+import { applyLocale } from '../../common/utils/locale.util';
+import { LookupGuestOrderDto } from './dto/lookup-guest-order.dto';
+import { GuestOrderAccess } from './entities/guest-order-access.entity';
+import { Order } from './entities/order.entity';
+
+const GUEST_ACCESS_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const GUEST_ACCESS_UNAUTHORIZED_MESSAGE = '비회원 주문 접근 토큰이 유효하지 않습니다.';
+
+type GuestAccessIssueResult = {
+  access: GuestOrderAccess;
+  guestAccessToken: string;
+  guestAccessTokenExpiresAt: Date;
+};
+
+@Injectable()
+export class GuestOrderAccessService {
+  private readonly logger = new Logger(GuestOrderAccessService.name);
+
+  constructor(
+    @InjectRepository(GuestOrderAccess)
+    private readonly guestOrderAccessRepository: Repository<GuestOrderAccess>,
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async issueAccessToken(orderId: number, manager?: EntityManager): Promise<GuestAccessIssueResult> {
+    const now = new Date();
+    const guestAccessToken = randomBytes(32).toString('hex');
+    const guestAccessTokenExpiresAt = new Date(now.getTime() + GUEST_ACCESS_TOKEN_TTL_MS);
+    const repository = this.getGuestOrderAccessRepository(manager);
+
+    const access = repository.create({
+      orderId,
+      tokenDigest: this.hashToken(guestAccessToken),
+      expiresAt: guestAccessTokenExpiresAt,
+      supersededAt: null,
+      supersededById: null,
+    });
+
+    const savedAccess = await repository.save(access);
+    return {
+      access: savedAccess,
+      guestAccessToken,
+      guestAccessTokenExpiresAt,
+    };
+  }
+
+  async getValidAccessOrThrow(
+    orderId: number,
+    rawToken: string | null | undefined,
+    manager?: EntityManager,
+  ): Promise<GuestOrderAccess> {
+    const token = this.normalizePresentedToken(rawToken);
+    const access = await this.getGuestOrderAccessRepository(manager).findOne({
+      where: {
+        orderId,
+        tokenDigest: this.hashToken(token),
+      },
+    });
+
+    if (!access || access.supersededAt || access.supersededById || access.expiresAt.getTime() <= Date.now()) {
+      throw new UnauthorizedException(GUEST_ACCESS_UNAUTHORIZED_MESSAGE);
+    }
+
+    return access;
+  }
+
+  async getOrderForAccessOrThrow(
+    orderId: number,
+    rawToken: string | null | undefined,
+    locale?: string,
+    manager?: EntityManager,
+  ): Promise<Order> {
+    await this.getValidAccessOrThrow(orderId, rawToken, manager);
+
+    const order = await this.getOrderRepository(manager)
+      .createQueryBuilder('order')
+      .leftJoinAndSelect('order.items', 'item')
+      .leftJoinAndSelect('item.product', 'product')
+      .leftJoinAndSelect('item.option', 'option')
+      .where('order.id = :id', { id: orderId })
+      .getOne();
+
+    if (!order) {
+      throw new NotFoundException('주문을 찾을 수 없습니다.');
+    }
+
+    return this.localizeOrder(order, locale);
+  }
+
+  async lookupOrderOrThrow(dto: LookupGuestOrderDto): Promise<Order> {
+    const order = await this.orderRepository
+      .createQueryBuilder('order')
+      .leftJoinAndSelect('order.items', 'item')
+      .leftJoinAndSelect('item.product', 'product')
+      .leftJoinAndSelect('item.option', 'option')
+      .where('order.orderNumber = :orderNumber', { orderNumber: dto.orderNumber.trim() })
+      .andWhere('order.guestEmailNormalized = :guestEmailNormalized', {
+        guestEmailNormalized: this.normalizeEmail(dto.email),
+      })
+      .getOne();
+
+    if (!order) {
+      throw new NotFoundException('주문 번호와 이메일이 일치하는 주문을 찾을 수 없습니다.');
+    }
+
+    return this.localizeOrder(order, dto.locale);
+  }
+
+  async lookupAndIssueAccessToken(
+    dto: LookupGuestOrderDto,
+  ): Promise<GuestAccessIssueResult & { order: Order }> {
+    const matchedOrder = await this.lookupOrderOrThrow(dto);
+
+    return this.withOrderAccessLock(matchedOrder.id, async (manager) => {
+      const repository = this.getGuestOrderAccessRepository(manager);
+      const order = await this.getOrderRepository(manager)
+        .createQueryBuilder('order')
+        .leftJoinAndSelect('order.items', 'item')
+        .leftJoinAndSelect('item.product', 'product')
+        .leftJoinAndSelect('item.option', 'option')
+        .where('order.id = :orderId', { orderId: matchedOrder.id })
+        .andWhere('order.orderNumber = :orderNumber', { orderNumber: dto.orderNumber.trim() })
+        .andWhere('order.guestEmailNormalized = :guestEmailNormalized', {
+          guestEmailNormalized: this.normalizeEmail(dto.email),
+        })
+        .getOne();
+
+      if (!order) {
+        throw new NotFoundException('주문 번호와 이메일이 일치하는 주문을 찾을 수 없습니다.');
+      }
+
+      const currentActiveAccess = await repository
+        .createQueryBuilder('guestOrderAccess')
+        .setLock('pessimistic_write')
+        .where('guestOrderAccess.orderId = :orderId', { orderId: order.id })
+        .andWhere('guestOrderAccess.supersededAt IS NULL')
+        .getOne();
+
+      const issued = await this.issueAccessToken(order.id, manager);
+      if (currentActiveAccess && currentActiveAccess.expiresAt.getTime() > Date.now()) {
+        currentActiveAccess.supersededAt = new Date();
+        currentActiveAccess.supersededById = issued.access.id;
+        await repository.save(currentActiveAccess);
+      }
+
+      return {
+        order: this.localizeOrder(order, dto.locale),
+        ...issued,
+      };
+    });
+  }
+
+  async rotateAccessTokenForOrder(
+    orderId: number,
+    currentRawToken: string,
+    manager: EntityManager,
+  ): Promise<GuestAccessIssueResult> {
+    if (!manager.queryRunner) {
+      throw new InternalServerErrorException('게스트 주문 접근 토큰 회전에는 QueryRunner가 필요합니다.');
+    }
+
+    const repository = this.getGuestOrderAccessRepository(manager);
+    const currentTokenDigest = this.hashToken(this.normalizePresentedToken(currentRawToken));
+    const currentAccess = await repository
+      .createQueryBuilder('guestOrderAccess')
+      .setLock('pessimistic_write')
+      .where('guestOrderAccess.orderId = :orderId', { orderId })
+      .andWhere('guestOrderAccess.tokenDigest = :tokenDigest', { tokenDigest: currentTokenDigest })
+      .getOne();
+
+    if (
+      !currentAccess
+      || currentAccess.supersededAt
+      || currentAccess.supersededById
+      || currentAccess.expiresAt.getTime() <= Date.now()
+    ) {
+      throw new UnauthorizedException(GUEST_ACCESS_UNAUTHORIZED_MESSAGE);
+    }
+
+    const issued = await this.issueAccessToken(orderId, manager);
+    currentAccess.supersededAt = new Date();
+    currentAccess.supersededById = issued.access.id;
+    await repository.save(currentAccess);
+
+    return issued;
+  }
+
+  async withOrderAccessLock<T>(orderId: number, operation: (manager: EntityManager) => Promise<T>): Promise<T> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+
+    try {
+      await this.acquireOrderAccessLock(queryRunner, orderId);
+      await queryRunner.startTransaction();
+
+      const result = await operation(queryRunner.manager);
+      await queryRunner.commitTransaction();
+      return result;
+    } catch (error) {
+      if (queryRunner.isTransactionActive) {
+        await queryRunner.rollbackTransaction();
+      }
+      throw error;
+    } finally {
+      await this.releaseOrderAccessLock(queryRunner, orderId);
+      await queryRunner.release();
+    }
+  }
+
+  private getGuestOrderAccessRepository(manager?: EntityManager): Repository<GuestOrderAccess> {
+    return manager ? manager.getRepository(GuestOrderAccess) : this.guestOrderAccessRepository;
+  }
+
+  private getOrderRepository(manager?: EntityManager): Repository<Order> {
+    return manager ? manager.getRepository(Order) : this.orderRepository;
+  }
+
+  private hashToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private normalizePresentedToken(rawToken: string | null | undefined): string {
+    const token = rawToken?.trim();
+    if (!token) {
+      throw new UnauthorizedException(GUEST_ACCESS_UNAUTHORIZED_MESSAGE);
+    }
+
+    return token;
+  }
+
+  private normalizeEmail(email: string): string {
+    return email.trim().toLowerCase();
+  }
+
+  private async acquireOrderAccessLock(
+    queryRunner: QueryRunner,
+    orderId: number,
+  ): Promise<void> {
+    const rows = await queryRunner.query('SELECT GET_LOCK(?, 10) AS acquired', [
+      this.orderAccessLockName(orderId),
+    ]) as Array<{ acquired?: number | string }>;
+
+    const acquired = rows[0]?.acquired;
+
+    if (Number(acquired) !== 1) {
+      throw new ConflictException('비회원 주문 조회가 이미 진행 중입니다. 잠시 후 다시 시도해주세요.');
+    }
+  }
+
+  private async releaseOrderAccessLock(queryRunner: QueryRunner, orderId: number): Promise<void> {
+
+    try {
+      await queryRunner.query('SELECT RELEASE_LOCK(?)', [this.orderAccessLockName(orderId)]);
+    } catch (error) {
+      this.logger.warn(`Failed to release guest order access lock for order ${orderId}: ${String(error)}`);
+    }
+  }
+
+  private orderAccessLockName(orderId: number): string {
+    return `guest-order-access:${orderId}`;
+  }
+
+  private localizeOrder(order: Order, locale?: string): Order {
+    if (!locale || locale === 'ko') {
+      return order;
+    }
+
+    const localizedItems = order.items?.map((item) => {
+      const localizedProduct = item.product
+        ? applyLocale(item.product, locale, ['name'])
+        : item.product;
+      const localizedOption = item.option
+        ? applyLocale(item.option, locale, ['name', 'value'])
+        : item.option;
+
+      return {
+        ...item,
+        product: localizedProduct,
+        option: localizedOption,
+        productName: localizedProduct?.name || item.productName,
+        optionName: localizedOption
+          ? `${localizedOption.name}: ${localizedOption.value}`
+          : item.optionName,
+      };
+    });
+
+    return { ...order, items: localizedItems ?? [] };
+  }
+}

--- a/backend/src/modules/orders/guest-order-creation.workflow.service.ts
+++ b/backend/src/modules/orders/guest-order-creation.workflow.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+import {
+  OrderCreationWorkflowService,
+  OrderLocale,
+  OrderPostCommitPayload,
+} from './order-creation.workflow.service';
+import { CreateGuestOrderDto } from './dto/create-guest-order.dto';
+
+export interface GuestOrderPostCommitPayload extends OrderPostCommitPayload {
+  guestEmailNormalized: string;
+  orderLocale: OrderLocale;
+}
+
+@Injectable()
+export class GuestOrderCreationWorkflowService {
+  constructor(
+    private readonly orderCreationWorkflow: OrderCreationWorkflowService,
+  ) {}
+
+  assertCreatePayload(dto: CreateGuestOrderDto): void {
+    this.orderCreationWorkflow.assertCreatePayload(dto);
+  }
+
+  async runCreateOrderTransaction(
+    manager: EntityManager,
+    dto: CreateGuestOrderDto,
+  ): Promise<GuestOrderPostCommitPayload> {
+    const { orderItems, subtotalAmount, shippingItemPolicies } = await this.orderCreationWorkflow.validateAndReserveStock(
+      manager,
+      dto,
+    );
+
+    const shippingFee = await this.orderCreationWorkflow.calculateShippingFee(
+      subtotalAmount,
+      dto.zipcode,
+      shippingItemPolicies,
+    );
+    const totalPayable = subtotalAmount + shippingFee;
+    const guestEmailNormalized = this.normalizeGuestEmail(dto.guestEmail);
+
+    const savedOrder = await this.orderCreationWorkflow.saveOrder(manager, {
+      userId: null,
+      totalAmount: totalPayable,
+      discountAmount: 0,
+      shippingFee,
+      pointsUsed: 0,
+      guestEmailNormalized,
+      orderLocale: dto.orderLocale,
+      recipientName: dto.recipientName,
+      recipientPhone: dto.recipientPhone,
+      zipcode: dto.zipcode,
+      address: dto.address,
+      addressDetail: dto.addressDetail ?? null,
+      memo: dto.memo ?? null,
+    });
+
+    await this.orderCreationWorkflow.savePolicyConsent(manager, null, savedOrder, dto);
+    await this.orderCreationWorkflow.saveOrderItems(manager, orderItems, Number(savedOrder.id));
+
+    return {
+      savedOrder,
+      totalPayable,
+      recipientName: dto.recipientName,
+      guestEmailNormalized,
+      orderLocale: dto.orderLocale,
+    };
+  }
+
+  private normalizeGuestEmail(email: string): string {
+    return email.trim().toLowerCase();
+  }
+}

--- a/backend/src/modules/orders/guest-orders.controller.ts
+++ b/backend/src/modules/orders/guest-orders.controller.ts
@@ -1,0 +1,58 @@
+import { Body, Controller, Get, Headers, HttpCode, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import {
+  ApiHeader,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Public } from '../../common/decorators/public.decorator';
+import { OptionalLocalePipe } from '../../common/pipes/optional-locale.pipe';
+import { CreateGuestOrderDto } from './dto/create-guest-order.dto';
+import { LookupGuestOrderDto } from './dto/lookup-guest-order.dto';
+import { GuestOrdersService } from './guest-orders.service';
+
+@ApiTags('비회원 주문')
+@Public()
+@Controller('guest/orders')
+export class GuestOrdersController {
+  constructor(private readonly guestOrdersService: GuestOrdersService) {}
+
+  @Post()
+  @Throttle({ guestCreate: { limit: 3, ttl: 60000 } })
+  @ApiOperation({ summary: '비회원 주문 생성', description: '회원 로그인 없이 주문을 생성하고 접근 토큰을 발급합니다.' })
+  @ApiResponse({ status: 201, description: '비회원 주문 생성 성공' })
+  @ApiResponse({ status: 400, description: '입력값 오류' })
+  @ApiResponse({ status: 429, description: '요청 한도 초과' })
+  create(@Body() dto: CreateGuestOrderDto) {
+    return this.guestOrdersService.create(dto);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '비회원 주문 상세 조회', description: '비회원 주문 접근 토큰으로 주문 상세를 조회합니다.' })
+  @ApiParam({ name: 'id', type: Number, description: '주문 ID' })
+  @ApiHeader({ name: 'X-Guest-Access-Token', required: true, description: '비회원 주문 접근 토큰' })
+  @ApiResponse({ status: 200, description: '비회원 주문 상세 조회 성공' })
+  @ApiResponse({ status: 401, description: '비회원 주문 접근 토큰이 유효하지 않음' })
+  @ApiResponse({ status: 404, description: '주문을 찾을 수 없음' })
+  getById(
+    @Param('id', ParseIntPipe) id: number,
+    @Headers('x-guest-access-token') guestAccessToken: string | undefined,
+    @Query('locale', OptionalLocalePipe) locale?: string,
+  ) {
+    return this.guestOrdersService.getById(id, guestAccessToken, locale as 'ko' | 'en' | undefined);
+  }
+
+  @Post('lookup')
+  @Throttle({ guestLookup: { limit: 5, ttl: 60000 } })
+  @HttpCode(200)
+  @ApiOperation({ summary: '비회원 주문 조회용 토큰 재발급', description: '주문 번호와 이메일로 비회원 주문을 확인하고 새 접근 토큰을 발급합니다.' })
+  @ApiResponse({ status: 200, description: '비회원 주문 조회 성공' })
+  @ApiResponse({ status: 400, description: '입력값 오류' })
+  @ApiResponse({ status: 404, description: '주문 번호와 이메일이 일치하는 주문을 찾을 수 없음' })
+  @ApiResponse({ status: 429, description: '요청 한도 초과' })
+  lookup(@Body() dto: LookupGuestOrderDto) {
+    return this.guestOrdersService.lookup(dto);
+  }
+}

--- a/backend/src/modules/orders/guest-orders.service.ts
+++ b/backend/src/modules/orders/guest-orders.service.ts
@@ -1,0 +1,134 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
+import { applyLocale } from '../../common/utils/locale.util';
+import { CreateGuestOrderDto } from './dto/create-guest-order.dto';
+import { LookupGuestOrderDto } from './dto/lookup-guest-order.dto';
+import { Order } from './entities/order.entity';
+import { GuestOrderCreationWorkflowService } from './guest-order-creation.workflow.service';
+import { GuestOrderAccessService } from './guest-order-access.service';
+import { OrderPostCommitService } from './order-post-commit.service';
+
+@Injectable()
+export class GuestOrdersService {
+  private readonly logger = new Logger(GuestOrdersService.name);
+
+  constructor(
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly guestOrderCreationWorkflow: GuestOrderCreationWorkflowService,
+    private readonly guestOrderAccessService: GuestOrderAccessService,
+    private readonly orderPostCommitService: OrderPostCommitService,
+  ) {}
+
+  async create(dto: CreateGuestOrderDto): Promise<{
+    order: Order;
+    guestAccessToken: string;
+    guestAccessTokenExpiresAt: Date;
+  }> {
+    this.guestOrderCreationWorkflow.assertCreatePayload(dto);
+
+    const result = await this.dataSource.transaction(async (manager) => {
+      const postCommit = await this.guestOrderCreationWorkflow.runCreateOrderTransaction(manager, dto);
+      const access = await this.guestOrderAccessService.issueAccessToken(
+        Number(postCommit.savedOrder.id),
+        manager,
+      );
+
+      return { postCommit, access };
+    });
+
+    this.logger.log(
+      `Guest order created: ${result.postCommit.savedOrder.orderNumber} email=${result.postCommit.guestEmailNormalized}`,
+    );
+    await this.orderPostCommitService.dispatchOrderCreated(null, result.postCommit);
+
+    const order = await this.findOne(
+      Number(result.postCommit.savedOrder.id),
+      dto.orderLocale,
+    );
+
+    return {
+      order,
+      guestAccessToken: result.access.guestAccessToken,
+      guestAccessTokenExpiresAt: result.access.guestAccessTokenExpiresAt,
+    };
+  }
+
+  async getById(
+    id: number,
+    guestAccessToken: string | undefined,
+    locale?: 'ko' | 'en',
+  ): Promise<Order> {
+    return this.guestOrderAccessService.getOrderForAccessOrThrow(id, guestAccessToken, locale);
+  }
+
+  async lookup(dto: LookupGuestOrderDto): Promise<{
+    order: Order;
+    guestAccessToken: string;
+    guestAccessTokenExpiresAt: Date;
+  }> {
+    const result = await this.guestOrderAccessService.lookupAndIssueAccessToken(dto);
+
+    return {
+      order: result.order,
+      guestAccessToken: result.guestAccessToken,
+      guestAccessTokenExpiresAt: result.guestAccessTokenExpiresAt,
+    };
+  }
+
+  async findOne(id: number, locale?: string, manager?: EntityManager): Promise<Order> {
+    const repository = manager ? manager.getRepository(Order) : this.orderRepository;
+    const order = typeof repository.createQueryBuilder === 'function'
+      ? await repository
+        .createQueryBuilder('order')
+        .leftJoinAndSelect('order.items', 'item')
+        .leftJoinAndSelect('item.product', 'product')
+        .leftJoinAndSelect('item.option', 'option')
+        .where('order.id = :id', { id })
+        .getOne()
+      : await repository.findOne({
+        where: { id },
+        relations: ['items', 'items.product', 'items.option'],
+      });
+
+    if (!order) {
+      throw new NotFoundException('주문을 찾을 수 없습니다.');
+    }
+
+    return this.localizeOrder(order, locale ?? this.readOrderLocale(order));
+  }
+
+  private readOrderLocale(order: Order): 'ko' | 'en' {
+    return (order as Order & { orderLocale?: 'ko' | 'en' }).orderLocale === 'en' ? 'en' : 'ko';
+  }
+
+  private localizeOrder(order: Order, locale?: string): Order {
+    if (!locale || locale === 'ko') {
+      return order;
+    }
+
+    const localizedItems = order.items?.map((item) => {
+      const localizedProduct = item.product
+        ? applyLocale(item.product, locale, ['name'])
+        : item.product;
+      const localizedOption = item.option
+        ? applyLocale(item.option, locale, ['name', 'value'])
+        : item.option;
+
+      return {
+        ...item,
+        product: localizedProduct,
+        option: localizedOption,
+        productName: localizedProduct?.name || item.productName,
+        optionName: localizedOption
+          ? `${localizedOption.name}: ${localizedOption.value}`
+          : item.optionName,
+      };
+    });
+
+    return { ...order, items: localizedItems ?? [] };
+  }
+}

--- a/backend/src/modules/orders/order-creation.workflow.service.ts
+++ b/backend/src/modules/orders/order-creation.workflow.service.ts
@@ -2,11 +2,15 @@ import { randomBytes } from 'crypto';
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { Brackets, EntityManager } from 'typeorm';
 import { Order, OrderStatus } from './entities/order.entity';
+import {
+  CreateOrderDto,
+  OrderItemDto,
+  PolicyConsentSnapshotDto,
+} from './dto/create-order.dto';
 import { OrderItem } from './entities/order-item.entity';
 import { Product, ProductStatus } from '../products/entities/product.entity';
 import { ProductOption } from '../products/entities/product-option.entity';
 import { CartItem } from '../cart/entities/cart-item.entity';
-import { CreateOrderDto } from './dto/create-order.dto';
 import { PointsService } from '../points/points.service';
 import { CouponsService } from '../coupons/coupons.service';
 import { CalculateDiscountDto } from '../coupons/dto/calculate-discount.dto';
@@ -16,6 +20,8 @@ import {
   PolicyConsentContext,
   PolicyConsentSnapshot,
 } from '../pages/entities/policy-consent.entity';
+
+export type OrderLocale = 'ko' | 'en';
 
 interface OrderItemBuildResult {
   orderItems: Partial<OrderItem>[];
@@ -28,6 +34,34 @@ interface OrderPriceResult {
   discountedAmount: number;
   shippingFee: number;
   totalPayable: number;
+}
+
+interface SharedOrderCreatePayload {
+  items: OrderItemDto[];
+}
+
+interface SharedOrderAddressPayload {
+  recipientName: string;
+  recipientPhone: string;
+  zipcode: string;
+  address: string;
+  addressDetail?: string | null;
+  memo?: string | null;
+}
+
+interface SharedPolicyConsentPayload {
+  policyConsents?: PolicyConsentSnapshotDto[];
+  marketingConsent?: boolean;
+}
+
+export interface PersistOrderInput extends SharedOrderAddressPayload {
+  userId: number | null;
+  totalAmount: number;
+  discountAmount: number;
+  shippingFee: number;
+  pointsUsed: number;
+  guestEmailNormalized: string | null;
+  orderLocale: OrderLocale;
 }
 
 export interface OrderPostCommitPayload {
@@ -44,7 +78,7 @@ export class OrderCreationWorkflowService {
     private readonly shippingFeeCalculator: ShippingFeeCalculatorService,
   ) {}
 
-  assertCreatePayload(dto: CreateOrderDto): void {
+  assertCreatePayload(dto: SharedOrderCreatePayload): void {
     if (!dto.items || dto.items.length === 0) {
       throw new BadRequestException('주문 항목이 없습니다.');
     }
@@ -68,7 +102,22 @@ export class OrderCreationWorkflowService {
       shippingItemPolicies,
     );
 
-    const savedOrder = await this.persistOrder(manager, userId, dto, pointsToUse, pricing);
+    const savedOrder = await this.saveOrder(manager, {
+      userId,
+      totalAmount: pricing.totalPayable,
+      discountAmount: pricing.discountAmount,
+      shippingFee: pricing.shippingFee,
+      pointsUsed: pointsToUse,
+      guestEmailNormalized: null,
+      orderLocale: this.resolveOrderLocale(dto),
+      recipientName: dto.recipientName,
+      recipientPhone: dto.recipientPhone,
+      zipcode: dto.zipcode,
+      address: dto.address,
+      addressDetail: dto.addressDetail ?? null,
+      memo: dto.memo ?? null,
+    });
+
     await this.applyCouponAndPoints(manager, userId, dto, pointsToUse, savedOrder);
     await this.savePolicyConsent(manager, userId, savedOrder, dto);
     await this.saveOrderItems(manager, orderItems, Number(savedOrder.id));
@@ -81,38 +130,15 @@ export class OrderCreationWorkflowService {
     };
   }
 
-  private generateOrderNumber(): string {
+  createOrderNumber(): string {
     const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const random = randomBytes(4).toString('hex').toUpperCase().slice(0, 5);
     return `ORD-${date}-${random}`;
   }
 
-  private async ensureSufficientPoints(
+  async validateAndReserveStock(
     manager: EntityManager,
-    userId: number,
-    pointsToUse: number,
-  ): Promise<void> {
-    if (pointsToUse <= 0) return;
-
-    const balance = await this.pointsService.getEffectiveBalanceInTx(manager, userId);
-    if (pointsToUse > balance) {
-      throw new BadRequestException('적립금이 부족합니다.');
-    }
-  }
-
-  /**
-   * 재고 정책 (issue #723):
-   *   - 옵션이 있는 상품: `product_option.stock` 만이 판매 가능 수량의 원장이다.
-   *     주문 시 옵션 재고만 차감하고, 상품 총 재고 (`product.stock`) 는 건드리지 않는다.
-   *     상품 총 재고는 옵션 합으로의 집계값/표시용이며, 옵션 재고와 동시 차감 시
-   *     이중 차감 버그가 발생한다.
-   *   - 옵션이 없는 상품: `product.stock` 이 원장이며, 그대로 차감한다.
-   *
-   * 취소·환불 시 복구도 동일한 분기를 사용한다 (AdminOrdersService.restoreStock 참고).
-   */
-  private async validateAndReserveStock(
-    manager: EntityManager,
-    dto: CreateOrderDto,
+    dto: SharedOrderCreatePayload,
   ): Promise<OrderItemBuildResult> {
     const orderItems: Partial<OrderItem>[] = [];
     const shippingItemPolicies: { isFreeShipping: boolean }[] = [];
@@ -190,95 +216,47 @@ export class OrderCreationWorkflowService {
     return { orderItems, subtotalAmount, shippingItemPolicies };
   }
 
-  private async calculateDiscountAndShipping(
-    userId: number,
-    dto: CreateOrderDto,
+  async calculateShippingFee(
     subtotalAmount: number,
-    pointsToUse: number,
+    zipcode: string,
     shippingItemPolicies: { isFreeShipping: boolean }[],
-  ): Promise<OrderPriceResult> {
-    let discountAmount = 0;
-    let discountedAmount = subtotalAmount;
-
-    if (dto.userCouponId || pointsToUse > 0) {
-      const calculateDto: CalculateDiscountDto = {
-        orderAmount: subtotalAmount,
-        userCouponId: dto.userCouponId,
-        pointsToUse,
-      };
-      const discountResult = await this.couponsService.calculate(userId, calculateDto);
-      discountAmount = discountResult.couponDiscount;
-      discountedAmount = discountResult.finalAmount;
-    }
-
+  ): Promise<number> {
     const shippingQuote = await this.shippingFeeCalculator.calculate(
       subtotalAmount,
-      dto.zipcode,
+      zipcode,
       shippingItemPolicies,
     );
-    const shippingFee = shippingQuote.shippingFee;
-    const totalPayable = discountedAmount + shippingFee;
 
-    return {
-      discountAmount,
-      discountedAmount,
-      shippingFee,
-      totalPayable,
-    };
+    return shippingQuote.shippingFee;
   }
 
-  private async persistOrder(
-    manager: EntityManager,
-    userId: number,
-    dto: CreateOrderDto,
-    pointsToUse: number,
-    pricing: OrderPriceResult,
-  ): Promise<Order> {
+  async saveOrder(manager: EntityManager, input: PersistOrderInput): Promise<Order> {
     const order = manager.create(Order, {
-      userId,
-      orderNumber: this.generateOrderNumber(),
+      userId: input.userId,
+      guestEmailNormalized: input.guestEmailNormalized,
+      orderNumber: this.createOrderNumber(),
+      orderLocale: input.orderLocale,
       status: OrderStatus.PENDING,
-      totalAmount: pricing.totalPayable,
-      discountAmount: pricing.discountAmount,
-      shippingFee: pricing.shippingFee,
-      recipientName: dto.recipientName,
-      recipientPhone: dto.recipientPhone,
-      zipcode: dto.zipcode,
-      address: dto.address,
-      addressDetail: dto.addressDetail ?? null,
-      memo: dto.memo ?? null,
-      pointsUsed: pointsToUse,
+      totalAmount: input.totalAmount,
+      discountAmount: input.discountAmount,
+      shippingFee: input.shippingFee,
+      recipientName: input.recipientName,
+      recipientPhone: input.recipientPhone,
+      zipcode: input.zipcode,
+      address: input.address,
+      addressDetail: input.addressDetail ?? null,
+      memo: input.memo ?? null,
+      pointsUsed: input.pointsUsed,
     });
+
     return manager.save(Order, order);
   }
 
-  private async applyCouponAndPoints(
+  async savePolicyConsent(
     manager: EntityManager,
-    userId: number,
-    dto: CreateOrderDto,
-    pointsToUse: number,
+    userId: number | null,
     savedOrder: Order,
-  ): Promise<void> {
-    if (dto.userCouponId) {
-      await this.couponsService.useCoupon(dto.userCouponId, userId, Number(savedOrder.id), manager);
-    }
-
-    if (pointsToUse > 0) {
-      await this.pointsService.deductFifo(
-        manager,
-        userId,
-        pointsToUse,
-        `주문 사용 (${savedOrder.orderNumber})`,
-        Number(savedOrder.id),
-      );
-    }
-  }
-
-  private async savePolicyConsent(
-    manager: EntityManager,
-    userId: number,
-    savedOrder: Order,
-    dto: CreateOrderDto,
+    dto: SharedPolicyConsentPayload,
   ): Promise<void> {
     const policies = dto.policyConsents?.length
       ? dto.policyConsents.map((policy) => ({
@@ -298,7 +276,7 @@ export class OrderCreationWorkflowService {
     });
   }
 
-  private async loadCurrentPolicySnapshots(manager: EntityManager): Promise<PolicyConsentSnapshot[]> {
+  async loadCurrentPolicySnapshots(manager: EntityManager): Promise<PolicyConsentSnapshot[]> {
     const rows = await manager.query(`
       SELECT slug, title, policy_version AS version, policy_effective_date AS effectiveDate
       FROM pages
@@ -323,7 +301,7 @@ export class OrderCreationWorkflowService {
     ];
   }
 
-  private async saveOrderItems(
+  async saveOrderItems(
     manager: EntityManager,
     orderItems: Partial<OrderItem>[],
     orderId: number,
@@ -332,6 +310,91 @@ export class OrderCreationWorkflowService {
       manager.create(OrderItem, { ...item, orderId }),
     );
     await manager.save(OrderItem, itemEntities);
+  }
+
+  private resolveOrderLocale(dto: CreateOrderDto): OrderLocale {
+    return (dto as CreateOrderDto & { orderLocale?: OrderLocale }).orderLocale === 'en' ? 'en' : 'ko';
+  }
+
+  private async ensureSufficientPoints(
+    manager: EntityManager,
+    userId: number,
+    pointsToUse: number,
+  ): Promise<void> {
+    if (pointsToUse <= 0) return;
+
+    const balance = await this.pointsService.getEffectiveBalanceInTx(manager, userId);
+    if (pointsToUse > balance) {
+      throw new BadRequestException('적립금이 부족합니다.');
+    }
+  }
+
+  /**
+   * 재고 정책 (issue #723):
+   *   - 옵션이 있는 상품: `product_option.stock` 만이 판매 가능 수량의 원장이다.
+   *     주문 시 옵션 재고만 차감하고, 상품 총 재고 (`product.stock`) 는 건드리지 않는다.
+   *     상품 총 재고는 옵션 합으로의 집계값/표시용이며, 옵션 재고와 동시 차감 시
+   *     이중 차감 버그가 발생한다.
+   *   - 옵션이 없는 상품: `product.stock` 이 원장이며, 그대로 차감한다.
+   *
+   * 취소·환불 시 복구도 동일한 분기를 사용한다 (AdminOrdersService.restoreStock 참고).
+   */
+  private async calculateDiscountAndShipping(
+    userId: number,
+    dto: CreateOrderDto,
+    subtotalAmount: number,
+    pointsToUse: number,
+    shippingItemPolicies: { isFreeShipping: boolean }[],
+  ): Promise<OrderPriceResult> {
+    let discountAmount = 0;
+    let discountedAmount = subtotalAmount;
+
+    if (dto.userCouponId || pointsToUse > 0) {
+      const calculateDto: CalculateDiscountDto = {
+        orderAmount: subtotalAmount,
+        userCouponId: dto.userCouponId,
+        pointsToUse,
+      };
+      const discountResult = await this.couponsService.calculate(userId, calculateDto);
+      discountAmount = discountResult.couponDiscount;
+      discountedAmount = discountResult.finalAmount;
+    }
+
+    const shippingFee = await this.calculateShippingFee(
+      subtotalAmount,
+      dto.zipcode,
+      shippingItemPolicies,
+    );
+    const totalPayable = discountedAmount + shippingFee;
+
+    return {
+      discountAmount,
+      discountedAmount,
+      shippingFee,
+      totalPayable,
+    };
+  }
+
+  private async applyCouponAndPoints(
+    manager: EntityManager,
+    userId: number,
+    dto: CreateOrderDto,
+    pointsToUse: number,
+    savedOrder: Order,
+  ): Promise<void> {
+    if (dto.userCouponId) {
+      await this.couponsService.useCoupon(dto.userCouponId, userId, Number(savedOrder.id), manager);
+    }
+
+    if (pointsToUse > 0) {
+      await this.pointsService.deductFifo(
+        manager,
+        userId,
+        pointsToUse,
+        `주문 사용 (${savedOrder.orderNumber})`,
+        Number(savedOrder.id),
+      );
+    }
   }
 
   private async clearCartItems(

--- a/backend/src/modules/orders/order-post-commit.service.ts
+++ b/backend/src/modules/orders/order-post-commit.service.ts
@@ -5,7 +5,7 @@ import { Order } from './entities/order.entity';
 import { NotificationService } from '../notification/notification.service';
 import { MessageNotificationService } from '../notification/message-notification.service';
 import { NotificationDispatchHelper } from '../notification/notification-dispatch.helper';
-import { buildOrderEmailItems, buildOrderUrl } from '../notification/order-email-context';
+import { buildGuestOrderLookupUrl, buildOrderEmailItems, buildOrderUrl } from '../notification/order-email-context';
 import { OrderPostCommitPayload } from './order-creation.workflow.service';
 
 @Injectable()
@@ -21,25 +21,31 @@ export class OrderPostCommitService {
     private readonly notificationDispatchHelper: NotificationDispatchHelper,
   ) {}
 
-  async dispatchOrderCreated(userId: number, payload: OrderPostCommitPayload): Promise<void> {
+  async dispatchOrderCreated(userId: number | null, payload: OrderPostCommitPayload): Promise<void> {
     try {
       const { savedOrder, totalPayable, recipientName } = payload;
+      const orderUserId = userId ?? this.getOrderUserId(savedOrder);
 
       void this.notifyOrderCreated(
-        userId,
+        orderUserId,
+        savedOrder,
         Number(savedOrder.id),
         savedOrder.orderNumber,
         totalPayable,
         recipientName,
       ).catch((err) => this.logger.warn(`Failed to send order created email: ${String(err)}`));
-      void this.messageNotificationService?.sendOrderCreated(Number(savedOrder.id));
+
+      if (orderUserId !== null) {
+        void this.messageNotificationService?.sendOrderCreated(Number(savedOrder.id));
+      }
     } catch (err) {
       this.logger.error('주문 post-commit 처리 실패 (주문 자체는 이미 커밋됨)', err as Error);
     }
   }
 
   private async notifyOrderCreated(
-    userId: number,
+    userId: number | null,
+    orderSnapshot: Order,
     orderId: number,
     orderNumber: string,
     totalAmount: number,
@@ -48,14 +54,30 @@ export class OrderPostCommitService {
     const order = typeof this.orderRepository.findOne === 'function'
       ? await this.orderRepository.findOne({
         where: { id: orderId },
-        relations: ['items'],
+        relations: ['items', 'user'],
       })
       : null;
-    const locale = 'ko';
+    const notificationOrder = order ?? orderSnapshot;
+    const locale = this.getOrderLocale(notificationOrder);
+    const guestEmailNormalized = this.getGuestEmailNormalized(notificationOrder);
+    const orderUrl = userId === null
+      ? buildGuestOrderLookupUrl(locale)
+      : buildOrderUrl(orderId, locale);
+
+    if (userId === null && !guestEmailNormalized) {
+      return;
+    }
 
     await this.notificationDispatchHelper.dispatch({
       event: 'order.confirmed',
-      userId,
+      ...(userId === null
+        ? {
+          recipient: {
+            email: guestEmailNormalized!,
+            name: recipientName,
+          },
+        }
+        : { userId }),
       resourceId: orderId,
       mode: 'fire-and-forget',
       logger: this.logger,
@@ -64,9 +86,23 @@ export class OrderPostCommitService {
           recipientName,
           orderNumber,
           totalAmount,
-          orderItems: buildOrderEmailItems(order, locale),
-          orderUrl: buildOrderUrl(orderId, locale),
+          locale,
+          orderItems: buildOrderEmailItems(notificationOrder, locale),
+          orderUrl,
         }),
     });
+  }
+
+  private getOrderUserId(order: Order | null | undefined): number | null {
+    const userId = (order as (Order & { userId?: number | null }) | null | undefined)?.userId;
+    return userId == null ? null : Number(userId);
+  }
+
+  private getGuestEmailNormalized(order: Order | null | undefined): string | null {
+    return (order as (Order & { guestEmailNormalized?: string | null }) | null | undefined)?.guestEmailNormalized ?? null;
+  }
+
+  private getOrderLocale(order: Order | null | undefined): 'ko' | 'en' {
+    return (order as (Order & { orderLocale?: 'ko' | 'en' }) | null | undefined)?.orderLocale ?? 'ko';
   }
 }

--- a/backend/src/modules/orders/order-service-requests.service.ts
+++ b/backend/src/modules/orders/order-service-requests.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { Order, OrderStatus } from './entities/order.entity';
@@ -29,6 +29,15 @@ interface PaymentCancellationService {
 }
 const ACTIVE_REQUEST_STATUSES = [OrderServiceRequestStatus.REQUESTED, OrderServiceRequestStatus.APPROVED];
 
+
+function assertMemberOwnedOrder(order: Order, userId: number): void {
+  if (order.userId == null) {
+    throw new ForbiddenException('비회원 주문은 주문 취소/반품/교환/환불 신청을 지원하지 않습니다.');
+  }
+
+  assertOwnership(order.userId, userId);
+}
+
 @Injectable()
 export class OrderServiceRequestsService {
   private readonly logger = new Logger(OrderServiceRequestsService.name);
@@ -46,7 +55,7 @@ export class OrderServiceRequestsService {
 
   async create(orderId: number, userId: number, dto: CreateOrderServiceRequestDto): Promise<OrderServiceRequest> {
     const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
-    assertOwnership(order.userId, userId);
+    assertMemberOwnedOrder(order, userId);
     this.assertRequestAllowed(order.status, dto.type);
 
     const existing = await this.requestRepository.findOne({
@@ -127,7 +136,7 @@ export class OrderServiceRequestsService {
 
   async findByOrderForUser(orderId: number, userId: number): Promise<OrderServiceRequest[]> {
     const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문을 찾을 수 없습니다.');
-    assertOwnership(order.userId, userId);
+    assertMemberOwnedOrder(order, userId);
     return this.requestRepository.find({
       where: { orderId, userId },
       order: { createdAt: 'DESC' },
@@ -269,7 +278,7 @@ export class OrderServiceRequestsService {
   }
 
   private async restorePoints(manager: import('typeorm').EntityManager, order: Order): Promise<void> {
-    if (!order.pointsUsed || order.pointsUsed <= 0) return;
+    if (!order.pointsUsed || order.pointsUsed <= 0 || order.userId == null) return;
 
     const last = await manager.findOne(PointHistory, {
       where: { userId: order.userId },

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -6,6 +6,7 @@ import { OrderItem } from './entities/order-item.entity';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { PolicyConsent } from '../pages/entities/policy-consent.entity';
 import { Payment } from '../payments/entities/payment.entity';
+import { GuestOrderAccess } from './entities/guest-order-access.entity';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 import { AdminOrderServiceRequestsController, OrderServiceRequestsController } from './order-service-requests.controller';
@@ -13,20 +14,37 @@ import { PointsModule } from '../points/points.module';
 import { CouponsModule } from '../coupons/coupons.module';
 import { ShippingModule } from '../shipping/shipping.module';
 import { OrderEventsModule } from './order-events.module';
+import { GuestOrdersController } from './guest-orders.controller';
+import { GuestOrdersService } from './guest-orders.service';
+import { GuestOrderCreationWorkflowService } from './guest-order-creation.workflow.service';
+import { GuestOrderAccessService } from './guest-order-access.service';
 import { OrderServiceRequestsService } from './order-service-requests.service';
 import { OrderCreationWorkflowService } from './order-creation.workflow.service';
 import { OrderPostCommitService } from './order-post-commit.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Order, OrderItem, OrderServiceRequest, PointHistory, PolicyConsent, Payment]),
+    TypeOrmModule.forFeature([Order, OrderItem, OrderServiceRequest, PointHistory, PolicyConsent, Payment, GuestOrderAccess]),
     PointsModule,
     CouponsModule,
     ShippingModule,
     OrderEventsModule,
   ],
-  controllers: [OrdersController, OrderServiceRequestsController, AdminOrderServiceRequestsController],
-  providers: [OrdersService, OrderCreationWorkflowService, OrderPostCommitService, OrderServiceRequestsService],
-  exports: [OrdersService, OrderServiceRequestsService, OrderEventsModule],
+  controllers: [
+    OrdersController,
+    GuestOrdersController,
+    OrderServiceRequestsController,
+    AdminOrderServiceRequestsController,
+  ],
+  providers: [
+    OrdersService,
+    OrderCreationWorkflowService,
+    GuestOrdersService,
+    GuestOrderCreationWorkflowService,
+    GuestOrderAccessService,
+    OrderPostCommitService,
+    OrderServiceRequestsService,
+  ],
+  exports: [OrdersService, GuestOrderAccessService, OrderServiceRequestsService, OrderEventsModule],
 })
 export class OrdersModule {}

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -8,6 +8,14 @@ import { paginate, PaginatedResult } from '../../common/utils/pagination.util';
 import { applyLocale } from '../../common/utils/locale.util';
 import { OrderCreationWorkflowService } from './order-creation.workflow.service';
 import { OrderPostCommitService } from './order-post-commit.service';
+function assertMemberOrderOwnership(order: Order, userId: number): void {
+  if (order.userId == null) {
+    throw new NotFoundException('주문을 찾을 수 없습니다.');
+  }
+
+  assertOwnership(order.userId, userId);
+}
+
 
 @Injectable()
 export class OrdersService {
@@ -82,7 +90,7 @@ export class OrdersService {
       throw new NotFoundException('주문을 찾을 수 없습니다.');
     }
 
-    assertOwnership(order.userId, userId);
+    assertMemberOrderOwnership(order, userId);
 
     return this.localizeOrder(order, locale);
   }

--- a/backend/src/modules/pages/entities/policy-consent.entity.ts
+++ b/backend/src/modules/pages/entities/policy-consent.entity.ts
@@ -28,8 +28,8 @@ export class PolicyConsent {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   id!: number;
 
-  @Column({ name: 'user_id', type: 'bigint' })
-  userId!: number;
+  @Column({ name: 'user_id', type: 'bigint', nullable: true })
+  userId!: number | null;
 
   @Column({ type: 'enum', enum: PolicyConsentContext })
   context!: PolicyConsentContext;
@@ -49,7 +49,7 @@ export class PolicyConsent {
   @CreateDateColumn({ name: 'consented_at' })
   consentedAt!: Date;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: true, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
-  user!: User;
+  user!: User | null;
 }

--- a/backend/src/modules/payments/__tests__/guest-payments.controller.spec.ts
+++ b/backend/src/modules/payments/__tests__/guest-payments.controller.spec.ts
@@ -39,9 +39,9 @@ describe('GuestPaymentsController', () => {
   });
 
   it('rejects prepare requests without a usable guest token header', async () => {
-    await expect(
-      Promise.resolve().then(() => controller.prepare(7, {} as never, { 'x-guest-access-token': '   ' })),
-    ).rejects.toThrow(UnauthorizedException);
+    await expect(controller.prepare(7, {} as never, { 'x-guest-access-token': '   ' })).rejects.toThrow(
+      UnauthorizedException,
+    );
     expect(guestPaymentsService.prepare).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/payments/__tests__/guest-payments.controller.spec.ts
+++ b/backend/src/modules/payments/__tests__/guest-payments.controller.spec.ts
@@ -38,10 +38,10 @@ describe('GuestPaymentsController', () => {
     expect(guestPaymentsService.confirm).toHaveBeenCalledWith(7, dto, 'upper-token');
   });
 
-  it('rejects prepare requests without a usable guest token header', () => {
-    expect(() => controller.prepare(7, {} as never, { 'x-guest-access-token': '   ' })).toThrow(
-      UnauthorizedException,
-    );
+  it('rejects prepare requests without a usable guest token header', async () => {
+    await expect(
+      Promise.resolve().then(() => controller.prepare(7, {} as never, { 'x-guest-access-token': '   ' })),
+    ).rejects.toThrow(UnauthorizedException);
     expect(guestPaymentsService.prepare).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/payments/__tests__/guest-payments.controller.spec.ts
+++ b/backend/src/modules/payments/__tests__/guest-payments.controller.spec.ts
@@ -1,0 +1,47 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { GuestPaymentsController } from '../guest-payments.controller';
+import { GuestPaymentsService } from '../guest-payments.service';
+
+describe('GuestPaymentsController', () => {
+  let controller: GuestPaymentsController;
+  let guestPaymentsService: {
+    prepare: jest.Mock;
+    confirm: jest.Mock;
+  };
+
+  beforeEach(() => {
+    guestPaymentsService = {
+      prepare: jest.fn().mockResolvedValue({ checkoutId: 'checkout-1' }),
+      confirm: jest.fn().mockResolvedValue({ ok: true }),
+    };
+
+    controller = new GuestPaymentsController(guestPaymentsService as unknown as GuestPaymentsService);
+  });
+
+  it('uses the first trimmed guest token from lowercase header arrays for prepare', async () => {
+    const dto = { locale: 'ko', gateway: 'naverpay' };
+
+    await expect(
+      controller.prepare(7, dto as never, { 'x-guest-access-token': [' guest-token ', 'ignored'] }),
+    ).resolves.toEqual({ checkoutId: 'checkout-1' });
+
+    expect(guestPaymentsService.prepare).toHaveBeenCalledWith(7, dto, 'guest-token');
+  });
+
+  it('accepts uppercase guest token headers for confirm', async () => {
+    const dto = { paymentKey: 'key', orderId: 'external-order-id', amount: 18000, gateway: 'paypal' };
+
+    await expect(
+      controller.confirm(7, dto as never, { 'X-Guest-Access-Token': ' upper-token ' }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(guestPaymentsService.confirm).toHaveBeenCalledWith(7, dto, 'upper-token');
+  });
+
+  it('rejects prepare requests without a usable guest token header', () => {
+    expect(() => controller.prepare(7, {} as never, { 'x-guest-access-token': '   ' })).toThrow(
+      UnauthorizedException,
+    );
+    expect(guestPaymentsService.prepare).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/payments/__tests__/guest-payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/guest-payments.service.spec.ts
@@ -1,0 +1,53 @@
+import { GuestPaymentsService } from '../guest-payments.service';
+import { PaymentsService } from '../payments.service';
+import { PaymentConfirmationService } from '../services/payment-confirmation.service';
+
+describe('GuestPaymentsService', () => {
+  let service: GuestPaymentsService;
+  let paymentsService: {
+    prepareForOrder: jest.Mock;
+  };
+  let paymentConfirmationService: {
+    assertGuestAccessTokenActive: jest.Mock;
+    confirmGuest: jest.Mock;
+  };
+
+  beforeEach(() => {
+    paymentsService = {
+      prepareForOrder: jest.fn().mockResolvedValue({ checkoutId: 'checkout-1' }),
+    };
+    paymentConfirmationService = {
+      assertGuestAccessTokenActive: jest.fn().mockResolvedValue(undefined),
+      confirmGuest: jest.fn().mockResolvedValue({ ok: true }),
+    };
+
+    service = new GuestPaymentsService(
+      paymentsService as unknown as PaymentsService,
+      paymentConfirmationService as unknown as PaymentConfirmationService,
+    );
+  });
+
+  it('verifies the guest access token before preparing payment', async () => {
+    await expect(
+      service.prepare(33, { locale: 'en', gateway: 'paypal' }, 'guest-access-token'),
+    ).resolves.toEqual({ checkoutId: 'checkout-1' });
+
+    expect(paymentConfirmationService.assertGuestAccessTokenActive).toHaveBeenCalledWith(33, 'guest-access-token');
+    expect(paymentsService.prepareForOrder).toHaveBeenCalledWith(33, {
+      locale: 'en',
+      gateway: 'paypal',
+    });
+  });
+
+  it('delegates guest confirmation to the confirmation service', async () => {
+    const dto = {
+      paymentKey: 'payment-key',
+      orderId: 'external-order-id',
+      amount: 18000,
+      gateway: 'paypal',
+    };
+
+    await expect(service.confirm(33, dto, 'guest-access-token')).resolves.toEqual({ ok: true });
+    expect(paymentConfirmationService.confirmGuest).toHaveBeenCalledWith(33, dto, 'guest-access-token');
+  });
+});

--- a/backend/src/modules/payments/__tests__/payments.module.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.module.spec.ts
@@ -1,5 +1,45 @@
+import { MODULE_METADATA } from '@nestjs/common/constants';
 import { createPaymentConfig } from '../../../config/payment.config';
+import { GuestOrderAccessService } from '../../orders/guest-order-access.service';
+import { OrdersModule } from '../../orders/orders.module';
 import { getAvailableGatewaysByLocale, resolveGatewayByLocale } from '../checkout-gateway.policy';
+import { GuestPaymentsController } from '../guest-payments.controller';
+import { GuestPaymentsService } from '../guest-payments.service';
+import { PaymentsController } from '../payments.controller';
+import { PaymentsModule } from '../payments.module';
+import { PaymentsService } from '../payments.service';
+import { PaymentConfirmationService } from '../services/payment-confirmation.service';
+
+describe('PaymentsModule wiring', () => {
+  it('imports OrdersModule for guest payment dependencies', () => {
+    const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, PaymentsModule) as unknown[];
+
+    expect(imports).toEqual(expect.arrayContaining([OrdersModule]));
+  });
+
+  it('registers guest payment controller and shared confirmation providers', () => {
+    const controllers = Reflect.getMetadata(MODULE_METADATA.CONTROLLERS, PaymentsModule) as unknown[];
+    const providers = Reflect.getMetadata(MODULE_METADATA.PROVIDERS, PaymentsModule) as Array<unknown>;
+
+    expect(controllers).toEqual(expect.arrayContaining([PaymentsController, GuestPaymentsController]));
+    expect(providers).toEqual(
+      expect.arrayContaining([PaymentConfirmationService, PaymentsService, GuestPaymentsService]),
+    );
+    expect(providers).toContainEqual({ provide: 'PaymentsService', useExisting: PaymentsService });
+  });
+
+  it('keeps explicit exports for member payments surface', () => {
+    const exportsList = Reflect.getMetadata(MODULE_METADATA.EXPORTS, PaymentsModule) as unknown[];
+
+    expect(exportsList).toEqual(expect.arrayContaining([PaymentsService, 'PaymentsService']));
+  });
+
+  it('OrdersModule explicitly exports GuestOrderAccessService for guest payment flows', () => {
+    const exportsList = Reflect.getMetadata(MODULE_METADATA.EXPORTS, OrdersModule) as unknown[];
+
+    expect(exportsList).toEqual(expect.arrayContaining([GuestOrderAccessService]));
+  });
+});
 
 describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
   it('NODE_ENV=production, PAYMENT_GATEWAY=mock → 시작 실패', () => {
@@ -8,9 +48,7 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
         NODE_ENV: 'production',
         PAYMENT_GATEWAY: 'mock',
       }),
-    ).toThrow(
-      'Mock payment gateway는 프로덕션에서 사용할 수 없습니다',
-    );
+    ).toThrow('Mock payment gateway는 프로덕션에서 사용할 수 없습니다');
   });
 
   it('NODE_ENV=production, PAYMENT_GATEWAY 미설정 → 시작 실패', () => {
@@ -18,9 +56,7 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
       createPaymentConfig({
         NODE_ENV: 'production',
       }),
-    ).toThrow(
-      'Mock payment gateway는 프로덕션에서 사용할 수 없습니다',
-    );
+    ).toThrow('Mock payment gateway는 프로덕션에서 사용할 수 없습니다');
   });
 
   it('NODE_ENV=development, PAYMENT_GATEWAY=mock → 정상 동작', () => {
@@ -28,6 +64,7 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
       NODE_ENV: 'development',
       PAYMENT_GATEWAY: 'mock',
     });
+
     expect(config.gateway).toBe('mock');
   });
 
@@ -36,6 +73,7 @@ describe('createPaymentConfig — 프로덕션 Mock 차단', () => {
       NODE_ENV: 'production',
       PAYMENT_GATEWAY: 'toss',
     });
+
     expect(config.gateway).toBe('toss');
   });
 

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -18,6 +18,8 @@ import { EximbayPaymentAdapter } from '../adapters/eximbay.adapter';
 import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import { PAYMENT_CONFIG, createPaymentConfig } from '../../../config/payment.config';
+import { PaymentConfirmationService } from '../services/payment-confirmation.service';
+import { GuestOrderAccessService } from '../../orders/guest-order-access.service';
 import { User } from '../../users/entities/user.entity';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order =>
@@ -218,6 +220,15 @@ describe('PaymentsService', () => {
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
         { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
         { provide: DataSource, useValue: mockDataSource },
+        {
+          provide: GuestOrderAccessService,
+          useValue: {
+            getValidAccessOrThrow: jest.fn(),
+            withOrderAccessLock: jest.fn(),
+            rotateAccessTokenForOrder: jest.fn(),
+          },
+        },
+        PaymentConfirmationService,
       ],
     }).compile();
 

--- a/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.webhook.spec.ts
@@ -17,6 +17,8 @@ import { EximbayPaymentAdapter } from '../adapters/eximbay.adapter';
 import { NotificationService } from '../../notification/notification.service';
 import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
 import { PAYMENT_CONFIG, createPaymentConfig } from '../../../config/payment.config';
+import { PaymentConfirmationService } from '../services/payment-confirmation.service';
+import { GuestOrderAccessService } from '../../orders/guest-order-access.service';
 
 describe('PaymentsService — webhook', () => {
   let service: PaymentsService;
@@ -78,6 +80,15 @@ describe('PaymentsService — webhook', () => {
         { provide: NotificationService, useValue: { sendPaymentConfirmed: jest.fn() } },
         { provide: NotificationDispatchHelper, useValue: { dispatch: jest.fn().mockResolvedValue(undefined) } },
         { provide: DataSource, useValue: mockDataSource },
+        {
+          provide: GuestOrderAccessService,
+          useValue: {
+            getValidAccessOrThrow: jest.fn(),
+            withOrderAccessLock: jest.fn(),
+            rotateAccessTokenForOrder: jest.fn(),
+          },
+        },
+        PaymentConfirmationService,
       ],
     }).compile();
 

--- a/backend/src/modules/payments/dto/guest-confirm-payment.dto.ts
+++ b/backend/src/modules/payments/dto/guest-confirm-payment.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+export class GuestConfirmPaymentDto {
+  @ApiProperty({ example: 'payment_key_from_toss', description: '결제 키' })
+  @IsString({ message: '결제 키를 입력해 주세요.' })
+  @IsNotEmpty({ message: '결제 키를 입력해 주세요.' })
+  paymentKey!: string;
+
+  @ApiProperty({ example: 35000, description: '결제 금액' })
+  @IsInt({ message: '결제 금액은 정수여야 합니다.' })
+  amount!: number;
+}

--- a/backend/src/modules/payments/dto/guest-prepare-payment.dto.ts
+++ b/backend/src/modules/payments/dto/guest-prepare-payment.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional, IsString } from 'class-validator';
+
+export class GuestPreparePaymentDto {
+  @ApiPropertyOptional({ example: 'ko', enum: ['ko', 'en'], description: '로케일' })
+  @IsOptional()
+  @IsString({ message: '로케일은 문자열이어야 합니다.' })
+  @IsIn(['ko', 'en'], { message: '로케일은 ko 또는 en만 지원합니다.' })
+  locale?: 'ko' | 'en';
+
+  @ApiPropertyOptional({
+    example: 'paypal',
+    enum: ['naverpay', 'bank_transfer', 'eximbay', 'paypal'],
+    description: '사용자가 명시적으로 선택한 결제 게이트웨이',
+  })
+  @IsOptional()
+  @IsString({ message: '결제 게이트웨이는 문자열이어야 합니다.' })
+  @IsIn(['naverpay', 'bank_transfer', 'eximbay', 'paypal'], { message: '결제 게이트웨이는 naverpay, bank_transfer, eximbay 또는 paypal만 지원합니다.' })
+  gateway?: 'naverpay' | 'bank_transfer' | 'eximbay' | 'paypal';
+}

--- a/backend/src/modules/payments/guest-payments.controller.ts
+++ b/backend/src/modules/payments/guest-payments.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ApiHeader,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Public } from '../../common/decorators/public.decorator';
+import { GuestPreparePaymentDto } from './dto/guest-prepare-payment.dto';
+import { GuestConfirmPaymentDto } from './dto/guest-confirm-payment.dto';
+import { GuestPaymentsService } from './guest-payments.service';
+
+@ApiTags('게스트 결제')
+@Controller('guest/orders')
+export class GuestPaymentsController {
+  constructor(private readonly guestPaymentsService: GuestPaymentsService) {}
+
+  @Public()
+  @Post(':id/payments/prepare')
+  @ApiOperation({ summary: '게스트 결제 준비', description: '게스트 주문의 결제를 준비합니다.' })
+  @ApiParam({ name: 'id', type: Number, description: '주문 ID' })
+  @ApiHeader({ name: 'X-Guest-Access-Token', required: true, description: '게스트 주문 접근 토큰' })
+  @ApiResponse({ status: 201, description: '결제 준비 성공' })
+  @ApiResponse({ status: 401, description: '게스트 접근 토큰 필요 또는 만료' })
+  prepare(
+    @Param('id', ParseIntPipe) orderId: number,
+    @Body() dto: GuestPreparePaymentDto,
+    @Headers() headers: Record<string, string | string[] | undefined>,
+  ) {
+    return this.guestPaymentsService.prepare(orderId, dto, this.readGuestAccessToken(headers));
+  }
+
+  @Public()
+  @Post(':id/payments/confirm')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '게스트 결제 승인', description: '게스트 주문의 결제를 확정하고 접근 토큰을 회전합니다.' })
+  @ApiParam({ name: 'id', type: Number, description: '주문 ID' })
+  @ApiHeader({ name: 'X-Guest-Access-Token', required: true, description: '게스트 주문 접근 토큰' })
+  @ApiResponse({ status: 200, description: '결제 승인 성공' })
+  @ApiResponse({ status: 401, description: '게스트 접근 토큰 필요 또는 만료' })
+  @ApiResponse({ status: 409, description: '이미 처리된 결제' })
+  confirm(
+    @Param('id', ParseIntPipe) orderId: number,
+    @Body() dto: GuestConfirmPaymentDto,
+    @Headers() headers: Record<string, string | string[] | undefined>,
+  ) {
+    return this.guestPaymentsService.confirm(orderId, dto, this.readGuestAccessToken(headers));
+  }
+
+  private readGuestAccessToken(headers: Record<string, string | string[] | undefined>): string {
+    const value = headers['x-guest-access-token'] ?? headers['X-Guest-Access-Token'];
+    const token = Array.isArray(value) ? value[0] : value;
+
+    if (!token?.trim()) {
+      throw new UnauthorizedException('게스트 주문 접근 토큰이 필요합니다.');
+    }
+
+    return token.trim();
+  }
+}

--- a/backend/src/modules/payments/guest-payments.controller.ts
+++ b/backend/src/modules/payments/guest-payments.controller.ts
@@ -33,7 +33,7 @@ export class GuestPaymentsController {
   @ApiHeader({ name: 'X-Guest-Access-Token', required: true, description: '게스트 주문 접근 토큰' })
   @ApiResponse({ status: 201, description: '결제 준비 성공' })
   @ApiResponse({ status: 401, description: '게스트 접근 토큰 필요 또는 만료' })
-  prepare(
+  async prepare(
     @Param('id', ParseIntPipe) orderId: number,
     @Body() dto: GuestPreparePaymentDto,
     @Headers() headers: Record<string, string | string[] | undefined>,
@@ -50,7 +50,7 @@ export class GuestPaymentsController {
   @ApiResponse({ status: 200, description: '결제 승인 성공' })
   @ApiResponse({ status: 401, description: '게스트 접근 토큰 필요 또는 만료' })
   @ApiResponse({ status: 409, description: '이미 처리된 결제' })
-  confirm(
+  async confirm(
     @Param('id', ParseIntPipe) orderId: number,
     @Body() dto: GuestConfirmPaymentDto,
     @Headers() headers: Record<string, string | string[] | undefined>,

--- a/backend/src/modules/payments/guest-payments.service.ts
+++ b/backend/src/modules/payments/guest-payments.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { GuestPreparePaymentDto } from './dto/guest-prepare-payment.dto';
+import { GuestConfirmPaymentDto } from './dto/guest-confirm-payment.dto';
+import { PaymentsService } from './payments.service';
+import { PaymentConfirmationService } from './services/payment-confirmation.service';
+
+@Injectable()
+export class GuestPaymentsService {
+  constructor(
+    private readonly paymentsService: PaymentsService,
+    private readonly paymentConfirmationService: PaymentConfirmationService,
+  ) {}
+
+  async prepare(orderId: number, dto: GuestPreparePaymentDto, guestAccessToken: string) {
+    await this.paymentConfirmationService.assertGuestAccessTokenActive(orderId, guestAccessToken);
+
+    return this.paymentsService.prepareForOrder(orderId, {
+      locale: dto.locale,
+      gateway: dto.gateway,
+    });
+  }
+
+  async confirm(orderId: number, dto: GuestConfirmPaymentDto, guestAccessToken: string) {
+    return this.paymentConfirmationService.confirmGuest(orderId, dto, guestAccessToken);
+  }
+}

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -6,12 +6,16 @@ import { Refund } from './entities/refund.entity';
 import { Shipping } from './entities/shipping.entity';
 import { Order } from '../orders/entities/order.entity';
 import { OrderEventsModule } from '../orders/order-events.module';
+import { OrdersModule } from '../orders/orders.module';
 import { PointHistory } from '../coupons/entities/point-history.entity';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
+import { GuestPaymentsController } from './guest-payments.controller';
+import { GuestPaymentsService } from './guest-payments.service';
 import { AdminOrderRefundsController } from './admin-order-refunds.controller';
 import { AdminPaymentWebhooksController } from './admin-payment-webhooks.controller';
 import { gatewayProviders } from './payment-gateway.provider';
+import { PaymentConfirmationService } from './services/payment-confirmation.service';
 import {
   getCheckoutGatewayOptions,
   getDefaultCheckoutGateway,
@@ -35,9 +39,24 @@ export function resolveGatewayByLocale(locale: string): CheckoutGatewayName {
 export { isCheckoutGatewayName };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment, PaymentWebhookEvent, Refund, Shipping, Order, PointHistory]), OrderEventsModule],
-  controllers: [PaymentsController, AdminOrderRefundsController, AdminPaymentWebhooksController],
-  providers: [...gatewayProviders, PaymentsService, { provide: 'PaymentsService', useExisting: PaymentsService }],
+  imports: [
+    TypeOrmModule.forFeature([Payment, PaymentWebhookEvent, Refund, Shipping, Order, PointHistory]),
+    OrderEventsModule,
+    OrdersModule,
+  ],
+  controllers: [
+    PaymentsController,
+    GuestPaymentsController,
+    AdminOrderRefundsController,
+    AdminPaymentWebhooksController,
+  ],
+  providers: [
+    ...gatewayProviders,
+    PaymentConfirmationService,
+    PaymentsService,
+    GuestPaymentsService,
+    { provide: 'PaymentsService', useExisting: PaymentsService },
+  ],
   exports: [PaymentsService, 'PaymentsService'],
 })
 export class PaymentsModule {}

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -1,6 +1,6 @@
 import {
-  Injectable, BadRequestException, ConflictException, NotFoundException, UnauthorizedException,
-  Logger, Inject, Optional,
+  Injectable, BadRequestException, ConflictException, ForbiddenException, NotFoundException, UnauthorizedException,
+  Logger, Inject,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, Repository } from 'typeorm';
@@ -29,19 +29,14 @@ import {
 } from './checkout-gateway.policy';
 import { assertOwnership } from '../../common/utils/ownership.util';
 import { findOrThrow } from '../../common/utils/repository.util';
-import { NotificationService } from '../notification/notification.service';
-import { MessageNotificationService } from '../notification/message-notification.service';
-import { NotificationDispatchHelper } from '../notification/notification-dispatch.helper';
 import { PaymentConfirmationService } from './services/payment-confirmation.service';
 import { PaymentRefundService } from './services/payment-refund.service';
 import { PaymentWebhookService } from './services/payment-webhook.service';
 import { PAYMENT_CONFIG, PaymentConfig } from '../../config/payment.config';
-import { OrderEventEmitter } from '../orders/order-event.emitter';
 
 @Injectable()
 export class PaymentsService {
   private readonly logger = new Logger(PaymentsService.name);
-  private readonly paymentConfirmationService: PaymentConfirmationService;
   private readonly paymentRefundService: PaymentRefundService;
   private readonly paymentWebhookService: PaymentWebhookService;
 
@@ -66,27 +61,9 @@ export class PaymentsService {
     private readonly naverpayAdapter: NaverPayPaymentAdapter,
     private readonly paypalAdapter: PayPalPaymentAdapter,
     private readonly eximbayAdapter: EximbayPaymentAdapter,
-    private readonly notificationService: NotificationService,
-    @Optional()
-    private readonly messageNotificationService: MessageNotificationService | undefined,
-    private readonly notificationDispatchHelper: NotificationDispatchHelper,
-    @Optional()
-    private readonly orderEventEmitter: OrderEventEmitter | undefined,
+    private readonly paymentConfirmationService: PaymentConfirmationService,
     private readonly dataSource: DataSource,
   ) {
-    this.paymentConfirmationService = new PaymentConfirmationService({
-      paymentRepository: this.paymentRepository,
-      orderRepository: this.orderRepository,
-      shippingRepository: this.shippingRepository,
-      dataSource: this.dataSource,
-      notificationService: this.notificationService,
-      messageNotificationService: this.messageNotificationService,
-      notificationDispatchHelper: this.notificationDispatchHelper,
-      resolveGatewayByType: (gatewayType) => this.resolveGatewayByType(gatewayType),
-      logger: this.logger,
-      defaultCarrier: this.paymentConfig.defaultCarrier,
-      orderEventEmitter: this.orderEventEmitter,
-    });
     this.paymentRefundService = new PaymentRefundService({
       paymentRepository: this.paymentRepository,
       refundRepository: this.refundRepository,
@@ -166,59 +143,84 @@ export class PaymentsService {
     redirectUrl?: string;
     gatewayPayload?: Record<string, string | number | boolean>;
   }> {
-    const order = await findOrThrow(this.orderRepository, { id: dto.orderId }, '주문을 찾을 수 없습니다.');
-    assertOwnership(order.userId, userId);
-    if (order.status !== OrderStatus.PENDING) {
-      throw new ConflictException('이미 처리된 주문입니다.');
-    }
+const order = await findOrThrow(this.orderRepository, { id: dto.orderId }, '주문을 찾을 수 없습니다.');
+this.assertMemberOwnership(order.userId, userId);
 
-    const locale = dto.locale ?? 'ko';
-    const availableGateways = getAvailableGatewaysByLocale(locale);
-    const gatewayName = dto.gateway && isCheckoutGatewayName(dto.gateway) && availableGateways.includes(dto.gateway)
-      ? dto.gateway
-      : dto.locale
-        ? resolveGatewayByLocale(locale)
-        : this.paymentConfig.gateway;
-    const selectedGateway = this.resolveGatewayByName(gatewayName);
+return this.prepareForOrder(Number(order.id), {
+  locale: dto.locale,
+  gateway: dto.gateway,
+});
 
-    let payment = await this.paymentRepository.findOne({ where: { orderId: dto.orderId } });
-    if (!payment) {
-      payment = this.paymentRepository.create({
-        orderId: dto.orderId,
-        amount: Number(order.totalAmount),
-        status: PaymentStatus.PENDING,
-        method: gatewayName === 'bank_transfer' ? PaymentMethod.BANK_TRANSFER : PaymentMethod.MOCK,
-        gateway: gatewayName === 'bank_transfer' ? PaymentGatewayType.MOCK : this.gatewayNameToType(gatewayName),
-      });
-      payment = await this.paymentRepository.save(payment);
-    } else {
-      await this.paymentRepository.update(payment.id, {
-        method: gatewayName === 'bank_transfer' ? PaymentMethod.BANK_TRANSFER : PaymentMethod.MOCK,
-        gateway: gatewayName === 'bank_transfer' ? PaymentGatewayType.MOCK : this.gatewayNameToType(gatewayName),
-      });
-      payment = await findOrThrow(this.paymentRepository, { id: payment.id }, '결제 정보를 찾을 수 없습니다.');
-    }
+  }
 
-    if (gatewayName === 'bank_transfer') {
-      return {
-        paymentId: Number(payment.id),
-        orderId: dto.orderId,
-        orderNumber: order.orderNumber,
-        amount: Number(order.totalAmount),
-        gateway: gatewayName,
-        clientKey: 'bank_transfer',
-        availableGateways,
-      };
-    }
+  async prepareForOrder(
+    orderId: number,
+    options: Pick<PreparePaymentDto, 'locale' | 'gateway'>,
+  ): Promise<{
+    paymentId: number;
+    orderId: number;
+    orderNumber: string;
+    amount: number;
+    gateway: string;
+    clientKey: string;
+    availableGateways: string[];
+    redirectUrl?: string;
+    gatewayPayload?: Record<string, string | number | boolean>;
+  }> {
+const normalizedOrderId = Number(orderId);
+const order = await findOrThrow(this.orderRepository, { id: normalizedOrderId }, '주문을 찾을 수 없습니다.');
 
-    const result = await selectedGateway.prepare(String(dto.orderId), Number(order.totalAmount), {
+if (order.status !== OrderStatus.PENDING) {
+  throw new ConflictException('이미 처리된 주문입니다.');
+}
+
+const locale = options.locale ?? 'ko';
+const availableGateways = getAvailableGatewaysByLocale(locale);
+const gatewayName = options.gateway && isCheckoutGatewayName(options.gateway) && availableGateways.includes(options.gateway)
+  ? options.gateway
+  : options.locale
+    ? resolveGatewayByLocale(locale)
+    : this.paymentConfig.gateway;
+const selectedGateway = this.resolveGatewayByName(gatewayName);
+
+let payment = await this.paymentRepository.findOne({ where: { orderId: normalizedOrderId } });
+if (!payment) {
+  payment = this.paymentRepository.create({
+    orderId: normalizedOrderId,
+    amount: Number(order.totalAmount),
+    status: PaymentStatus.PENDING,
+    method: gatewayName === 'bank_transfer' ? PaymentMethod.BANK_TRANSFER : PaymentMethod.MOCK,
+    gateway: gatewayName === 'bank_transfer' ? PaymentGatewayType.MOCK : this.gatewayNameToType(gatewayName),
+  });
+  payment = await this.paymentRepository.save(payment);
+} else {
+  await this.paymentRepository.update(payment.id, {
+    method: gatewayName === 'bank_transfer' ? PaymentMethod.BANK_TRANSFER : PaymentMethod.MOCK,
+    gateway: gatewayName === 'bank_transfer' ? PaymentGatewayType.MOCK : this.gatewayNameToType(gatewayName),
+  });
+  payment = await findOrThrow(this.paymentRepository, { id: payment.id }, '결제 정보를 찾을 수 없습니다.');
+}
+
+if (gatewayName === 'bank_transfer') {
+  return {
+    paymentId: Number(payment.id),
+    orderId: normalizedOrderId,
+    orderNumber: order.orderNumber,
+    amount: Number(order.totalAmount),
+    gateway: gatewayName,
+    clientKey: 'bank_transfer',
+    availableGateways,
+  };
+}
+
+    const result = await selectedGateway.prepare(String(normalizedOrderId), Number(order.totalAmount), {
       locale,
       orderNumber: order.orderNumber,
     });
 
     return {
       paymentId: Number(payment.id),
-      orderId: dto.orderId,
+      orderId: normalizedOrderId,
       orderNumber: order.orderNumber,
       amount: Number(order.totalAmount),
       gateway: gatewayName,
@@ -248,7 +250,7 @@ export class PaymentsService {
     cancelReason: string;
   }> {
     const payment = await findOrThrow(this.paymentRepository, { orderId: dto.orderId }, '결제 정보를 찾을 수 없습니다.', ['order']);
-    assertOwnership(payment.order.userId, userId);
+    this.assertMemberOwnership(payment.order.userId, userId);
 
     if (payment.status !== PaymentStatus.CONFIRMED) {
       throw new BadRequestException('취소 가능한 상태가 아닙니다.');
@@ -461,7 +463,7 @@ export class PaymentsService {
   }
 
   private async restorePoints(manager: EntityManager, order: Order): Promise<void> {
-    if (!order.pointsUsed || order.pointsUsed <= 0) return;
+    if (!order.pointsUsed || order.pointsUsed <= 0 || order.userId === null) return;
 
     const last = await manager.findOne(PointHistory, {
       where: { userId: order.userId },
@@ -476,6 +478,14 @@ export class PaymentsService {
       orderId: Number(order.id),
       description: `주문 ${order.orderNumber} 취소로 인한 적립금 복구`,
     });
+  }
+
+  private assertMemberOwnership(orderUserId: number | null, userId: number): void {
+    if (orderUserId === null) {
+      throw new ForbiddenException('접근 권한이 없습니다.');
+    }
+
+    assertOwnership(orderUserId, userId);
   }
 }
 

--- a/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
@@ -3,9 +3,19 @@ import {
   ConflictException,
   ForbiddenException,
   InternalServerErrorException,
-  Logger,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
+import { createPaymentConfig } from '../../../config/payment.config';
+import { NotificationService } from '../../notification/notification.service';
+import { NotificationDispatchHelper } from '../../notification/notification-dispatch.helper';
+import { TossPaymentAdapter } from '../adapters/toss.adapter';
+import { StripePaymentAdapter } from '../adapters/stripe.adapter';
+import { KGInicisPaymentAdapter } from '../adapters/inicis.adapter';
+import { NaverPayPaymentAdapter } from '../adapters/naverpay.adapter';
+import { PayPalPaymentAdapter } from '../adapters/paypal.adapter';
+import { EximbayPaymentAdapter } from '../adapters/eximbay.adapter';
+import { GuestOrderAccessService } from '../../orders/guest-order-access.service';
 import { PaymentConfirmationService } from './payment-confirmation.service';
 import {
   Payment,
@@ -70,14 +80,27 @@ interface BuildArgs {
     update: jest.Mock;
   }>;
   orderRepo?: Partial<{ findOne: jest.Mock; update: jest.Mock }>;
-  shippingRepo?: Partial<{ findOne: jest.Mock }>;
   dataSource?: ReturnType<typeof makeDataSource>;
-  gateway?: Partial<PaymentGateway>;
-  resolveGateway?: jest.Mock;
+  defaultGateway?: Partial<PaymentGateway>;
+  tossGateway?: Partial<PaymentGateway>;
+  stripeGateway?: Partial<PaymentGateway>;
+  inicisGateway?: Partial<PaymentGateway>;
+  naverpayGateway?: Partial<PaymentGateway>;
+  paypalGateway?: Partial<PaymentGateway>;
+  eximbayGateway?: Partial<PaymentGateway>;
   notifyDispatch?: jest.Mock;
   notificationSend?: jest.Mock;
   orderEventEmit?: jest.Mock;
 }
+
+const makeGateway = (overrides: Partial<PaymentGateway> = {}): PaymentGateway => ({
+  prepare: jest.fn(),
+  confirm: jest.fn(),
+  cancel: jest.fn(),
+  partialCancel: jest.fn(),
+  verifyWebhook: jest.fn(),
+  ...overrides,
+}) as PaymentGateway;
 
 const buildService = (args: BuildArgs = {}) => {
   const paymentRepo = {
@@ -90,55 +113,64 @@ const buildService = (args: BuildArgs = {}) => {
     update: jest.fn().mockResolvedValue({}),
     ...args.orderRepo,
   };
-  const shippingRepo = {
-    findOne: jest.fn(),
-    ...args.shippingRepo,
-  };
   const dataSource = args.dataSource ?? makeDataSource();
-  const gateway: PaymentGateway = {
-    prepare: jest.fn(),
-    confirm: jest.fn(),
-    cancel: jest.fn(),
-    partialCancel: jest.fn(),
-    verifyWebhook: jest.fn(),
-    ...args.gateway,
-  } as PaymentGateway;
-  const resolveGatewayByType = args.resolveGateway ?? jest.fn(() => gateway);
+  const defaultGateway = makeGateway(args.defaultGateway);
+  const tossGateway = makeGateway(args.tossGateway);
+  const stripeGateway = makeGateway(args.stripeGateway);
+  const inicisGateway = makeGateway(args.inicisGateway);
+  const naverpayGateway = makeGateway(args.naverpayGateway);
+  const paypalGateway = makeGateway(args.paypalGateway);
+  const eximbayGateway = makeGateway(args.eximbayGateway);
   const notificationDispatch =
     args.notifyDispatch ?? jest.fn().mockResolvedValue(undefined);
   const notificationSend =
     args.notificationSend ?? jest.fn().mockResolvedValue(undefined);
-
   const orderEventEmit = args.orderEventEmit ?? jest.fn();
+  const guestOrderAccessService = {
+    getValidAccessOrThrow: jest.fn(),
+    withOrderAccessLock: jest.fn(),
+    rotateAccessTokenForOrder: jest.fn(),
+  };
 
-  const service = new PaymentConfirmationService({
-    paymentRepository: paymentRepo as never,
-    orderRepository: orderRepo as never,
-    shippingRepository: shippingRepo as never,
-    dataSource: dataSource as never,
-    notificationService: {
-      sendPaymentConfirmed: notificationSend,
-    } as never,
-    notificationDispatchHelper: {
-      dispatch: notificationDispatch,
-    } as never,
-    resolveGatewayByType,
-    logger: new Logger('PaymentConfirmationService.spec'),
-    defaultCarrier: 'mock',
-    orderEventEmitter: { emitOrderCompleted: orderEventEmit } as never,
-  });
+  const service = new PaymentConfirmationService(
+    paymentRepo as never,
+    orderRepo as never,
+    defaultGateway as never,
+    createPaymentConfig({
+      NODE_ENV: 'development',
+      PAYMENT_GATEWAY: 'mock',
+      DEFAULT_CARRIER: 'mock',
+    }),
+    tossGateway as unknown as TossPaymentAdapter,
+    stripeGateway as unknown as StripePaymentAdapter,
+    inicisGateway as unknown as KGInicisPaymentAdapter,
+    naverpayGateway as unknown as NaverPayPaymentAdapter,
+    paypalGateway as unknown as PayPalPaymentAdapter,
+    eximbayGateway as unknown as EximbayPaymentAdapter,
+    dataSource as never,
+    { sendPaymentConfirmed: notificationSend } as unknown as NotificationService,
+    undefined,
+    { dispatch: notificationDispatch } as unknown as NotificationDispatchHelper,
+    { emitOrderCompleted: orderEventEmit } as never,
+    guestOrderAccessService as unknown as GuestOrderAccessService,
+  );
 
   return {
     service,
     paymentRepo,
     orderRepo,
-    shippingRepo,
     dataSource,
-    gateway,
-    resolveGatewayByType,
+    defaultGateway,
+    tossGateway,
+    stripeGateway,
+    inicisGateway,
+    naverpayGateway,
+    paypalGateway,
+    eximbayGateway,
     notificationDispatch,
     notificationSend,
     orderEventEmit,
+    guestOrderAccessService,
   };
 };
 
@@ -150,10 +182,10 @@ describe('PaymentConfirmationService', () => {
   describe('confirm() — 정상 흐름', () => {
     it('PENDING 결제를 CONFIRMED 로 전환하고 paidAt 을 기록한다', async () => {
       const payment = makePayment();
-      const { service, paymentRepo, dataSource, gateway } = buildService({
+      const { service, paymentRepo, dataSource, defaultGateway } = buildService({
         paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
       });
-      (gateway.confirm as jest.Mock).mockResolvedValue({
+      (defaultGateway.confirm as jest.Mock).mockResolvedValue({
         paymentKey: 'pay_abc',
         method: 'mock',
         amount: 30000,
@@ -195,10 +227,10 @@ describe('PaymentConfirmationService', () => {
 
     it('order 를 PAID 로 갱신하고 신규 shipping 을 생성한다', async () => {
       const payment = makePayment();
-      const { service, dataSource, gateway } = buildService({
+      const { service, dataSource, defaultGateway } = buildService({
         paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
       });
-      (gateway.confirm as jest.Mock).mockResolvedValue({
+      (defaultGateway.confirm as jest.Mock).mockResolvedValue({
         paymentKey: 'pay_abc',
         method: 'mock',
         amount: 30000,
@@ -232,11 +264,11 @@ describe('PaymentConfirmationService', () => {
         findOne: jest.fn().mockResolvedValue(existingShipping),
       });
       const dataSource = makeDataSource(manager);
-      const { service, gateway } = buildService({
+      const { service, defaultGateway } = buildService({
         paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
         dataSource,
       });
-      (gateway.confirm as jest.Mock).mockResolvedValue({
+      (defaultGateway.confirm as jest.Mock).mockResolvedValue({
         paymentKey: 'pay_abc',
         method: 'mock',
         amount: 30000,
@@ -279,14 +311,14 @@ describe('PaymentConfirmationService', () => {
 
     it('이미 CONFIRMED → ConflictException (이중 결제 방지)', async () => {
       const payment = makePayment({ status: PaymentStatus.CONFIRMED });
-      const { service, gateway } = buildService({
+      const { service, defaultGateway } = buildService({
         paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
       });
 
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
       ).rejects.toThrow(ConflictException);
-      expect(gateway.confirm).not.toHaveBeenCalled();
+      expect(defaultGateway.confirm).not.toHaveBeenCalled();
     });
 
     it('PENDING 외 상태 (FAILED) → BadRequestException', async () => {
@@ -302,33 +334,33 @@ describe('PaymentConfirmationService', () => {
 
     it('REFUNDED 상태 → BadRequestException (환불 후 재결제 거부)', async () => {
       const payment = makePayment({ status: PaymentStatus.REFUNDED });
-      const { service, gateway } = buildService({
+      const { service, defaultGateway } = buildService({
         paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
       });
 
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
       ).rejects.toThrow(BadRequestException);
-      expect(gateway.confirm).not.toHaveBeenCalled();
+      expect(defaultGateway.confirm).not.toHaveBeenCalled();
     });
 
     it('amount 가 주문 totalAmount 와 불일치 → BadRequestException', async () => {
       const payment = makePayment();
-      const { service, gateway } = buildService({
+      const { service, defaultGateway } = buildService({
         paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
       });
 
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pk', amount: 99999 }, 10),
       ).rejects.toThrow(BadRequestException);
-      expect(gateway.confirm).not.toHaveBeenCalled();
+      expect(defaultGateway.confirm).not.toHaveBeenCalled();
     });
   });
 
   describe('confirm() — 게이트웨이 분기/실패', () => {
     it('payment.gateway 값으로 어댑터를 라우팅한다 (TOSS)', async () => {
       const payment = makePayment({ gateway: PaymentGatewayType.TOSS });
-      const tossGateway: PaymentGateway = {
+      const tossAdapter: PaymentGateway = {
         prepare: jest.fn(),
         confirm: jest.fn().mockResolvedValue({
           paymentKey: 'pay_toss',
@@ -341,11 +373,9 @@ describe('PaymentConfirmationService', () => {
         partialCancel: jest.fn(),
         verifyWebhook: jest.fn(),
       };
-      const resolveGateway = jest.fn(() => tossGateway);
-
-      const { service } = buildService({
+      const { service, tossGateway } = buildService({
         paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
-        resolveGateway,
+        tossGateway: tossAdapter,
       });
 
       await service.confirm(
@@ -353,7 +383,6 @@ describe('PaymentConfirmationService', () => {
         10,
       );
 
-      expect(resolveGateway).toHaveBeenCalledWith(PaymentGatewayType.TOSS);
       expect(tossGateway.confirm).toHaveBeenCalledWith(
         'pay_toss',
         30000,
@@ -367,8 +396,8 @@ describe('PaymentConfirmationService', () => {
         findOne: jest.fn().mockResolvedValue(payment),
         update: jest.fn().mockResolvedValue({}),
       };
-      const { service, gateway, dataSource } = buildService({ paymentRepo });
-      (gateway.confirm as jest.Mock).mockRejectedValue(
+      const { service, defaultGateway, dataSource } = buildService({ paymentRepo });
+      (defaultGateway.confirm as jest.Mock).mockRejectedValue(
         new Error('gateway down'),
       );
 
@@ -407,11 +436,11 @@ describe('PaymentConfirmationService', () => {
         findOne: jest.fn().mockResolvedValue(payment),
         update: jest.fn().mockResolvedValue({}),
       };
-      const { service, gateway } = buildService({
+      const { service, defaultGateway } = buildService({
         paymentRepo,
         dataSource: dataSource as ReturnType<typeof makeDataSource>,
       });
-      (gateway.confirm as jest.Mock).mockResolvedValue({
+      (defaultGateway.confirm as jest.Mock).mockResolvedValue({
         paymentKey: 'pk',
         method: 'mock',
         amount: 30000,
@@ -431,10 +460,10 @@ describe('PaymentConfirmationService', () => {
   describe('confirm() — 알림 디스패치', () => {
     it('성공 시 fire-and-forget 으로 결제완료 알림을 디스패치한다', async () => {
       const payment = makePayment();
-      const { service, gateway, notificationDispatch } = buildService({
+      const { service, defaultGateway, notificationDispatch } = buildService({
         paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
       });
-      (gateway.confirm as jest.Mock).mockResolvedValue({
+      (defaultGateway.confirm as jest.Mock).mockResolvedValue({
         paymentKey: 'pk',
         method: 'mock',
         amount: 30000,
@@ -455,6 +484,70 @@ describe('PaymentConfirmationService', () => {
           mode: 'fire-and-forget',
         }),
       );
+    });
+  });
+
+  describe('confirmGuest() — duplicate loser local-truth handling', () => {
+    it('duplicate-like provider error + authoritative confirmed state → 409 without FAILED/CANCELLED recovery', async () => {
+      const guestOrder = makeOrder({
+        userId: null,
+        status: OrderStatus.PENDING,
+        orderLocale: 'ko',
+        guestEmailNormalized: 'guest@example.com',
+      } as Partial<Order>);
+      const payment = makePayment({ order: guestOrder });
+      const lockedPayment = makePayment({
+        status: PaymentStatus.CONFIRMED,
+        order: makeOrder({
+          userId: null,
+          status: OrderStatus.PAID,
+          orderLocale: 'ko',
+          guestEmailNormalized: 'guest@example.com',
+        } as Partial<Order>),
+      });
+      const manager = makeTransactionManager({
+        findOne: jest.fn().mockResolvedValue(lockedPayment),
+      });
+      const { service, defaultGateway, guestOrderAccessService } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+      (defaultGateway.confirm as jest.Mock).mockRejectedValue(new Error('already captured by provider'));
+      (guestOrderAccessService.getValidAccessOrThrow as jest.Mock).mockResolvedValue({ id: 1 });
+      (guestOrderAccessService.withOrderAccessLock as jest.Mock).mockImplementation(
+        async (_orderId: number, operation: (txManager: typeof manager) => Promise<unknown>) => operation(manager),
+      );
+
+      await expect(
+        service.confirmGuest(1, { paymentKey: 'pay_guest_dup', amount: 30000 }, 'guest-token'),
+      ).rejects.toThrow(ConflictException);
+      expect(manager.update).not.toHaveBeenCalledWith(Payment, lockedPayment.id, { status: PaymentStatus.FAILED });
+      expect(manager.update).not.toHaveBeenCalledWith(Order, 1, { status: OrderStatus.CANCELLED });
+    });
+
+    it('duplicate-like provider error + stale token after re-read → 401 without FAILED/CANCELLED recovery', async () => {
+      const guestOrder = makeOrder({
+        userId: null,
+        status: OrderStatus.PENDING,
+        orderLocale: 'ko',
+        guestEmailNormalized: 'guest@example.com',
+      } as Partial<Order>);
+      const payment = makePayment({ order: guestOrder });
+      const manager = makeTransactionManager();
+      const { service, defaultGateway, guestOrderAccessService } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+      });
+      (defaultGateway.confirm as jest.Mock).mockRejectedValue(new Error('duplicate payment request'));
+      (guestOrderAccessService.getValidAccessOrThrow as jest.Mock)
+        .mockResolvedValueOnce({ id: 1 })
+        .mockRejectedValueOnce(new UnauthorizedException('stale token'));
+      (guestOrderAccessService.withOrderAccessLock as jest.Mock).mockImplementation(
+        async (_orderId: number, operation: (txManager: typeof manager) => Promise<unknown>) => operation(manager),
+      );
+
+      await expect(
+        service.confirmGuest(1, { paymentKey: 'pay_guest_dup', amount: 30000 }, 'guest-token'),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(manager.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/payments/services/payment-confirmation.service.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.ts
@@ -1,12 +1,19 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
+  Inject,
+  Injectable,
   InternalServerErrorException,
   Logger,
+  NotFoundException,
+  Optional,
 } from '@nestjs/common';
-import { DataSource, In, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, EntityManager, In, Repository } from 'typeorm';
 import { ConfirmPaymentDto } from '../dto/confirm-payment.dto';
-import { Payment, PaymentMethod, PaymentStatus, PaymentGatewayType } from '../entities/payment.entity';
+import { GuestConfirmPaymentDto } from '../dto/guest-confirm-payment.dto';
+import { Payment, PaymentGatewayType, PaymentMethod, PaymentStatus } from '../entities/payment.entity';
 import { Order, OrderStatus } from '../../orders/entities/order.entity';
 import { Shipping, ShippingStatus } from '../entities/shipping.entity';
 import { PaymentGateway } from '../interfaces/payment-gateway.interface';
@@ -18,79 +25,109 @@ import { findOrThrow } from '../../../common/utils/repository.util';
 import { restoreOrderStock } from '../../orders/order-stock.util';
 import { OrderEventEmitter } from '../../orders/order-event.emitter';
 import { OrderCompletedEvent } from '../../orders/events/order-completed.event';
-import { buildOrderEmailItems, buildOrderUrl } from '../../notification/order-email-context';
+import {
+  buildGuestOrderLookupUrl,
+  buildOrderEmailItems,
+  buildOrderUrl,
+} from '../../notification/order-email-context';
+import { PAYMENT_CONFIG, type PaymentConfig } from '../../../config/payment.config';
+import { TossPaymentAdapter } from '../adapters/toss.adapter';
+import { StripePaymentAdapter } from '../adapters/stripe.adapter';
+import { KGInicisPaymentAdapter } from '../adapters/inicis.adapter';
+import { NaverPayPaymentAdapter } from '../adapters/naverpay.adapter';
+import { PayPalPaymentAdapter } from '../adapters/paypal.adapter';
+import { EximbayPaymentAdapter } from '../adapters/eximbay.adapter';
+import { GuestOrderAccessService } from '../../orders/guest-order-access.service';
 
-type ResolveGatewayByType = (gatewayType: PaymentGatewayType) => PaymentGateway;
+type CustomerType = 'member' | 'guest';
+type ConfirmResponse = {
+  paymentId: number;
+  orderId: number;
+  orderNumber: string;
+  status: PaymentStatus;
+  method: string;
+  amount: number;
+  paidAt: Date;
+};
+type GuestConfirmResponse = ConfirmResponse & {
+  guestAccessToken: string;
+  guestAccessTokenExpiresAt: string;
+};
+type PostCommitPayload = {
+  userId: number | null;
+  orderId: number;
+  orderNumber: string;
+  recipientName: string;
+  amount: number;
+  method: string;
+  locale: 'ko' | 'en';
+  customerType: CustomerType;
+  isFirstPurchase: boolean;
+  guestEmail: string | null;
+};
 
-interface PaymentConfirmationDependencies {
-  paymentRepository: Repository<Payment>;
-  orderRepository: Repository<Order>;
-  shippingRepository: Repository<Shipping>;
-  dataSource: DataSource;
-  notificationService: NotificationService;
-  messageNotificationService?: MessageNotificationService;
-  notificationDispatchHelper: NotificationDispatchHelper;
-  resolveGatewayByType: ResolveGatewayByType;
-  logger: Logger;
-  defaultCarrier: string;
-  orderEventEmitter?: OrderEventEmitter;
-}
-
+@Injectable()
 export class PaymentConfirmationService {
-  constructor(private readonly deps: PaymentConfirmationDependencies) {}
+  private readonly logger = new Logger(PaymentConfirmationService.name);
 
-  async confirm(
-    dto: ConfirmPaymentDto,
-    userId: number,
-  ): Promise<{
-    paymentId: number;
-    orderId: number;
-    orderNumber: string;
-    status: PaymentStatus;
-    method: string;
-    amount: number;
-    paidAt: Date;
-  }> {
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+    @Inject('PaymentGateway')
+    private readonly gateway: PaymentGateway,
+    @Inject(PAYMENT_CONFIG)
+    private readonly paymentConfig: PaymentConfig,
+    private readonly tossAdapter: TossPaymentAdapter,
+    private readonly stripeAdapter: StripePaymentAdapter,
+    private readonly inicisAdapter: KGInicisPaymentAdapter,
+    private readonly naverpayAdapter: NaverPayPaymentAdapter,
+    private readonly paypalAdapter: PayPalPaymentAdapter,
+    private readonly eximbayAdapter: EximbayPaymentAdapter,
+    private readonly dataSource: DataSource,
+    private readonly notificationService: NotificationService,
+    @Optional()
+    private readonly messageNotificationService: MessageNotificationService | undefined,
+    private readonly notificationDispatchHelper: NotificationDispatchHelper,
+    @Optional()
+    private readonly orderEventEmitter: OrderEventEmitter | undefined,
+    private readonly guestOrderAccessService: GuestOrderAccessService,
+  ) {}
+
+  async confirm(dto: ConfirmPaymentDto, userId: number): Promise<ConfirmResponse> {
     const payment = await findOrThrow(
-      this.deps.paymentRepository,
+      this.paymentRepository,
       { orderId: dto.orderId },
       '결제 정보를 찾을 수 없습니다.',
       ['order'],
     );
-    assertOwnership(payment.order.userId, userId);
-
-    if (payment.status === PaymentStatus.CONFIRMED) {
-      throw new ConflictException('이미 승인된 결제입니다.');
-    }
-    if (payment.status !== PaymentStatus.PENDING) {
-      throw new BadRequestException('결제 승인이 불가능한 상태입니다.');
-    }
-
-    if (Number(payment.order.totalAmount) !== Number(dto.amount)) {
-      throw new BadRequestException('결제 금액이 일치하지 않습니다.');
-    }
+    this.assertMemberOwnership(payment.order.userId, userId);
+    this.assertConfirmablePayment(payment.order, payment, dto.amount);
 
     try {
-      const confirmGateway = this.deps.resolveGatewayByType(payment.gateway);
-      const result = await confirmGateway.confirm(
+      const result = await this.resolveGatewayByType(payment.gateway).confirm(
         dto.paymentKey,
         Number(payment.amount),
         payment.order.orderNumber,
       );
 
+      const paidAt = new Date();
+      let payload: PostCommitPayload | null = null;
       let isFirstPurchase = false;
-      await this.deps.dataSource.transaction(async (manager) => {
+
+      await this.dataSource.transaction(async (manager) => {
         await manager.update(Payment, payment.id, {
           status: PaymentStatus.CONFIRMED,
           paymentKey: result.paymentKey,
           method: result.method as PaymentMethod,
-          paidAt: new Date(),
+          paidAt,
           rawResponse: result.rawResponse as object,
         });
 
         await manager.update(Order, dto.orderId, { status: OrderStatus.PAID });
 
-        if (this.deps.orderEventEmitter) {
+        if (this.orderEventEmitter && payment.order.userId !== null) {
           const paidOrderCount = await manager.count(Order, {
             where: {
               userId: payment.order.userId,
@@ -106,36 +143,29 @@ export class PaymentConfirmationService {
           isFirstPurchase = paidOrderCount <= 1;
         }
 
-        const existing = await manager.findOne(Shipping, { where: { orderId: dto.orderId } });
-        if (!existing) {
+        const existingShipping = await manager.findOne(Shipping, { where: { orderId: dto.orderId } });
+        if (!existingShipping) {
           await manager.save(Shipping, {
             orderId: dto.orderId,
-            carrier: this.deps.defaultCarrier,
+            carrier: this.paymentConfig.defaultCarrier,
             status: ShippingStatus.PAYMENT_CONFIRMED,
           });
         }
+
+        payload = this.buildPostCommitPayload(payment.order, {
+          amount: Number(payment.amount),
+          customerType: 'member',
+          isFirstPurchase,
+          method: result.method,
+        });
       });
 
-      this.deps.orderEventEmitter?.emitOrderCompleted(
-        new OrderCompletedEvent(
-          payment.order.userId,
-          dto.orderId,
-          payment.order.orderNumber,
-          isFirstPurchase,
-        ),
-      );
+      if (!payload) {
+        throw new InternalServerErrorException('결제 승인 후처리 정보를 구성하지 못했습니다.');
+      }
 
-      this.deps.logger.log(`Payment confirmed: orderId=${dto.orderId}`);
-
-      void this.notifyPaymentConfirmed(
-        payment.order.userId,
-        dto.orderId,
-        payment.order.orderNumber,
-        payment.order.recipientName,
-        Number(payment.amount),
-        result.method,
-      );
-      void this.deps.messageNotificationService?.sendPaymentConfirmed(dto.orderId, result.method);
+      this.dispatchPostCommit(payload);
+      this.logger.log(`Payment confirmed: orderId=${dto.orderId} customerType=member`);
 
       return {
         paymentId: Number(payment.id),
@@ -144,52 +174,339 @@ export class PaymentConfirmationService {
         status: PaymentStatus.CONFIRMED,
         method: result.method,
         amount: Number(payment.amount),
-        paidAt: new Date(),
+        paidAt,
       };
     } catch (err) {
-      // #723: 결제 승인 실패 시 payment를 FAILED로, order를 CANCELLED로 마킹하고
-      // 주문 생성 시 차감했던 재고를 복구한다. 같은 트랜잭션으로 묶어 부분 커밋 방지.
-      await this.deps.dataSource.transaction(async (manager) => {
-        await manager.update(Payment, payment.id, { status: PaymentStatus.FAILED });
-        await manager.update(Order, dto.orderId, { status: OrderStatus.CANCELLED });
-        await restoreOrderStock(manager, dto.orderId);
+      await this.dataSource.transaction(async (manager) => {
+        await this.applyFailedPaymentRecovery(manager, payment.id, dto.orderId);
       });
-      if (err instanceof ConflictException || err instanceof BadRequestException) throw err;
+
+      if (err instanceof ConflictException || err instanceof BadRequestException) {
+        throw err;
+      }
       throw new InternalServerErrorException('결제 승인에 실패했습니다.');
     }
   }
 
-  private async notifyPaymentConfirmed(
-    userId: number,
+  async assertGuestAccessTokenActive(orderId: number, guestAccessToken: string): Promise<void> {
+    await this.guestOrderAccessService.getValidAccessOrThrow(orderId, guestAccessToken);
+  }
+
+  async confirmGuest(
     orderId: number,
-    orderNumber: string,
-    recipientName: string,
-    amount: number,
-    method: string,
-  ): Promise<void> {
-    const order = typeof this.deps.orderRepository.findOne === 'function'
-      ? await this.deps.orderRepository.findOne({
+    dto: GuestConfirmPaymentDto,
+    guestAccessToken: string,
+  ): Promise<GuestConfirmResponse> {
+    await this.assertGuestAccessTokenActive(orderId, guestAccessToken);
+
+    const payment = await findOrThrow(
+      this.paymentRepository,
+      { orderId },
+      '결제 정보를 찾을 수 없습니다.',
+      ['order'],
+    );
+    this.assertConfirmablePayment(payment.order, payment, dto.amount);
+
+    try {
+      const result = await this.resolveGatewayByType(payment.gateway).confirm(
+        dto.paymentKey,
+        Number(payment.amount),
+        payment.order.orderNumber,
+      );
+
+      const outcome = await this.guestOrderAccessService.withOrderAccessLock(orderId, async (manager) => {
+        await this.guestOrderAccessService.getValidAccessOrThrow(orderId, guestAccessToken, manager);
+        const lockedPayment = await this.loadLockedPayment(orderId, manager);
+        const lockedOrder = lockedPayment.order;
+        const shipping = await manager.findOne(Shipping, {
+          where: { orderId },
+          lock: { mode: 'pessimistic_write' },
+        });
+
+        this.assertConfirmablePayment(lockedOrder, lockedPayment, dto.amount);
+
+        const paidAt = new Date();
+        await manager.update(Payment, lockedPayment.id, {
+          status: PaymentStatus.CONFIRMED,
+          paymentKey: result.paymentKey,
+          method: result.method as PaymentMethod,
+          paidAt,
+          rawResponse: result.rawResponse as object,
+        });
+        await manager.update(Order, orderId, { status: OrderStatus.PAID });
+
+        if (!shipping) {
+          await manager.save(Shipping, {
+            orderId,
+            carrier: this.paymentConfig.defaultCarrier,
+            status: ShippingStatus.PAYMENT_CONFIRMED,
+          });
+        }
+
+        const rotatedAccess = await this.guestOrderAccessService.rotateAccessTokenForOrder(
+          orderId,
+          guestAccessToken,
+          manager,
+        );
+        const payload = this.buildPostCommitPayload(lockedOrder, {
+          amount: Number(lockedPayment.amount),
+          customerType: 'guest',
+          isFirstPurchase: false,
+          method: result.method,
+        });
+
+        return {
+          payload,
+          response: {
+            paymentId: Number(lockedPayment.id),
+            orderId,
+            orderNumber: lockedOrder.orderNumber,
+            status: PaymentStatus.CONFIRMED,
+            method: result.method,
+            amount: Number(lockedPayment.amount),
+            paidAt,
+            guestAccessToken: rotatedAccess.guestAccessToken,
+            guestAccessTokenExpiresAt: rotatedAccess.guestAccessTokenExpiresAt.toISOString(),
+          },
+        };
+      });
+
+      this.dispatchPostCommit(outcome.payload);
+      this.logger.log(`Payment confirmed: orderId=${orderId} customerType=guest`);
+      return outcome.response;
+    } catch (err) {
+      return this.guestOrderAccessService.withOrderAccessLock(orderId, async (manager) => {
+        await this.guestOrderAccessService.getValidAccessOrThrow(orderId, guestAccessToken, manager);
+        const lockedPayment = await this.loadLockedPayment(orderId, manager);
+
+        if (this.isDuplicateLikeGuestConfirmError(err)) {
+          if (lockedPayment.status === PaymentStatus.CONFIRMED || lockedPayment.order.status === OrderStatus.PAID) {
+            throw new ConflictException('이미 승인된 결제입니다.');
+          }
+        }
+
+        this.assertPendingBeforeFailureRecovery(lockedPayment.order, lockedPayment);
+        await this.applyFailedPaymentRecovery(manager, lockedPayment.id, orderId);
+
+        if (err instanceof ConflictException || err instanceof BadRequestException) {
+          throw err;
+        }
+        throw new InternalServerErrorException('결제 승인에 실패했습니다.');
+      });
+    }
+  }
+
+  private assertConfirmablePayment(order: Order, payment: Payment, amount: number): void {
+    if (payment.status === PaymentStatus.CONFIRMED || order.status === OrderStatus.PAID) {
+      throw new ConflictException('이미 승인된 결제입니다.');
+    }
+    if (payment.status !== PaymentStatus.PENDING || order.status !== OrderStatus.PENDING) {
+      throw new BadRequestException('결제 승인이 불가능한 상태입니다.');
+    }
+    if (Number(order.totalAmount) !== Number(amount)) {
+      throw new BadRequestException('결제 금액이 일치하지 않습니다.');
+    }
+  }
+
+  private assertMemberOwnership(orderUserId: number | null, userId: number): void {
+    if (orderUserId === null) {
+      throw new ForbiddenException('접근 권한이 없습니다.');
+    }
+
+    assertOwnership(orderUserId, userId);
+  }
+
+  private assertPendingBeforeFailureRecovery(order: Order, payment: Payment): void {
+    if (payment.status === PaymentStatus.CONFIRMED || order.status === OrderStatus.PAID) {
+      throw new ConflictException('이미 승인된 결제입니다.');
+    }
+    if (payment.status !== PaymentStatus.PENDING || order.status !== OrderStatus.PENDING) {
+      throw new BadRequestException('결제 승인이 불가능한 상태입니다.');
+    }
+  }
+
+  private isDuplicateLikeGuestConfirmError(err: unknown): boolean {
+    if (err instanceof ConflictException) {
+      return true;
+    }
+
+    const details = [
+      err instanceof Error ? err.message : '',
+      this.readNestedErrorText(err, 'code'),
+      this.readNestedErrorText(err, 'type'),
+      this.readNestedErrorText(err, 'status'),
+      this.readNestedErrorText(err, 'statusCode'),
+      this.readNestedErrorText(err, 'response.status'),
+      this.readNestedErrorText(err, 'response.statusCode'),
+      this.readNestedErrorText(err, 'response.code'),
+      this.readNestedErrorText(err, 'response.errorCode'),
+      this.readNestedErrorText(err, 'response.message'),
+      this.readNestedErrorText(err, 'response.error'),
+      this.readNestedErrorText(err, 'body.code'),
+      this.readNestedErrorText(err, 'body.message'),
+      this.readNestedErrorText(err, 'rawResponse.code'),
+      this.readNestedErrorText(err, 'rawResponse.message'),
+    ]
+      .filter((value) => value.length > 0)
+      .join(' ')
+      .toLowerCase();
+
+    return [
+      'already',
+      'duplicate',
+      'idempot',
+      'captured',
+      'processed',
+      '409',
+      '422',
+      'conflict',
+    ].some((token) => details.includes(token));
+  }
+
+  private readNestedErrorText(err: unknown, path: string): string {
+    if (typeof err !== 'object' || err === null) {
+      return '';
+    }
+
+    const value = path.split('.').reduce<unknown>((current, key) => {
+      if (typeof current !== 'object' || current === null || !(key in current)) {
+        return undefined;
+      }
+
+      return (current as Record<string, unknown>)[key];
+    }, err);
+
+    return value === undefined || value === null ? '' : String(value);
+  }
+
+  private buildPostCommitPayload(
+    order: Order,
+    args: { amount: number; customerType: CustomerType; isFirstPurchase: boolean; method: string },
+  ): PostCommitPayload {
+    return {
+      userId: args.customerType === 'member' ? order.userId : null,
+      orderId: Number(order.id),
+      orderNumber: order.orderNumber,
+      recipientName: order.recipientName,
+      amount: args.amount,
+      method: args.method,
+      locale: order.orderLocale,
+      customerType: args.customerType,
+      isFirstPurchase: args.customerType === 'member' ? args.isFirstPurchase : false,
+      guestEmail: args.customerType === 'guest' ? order.guestEmailNormalized : null,
+    };
+  }
+
+  private dispatchPostCommit(payload: PostCommitPayload): void {
+    this.orderEventEmitter?.emitOrderCompleted(
+      new OrderCompletedEvent(
+        payload.userId,
+        payload.orderId,
+        payload.orderNumber,
+        payload.isFirstPurchase,
+        payload.customerType,
+      ),
+    );
+
+    void this.notifyPaymentConfirmed(payload).catch((err) => {
+      this.logger.warn(`Failed to send payment confirmed email: ${String(err)}`);
+    });
+
+    if (payload.customerType === 'member') {
+      void this.messageNotificationService?.sendPaymentConfirmed(payload.orderId, payload.method);
+    }
+  }
+
+  private async notifyPaymentConfirmed(payload: PostCommitPayload): Promise<void> {
+    const order = await this.loadOrderForNotification(payload.orderId);
+    const send = (recipient: { email: string }) =>
+      this.notificationService.sendPaymentConfirmed(recipient.email, {
+        recipientName: payload.recipientName,
+        orderNumber: payload.orderNumber,
+        amount: payload.amount,
+        method: payload.method,
+        locale: payload.locale,
+        orderItems: buildOrderEmailItems(order, payload.locale),
+        orderUrl: payload.customerType === 'member'
+          ? buildOrderUrl(payload.orderId, payload.locale)
+          : buildGuestOrderLookupUrl(payload.locale),
+      });
+
+    if (payload.customerType === 'member' && payload.userId !== null) {
+      await this.notificationDispatchHelper.dispatch({
+        event: 'payment.confirmed',
+        userId: payload.userId,
+        resourceId: payload.orderId,
+        mode: 'fire-and-forget',
+        logger: this.logger,
+        send,
+      });
+      return;
+    }
+
+    await this.notificationDispatchHelper.dispatch({
+      event: 'payment.confirmed',
+      recipient: {
+        email: payload.guestEmail ?? '',
+        name: payload.recipientName,
+      },
+      resourceId: payload.orderId,
+      mode: 'fire-and-forget',
+      logger: this.logger,
+      send,
+    });
+  }
+
+  private async loadOrderForNotification(orderId: number): Promise<Order | null> {
+    return typeof this.orderRepository.findOne === 'function'
+      ? this.orderRepository.findOne({
         where: { id: orderId },
         relations: ['items'],
       })
       : null;
-    const locale = 'ko';
+  }
 
-    await this.deps.notificationDispatchHelper.dispatch({
-      event: 'payment.confirmed',
-      userId,
-      resourceId: orderId,
-      mode: 'fire-and-forget',
-      logger: this.deps.logger,
-      send: (recipient) =>
-        this.deps.notificationService.sendPaymentConfirmed(recipient.email, {
-          recipientName,
-          orderNumber,
-          amount,
-          method,
-          orderItems: buildOrderEmailItems(order, locale),
-          orderUrl: buildOrderUrl(orderId, locale),
-        }),
+  private async loadLockedPayment(orderId: number, manager: EntityManager): Promise<Payment> {
+    const payment = await manager.findOne(Payment, {
+      where: { orderId },
+      relations: ['order'],
+      lock: { mode: 'pessimistic_write' },
     });
+
+    if (!payment) {
+      throw new NotFoundException('결제 정보를 찾을 수 없습니다.');
+    }
+
+    return payment;
+  }
+
+  private async applyFailedPaymentRecovery(
+    manager: EntityManager,
+    paymentId: number,
+    orderId: number,
+  ): Promise<void> {
+    await manager.update(Payment, paymentId, { status: PaymentStatus.FAILED });
+    await manager.update(Order, orderId, { status: OrderStatus.CANCELLED });
+    await restoreOrderStock(manager, orderId);
+  }
+
+  private resolveGatewayByType(gatewayType: PaymentGatewayType): PaymentGateway {
+    switch (gatewayType) {
+      case PaymentGatewayType.TOSS:
+        return this.tossAdapter;
+      case PaymentGatewayType.STRIPE:
+        return this.stripeAdapter;
+      case PaymentGatewayType.INICIS:
+        return this.inicisAdapter;
+      case PaymentGatewayType.NAVERPAY:
+        return this.naverpayAdapter;
+      case PaymentGatewayType.PAYPAL:
+        return this.paypalAdapter;
+      case PaymentGatewayType.EXIMBAY:
+        return this.eximbayAdapter;
+      case PaymentGatewayType.MOCK:
+      default:
+        return this.gateway;
+    }
   }
 }

--- a/backend/src/modules/scheduler/jobs/order-scheduler.job.ts
+++ b/backend/src/modules/scheduler/jobs/order-scheduler.job.ts
@@ -8,8 +8,7 @@ import { NotificationService } from '../../notification/notification.service';
 import { SettingsService } from '../../settings/settings.service';
 import { MembershipService } from '../../membership/membership.service';
 import { canOrderStatusTransition } from '../../orders/policies/order-status-transition.policy';
-import { buildOrderEmailItems, buildOrderUrl } from '../../notification/order-email-context';
-import { renderOrderCancelled } from '../../notification/templates/render';
+import { buildGuestOrderLookupUrl, buildOrderEmailItems, buildOrderUrl } from '../../notification/order-email-context';
 
 interface OrderSchedulerJobDependencies {
   orderRepo: Repository<Order>;
@@ -30,7 +29,7 @@ export class OrderSchedulerJob {
 
     const pendingOrders = await this.deps.orderRepo.find({
       where: { status: OrderStatus.PENDING, createdAt: LessThan(cutoff) },
-      relations: { items: true },
+      relations: { items: true, user: true },
     });
 
     if (pendingOrders.length === 0) {
@@ -73,18 +72,24 @@ export class OrderSchedulerJob {
 
       await this.deps.orderRepo.update(order.id, { status: OrderStatus.COMPLETED });
 
-      const completedAmount = Number(order.totalAmount) - Number(order.discountAmount ?? 0);
-      void this.deps.membershipService.incrementAccumulatedAmount(order.userId, completedAmount)
-        .catch((err) => this.deps.logger.warn(`Failed to increment tier amount for user ${order.userId}: ${String(err)}`));
+      const userId = this.getOrderUserId(order);
+      if (userId !== null) {
+        const completedAmount = Number(order.totalAmount) - Number(order.discountAmount ?? 0);
+        void this.deps.membershipService.incrementAccumulatedAmount(userId, completedAmount)
+          .catch((err) => this.deps.logger.warn(`Failed to increment tier amount for user ${userId}: ${String(err)}`));
+      }
 
-      if (order.user?.email) {
+      const email = order.user?.email ?? this.getGuestEmailNormalized(order);
+      if (email) {
+        const locale = this.getOrderLocale(order);
         void Promise.resolve(
-          this.deps.notificationService.sendOrderConfirmed(order.user.email, {
+          this.deps.notificationService.sendOrderConfirmed(email, {
             orderNumber: order.orderNumber,
             totalAmount: order.totalAmount,
             recipientName: order.recipientName,
-            orderItems: buildOrderEmailItems(order, 'ko'),
-            orderUrl: buildOrderUrl(Number(order.id), 'ko'),
+            locale,
+            orderItems: buildOrderEmailItems(order, locale),
+            orderUrl: this.resolveOrderUrl(Number(order.id), order),
           }),
         )
           .catch((err) => this.deps.logger.warn(`Failed to send confirmation email: ${String(err)}`));
@@ -129,19 +134,17 @@ export class OrderSchedulerJob {
 
       await queryRunner.commitTransaction();
 
-      const user = await this.deps.userRepo.findOne({ where: { id: order.userId } });
-      if (user?.email) {
-        const rendered = renderOrderCancelled({
-          recipientName: order.recipientName,
-          orderNumber: order.orderNumber,
-          reason: '결제 미완료 자동 취소',
-          orderItems: buildOrderEmailItems(order, 'ko'),
-          orderUrl: buildOrderUrl(Number(order.id), 'ko'),
-        });
+      const email = order.user?.email ?? this.getGuestEmailNormalized(order);
+      if (email) {
+        const locale = this.getOrderLocale(order);
         void Promise.resolve(
-          this.deps.notificationService.sendEmail({
-            to: user.email,
-            ...rendered,
+          this.deps.notificationService.sendOrderCancelled(email, {
+            recipientName: order.recipientName,
+            orderNumber: order.orderNumber,
+            reason: '결제 미완료 자동 취소',
+            locale,
+            orderItems: buildOrderEmailItems(order, locale),
+            orderUrl: this.resolveOrderUrl(Number(order.id), order),
           }),
         )
           .catch((err) => this.deps.logger.warn(`Failed to send cancellation email: ${String(err)}`));
@@ -165,5 +168,25 @@ export class OrderSchedulerJob {
     } catch {
       return defaultValue;
     }
+  }
+
+  private getOrderUserId(order: Order): number | null {
+    const userId = (order as Order & { userId?: number | null }).userId;
+    return userId == null ? null : Number(userId);
+  }
+
+  private getGuestEmailNormalized(order: Order): string | null {
+    return (order as Order & { guestEmailNormalized?: string | null }).guestEmailNormalized ?? null;
+  }
+
+  private getOrderLocale(order: Order): 'ko' | 'en' {
+    return (order as Order & { orderLocale?: 'ko' | 'en' }).orderLocale ?? 'ko';
+  }
+
+  private resolveOrderUrl(orderId: number, order: Order): string | undefined {
+    const locale = this.getOrderLocale(order);
+    return this.getOrderUserId(order) === null
+      ? buildGuestOrderLookupUrl(locale)
+      : buildOrderUrl(orderId, locale);
   }
 }

--- a/backend/src/modules/shipping/shipping.service.ts
+++ b/backend/src/modules/shipping/shipping.service.ts
@@ -1,5 +1,5 @@
 import {
-  Injectable, BadRequestException,
+  Injectable, BadRequestException, ForbiddenException,
   Logger, Optional,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -25,7 +25,7 @@ import { ShippingQuoteItemDto } from './dto/shipping-quote.dto';
 import { Product } from '../products/entities/product.entity';
 import { ProductOption } from '../products/entities/product-option.entity';
 import { assertShippingStatusTransition } from './policies/shipping-status-transition.policy';
-import { buildOrderEmailItems, buildOrderUrl } from '../notification/order-email-context';
+import { buildGuestOrderLookupUrl, buildOrderEmailItems, buildOrderUrl } from '../notification/order-email-context';
 
 @Injectable()
 export class ShippingService {
@@ -61,8 +61,11 @@ export class ShippingService {
     tracking: TrackingResult | null;
   }> {
     const order = await findOrThrow(this.orderRepository, { id: orderId }, '배송 정보를 찾을 수 없습니다.');
-    assertOwnership(order.userId, userId);
-
+    const orderUserId = this.getOrderUserId(order);
+    if (orderUserId === null) {
+      throw new ForbiddenException('접근 권한이 없습니다.');
+    }
+    assertOwnership(orderUserId, userId);
     const shipping = await findOrThrow(this.shippingRepository, { orderId }, '배송 정보를 찾을 수 없습니다.');
     const normalizedShipping = await this.syncShippingStatusFromOrder(order, shipping);
 
@@ -110,7 +113,7 @@ export class ShippingService {
   }
 
   async registerTracking(orderId: number, dto: RegisterTrackingDto): Promise<Shipping | null> {
-    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문 정보를 찾을 수 없습니다.');
+    const order = await findOrThrow(this.orderRepository, { id: orderId }, '주문 정보를 찾을 수 없습니다.', ['items', 'user']);
 
     const shipping = await findOrThrow(this.shippingRepository, { orderId }, '배송 정보를 찾을 수 없습니다.');
 
@@ -128,14 +131,17 @@ export class ShippingService {
     await this.orderRepository.update(orderId, { status: OrderStatus.PREPARING });
 
     void this.notifyShippingUpdate(
-      order.userId,
+      order,
       orderId,
       order.orderNumber,
       order.recipientName,
       dto.carrier,
       dto.trackingNumber,
     );
-    void this.messageNotificationService?.sendShippingStarted(orderId);
+
+    if (!this.isGuestOrder(order)) {
+      void this.messageNotificationService?.sendShippingStarted(orderId);
+    }
 
     return this.shippingRepository.findOne({ where: { orderId } });
   }
@@ -207,24 +213,38 @@ export class ShippingService {
   }
 
   private async notifyShippingUpdate(
-    userId: number,
+    order: Order,
     orderId: number,
     orderNumber: string,
     recipientName: string,
     carrier: string,
     trackingNumber: string,
   ): Promise<void> {
-    const order = typeof this.orderRepository.findOne === 'function'
+    const persistedOrder = typeof this.orderRepository.findOne === 'function'
       ? await this.orderRepository.findOne({
         where: { id: orderId },
-        relations: ['items'],
+        relations: ['items', 'user'],
       })
       : null;
-    const locale = 'ko';
+    const notificationOrder = persistedOrder ?? order;
+    const locale = this.getOrderLocale(notificationOrder);
+    const guestEmailNormalized = this.getGuestEmailNormalized(notificationOrder);
+    const orderUrl = this.resolveOrderUrl(orderId, notificationOrder);
+
+    if (this.isGuestOrder(notificationOrder) && !guestEmailNormalized) {
+      return;
+    }
 
     await this.notificationDispatchHelper.dispatch({
       event: 'shipping.updated',
-      userId,
+      ...(this.isGuestOrder(notificationOrder)
+        ? {
+          recipient: {
+            email: guestEmailNormalized!,
+            name: recipientName,
+          },
+        }
+        : { userId: this.getOrderUserId(notificationOrder)! }),
       resourceId: orderId,
       mode: 'fire-and-forget',
       logger: this.logger,
@@ -234,8 +254,9 @@ export class ShippingService {
           orderNumber,
           carrier,
           trackingNumber,
-          orderItems: buildOrderEmailItems(order, locale),
-          orderUrl: buildOrderUrl(orderId, locale),
+          locale,
+          orderItems: buildOrderEmailItems(notificationOrder, locale),
+          orderUrl,
         }),
     });
   }
@@ -261,7 +282,25 @@ export class ShippingService {
         { id: shipping.id, status: shipping.status },
         { status: ShippingStatus.DELIVERED, shippedAt, deliveredAt },
       );
-      void this.messageNotificationService?.sendShippingDelivered(Number(order.id));
+
+      if (this.isGuestOrder(order)) {
+        const email = this.getGuestEmailNormalized(order);
+        const locale = this.getOrderLocale(order);
+        if (email && shipping.trackingNumber) {
+          void this.notificationService.sendShippingUpdate(email, {
+            recipientName: order.recipientName,
+            orderNumber: order.orderNumber,
+            carrier: shipping.carrier ?? 'unknown',
+            trackingNumber: shipping.trackingNumber,
+            locale,
+            orderItems: buildOrderEmailItems(order, locale),
+            orderUrl: buildGuestOrderLookupUrl(locale),
+          });
+        }
+      } else {
+        void this.messageNotificationService?.sendShippingDelivered(Number(order.id));
+      }
+
       return { ...shipping, status: ShippingStatus.DELIVERED, shippedAt, deliveredAt };
     }
 
@@ -302,5 +341,29 @@ export class ShippingService {
 
       throw err;
     }
+  }
+
+  private isGuestOrder(order: Order): boolean {
+    return this.getOrderUserId(order) === null;
+  }
+
+  private getOrderUserId(order: Order): number | null {
+    const userId = (order as Order & { userId?: number | null }).userId;
+    return userId == null ? null : Number(userId);
+  }
+
+  private getGuestEmailNormalized(order: Order): string | null {
+    return (order as Order & { guestEmailNormalized?: string | null }).guestEmailNormalized ?? null;
+  }
+
+  private getOrderLocale(order: Order): 'ko' | 'en' {
+    return (order as Order & { orderLocale?: 'ko' | 'en' }).orderLocale ?? 'ko';
+  }
+
+  private resolveOrderUrl(orderId: number, order: Order): string | undefined {
+    const locale = this.getOrderLocale(order);
+    return this.isGuestOrder(order)
+      ? buildGuestOrderLookupUrl(locale)
+      : buildOrderUrl(orderId, locale);
   }
 }

--- a/backend/test/suites/orders.e2e-spec.ts
+++ b/backend/test/suites/orders.e2e-spec.ts
@@ -13,15 +13,26 @@ let app: INestApplication;
 let dataSource: DataSource;
 
 export function registerOrdersSuite(getApp: () => INestApplication) {
+
   describe('Orders (e2e)', () => {
     let userACookies: AuthCookies;
     let userBCookies: AuthCookies;
     let productId: number;
     let productOptionId: number;
+    let guestProductId: number;
     let orderId: number;
+    let guestOrderId: number;
+    let guestOrderNumber: string;
+    let guestAccessToken: string;
+    let previousGuestAccessToken: string;
+    let guestAccessTokenExpiresAt: string;
 
     const userAEmail = `orders-user-a-${Date.now()}@test.com`;
     const userBEmail = `orders-user-b-${Date.now()}@test.com`;
+    const guestEmail = `guest-orders-${Date.now()}@test.com`;
+    const throttleGuestCreateEmail = `guest-orders-create-throttle-${Date.now()}@test.com`;
+    const throttleGuestLookupEmail = `guest-orders-lookup-throttle-${Date.now()}@test.com`;
+
 
     beforeAll(async () => {
       app = getApp();
@@ -63,21 +74,35 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
         [productId],
       );
       productOptionId = (optResult as { insertId: number }).insertId;
+
+      const guestProductResult = await dataSource.query(`
+        INSERT INTO products (name, name_en, slug, price, sale_price, stock, status, is_visible_en)
+        VALUES ('비회원주문테스트상품', 'Guest Order Test Product', 'guest-orders-test-product-e2e', 18000, NULL, 10, 'active', 1)
+      `);
+      guestProductId = (guestProductResult as { insertId: number }).insertId;
     });
 
     afterAll(async () => {
       await dataSource.query('SET FOREIGN_KEY_CHECKS = 0');
-      await dataSource.query(`DELETE FROM order_items WHERE product_id = ?`, [productId]);
+      await dataSource.query(`DELETE FROM order_items WHERE product_id IN (?, ?)`, [productId, guestProductId]);
+      await dataSource.query(
+        `DELETE FROM guest_order_access WHERE order_id IN (
+          SELECT id FROM orders WHERE guest_email_normalized IN (?, ?, ?)
+        )`,
+        [guestEmail, throttleGuestCreateEmail, throttleGuestLookupEmail],
+      );
       await dataSource.query(
         `DELETE FROM orders WHERE user_id IN (
           SELECT id FROM users WHERE email IN (?, ?)
-        )`,
-        [userAEmail, userBEmail],
+        ) OR guest_email_normalized IN (?, ?, ?)`,
+        [userAEmail, userBEmail, guestEmail, throttleGuestCreateEmail, throttleGuestLookupEmail],
       );
       await dataSource.query(`DELETE FROM product_options WHERE product_id = ?`, [productId]);
-      await dataSource.query(`DELETE FROM products WHERE slug = 'orders-test-product-e2e'`);
+      await dataSource.query(`DELETE FROM products WHERE slug IN ('orders-test-product-e2e', 'guest-orders-test-product-e2e')`);
       await dataSource.query(`DELETE FROM users WHERE email IN (?, ?)`, [userAEmail, userBEmail]);
       await dataSource.query('SET FOREIGN_KEY_CHECKS = 1');
+
+
     });
 
     describe('POST /api/orders', () => {
@@ -90,6 +115,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
             recipientPhone: '010-1234-5678',
             zipcode: '12345',
             address: '서울시 강남구',
+            orderLocale: 'ko',
           })
           .expect(401);
       });
@@ -104,12 +130,19 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
             recipientPhone: '010-1234-5678',
             zipcode: '12345',
             address: '서울시 강남구',
+            orderLocale: 'en',
           })
           .expect(201);
 
         const body = res.body as { id: number; orderNumber: string; items: unknown[] };
         expect(body.orderNumber).toMatch(/^ORD-\d{8}-[A-Z0-9]{5}$/);
         orderId = body.id;
+
+        const orderRow = await dataSource.query(
+          `SELECT order_locale AS orderLocale FROM orders WHERE id = ?`,
+          [orderId],
+        ) as Array<{ orderLocale: 'ko' | 'en' }>;
+        expect(orderRow[0]?.orderLocale).toBe('en');
       });
 
       it('after order: products.stock decreased by quantity', async () => {
@@ -138,6 +171,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
             recipientPhone: '010-1234-5678',
             zipcode: '12345',
             address: '서울시 강남구',
+            orderLocale: 'ko',
           })
           .expect(201);
 
@@ -164,6 +198,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
             recipientPhone: '010-1234-5678',
             zipcode: '12345',
             address: '서울시 강남구',
+            orderLocale: 'ko',
           })
           .expect(400);
       });
@@ -178,6 +213,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
             recipientPhone: '010-1234-5678',
             zipcode: '12345',
             address: '서울시 강남구',
+            orderLocale: 'ko',
           })
           .expect(400);
       });
@@ -192,6 +228,7 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
             recipientPhone: '010-1234-5678',
             zipcode: '12345',
             address: '서울시 강남구',
+            orderLocale: 'ko',
             pointsUsed: 1,
           })
           .expect(400);
@@ -207,9 +244,149 @@ export function registerOrdersSuite(getApp: () => INestApplication) {
             recipientPhone: '010-1234-5678',
             zipcode: '12345',
             address: '서울시 강남구',
+            orderLocale: 'ko',
           })
           .expect(400);
       });
+    });
+
+    describe('Guest orders', () => {
+      it('guest create returns top-level token, expiry, and guest-safe order fields', async () => {
+        const res = await request(app.getHttpServer())
+          .post('/api/guest/orders')
+          .send({
+            items: [{ productId: guestProductId, quantity: 1 }],
+            guestEmail: `  ${guestEmail.toUpperCase()}  `,
+            recipientName: '비회원 주문자',
+            recipientPhone: '010-9999-0000',
+            zipcode: '54321',
+            address: '서울시 마포구',
+            addressDetail: '202호',
+            memo: '경비실에 맡겨주세요',
+            orderLocale: 'en',
+            policyConsents: [{ slug: 'terms', version: 'v1', effectiveDate: '2026-07-22' }],
+            marketingConsent: true,
+          })
+          .expect(201);
+
+        const body = res.body as {
+          order: {
+            id: number;
+            orderNumber: string;
+            userId: number | null;
+            guestEmailNormalized: string | null;
+            orderLocale: 'ko' | 'en';
+            pointsUsed: number;
+            discountAmount: number;
+            items: unknown[];
+          };
+          guestAccessToken: string;
+          guestAccessTokenExpiresAt: string;
+        };
+
+        expect(body.order.orderNumber).toMatch(/^ORD-\d{8}-[A-Z0-9]{5}$/);
+        expect(body.order.userId).toBeNull();
+        expect(body.order.guestEmailNormalized).toBe(guestEmail);
+        expect(body.order.orderLocale).toBe('en');
+        expect(body.order.pointsUsed).toBe(0);
+        expect(Number(body.order.discountAmount)).toBe(0);
+        expect(Array.isArray(body.order.items)).toBe(true);
+        expect(body.guestAccessToken).toMatch(/^[a-f0-9]{64}$/);
+        expect(typeof body.guestAccessTokenExpiresAt).toBe('string');
+
+        guestOrderId = body.order.id;
+        guestOrderNumber = body.order.orderNumber;
+        guestAccessToken = body.guestAccessToken;
+        guestAccessTokenExpiresAt = body.guestAccessTokenExpiresAt;
+      });
+
+      it('guest create rejects crafted member-only discount fields', () => {
+        return request(app.getHttpServer())
+          .post('/api/guest/orders')
+          .send({
+            items: [{ productId: guestProductId, quantity: 1 }],
+            guestEmail,
+            recipientName: '비회원 주문자',
+            recipientPhone: '010-9999-0000',
+            zipcode: '54321',
+            address: '서울시 마포구',
+            orderLocale: 'en',
+            pointsUsed: 1000,
+            userCouponId: 1,
+          })
+          .expect(400);
+      });
+
+      it('guest detail requires X-Guest-Access-Token', () => {
+        return request(app.getHttpServer())
+          .get(`/api/guest/orders/${guestOrderId}`)
+          .expect(401);
+      });
+
+      it('guest detail accepts locale=en and localizes the order response', async () => {
+        const res = await request(app.getHttpServer())
+          .get(`/api/guest/orders/${guestOrderId}`)
+          .set('X-Guest-Access-Token', guestAccessToken)
+          .query({ locale: 'en' })
+          .expect(200);
+
+        const body = res.body as {
+          id: number;
+          items: Array<{ productName?: string; product?: { name?: string } }>;
+        };
+        const item = body.items[0];
+
+        expect(body.id).toBe(guestOrderId);
+        expect(item).toBeDefined();
+        expect(item.productName ?? item.product?.name).toBe('Guest Order Test Product');
+      });
+
+      it('guest lookup returns rotated top-level token and localized order response', async () => {
+        previousGuestAccessToken = guestAccessToken;
+        const res = await request(app.getHttpServer())
+          .post('/api/guest/orders/lookup')
+          .send({
+            orderNumber: guestOrderNumber,
+            email: guestEmail,
+            locale: 'en',
+          })
+          .expect(200);
+
+        const body = res.body as {
+          order: {
+            id: number;
+            items: Array<{ productName?: string; product?: { name?: string } }>;
+          };
+          guestAccessToken: string;
+          guestAccessTokenExpiresAt: string;
+        };
+
+        expect(body.order.id).toBe(guestOrderId);
+        expect(body.guestAccessToken).toMatch(/^[a-f0-9]{64}$/);
+        expect(body.guestAccessToken).not.toBe(previousGuestAccessToken);
+        expect(typeof body.guestAccessTokenExpiresAt).toBe('string');
+        expect(body.order.items[0].productName ?? body.order.items[0].product?.name).toBe('Guest Order Test Product');
+
+        guestAccessToken = body.guestAccessToken;
+        guestAccessTokenExpiresAt = body.guestAccessTokenExpiresAt;
+      });
+
+      it('guest lookup supersedes the prior token for detail access', async () => {
+        await request(app.getHttpServer())
+          .get(`/api/guest/orders/${guestOrderId}`)
+          .set('X-Guest-Access-Token', guestAccessToken)
+          .query({ locale: 'en' })
+          .expect(200);
+
+        await request(app.getHttpServer())
+          .get(`/api/guest/orders/${guestOrderId}`)
+          .set('X-Guest-Access-Token', previousGuestAccessToken)
+          .expect(401);
+
+        expect(typeof guestAccessTokenExpiresAt).toBe('string');
+      });
+
+
     });
 
     describe('GET /api/orders', () => {

--- a/backend/test/suites/payments.e2e-spec.ts
+++ b/backend/test/suites/payments.e2e-spec.ts
@@ -18,9 +18,11 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
     let productId: number;
     let orderId: number;
     let orderAmount: number;
+    const guestOrderIds: number[] = [];
 
     const userEmail = `payments-user-${Date.now()}@test.com`;
     const otherEmail = `payments-other-${Date.now()}@test.com`;
+    const guestEmail = `payments-guest-${Date.now()}@test.com`;
 
     beforeAll(async () => {
       app = getApp();
@@ -71,10 +73,49 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
       orderAmount = Number((orderRes.body as { totalAmount: number | string }).totalAmount);
     });
 
+    const createGuestOrder = async (email = guestEmail) => {
+      const orderRes = await request(app.getHttpServer())
+        .post('/api/guest/orders')
+        .send({
+          items: [{ productId, quantity: 1 }],
+          guestEmail: email,
+          recipientName: '게스트결제',
+          recipientPhone: '010-9876-5432',
+          zipcode: '54321',
+          address: '서울시 마포구',
+          orderLocale: 'ko',
+        });
+
+      if (orderRes.status !== 201) {
+        throw new Error(`Create guest order failed: ${orderRes.status} ${JSON.stringify(orderRes.body)}`);
+      }
+
+      const body = orderRes.body as {
+        order: { id: number; totalAmount: number | string; orderNumber: string };
+        guestAccessToken: string;
+        guestAccessTokenExpiresAt: string;
+      };
+      guestOrderIds.push(Number(body.order.id));
+      return {
+        orderId: Number(body.order.id),
+        orderAmount: Number(body.order.totalAmount),
+        orderNumber: body.order.orderNumber,
+        guestAccessToken: body.guestAccessToken,
+        guestAccessTokenExpiresAt: body.guestAccessTokenExpiresAt,
+      };
+    };
+
     afterAll(async () => {
       await dataSource.query('SET FOREIGN_KEY_CHECKS = 0');
       await dataSource.query(`DELETE FROM shipping WHERE order_id = ?`, [orderId]);
       await dataSource.query(`DELETE FROM payments WHERE order_id = ?`, [orderId]);
+      if (guestOrderIds.length > 0) {
+        await dataSource.query(`DELETE FROM guest_order_access WHERE order_id IN (${guestOrderIds.map(() => '?').join(', ')})`, guestOrderIds);
+        await dataSource.query(`DELETE FROM shipping WHERE order_id IN (${guestOrderIds.map(() => '?').join(', ')})`, guestOrderIds);
+        await dataSource.query(`DELETE FROM payments WHERE order_id IN (${guestOrderIds.map(() => '?').join(', ')})`, guestOrderIds);
+        await dataSource.query(`DELETE FROM order_items WHERE order_id IN (${guestOrderIds.map(() => '?').join(', ')})`, guestOrderIds);
+        await dataSource.query(`DELETE FROM orders WHERE id IN (${guestOrderIds.map(() => '?').join(', ')})`, guestOrderIds);
+      }
       await dataSource.query(`DELETE FROM order_items WHERE product_id = ?`, [productId]);
       await dataSource.query(
         `DELETE FROM orders WHERE user_id IN (
@@ -82,8 +123,8 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
         )`,
         [userEmail, otherEmail],
       );
+      await dataSource.query(`DELETE FROM users WHERE email IN (?, ?, ?)`, [userEmail, otherEmail, guestEmail]);
       await dataSource.query(`DELETE FROM products WHERE slug = 'payments-test-product-e2e'`);
-      await dataSource.query(`DELETE FROM users WHERE email IN (?, ?)`, [userEmail, otherEmail]);
       await dataSource.query('SET FOREIGN_KEY_CHECKS = 1');
     });
 
@@ -185,6 +226,172 @@ export function registerPaymentsSuite(getApp: () => INestApplication) {
           .set('Cookie', cookieHeader(userCookies))
           .send({ orderId, paymentKey: 'pay_mock_key', amount: orderAmount })
           .expect(409);
+      });
+    });
+
+    describe('POST /api/guest/orders/:id/payments/prepare', () => {
+      it('missing token → 401', async () => {
+        const guestOrder = await createGuestOrder();
+
+        await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/prepare`)
+          .send({ locale: 'ko' })
+          .expect(401);
+      });
+
+      it('invalid token → 401', async () => {
+        const guestOrder = await createGuestOrder();
+
+        await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/prepare`)
+          .set('X-Guest-Access-Token', 'invalid-token')
+          .send({ locale: 'ko' })
+          .expect(401);
+      });
+
+      it('valid token → 200/201 with member prepare shape', async () => {
+        const guestOrder = await createGuestOrder();
+
+        const res = await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/prepare`)
+          .set('X-Guest-Access-Token', guestOrder.guestAccessToken)
+          .send({})
+          .expect((r) => {
+            if (r.status !== 200 && r.status !== 201) throw new Error(`Expected 200/201 got ${r.status}: ${JSON.stringify(r.body)}`);
+          });
+
+        const body = res.body as { clientKey: string; orderId: number; amount: number; gateway: string };
+        expect(body.clientKey).toBeDefined();
+        expect(body.orderId).toBe(guestOrder.orderId);
+        expect(body.amount).toBe(guestOrder.orderAmount);
+        expect(body.gateway).toBe('mock');
+      });
+
+
+  });
+
+    describe('POST /api/guest/orders/:id/payments/confirm', () => {
+      it('invalid token → 401', async () => {
+        const guestOrder = await createGuestOrder();
+
+        await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/confirm`)
+          .set('X-Guest-Access-Token', 'invalid-token')
+          .send({ paymentKey: 'pay_guest_invalid', amount: guestOrder.orderAmount })
+          .expect(401);
+      });
+
+      it('valid token → 200 with rotated token fields, stale old token 401, rotated token usable', async () => {
+        const guestOrder = await createGuestOrder();
+
+        await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/prepare`)
+          .set('X-Guest-Access-Token', guestOrder.guestAccessToken)
+          .send({})
+          .expect((r) => {
+            if (r.status !== 200 && r.status !== 201) throw new Error(`Expected 200/201 got ${r.status}: ${JSON.stringify(r.body)}`);
+          });
+
+
+        const confirmRes = await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/confirm`)
+          .set('X-Guest-Access-Token', guestOrder.guestAccessToken)
+          .send({ paymentKey: 'pay_guest_mock_key', amount: guestOrder.orderAmount })
+          .expect((r) => {
+            if (r.status !== 200 && r.status !== 201) throw new Error(`Expected 200/201 got ${r.status}: ${JSON.stringify(r.body)}`);
+          });
+
+        const confirmBody = confirmRes.body as {
+          status: string;
+          orderId: number;
+          guestAccessToken: string;
+          guestAccessTokenExpiresAt: string;
+        };
+        expect(confirmBody.status).toBe('confirmed');
+        expect(confirmBody.orderId).toBe(guestOrder.orderId);
+        expect(confirmBody.guestAccessToken).toBeDefined();
+        expect(confirmBody.guestAccessTokenExpiresAt).toBeDefined();
+        expect(confirmBody.guestAccessToken).not.toBe(guestOrder.guestAccessToken);
+
+        await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/prepare`)
+          .set('X-Guest-Access-Token', guestOrder.guestAccessToken)
+          .send({ locale: 'ko' })
+          .expect(401);
+
+        const rotatedDetailRes = await request(app.getHttpServer())
+          .get(`/api/guest/orders/${guestOrder.orderId}`)
+          .set('X-Guest-Access-Token', confirmBody.guestAccessToken)
+          .query({ locale: 'ko' })
+          .expect(200);
+        expect(Number((rotatedDetailRes.body as { id: number | string; status: string }).id)).toBe(guestOrder.orderId);
+        expect((rotatedDetailRes.body as { id: number | string; status: string }).status).toBe('paid');
+      });
+
+      it('simultaneous confirm → one winner, one stale/conflict loser, final order stays paid', async () => {
+        const guestOrder = await createGuestOrder(`payments-guest-race-${Date.now()}@test.com`);
+
+        await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/prepare`)
+          .set('X-Guest-Access-Token', guestOrder.guestAccessToken)
+          .send({})
+          .expect((r) => {
+            if (r.status !== 200 && r.status !== 201) throw new Error(`Expected 200/201 got ${r.status}: ${JSON.stringify(r.body)}`);
+          });
+
+        const [firstResult, secondResult] = await Promise.allSettled([
+          request(app.getHttpServer())
+            .post(`/api/guest/orders/${guestOrder.orderId}/payments/confirm`)
+            .set('X-Guest-Access-Token', guestOrder.guestAccessToken)
+            .send({ paymentKey: 'pay_guest_race_first', amount: guestOrder.orderAmount }),
+          request(app.getHttpServer())
+            .post(`/api/guest/orders/${guestOrder.orderId}/payments/confirm`)
+            .set('X-Guest-Access-Token', guestOrder.guestAccessToken)
+            .send({ paymentKey: 'pay_guest_race_second', amount: guestOrder.orderAmount }),
+        ]);
+
+        expect(firstResult.status).toBe('fulfilled');
+        expect(secondResult.status).toBe('fulfilled');
+
+        const responses = [firstResult, secondResult].map((result) => {
+          if (result.status !== 'fulfilled') {
+            throw result.reason;
+          }
+          return result.value;
+        });
+        const statuses = responses.map((response) => response.status).sort((a, b) => a - b);
+        expect(statuses.filter((status) => status === 200 || status === 201)).toHaveLength(1);
+        expect(statuses.filter((status) => status === 401 || status === 409)).toHaveLength(1);
+
+        const successResponse = responses.find((response) => response.status === 200 || response.status === 201);
+        expect(successResponse).toBeDefined();
+
+        const successBody = successResponse!.body as {
+          status: string;
+          orderId: number | string;
+          guestAccessToken: string;
+          guestAccessTokenExpiresAt: string;
+        };
+        expect(successBody.status).toBe('confirmed');
+        expect(Number(successBody.orderId)).toBe(guestOrder.orderId);
+        expect(successBody.guestAccessToken).toBeDefined();
+        expect(successBody.guestAccessTokenExpiresAt).toBeDefined();
+        expect(successBody.guestAccessToken).not.toBe(guestOrder.guestAccessToken);
+
+        await request(app.getHttpServer())
+          .post(`/api/guest/orders/${guestOrder.orderId}/payments/prepare`)
+          .set('X-Guest-Access-Token', guestOrder.guestAccessToken)
+          .send({})
+          .expect(401);
+
+        const paidDetailRes = await request(app.getHttpServer())
+          .get(`/api/guest/orders/${guestOrder.orderId}`)
+          .set('X-Guest-Access-Token', successBody.guestAccessToken)
+          .query({ locale: 'ko' })
+          .expect(200);
+
+        expect(Number((paidDetailRes.body as { id: number | string; status: string }).id)).toBe(guestOrder.orderId);
+        expect((paidDetailRes.body as { id: number | string; status: string }).status).toBe('paid');
       });
     });
 

--- a/src/__tests__/middleware-backend-fallback.test.ts
+++ b/src/__tests__/middleware-backend-fallback.test.ts
@@ -61,20 +61,14 @@ describe('middleware backend admin-role fallback', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('allows /checkout when JWT_PUBLIC_KEY is unavailable but backend /auth/me confirms the session', async () => {
-    const fetchMock = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ id: 9, role: 'user' }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        }),
-    );
+  it('allows /checkout without backend fallback when JWT_PUBLIC_KEY is unavailable', async () => {
+    const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
     const res = await middleware(makeRequest('/ko/checkout'));
 
     expect(res.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('redirects /admin when backend fallback returns a non-admin role', async () => {

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -132,13 +132,10 @@ describe('middleware', () => {
     expect(location).toContain('redirect=%2Fmy');
   });
 
-  it('redirects /checkout to /login when no accessToken cookie', async () => {
+  it('passes through /checkout when no accessToken cookie', async () => {
     const req = makeRequest('/checkout');
     const res = await middleware(req);
-    expect(res.status).toBe(307);
-    const location = res.headers.get('location');
-    expect(location).toContain('/login');
-    expect(location).toContain('redirect=%2Fcheckout');
+    expect(res.status).toBe(200);
   });
 
   it('redirects /my to /login when accessToken cookie has a forged signature', async () => {
@@ -151,7 +148,7 @@ describe('middleware', () => {
     expect(location).toContain('redirect=%2Fmy');
   });
 
-  it('redirects /checkout to /login when accessToken cookie is expired', async () => {
+  it('passes through /checkout when accessToken cookie is expired', async () => {
     const expiredToken = await makeSignedToken({
       sub: 6,
       role: 'user',
@@ -160,28 +157,28 @@ describe('middleware', () => {
     });
     const req = makeRequest('/checkout', expiredToken);
     const res = await middleware(req);
-    expect(res.status).toBe(307);
-    const location = res.headers.get('location');
-    expect(location).toContain('/login');
-    expect(location).toContain('redirect=%2Fcheckout');
+    expect(res.status).toBe(200);
   });
 
-  it('redirects sub-paths like /admin/products and /my/orders', async () => {
-    for (const path of ['/admin/products', '/admin/settings', '/my/orders', '/checkout/success']) {
+  it('redirects protected admin/my sub-paths but leaves checkout sub-paths public', async () => {
+    for (const path of ['/admin/products', '/admin/settings', '/my/orders']) {
       const req = makeRequest(path);
       const res = await middleware(req);
       expect(res.status).toBe(307);
-      const location = res.headers.get('location');
-      expect(location).toContain('/login');
+      expect(res.headers.get('location')).toContain('/login');
+    }
+
+    for (const path of ['/checkout/success', '/checkout/fail']) {
+      const req = makeRequest(path);
+      const res = await middleware(req);
+      expect(res.status).toBe(200);
     }
   });
 
-  it('preserves query string in redirect param', async () => {
+  it('does not redirect public checkout query strings through login', async () => {
     const req = makeRequest('/checkout?coupon=ABC');
     const res = await middleware(req);
-    expect(res.status).toBe(307);
-    const location = res.headers.get('location');
-    expect(location).toContain('redirect=%2Fcheckout%3Fcoupon%3DABC');
+    expect(res.status).toBe(200);
   });
 
   it('passes through public routes without cookie', async () => {
@@ -222,13 +219,10 @@ describe('middleware', () => {
     expect(location).toContain('redirect=%2Fko%2Fadmin');
   });
 
-  it('redirects locale-prefixed /en/checkout to /en/login', async () => {
+  it('passes through locale-prefixed /en/checkout', async () => {
     const req = makeRequest('/en/checkout');
     const res = await middleware(req);
-    expect(res.status).toBe(307);
-    const location = res.headers.get('location');
-    expect(location).toContain('/en/login');
-    expect(location).toContain('redirect=%2Fen%2Fcheckout');
+    expect(res.status).toBe(200);
   });
 
   it('passes through locale-prefixed admin when token has admin role', async () => {

--- a/src/app/[locale]/cart/page.tsx
+++ b/src/app/[locale]/cart/page.tsx
@@ -7,7 +7,6 @@ import { ChevronDown } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { useCart } from '@/contexts/CartContext';
-import { useAuth } from '@/contexts/AuthContext';
 import { useMobileNav } from '@/contexts/MobileNavContext';
 import { Button } from '@/components/ui/button';
 import EmptyState from '@/components/shared/EmptyState';
@@ -24,7 +23,6 @@ export default function CartPage() {
   const params = useParams<{ locale?: string }>();
   const locale = (params?.locale ?? 'ko') as Locale;
   const { isVisible: isNavVisible } = useMobileNav();
-  const { isAuthenticated } = useAuth();
   const { items, isLoading, updateQuantity, removeItem } = useCart();
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [shippingQuote, setShippingQuote] = useState<ShippingQuoteResponse | null>(null);
@@ -105,10 +103,6 @@ export default function CartPage() {
     }
     const selectedItems = items.filter((item) => selectedIds.has(item.id));
     sessionStorage.setItem(SESSION_KEYS.CHECKOUT_ITEMS, JSON.stringify(selectedItems));
-    if (!isAuthenticated) {
-      router.push(`/${locale}/login?redirect=${encodeURIComponent(`/${locale}/checkout`)}`);
-      return;
-    }
     router.push(`/${locale}/checkout`);
   };
 

--- a/src/app/[locale]/checkout/fail/__tests__/CheckoutFailPage.test.tsx
+++ b/src/app/[locale]/checkout/fail/__tests__/CheckoutFailPage.test.tsx
@@ -1,0 +1,74 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import CheckoutFailPage from '@/app/[locale]/checkout/fail/page';
+import { SESSION_KEYS } from '@/constants/storage';
+import { toast } from 'sonner';
+
+const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, string>) => {
+    const messages: Record<string, string> = {
+      failedTitle: '결제 실패',
+      back: '돌아가기',
+      loading: '로딩 중...',
+      defaultFailMessage: '결제에 실패했습니다.',
+      errorCode: `오류 코드: ${values?.code ?? ''}`,
+    };
+    return messages[key] ?? key;
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
+
+describe('CheckoutFailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockSearchParams = new URLSearchParams('code=PAY_FAIL&message=결제 실패');
+  });
+
+  it('clears hosted contexts but preserves checkout items and guest context', async () => {
+    sessionStorage.setItem(SESSION_KEYS.TOSS_CONTEXT, JSON.stringify({ orderId: 1 }));
+    sessionStorage.setItem(SESSION_KEYS.PAYPAL_CONTEXT, JSON.stringify({ orderId: 1 }));
+    sessionStorage.setItem(SESSION_KEYS.NAVERPAY_CONTEXT, JSON.stringify({ orderId: 1 }));
+    sessionStorage.setItem(SESSION_KEYS.EXIMBAY_CONTEXT, JSON.stringify({ orderId: 1 }));
+    sessionStorage.setItem(SESSION_KEYS.CHECKOUT_ITEMS, JSON.stringify([{ id: 1 }]));
+    sessionStorage.setItem(SESSION_KEYS.GUEST_ORDER_CONTEXT, JSON.stringify({ orderId: 1, orderNumber: 'GUEST-001' }));
+
+    await act(async () => {
+      render(<CheckoutFailPage params={Promise.resolve({ locale: 'ko' as const })} />);
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('결제 실패');
+    });
+
+    expect(sessionStorage.getItem(SESSION_KEYS.TOSS_CONTEXT)).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEYS.PAYPAL_CONTEXT)).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEYS.NAVERPAY_CONTEXT)).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEYS.EXIMBAY_CONTEXT)).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEYS.CHECKOUT_ITEMS)).toBe(JSON.stringify([{ id: 1 }]));
+    expect(sessionStorage.getItem(SESSION_KEYS.GUEST_ORDER_CONTEXT)).toBe(JSON.stringify({ orderId: 1, orderNumber: 'GUEST-001' }));
+  });
+
+  it('retries by routing back to locale checkout', async () => {
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(<CheckoutFailPage params={Promise.resolve({ locale: 'ko' as const })} />);
+    });
+
+    await user.click(screen.getByRole('button', { name: '돌아가기' }));
+    expect(mockReplace).toHaveBeenCalledWith('/ko/checkout');
+  });
+});

--- a/src/app/[locale]/checkout/fail/page.tsx
+++ b/src/app/[locale]/checkout/fail/page.tsx
@@ -8,30 +8,33 @@ import type { Locale } from '@/i18n/routing';
 import { SESSION_KEYS } from '@/constants/storage';
 import { useTranslations } from 'next-intl';
 
+function clearHostedProviderContexts(): void {
+  sessionStorage.removeItem(SESSION_KEYS.TOSS_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.PAYPAL_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.NAVERPAY_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.EXIMBAY_CONTEXT);
+}
+
 function CheckoutFailContent({ locale }: { locale: Locale }) {
   const searchParams = useSearchParams();
   const router = useRouter();
-
   const t = useTranslations('checkoutResult');
   const code = searchParams.get('code') ?? '';
   const message = searchParams.get('message') ?? t('defaultFailMessage');
 
   useEffect(() => {
     toast.error(message);
-    sessionStorage.removeItem(SESSION_KEYS.TOSS_CONTEXT);
-    sessionStorage.removeItem(SESSION_KEYS.EXIMBAY_CONTEXT);
+    clearHostedProviderContexts();
   }, [message]);
 
   return (
     <div className="mx-auto max-w-lg px-4 py-16 text-center">
       <h1 className="mb-4 text-xl font-bold text-destructive">{t('failedTitle')}</h1>
-      {code && (
-        <p className="mb-2 text-xs text-muted-foreground">{t('errorCode', { code })}</p>
-      )}
+      {code && <p className="mb-2 text-xs text-muted-foreground">{t('errorCode', { code })}</p>}
       <p className="mb-6 text-sm text-muted-foreground">{message}</p>
       <button
         onClick={() => router.replace(`/${locale}/checkout`)}
-        className="rounded-md bg-foreground px-6 py-2 text-sm font-semibold text-background hover:opacity-90 transition-opacity"
+        className="rounded-md bg-foreground px-6 py-2 text-sm font-semibold text-background transition-opacity hover:opacity-90"
       >
         {t('back')}
       </button>
@@ -45,14 +48,13 @@ export default function CheckoutFailPage({
   params: Promise<{ locale: Locale }>;
 }) {
   const { locale } = use(params);
+  const t = useTranslations('checkoutResult');
 
   return (
     <Suspense
       fallback={
         <div className="mx-auto max-w-lg px-4 py-16 text-center">
-          <p className="text-sm text-muted-foreground">
-            {locale === 'en' ? 'Loading...' : '로딩 중...'}
-          </p>
+          <p className="text-sm text-muted-foreground">{t('loading')}</p>
         </div>
       }
     >

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -9,7 +9,14 @@ import { useCart } from '@/contexts/CartContext';
 import { useMobileNav } from '@/contexts/MobileNavContext';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/components/ui/utils';
-import type { CartItem, CheckoutGatewayName, PreparePaymentResponse, ShippingQuoteResponse, UserAddress, CalculateDiscountResponse } from '@/lib/api';
+import type {
+  CalculateDiscountResponse,
+  CartItem,
+  CheckoutGatewayName,
+  PreparePaymentResponse,
+  ShippingQuoteResponse,
+  UserAddress,
+} from '@/lib/api';
 import { shippingApi, usersApi } from '@/lib/api';
 import { SESSION_KEYS } from '@/constants/storage';
 import { getDefaultCheckoutGateway, getGatewayOptionsByLocale } from '@/constants/checkoutPaymentMethods';
@@ -44,8 +51,8 @@ export interface FormErrors {
   recipientPhone?: string;
   zipcode?: string;
   address?: string;
+  guestEmail?: string;
 }
-
 
 function normalizeInputValue(value: unknown): string {
   if (value == null) return '';
@@ -75,9 +82,13 @@ export default function CheckoutPage({
   const [sessionChecked, setSessionChecked] = useState(false);
   const [step, setStep] = useState<PaymentStep>('idle');
   const [prepareResult, setPrepareResult] = useState<PreparePaymentResponse | null>(null);
-  const [selectedGateway, setSelectedGateway] = useState<CheckoutGatewayName>(() => getDefaultCheckoutGateway(locale));
+  const [selectedGateway, setSelectedGateway] = useState<CheckoutGatewayName>(() =>
+    getDefaultCheckoutGateway(locale),
+  );
   const [currentOrderId, setCurrentOrderId] = useState<number | null>(null);
   const [currentOrderNumber, setCurrentOrderNumber] = useState('');
+  const [currentGuestAccessToken, setCurrentGuestAccessToken] = useState('');
+  const [currentGuestAccessTokenExpiresAt, setCurrentGuestAccessTokenExpiresAt] = useState('');
   const [confirmedGrandTotal, setConfirmedGrandTotal] = useState<number | null>(null);
   const [shippingQuote, setShippingQuote] = useState<ShippingQuoteResponse | null>(null);
   const [form, setForm] = useState<ShippingForm>({
@@ -88,6 +99,7 @@ export default function CheckoutPage({
     addressDetail: '',
     memo: '',
   });
+  const [guestEmail, setGuestEmail] = useState('');
   const [errors, setErrors] = useState<FormErrors>({});
   const [requiredConsent, setRequiredConsent] = useState(false);
   const [marketingConsent, setMarketingConsent] = useState(false);
@@ -99,6 +111,7 @@ export default function CheckoutPage({
   const [selectedAddressId, setSelectedAddressId] = useState<number | 'manual' | null>(null);
   const [addressLoading, setAddressLoading] = useState(false);
 
+  const isGuestCheckout = !isAuthenticated;
   const totalAmount = checkoutItems.reduce((sum, item) => sum + item.subtotal, 0);
   const shippingFee = shippingQuote?.shippingFee ?? 0;
   const freeShippingThreshold = shippingQuote?.threshold ?? 0;
@@ -133,16 +146,14 @@ export default function CheckoutPage({
 
   useEffect(() => {
     if (isLoading) return;
+
     setSessionChecked(false);
-    if (!isAuthenticated) {
-      router.replace(`/${locale}/login`);
-      return;
-    }
     const raw = sessionStorage.getItem(SESSION_KEYS.CHECKOUT_ITEMS);
     if (!raw) {
       router.replace(`/${locale}/cart`);
       return;
     }
+
     try {
       const parsed = JSON.parse(raw) as CartItem[];
       if (!Array.isArray(parsed) || parsed.length === 0) {
@@ -154,7 +165,7 @@ export default function CheckoutPage({
     } catch {
       router.replace(`/${locale}/cart`);
     }
-  }, [isAuthenticated, isLoading, locale, router]);
+  }, [isLoading, locale, router]);
 
   useEffect(() => {
     if (totalAmount <= 0) {
@@ -164,15 +175,16 @@ export default function CheckoutPage({
 
     let cancelled = false;
     const zipcode = /^\d{3,10}$/.test(form.zipcode.trim()) ? form.zipcode.trim() : '00000';
-    shippingApi.quote(
-      totalAmount,
-      zipcode,
-      checkoutItems.map((item) => ({
-        productId: item.productId,
-        productOptionId: item.productOptionId,
-        quantity: item.quantity,
-      })),
-    )
+    shippingApi
+      .quote(
+        totalAmount,
+        zipcode,
+        checkoutItems.map((item) => ({
+          productId: item.productId,
+          productOptionId: item.productOptionId,
+          quantity: item.quantity,
+        })),
+      )
       .then((quote) => {
         if (!cancelled) setShippingQuote(quote);
       })
@@ -228,9 +240,17 @@ export default function CheckoutPage({
     }
   };
 
+  const handleGuestEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setGuestEmail(e.target.value);
+    if (errors.guestEmail) {
+      setErrors((prev) => ({ ...prev, guestEmail: undefined }));
+    }
+  };
+
   const { handleSubmit, handlePaymentError } = useCheckout({
     checkoutItems,
     form,
+    guestEmail,
     grandTotal,
     locale,
     paymentRef,
@@ -238,21 +258,23 @@ export default function CheckoutPage({
     selectedGateway,
     currentOrderId,
     currentOrderNumber,
+    currentGuestAccessToken,
     requiredConsent,
     marketingConsent,
     selectedUserCouponId,
     pointsUsed,
+    isGuestCheckout,
     setStep,
     setPrepareResult,
     setCurrentOrderId,
     setCurrentOrderNumber,
+    setCurrentGuestAccessToken,
+    setCurrentGuestAccessTokenExpiresAt,
     setConfirmedGrandTotal,
     setErrors,
     refetch,
   });
 
-  // Keep the server render and the first client render identical for checkout.
-  // The actual order form depends on sessionStorage restored after OAuth redirects.
   if (!sessionChecked || checkoutItems.length === 0) {
     return null;
   }
@@ -276,13 +298,38 @@ export default function CheckoutPage({
               <h2 className="typo-h3">{t('shippingInfo')}</h2>
 
               <div className="mt-4 layout-stack-md">
-                <AddressSelectorSection
-                  addresses={addresses}
-                  selectedAddressId={selectedAddressId}
-                  addressLoading={addressLoading}
-                  onSelect={handleAddressSelect}
-                  locale={locale}
-                />
+                {isGuestCheckout ? (
+                  <div className="rounded-lg border border-soft bg-muted/20 p-4">
+                    <h3 className="text-sm font-semibold text-foreground">{t('guestCheckoutTitle')}</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">{t('guestCheckoutDescription')}</p>
+                    <label className="mt-4 block text-sm font-medium text-foreground" htmlFor="guestEmail">
+                      {t('guestEmailLabel')}
+                    </label>
+                    <input
+                      id="guestEmail"
+                      name="guestEmail"
+                      type="email"
+                      autoComplete="email"
+                      value={guestEmail}
+                      onChange={handleGuestEmailChange}
+                      placeholder={t('guestEmailPlaceholder')}
+                      className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                    />
+                    {errors.guestEmail ? (
+                      <p className="mt-2 text-sm text-destructive">{errors.guestEmail}</p>
+                    ) : (
+                      <p className="mt-2 text-xs text-muted-foreground">{t('guestEmailDescription')}</p>
+                    )}
+                  </div>
+                ) : (
+                  <AddressSelectorSection
+                    addresses={addresses}
+                    selectedAddressId={selectedAddressId}
+                    addressLoading={addressLoading}
+                    onSelect={handleAddressSelect}
+                    locale={locale}
+                  />
+                )}
 
                 <ShippingFormSection form={form} errors={errors} onChange={handleChange} />
                 <PhoneInputSection form={form} errors={errors} onChange={handleChange} />
@@ -304,6 +351,8 @@ export default function CheckoutPage({
                     orderNumber={currentOrderNumber}
                     amount={grandTotal}
                     locale={locale}
+                    guestAccessToken={currentGuestAccessToken || undefined}
+                    guestAccessTokenExpiresAt={currentGuestAccessTokenExpiresAt || undefined}
                     onError={handlePaymentError}
                   />
                 ) : (
@@ -317,19 +366,21 @@ export default function CheckoutPage({
               </div>
             </section>
 
-            <section className="surface-card p-6">
-              <h2 className="typo-h3">{t('couponPoints')}</h2>
-              <div className="mt-4">
-                <CouponSelector
-                  orderAmount={totalAmount}
-                  onDiscountChange={(result, userCouponId, appliedPoints = 0) => {
-                    setDiscountResult(result);
-                    setSelectedUserCouponId(userCouponId);
-                    setPointsUsed(appliedPoints);
-                  }}
-                />
-              </div>
-            </section>
+            {!isGuestCheckout && (
+              <section className="surface-card p-6">
+                <h2 className="typo-h3">{t('couponPoints')}</h2>
+                <div className="mt-4">
+                  <CouponSelector
+                    orderAmount={totalAmount}
+                    onDiscountChange={(result, userCouponId, appliedPoints = 0) => {
+                      setDiscountResult(result);
+                      setSelectedUserCouponId(userCouponId);
+                      setPointsUsed(appliedPoints);
+                    }}
+                  />
+                </div>
+              </section>
+            )}
 
             <section className="surface-card p-6">
               <h2 className="typo-h3">{t('consent.title')}</h2>

--- a/src/app/[locale]/checkout/success/__tests__/CheckoutSuccessPage.test.tsx
+++ b/src/app/[locale]/checkout/success/__tests__/CheckoutSuccessPage.test.tsx
@@ -1,17 +1,21 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import CheckoutSuccessPage from '@/app/[locale]/checkout/success/page';
 import { toast } from 'sonner';
+import { ApiHttpError } from '@/lib/api-error';
+import { SESSION_KEYS } from '@/constants/storage';
 
-// ---- next/navigation ----
 const mockReplace = vi.fn();
 let mockSearchParams = new URLSearchParams();
+const mockRefetch = vi.fn().mockResolvedValue(undefined);
+const mockMemberConfirm = vi.fn();
+const mockGuestConfirm = vi.fn();
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace, push: vi.fn() }),
   useSearchParams: () => mockSearchParams,
 }));
 
-// ---- sonner ----
 vi.mock('sonner', () => ({
   toast: {
     error: vi.fn(),
@@ -20,309 +24,186 @@ vi.mock('sonner', () => ({
   },
 }));
 
-// ---- CartContext ----
 vi.mock('@/contexts/CartContext', () => ({
-  useCart: () => ({
-    refetch: vi.fn().mockResolvedValue(undefined),
-  }),
-  CartContext: {},
-  CartProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useCart: () => ({ refetch: mockRefetch }),
 }));
 
-// ---- api ----
-const mockConfirm = vi.fn();
 vi.mock('@/lib/api', () => ({
-  paymentsApi: { confirm: (...args: unknown[]) => mockConfirm(...args) },
+  paymentsApi: { confirm: (...args: unknown[]) => mockMemberConfirm(...args) },
+  guestPaymentsApi: { confirm: (...args: unknown[]) => mockGuestConfirm(...args) },
 }));
 
-// ---- error utility ----
 vi.mock('@/utils/error', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  handleApiError: vi.fn((_err: unknown) => '결제 확인 중 오류가 발생했습니다.'),
+  handleApiError: vi.fn(() => '결제 확인 중 오류가 발생했습니다.'),
 }));
 
 vi.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => {
-    const messages: Record<string, string> = {
-      confirmFailedTitle: '결제 확인 실패',
-      confirmFailedDescription: '결제 확인 중 문제가 발생했습니다. 고객센터에 문의해주세요.',
-      processingTitle: '결제 처리 중...',
-      processingDescription: '잠시만 기다려주세요.',
-      backToCart: '장바구니로 돌아가기',
+  useTranslations: () => {
+    return (key: string, values?: Record<string, string>) => {
+      const messages: Record<string, string> = {
+        failedTitle: '결제 실패',
+        confirmFailedTitle: '결제 확인 실패',
+        confirmFailedDescription: '결제 확인 중 문제가 발생했습니다. 고객센터에 문의해주세요.',
+        processingTitle: '결제 처리 중...',
+        processingDescription: '잠시만 기다려주세요.',
+        backToCart: '장바구니로 돌아가기',
+        back: '돌아가기',
+        loading: '로딩 중...',
+        guestAccessExpired: '비회원 주문 조회 권한이 만료되었습니다. 주문조회에서 다시 확인해 주세요.',
+        errorCode: `오류 코드: ${values?.code ?? ''}`,
+        defaultFailMessage: '결제에 실패했습니다.',
+      };
+      return messages[key] ?? key;
     };
-
-    return messages[key] ?? key;
   },
 }));
 
 const makeParams = () => Promise.resolve({ locale: 'ko' as const });
 
-describe('CheckoutSuccessPage', () => {
+const memberContext = {
+  orderId: 1,
+  orderNumber: 'ORD-001',
+  amount: 40000,
+};
+
+const guestContext = {
+  orderId: 2,
+  orderNumber: 'GUEST-001',
+  amount: 52000,
+  guestAccessToken: 'guest-token-1',
+  guestAccessTokenExpiresAt: '2026-08-21T00:00:00.000Z',
+};
+
+function setTossSearchParams(amount = '40000') {
+  mockSearchParams = new URLSearchParams();
+  mockSearchParams.set('paymentKey', 'pay_abc123');
+  mockSearchParams.set('orderId', 'ORD-001');
+  mockSearchParams.set('amount', amount);
+}
+
+describe('CheckoutSuccessPage guest coverage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
     mockSearchParams = new URLSearchParams();
   });
 
-  const validPaymentContext = {
-    orderId: 1,
-    orderNumber: 'ORD-001',
-    amount: 40000,
-  };
+  it('persists rotated guest context and redirects to guest order complete after guest hosted confirm', async () => {
+    mockSearchParams.set('token', 'PAYPAL-ORDER-1');
+    sessionStorage.setItem(SESSION_KEYS.PAYPAL_CONTEXT, JSON.stringify(guestContext));
+    sessionStorage.setItem(SESSION_KEYS.CHECKOUT_ITEMS, JSON.stringify([{ id: 1 }]));
+    sessionStorage.setItem(SESSION_KEYS.GUEST_ORDER_CONTEXT, JSON.stringify({ stale: true }));
 
-  const setupValidSearchParams = () => {
-    mockSearchParams.set('paymentKey', 'pay_abc123');
-    mockSearchParams.set('orderId', 'ORD-001');
-    mockSearchParams.set('amount', '40000');
-  };
-
-  describe('보안: 결제 금액 처리', () => {
-    it('URL의 amount가 sessionStorage의 ctx.amount와 다르면 결제 확인을 하지 않고 cart로 리다이렉션한다', async () => {
-      mockSearchParams.set('paymentKey', 'pay_abc123');
-      mockSearchParams.set('orderId', 'ORD-001');
-      mockSearchParams.set('amount', '1000');
-
-      sessionStorage.setItem('tossPaymentContext', JSON.stringify(validPaymentContext));
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockReplace).toHaveBeenCalledWith('/ko/cart');
-      });
-      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('결제 금액이 일치하지 않습니다.');
-      expect(mockConfirm).not.toHaveBeenCalled();
+    mockGuestConfirm.mockResolvedValue({
+      paymentId: 10,
+      orderId: 2,
+      orderNumber: 'GUEST-001',
+      status: 'paid',
+      method: 'paypal',
+      amount: 52000,
+      paidAt: '2026-07-22T00:00:00.000Z',
+      guestAccessToken: 'guest-token-rotated',
+      guestAccessTokenExpiresAt: '2026-08-22T00:00:00.000Z',
     });
 
-    it('URL과 sessionStorage의 금액이 일치하면 ctx.amount로 결제 확인을 진행한다', async () => {
-      mockSearchParams.set('paymentKey', 'pay_abc123');
-      mockSearchParams.set('orderId', 'ORD-001');
-      mockSearchParams.set('amount', '40000');
-
-      const ctxAmount = 40000;
-      sessionStorage.setItem('tossPaymentContext', JSON.stringify({
-        ...validPaymentContext,
-        amount: ctxAmount,
-      }));
-
-      mockConfirm.mockResolvedValue({
-        paymentId: 1,
-        orderId: 1,
-        orderNumber: 'ORD-001',
-        status: 'paid',
-        method: 'card',
-        amount: ctxAmount,
-        paidAt: new Date().toISOString(),
-      });
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockConfirm).toHaveBeenCalledWith({
-          orderId: 1,
-          paymentKey: 'pay_abc123',
-          amount: ctxAmount,
-        });
-      });
-    });
-  });
-
-  describe('필수 파라미터 검증', () => {
-    it('paymentKey가 없으면 cart로 리다이렉션한다', async () => {
-      mockSearchParams.set('orderId', 'ORD-001');
-      mockSearchParams.set('amount', '40000');
-      // paymentKey 없음
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockReplace).toHaveBeenCalledWith('/ko/cart');
-      });
-      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('결제 정보가 올바르지 않습니다.');
+    await act(async () => {
+      render(<CheckoutSuccessPage params={makeParams()} />);
     });
 
-    it('tossPaymentContext가 sessionStorage에 없으면 cart로 리다이렉션한다', async () => {
-      setupValidSearchParams();
-      // sessionStorage에 tossPaymentContext 없음
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockReplace).toHaveBeenCalledWith('/ko/cart');
-      });
-      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('결제 컨텍스트를 찾을 수 없습니다.');
-    });
-  });
-
-  describe('결제 완료 후 동작', () => {
-
-    it('PayPal token + paypalPaymentContext가 있으면 token으로 결제 확인을 진행한다', async () => {
-      mockSearchParams.set('token', 'PAYPAL-ORDER-1');
-      sessionStorage.setItem('paypalPaymentContext', JSON.stringify(validPaymentContext));
-
-      mockConfirm.mockResolvedValue({
-        paymentId: 1,
-        orderId: 1,
-        orderNumber: 'ORD-001',
-        status: 'paid',
-        method: 'paypal',
-        amount: 40000,
-        paidAt: new Date().toISOString(),
-      });
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockConfirm).toHaveBeenCalledWith({
-          orderId: 1,
-          paymentKey: 'PAYPAL-ORDER-1',
-          amount: 40000,
-        });
-      });
-    });
-
-
-    it('NaverPay resultCode=Success + paymentId가 있으면 네이버페이 컨텍스트로 결제 확인을 진행한다', async () => {
-      mockSearchParams.set('resultCode', 'Success');
-      mockSearchParams.set('paymentId', 'NPAYMENT-1');
-      sessionStorage.setItem('naverpayPaymentContext', JSON.stringify(validPaymentContext));
-
-      mockConfirm.mockResolvedValue({
-        paymentId: 1,
-        orderId: 1,
-        orderNumber: 'ORD-001',
-        status: 'paid',
-        method: 'card',
-        amount: 40000,
-        paidAt: new Date().toISOString(),
-      });
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockConfirm).toHaveBeenCalledWith({
-          orderId: 1,
-          paymentKey: 'NPAYMENT-1',
-          amount: 40000,
-        });
-      });
-    });
-
-    it('Eximbay rescode=0000 callback은 원본 query string으로 서버 검증을 진행한다', async () => {
-      mockSearchParams.set('rescode', '0000');
-      mockSearchParams.set('order_id', 'ORD-001');
-      mockSearchParams.set('transaction_id', 'EXIMBAY-TX-1');
-      sessionStorage.setItem('eximbayPaymentContext', JSON.stringify(validPaymentContext));
-
-      mockConfirm.mockResolvedValue({
-        paymentId: 1,
-        orderId: 1,
-        orderNumber: 'ORD-001',
-        status: 'paid',
-        method: 'card',
-        amount: 40000,
-        paidAt: new Date().toISOString(),
-      });
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockConfirm).toHaveBeenCalledWith({
-          orderId: 1,
-          paymentKey: 'rescode=0000&order_id=ORD-001&transaction_id=EXIMBAY-TX-1',
-          amount: 40000,
-        });
-      });
-    });
-
-    it('NaverPay resultCode 실패는 결제 확인 없이 cart로 이동한다', async () => {
-      mockSearchParams.set('resultCode', 'UserCancel');
-      mockSearchParams.set('resultMessage', '사용자 취소');
-      sessionStorage.setItem('naverpayPaymentContext', JSON.stringify(validPaymentContext));
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockReplace).toHaveBeenCalledWith('/ko/cart');
-      });
-      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('사용자 취소');
-      expect(mockConfirm).not.toHaveBeenCalled();
-    });
-
-    it('결제 확인 성공 시 sessionStorageアイテムをクリア하고 order/complete页面로リ다이렉션한다', async () => {
-      setupValidSearchParams();
-      sessionStorage.setItem('tossPaymentContext', JSON.stringify(validPaymentContext));
-      sessionStorage.setItem('checkoutItems', JSON.stringify([{ id: 1 }]));
-
-      mockConfirm.mockResolvedValue({
-        paymentId: 1,
-        orderId: 1,
-        orderNumber: 'ORD-001',
-        status: 'paid',
-        method: 'card',
-        amount: 40000,
-        paidAt: new Date().toISOString(),
-      });
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(mockReplace).toHaveBeenCalledWith('/ko/order/complete?orderId=1&orderNumber=ORD-001');
-      });
-      expect(sessionStorage.getItem('tossPaymentContext')).toBeNull();
-      expect(sessionStorage.getItem('checkoutItems')).toBeNull();
-    });
-
-    it('결제 확인 실패 시エラーメッセージを表示して재시도 버튼을 표시한다', async () => {
-      setupValidSearchParams();
-      sessionStorage.setItem('tossPaymentContext', JSON.stringify(validPaymentContext));
-
-      mockConfirm.mockRejectedValue(new Error('Payment failed'));
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      await waitFor(() => {
-        expect(vi.mocked(toast.error)).toHaveBeenCalled();
-      });
-      expect(screen.getByText('결제 확인 실패')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: '장바구니로 돌아가기' })).toBeInTheDocument();
-    });
-  });
-
-  describe('로딩 상태', () => {
-    it('결제 처리 중에는 로딩 메시지를 표시한다', async () => {
-      setupValidSearchParams();
-      sessionStorage.setItem('tossPaymentContext', JSON.stringify(validPaymentContext));
-
-      // 결제가 끝나지 않도록 mock을 설정하지 않음
-      mockConfirm.mockImplementation(
-        () => new Promise(() => {}) //，永远に解决しない
+    await waitFor(() => {
+      expect(mockGuestConfirm).toHaveBeenCalledWith(
+        2,
+        { paymentKey: 'PAYPAL-ORDER-1', amount: 52000 },
+        'guest-token-1',
       );
-
-      await act(async () => {
-        render(<CheckoutSuccessPage params={makeParams()} />);
-      });
-
-      expect(screen.getByText('결제 처리 중...')).toBeInTheDocument();
     });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/ko/order/complete?orderId=2&orderNumber=GUEST-001&flow=guest');
+    });
+
+    expect(JSON.parse(sessionStorage.getItem(SESSION_KEYS.GUEST_ORDER_CONTEXT) ?? '{}')).toEqual({
+      orderId: 2,
+      orderNumber: 'GUEST-001',
+      guestAccessToken: 'guest-token-rotated',
+      guestAccessTokenExpiresAt: '2026-08-22T00:00:00.000Z',
+    });
+    expect(sessionStorage.getItem(SESSION_KEYS.PAYPAL_CONTEXT)).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEYS.CHECKOUT_ITEMS)).toBeNull();
+    expect(mockRefetch).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith('결제가 완료되었습니다.');
+  });
+
+  it('clears guest state and redirects to lookup when guest confirm returns 401', async () => {
+    setTossSearchParams('52000');
+    sessionStorage.setItem(SESSION_KEYS.TOSS_CONTEXT, JSON.stringify(guestContext));
+    sessionStorage.setItem(SESSION_KEYS.CHECKOUT_ITEMS, JSON.stringify([{ id: 1 }]));
+    sessionStorage.setItem(SESSION_KEYS.GUEST_ORDER_CONTEXT, JSON.stringify(guestContext));
+
+    mockGuestConfirm.mockRejectedValue(new ApiHttpError('Unauthorized', 401));
+
+    await act(async () => {
+      render(<CheckoutSuccessPage params={makeParams()} />);
+    });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/ko/order/lookup');
+    });
+
+    expect(sessionStorage.getItem(SESSION_KEYS.TOSS_CONTEXT)).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEYS.CHECKOUT_ITEMS)).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEYS.GUEST_ORDER_CONTEXT)).toBeNull();
+    expect(toast.error).toHaveBeenCalledWith('비회원 주문 조회 권한이 만료되었습니다. 주문조회에서 다시 확인해 주세요.');
+  });
+
+  it('keeps member hosted confirm behavior for non-guest contexts', async () => {
+    setTossSearchParams();
+    sessionStorage.setItem(SESSION_KEYS.TOSS_CONTEXT, JSON.stringify(memberContext));
+    sessionStorage.setItem(SESSION_KEYS.CHECKOUT_ITEMS, JSON.stringify([{ id: 1 }]));
+
+    mockMemberConfirm.mockResolvedValue({
+      paymentId: 1,
+      orderId: 1,
+      orderNumber: 'ORD-001',
+      status: 'paid',
+      method: 'card',
+      amount: 40000,
+      paidAt: '2026-07-22T00:00:00.000Z',
+    });
+
+    await act(async () => {
+      render(<CheckoutSuccessPage params={makeParams()} />);
+    });
+
+    await waitFor(() => {
+      expect(mockMemberConfirm).toHaveBeenCalledWith({
+        orderId: 1,
+        paymentKey: 'pay_abc123',
+        amount: 40000,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/ko/order/complete?orderId=1&orderNumber=ORD-001');
+    });
+    expect(sessionStorage.getItem(SESSION_KEYS.GUEST_ORDER_CONTEXT)).toBeNull();
+  });
+
+  it('shows failure UI when confirm fails with a non-guest error', async () => {
+    setTossSearchParams();
+    sessionStorage.setItem(SESSION_KEYS.TOSS_CONTEXT, JSON.stringify(memberContext));
+
+    mockMemberConfirm.mockRejectedValue(new Error('Payment failed'));
+
+    await act(async () => {
+      render(<CheckoutSuccessPage params={makeParams()} />);
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText('결제 확인 실패')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '장바구니로 돌아가기' })).toBeInTheDocument();
   });
 });

--- a/src/app/[locale]/checkout/success/page.tsx
+++ b/src/app/[locale]/checkout/success/page.tsx
@@ -6,11 +6,32 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
 import { useCart } from '@/contexts/CartContext';
-import { paymentsApi } from '@/lib/api';
+import { guestPaymentsApi, paymentsApi, type ConfirmPaymentResponse, type GuestConfirmPaymentResponse } from '@/lib/api';
 import type { Locale } from '@/i18n/routing';
 import { SESSION_KEYS } from '@/constants/storage';
 import { toastMessage } from '@/utils/toastMessages';
+import { ApiHttpError } from '@/lib/api-error';
 import { useTranslations } from 'next-intl';
+
+interface HostedPaymentContext {
+  orderId: number;
+  orderNumber: string;
+  amount: number;
+  guestAccessToken?: string;
+  guestAccessTokenExpiresAt?: string;
+}
+
+function clearHostedProviderContexts(): void {
+  sessionStorage.removeItem(SESSION_KEYS.TOSS_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.PAYPAL_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.NAVERPAY_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.EXIMBAY_CONTEXT);
+}
+
+function clearCheckoutState(): void {
+  sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
+  clearHostedProviderContexts();
+}
 
 function CheckoutSuccessContent({ locale }: { locale: Locale }) {
   const router = useRouter();
@@ -52,7 +73,10 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
       return;
     }
 
-    if (!paymentKey || (!paypalToken && !isNaverPayReturn && !isEximbayReturn && (!tossOrderId || !amountParam))) {
+    if (
+      !paymentKey ||
+      (!paypalToken && !isNaverPayReturn && !isEximbayReturn && (!tossOrderId || !amountParam))
+    ) {
       toast.error(toastMessage('paymentInvalidInfo'));
       router.replace(`/${locale}/cart`);
       return;
@@ -65,11 +89,14 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
       return;
     }
 
-    const ctx = JSON.parse(raw) as {
-      orderId: number;
-      orderNumber: string;
-      amount: number;
-    };
+    let ctx: HostedPaymentContext;
+    try {
+      ctx = JSON.parse(raw) as HostedPaymentContext;
+    } catch {
+      toast.error(toastMessage('paymentContextMissing'));
+      router.replace(`/${locale}/cart`);
+      return;
+    }
 
     if (!paypalToken && !isNaverPayReturn && !isEximbayReturn) {
       const amount = Number(amountParam);
@@ -80,21 +107,51 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
       }
     }
 
-    paymentsApi
-      .confirm({ orderId: ctx.orderId, paymentKey, amount: ctx.amount })
-      .then(async () => {
+    const isGuestConfirmResponse = (
+      result: ConfirmPaymentResponse | GuestConfirmPaymentResponse,
+    ): result is GuestConfirmPaymentResponse => 'guestAccessToken' in result;
+
+    const confirmPromise: Promise<ConfirmPaymentResponse | GuestConfirmPaymentResponse> = ctx.guestAccessToken
+      ? guestPaymentsApi.confirm(
+          ctx.orderId,
+          { paymentKey, amount: ctx.amount },
+          ctx.guestAccessToken,
+        )
+      : paymentsApi.confirm({ orderId: ctx.orderId, paymentKey, amount: ctx.amount });
+
+    confirmPromise
+      .then(async (result) => {
         toast.success(toastMessage('paymentComplete'));
-        sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
-        sessionStorage.removeItem(SESSION_KEYS.TOSS_CONTEXT);
-        sessionStorage.removeItem(SESSION_KEYS.PAYPAL_CONTEXT);
-        sessionStorage.removeItem(SESSION_KEYS.NAVERPAY_CONTEXT);
-        sessionStorage.removeItem(SESSION_KEYS.EXIMBAY_CONTEXT);
+        clearCheckoutState();
+
+        if (isGuestConfirmResponse(result)) {
+          sessionStorage.setItem(
+            SESSION_KEYS.GUEST_ORDER_CONTEXT,
+            JSON.stringify({
+              orderId: result.orderId,
+              orderNumber: result.orderNumber,
+              guestAccessToken: result.guestAccessToken,
+              guestAccessTokenExpiresAt: result.guestAccessTokenExpiresAt,
+            }),
+          );
+        }
+
         await refetch();
         router.replace(
-          `/${locale}/order/complete?orderId=${ctx.orderId}&orderNumber=${ctx.orderNumber}`,
+          isGuestConfirmResponse(result)
+            ? `/${locale}/order/complete?orderId=${result.orderId}&orderNumber=${result.orderNumber}&flow=guest`
+            : `/${locale}/order/complete?orderId=${ctx.orderId}&orderNumber=${ctx.orderNumber}`,
         );
       })
       .catch((err: unknown) => {
+        if (ctx.guestAccessToken && err instanceof ApiHttpError && err.status === 401) {
+          clearCheckoutState();
+          sessionStorage.removeItem(SESSION_KEYS.GUEST_ORDER_CONTEXT);
+          toast.error(t('guestAccessExpired'));
+          router.replace(`/${locale}/order/lookup`);
+          return;
+        }
+
         toast.error(handleApiError(err, toastMessage('paymentConfirmError')));
         setProcessing(false);
       });
@@ -105,12 +162,10 @@ function CheckoutSuccessContent({ locale }: { locale: Locale }) {
     return (
       <div className="mx-auto max-w-lg px-4 py-16 text-center">
         <h1 className="mb-4 text-xl font-bold text-destructive">{t('confirmFailedTitle')}</h1>
-        <p className="mb-6 text-sm text-muted-foreground">
-          {t('confirmFailedDescription')}
-        </p>
+        <p className="mb-6 text-sm text-muted-foreground">{t('confirmFailedDescription')}</p>
         <button
           onClick={() => router.replace(`/${locale}/cart`)}
-          className="rounded-md bg-foreground px-6 py-2 text-sm font-semibold text-background hover:opacity-90 transition-opacity"
+          className="rounded-md bg-foreground px-6 py-2 text-sm font-semibold text-background transition-opacity hover:opacity-90"
         >
           {t('backToCart')}
         </button>

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import * as Accordion from '@radix-ui/react-accordion';
 import { faqsApi } from '@/lib/api';
@@ -12,25 +13,25 @@ import { cn } from '@/components/ui/utils';
 import { useTranslations } from 'next-intl';
 
 const CATEGORIES = [
-  { value: '전체', key: 'all' },
-  { value: '배송', key: 'shipping' },
-  { value: '결제', key: 'payment' },
-  { value: '교환/반품', key: 'exchange' },
-  { value: '회원', key: 'member' },
-  { value: '기타', key: 'other' },
-];
+  { key: 'all', value: '전체' },
+  { key: 'shipping', value: '배송' },
+  { key: 'payment', value: '결제' },
+  { key: 'exchange', value: '교환/반품' },
+  { key: 'member', value: '회원' },
+  { key: 'other', value: '기타' },
+] as const;
 
 export default function FaqPage() {
   const params = useParams<{ locale: string }>();
   const locale = params.locale;
   const [faqs, setFaqs] = useState<Faq[]>([]);
   const t = useTranslations('faqPage');
-  const [activeCategory, setActiveCategory] = useState('전체');
+  const [activeCategory, setActiveCategory] = useState<(typeof CATEGORIES)[number]['key']>('all');
 
   const { execute: loadFaqs, isLoading: loading } = useAsyncAction(
     async () => {
-      const cat = activeCategory === '전체' ? undefined : activeCategory;
-      const res = await faqsApi.getList(cat, locale);
+      const categoryValue = CATEGORIES.find((category) => category.key === activeCategory)?.value;
+      const res = await faqsApi.getList(categoryValue === '전체' ? undefined : categoryValue, locale);
       setFaqs(Array.isArray(res) ? res : (res?.data ?? []));
     },
     { errorMessage: t('loadError') },
@@ -42,18 +43,18 @@ export default function FaqPage() {
   }, [activeCategory, locale]);
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8">
-      <h1 className="typo-h1 mb-6">{t('title')}</h1>
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="mb-6 typo-h1">{t('title')}</h1>
 
-      <div className="flex gap-2 flex-wrap mb-6">
+      <div className="mb-6 flex flex-wrap gap-2">
         {CATEGORIES.map((cat) => (
           <button
-            key={cat.value}
-            onClick={() => setActiveCategory(cat.value)}
+            key={cat.key}
+            onClick={() => setActiveCategory(cat.key)}
             className={cn(
-              'px-4 py-1.5 rounded-full typo-button border transition-colors',
-              activeCategory === cat.value
-                ? 'bg-foreground text-background border-foreground'
+              'rounded-full border px-4 py-1.5 typo-button transition-colors',
+              activeCategory === cat.key
+                ? 'border-foreground bg-foreground text-background'
                 : 'border-border text-muted-foreground hover:border-foreground',
             )}
           >
@@ -63,9 +64,16 @@ export default function FaqPage() {
       </div>
 
       <section className="mb-6 rounded-lg border border-border bg-muted/20 p-5">
-        <h2 className="typo-h3 text-foreground">{t('memberOnlyOrderTitle')}</h2>
-        <p className="mt-2 typo-body text-muted-foreground">{t('memberOnlyOrderDescription')}</p>
-        <p className="mt-2 typo-body-sm text-muted-foreground">{t('memberOnlyOrderAction')}</p>
+        <h2 className="typo-h3 text-foreground">{t('orderLookupTitle')}</h2>
+        <p className="mt-2 typo-body text-muted-foreground">{t('orderLookupGuestDescription')}</p>
+        <Link
+          href={`/${locale}/order/lookup`}
+          className="mt-3 inline-flex text-sm font-semibold text-foreground underline underline-offset-4"
+        >
+          {t('orderLookupGuestAction')}
+        </Link>
+        <p className="mt-4 typo-body text-muted-foreground">{t('orderLookupMemberDescription')}</p>
+        <p className="mt-2 typo-body-sm text-muted-foreground">{t('orderLookupMemberAction')}</p>
       </section>
 
       {loading ? (
@@ -77,19 +85,19 @@ export default function FaqPage() {
       ) : (faqs?.length ?? 0) === 0 ? (
         <EmptyState title={t('empty')} />
       ) : (
-        <Accordion.Root type="single" collapsible className="divide-y divide-border border-t border-b">
+        <Accordion.Root type="single" collapsible className="divide-y divide-border border-b border-t">
           {faqs.map((faq) => (
             <Accordion.Item key={faq.id} value={String(faq.id)}>
               <Accordion.Header>
-                <Accordion.Trigger className="flex items-center justify-between w-full px-2 py-4 text-left typo-h3 text-foreground hover:bg-muted transition-colors">
+                <Accordion.Trigger className="flex w-full items-center justify-between px-2 py-4 text-left typo-h3 text-foreground transition-colors hover:bg-muted">
                   <span>{faq.question}</span>
-                  <span className="faq-arrow ml-4 shrink-0 text-muted-foreground transition-transform duration-200">▼</span>
+                  <span className="faq-arrow ml-4 shrink-0 text-muted-foreground transition-transform duration-200">
+                    ▼
+                  </span>
                 </Accordion.Trigger>
               </Accordion.Header>
-              <Accordion.Content className="overflow-hidden data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up">
-                <div className="px-2 pb-4 typo-body text-muted-foreground bg-muted">
-                  {faq.answer}
-                </div>
+              <Accordion.Content className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+                <div className="bg-muted px-2 pb-4 typo-body text-muted-foreground">{faq.answer}</div>
               </Accordion.Content>
             </Accordion.Item>
           ))}

--- a/src/app/[locale]/order/complete/page.tsx
+++ b/src/app/[locale]/order/complete/page.tsx
@@ -1,69 +1,141 @@
 'use client';
 
 import { Suspense, use } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { CheckCircle } from 'lucide-react';
 import { toast } from 'sonner';
-import { ordersApi } from '@/lib/api';
+import { guestOrdersApi, ordersApi } from '@/lib/api';
 import type { OrderResponse } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import { handleApiError } from '@/utils/error';
 import { toastMessage } from '@/utils/toastMessages';
 import { BankTransferAccountInfo } from '@/components/shared/checkout/BankTransferAccountInfo';
+import { useAuth } from '@/contexts/AuthContext';
+import { ApiHttpError } from '@/lib/api-error';
+import { SESSION_KEYS } from '@/constants/storage';
 import { useFormatter, useTranslations } from 'next-intl';
+
+interface GuestOrderContext {
+  orderId: number;
+  orderNumber: string;
+  guestAccessToken: string;
+  guestAccessTokenExpiresAt: string;
+}
 
 function OrderCompleteContent({ locale }: { locale: string }) {
   const t = useTranslations('orderComplete');
+  const checkoutResultT = useTranslations('checkoutResult');
   const format = useFormatter();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
   const orderId = searchParams.get('orderId');
   const orderNumber = searchParams.get('orderNumber');
   const paymentMethod = searchParams.get('payment');
 
   const [order, setOrder] = useState<OrderResponse | null>(null);
+  const [mode, setMode] = useState<'guest' | 'member' | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  const redirectTarget = useMemo(() => {
+    const query = searchParams.toString();
+    return `/${locale}/order/complete${query ? `?${query}` : ''}`;
+  }, [locale, searchParams]);
+
   useEffect(() => {
+    if (authLoading) return;
     if (!orderId || !orderNumber) {
-      router.replace('/');
-      return;
-    }
-    const id = Number(orderId);
-    if (isNaN(id)) {
-      router.replace('/');
+      router.replace(`/${locale}/`);
       return;
     }
 
+    const id = Number(orderId);
+    if (Number.isNaN(id)) {
+      router.replace(`/${locale}/`);
+      return;
+    }
+
+    let guestContext: GuestOrderContext | null = null;
+    const rawGuestContext = sessionStorage.getItem(SESSION_KEYS.GUEST_ORDER_CONTEXT);
+    if (rawGuestContext) {
+      try {
+        const parsed = JSON.parse(rawGuestContext) as GuestOrderContext;
+        if (
+          parsed.orderId === id
+          && parsed.orderNumber === orderNumber
+          && parsed.guestAccessToken
+          && parsed.guestAccessTokenExpiresAt
+        ) {
+          guestContext = parsed;
+        } else {
+          sessionStorage.removeItem(SESSION_KEYS.GUEST_ORDER_CONTEXT);
+        }
+      } catch {
+        sessionStorage.removeItem(SESSION_KEYS.GUEST_ORDER_CONTEXT);
+      }
+    }
+
+    setIsLoading(true);
+
+    if (guestContext) {
+      setMode('guest');
+      guestOrdersApi
+        .getById(id, guestContext.guestAccessToken, locale === 'en' ? 'en' : 'ko')
+        .then((data) => setOrder(data))
+        .catch((err: unknown) => {
+          if (err instanceof ApiHttpError && err.status === 401) {
+            sessionStorage.removeItem(SESSION_KEYS.GUEST_ORDER_CONTEXT);
+            toast.error(checkoutResultT('guestAccessExpired'));
+            router.replace(`/${locale}/order/lookup`);
+            return;
+          }
+          toast.error(handleApiError(err, toastMessage('orderLoadError')));
+          router.replace(`/${locale}/`);
+        })
+        .finally(() => setIsLoading(false));
+      return;
+    }
+
+    if (!isAuthenticated) {
+      setMode(null);
+      setIsLoading(false);
+      router.replace(`/${locale}/login?redirect=${encodeURIComponent(redirectTarget)}`);
+      return;
+    }
+
+    setMode('member');
     ordersApi
       .getById(id)
       .then((data) => setOrder(data))
       .catch((err: unknown) => {
         toast.error(handleApiError(err, toastMessage('orderLoadError')));
-        router.replace('/');
+        router.replace(`/${locale}/`);
       })
       .finally(() => setIsLoading(false));
-  }, [orderId, orderNumber, router]);
+  }, [authLoading, checkoutResultT, isAuthenticated, locale, orderId, orderNumber, redirectTarget, router, t]);
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-2xl px-4 py-16 space-y-4">
-        <div className="h-16 w-16 animate-pulse rounded-full bg-muted mx-auto" />
+      <div className="mx-auto max-w-2xl space-y-4 px-4 py-16">
+        <div className="mx-auto h-16 w-16 animate-pulse rounded-full bg-muted" />
         <div className="h-8 animate-pulse rounded bg-muted" />
         <div className="h-4 animate-pulse rounded bg-muted" />
       </div>
     );
   }
 
-  if (!order) {
+  if (!order || !mode) {
     return null;
   }
 
+  const primaryLink = mode === 'guest' ? `/${locale}/order/lookup` : `/${locale}/my/orders`;
+  const primaryLabel = mode === 'guest' ? t('guestPrimaryAction') : t('viewOrders');
+
   return (
     <div className="mx-auto max-w-2xl px-4 py-16">
-      <div className="text-center space-y-4 mb-10">
+      <div className="mb-10 space-y-4 text-center">
         <CheckCircle className="mx-auto h-16 w-16 text-green-500" aria-hidden="true" />
         <h1 className="text-2xl font-bold">{t('title')}</h1>
         <p className="text-muted-foreground">
@@ -79,47 +151,54 @@ function OrderCompleteContent({ locale }: { locale: string }) {
             minute: '2-digit',
           })}
         </p>
+        {mode === 'guest' && (
+          <p className="text-sm text-muted-foreground">{t('guestAccessHint')}</p>
+        )}
       </div>
 
       {paymentMethod === 'bank_transfer' && (
-        <section className="surface-card p-6 mb-8">
+        <section className="surface-card mb-8 p-6">
           <BankTransferAccountInfo />
         </section>
       )}
 
-      <section className="surface-card p-6 space-y-4 mb-8">
-        <h2 className="font-semibold text-lg">{t('items')}</h2>
+      <section className="surface-card mb-8 space-y-4 p-6">
+        <h2 className="text-lg font-semibold">{t('items')}</h2>
         <ul className="divide-y divide-soft text-sm">
           {order.items.map((item) => (
-            <li key={item.id} className="py-3 flex justify-between gap-2">
+            <li key={item.id} className="flex justify-between gap-2 py-3">
               <div>
                 <p className="font-medium">{item.productName}</p>
-                {item.optionName && (
-                  <p className="text-xs text-muted-foreground">{item.optionName}</p>
-                )}
+                {item.optionName && <p className="text-xs text-muted-foreground">{item.optionName}</p>}
                 <p className="text-muted-foreground">{t('quantity', { quantity: item.quantity })}</p>
               </div>
-              <p className="font-medium shrink-0">
+              <p className="shrink-0 font-medium">
                 {formatCurrency(item.price * item.quantity, locale === 'en' ? 'en' : 'ko')}
               </p>
             </li>
           ))}
         </ul>
 
-        <div className="border-t border-soft pt-4 space-y-2 text-sm">
+        <div className="space-y-2 border-t border-soft pt-4 text-sm">
           <div className="flex justify-between">
             <span className="text-muted-foreground">{t('shippingFee')}</span>
-            <span>{order.shippingFee === 0 ? t('free') : formatCurrency(order.shippingFee, locale === 'en' ? 'en' : 'ko')}</span>
+            <span>
+              {order.shippingFee === 0
+                ? t('free')
+                : formatCurrency(order.shippingFee, locale === 'en' ? 'en' : 'ko')}
+            </span>
           </div>
           {order.discountAmount > 0 && (
             <div className="flex justify-between">
               <span className="text-muted-foreground">{t('discount')}</span>
-              <span className="text-destructive">-{formatCurrency(order.discountAmount, locale === 'en' ? 'en' : 'ko')}</span>
+              <span className="text-destructive">
+                -{formatCurrency(order.discountAmount, locale === 'en' ? 'en' : 'ko')}
+              </span>
             </div>
           )}
         </div>
 
-        <div className="border-t border-soft pt-4 flex justify-between font-bold">
+        <div className="flex justify-between border-t border-soft pt-4 font-bold">
           <span>{t('paymentAmount')}</span>
           <span>{formatCurrency(order.totalAmount, locale === 'en' ? 'en' : 'ko')}</span>
         </div>
@@ -127,14 +206,14 @@ function OrderCompleteContent({ locale }: { locale: string }) {
 
       <div className="flex gap-3">
         <Link
-          href="/my/orders"
-          className="flex-1 rounded-md border border-soft py-3 text-center text-sm font-semibold hover:bg-muted transition-colors"
+          href={primaryLink}
+          className="flex-1 rounded-md border border-soft py-3 text-center text-sm font-semibold transition-colors hover:bg-muted"
         >
-          {t('viewOrders')}
+          {primaryLabel}
         </Link>
         <Link
-          href="/"
-          className="flex-1 rounded-md bg-foreground py-3 text-center text-sm font-semibold text-background hover:opacity-90 transition-opacity"
+          href={`/${locale}/`}
+          className="flex-1 rounded-md bg-foreground py-3 text-center text-sm font-semibold text-background transition-opacity hover:opacity-90"
         >
           {t('continueShopping')}
         </Link>
@@ -153,8 +232,8 @@ export default function OrderCompletePage({
   return (
     <Suspense
       fallback={
-        <div className="mx-auto max-w-2xl px-4 py-16 space-y-4">
-          <div className="h-16 w-16 animate-pulse rounded-full bg-muted mx-auto" />
+        <div className="mx-auto max-w-2xl space-y-4 px-4 py-16">
+          <div className="mx-auto h-16 w-16 animate-pulse rounded-full bg-muted" />
           <div className="h-8 animate-pulse rounded bg-muted" />
           <div className="h-4 animate-pulse rounded bg-muted" />
         </div>

--- a/src/app/[locale]/order/lookup/__tests__/OrderLookupPage.test.tsx
+++ b/src/app/[locale]/order/lookup/__tests__/OrderLookupPage.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import OrderLookupPage from '@/app/[locale]/order/lookup/page';
+import { guestOrdersApi } from '@/lib/api';
+import { ApiHttpError } from '@/lib/api-error';
+import { SESSION_KEYS } from '@/constants/storage';
+import { toast } from 'sonner';
+
+const mockReplace = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ locale: 'ko' }),
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const messages: Record<string, string> = {
+      eyebrow: '비회원 고객 지원',
+      title: '비회원 주문조회',
+      description: '결제에 사용한 주문번호와 이메일을 입력하면 비회원 주문을 확인할 수 있습니다.',
+      orderNumberLabel: '주문번호',
+      orderNumberPlaceholder: 'ORD-000001',
+      emailLabel: '이메일',
+      emailPlaceholder: 'you@example.com',
+      submit: '주문조회',
+      submitting: '조회 중...',
+      guestLookupSuccess: '비회원 주문을 찾았습니다.',
+      guestLookupNotFound: '주문번호와 이메일이 일치하는 비회원 주문을 찾을 수 없습니다.',
+      guestLookupValidationError: '주문번호와 이메일을 다시 확인해 주세요.',
+      guestLookupError: '지금은 비회원 주문을 조회할 수 없습니다.',
+      memberHintTitle: '회원 주문 내역이 필요하신가요?',
+      memberHintDescription: '로그인하면 마이페이지에서 회원 주문, 결제 상태, 배송 현황을 확인할 수 있습니다.',
+      memberHintAction: '로그인으로 이동',
+    };
+    return messages[key] ?? key;
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/api', () => ({
+  guestOrdersApi: { lookup: vi.fn(), create: vi.fn(), getById: vi.fn() },
+}));
+
+describe('OrderLookupPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('rewrites guest context and redirects to order complete after successful lookup', async () => {
+    vi.mocked(guestOrdersApi.lookup).mockResolvedValue({
+      order: {
+        id: 7,
+        orderNumber: 'GUEST-7001',
+      },
+      guestAccessToken: 'rotated-guest-token',
+      guestAccessTokenExpiresAt: '2026-08-22T00:00:00.000Z',
+    } as Awaited<ReturnType<typeof guestOrdersApi.lookup>>);
+
+    const user = userEvent.setup();
+    render(<OrderLookupPage />);
+
+    await user.type(screen.getByLabelText('주문번호'), ' GUEST-7001 ');
+    await user.type(screen.getByLabelText('이메일'), ' guest@example.com ');
+    await user.click(screen.getByRole('button', { name: '주문조회' }));
+
+    await waitFor(() => {
+      expect(guestOrdersApi.lookup).toHaveBeenCalledWith({
+        orderNumber: 'GUEST-7001',
+        email: 'guest@example.com',
+        locale: 'ko',
+      });
+    });
+
+    expect(JSON.parse(sessionStorage.getItem(SESSION_KEYS.GUEST_ORDER_CONTEXT) ?? '{}')).toEqual({
+      orderId: 7,
+      orderNumber: 'GUEST-7001',
+      guestAccessToken: 'rotated-guest-token',
+      guestAccessTokenExpiresAt: '2026-08-22T00:00:00.000Z',
+    });
+    expect(toast.success).toHaveBeenCalledWith('비회원 주문을 찾았습니다.');
+    expect(mockReplace).toHaveBeenCalledWith('/ko/order/complete?orderId=7&orderNumber=GUEST-7001&flow=guest');
+  });
+
+  it('shows not-found guest toast on 404 lookup failure', async () => {
+    vi.mocked(guestOrdersApi.lookup).mockRejectedValue(new ApiHttpError('Not found', 404));
+
+    const user = userEvent.setup();
+    render(<OrderLookupPage />);
+
+    await user.type(screen.getByLabelText('주문번호'), 'GUEST-404');
+    await user.type(screen.getByLabelText('이메일'), 'guest@example.com');
+    await user.click(screen.getByRole('button', { name: '주문조회' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('주문번호와 이메일이 일치하는 비회원 주문을 찾을 수 없습니다.');
+    });
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/order/lookup/page.tsx
+++ b/src/app/[locale]/order/lookup/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { ApiHttpError } from '@/lib/api-error';
+import { SESSION_KEYS } from '@/constants/storage';
+import { guestOrdersApi } from '@/lib/api';
+
+export default function OrderLookupPage() {
+  const { locale } = useParams<{ locale: string }>();
+  const router = useRouter();
+  const t = useTranslations('orderLookup');
+
+  const [orderNumber, setOrderNumber] = useState('');
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      const result = await guestOrdersApi.lookup({
+        orderNumber: orderNumber.trim(),
+        email: email.trim(),
+        locale: locale === 'en' ? 'en' : 'ko',
+      });
+
+      sessionStorage.setItem(
+        SESSION_KEYS.GUEST_ORDER_CONTEXT,
+        JSON.stringify({
+          orderId: result.order.id,
+          orderNumber: result.order.orderNumber,
+          guestAccessToken: result.guestAccessToken,
+          guestAccessTokenExpiresAt: result.guestAccessTokenExpiresAt,
+        }),
+      );
+      toast.success(t('guestLookupSuccess'));
+      router.replace(
+        `/${locale}/order/complete?orderId=${result.order.id}&orderNumber=${result.order.orderNumber}&flow=guest`,
+      );
+    } catch (error) {
+      if (error instanceof ApiHttpError) {
+        if (error.status === 404) {
+          toast.error(t('guestLookupNotFound'));
+        } else if (error.status === 400) {
+          toast.error(t('guestLookupValidationError'));
+        } else {
+          toast.error(t('guestLookupError'));
+        }
+      } else {
+        toast.error(t('guestLookupError'));
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="layout-container layout-page max-w-2xl">
+      <div className="surface-card p-6 md:p-8">
+        <p className="text-sm font-medium text-muted-foreground">{t('eyebrow')}</p>
+        <h1 className="mt-2 text-2xl font-bold">{t('title')}</h1>
+        <p className="mt-3 text-sm text-muted-foreground">{t('description')}</p>
+
+        <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="orderNumber" className="text-sm font-medium text-foreground">
+              {t('orderNumberLabel')}
+            </label>
+            <input
+              id="orderNumber"
+              name="orderNumber"
+              type="text"
+              autoComplete="off"
+              value={orderNumber}
+              onChange={(event) => setOrderNumber(event.target.value)}
+              placeholder={t('orderNumberPlaceholder')}
+              className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email" className="text-sm font-medium text-foreground">
+              {t('emailLabel')}
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder={t('emailPlaceholder')}
+              className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-md bg-foreground px-4 py-3 text-sm font-semibold text-background transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isSubmitting ? t('submitting') : t('submit')}
+          </button>
+        </form>
+
+        <div className="mt-6 rounded-lg border border-soft bg-muted/20 p-4 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">{t('memberHintTitle')}</p>
+          <p className="mt-1">{t('memberHintDescription')}</p>
+          <Link href={`/${locale}/login`} className="mt-3 inline-flex font-semibold text-foreground underline underline-offset-4">
+            {t('memberHintAction')}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/CheckoutPage.test.tsx
+++ b/src/components/__tests__/CheckoutPage.test.tsx
@@ -80,6 +80,11 @@ vi.mock('next-intl', () => ({
       'consent.requiredDescription': '주문할 상품의 상품명, 가격, 배송정보, 교환·환불 규정을 확인했으며 구매에 동의합니다.',
       'consent.marketingLabel': '[선택] 마케팅 정보 수신에 동의합니다.',
       'consent.marketingDescription': '신상품, 프로모션, 이벤트 안내를 받을 수 있습니다.',
+      guestCheckoutTitle: '비회원 주문',
+      guestCheckoutDescription: '비회원 안내',
+      guestEmailLabel: '비회원 이메일',
+      guestEmailPlaceholder: 'you@example.com',
+      guestEmailDescription: '주문 안내와 비회원 주문조회에 사용할 이메일입니다.',
     };
     return dict[key] ?? key;
   },
@@ -137,7 +142,9 @@ vi.mock('@/components/shared/checkout/PaymentGateway', () => ({
 // ---- api ----
 vi.mock('@/lib/api', () => ({
   ordersApi: { create: vi.fn(), getById: vi.fn() },
+  guestOrdersApi: { create: vi.fn(), getById: vi.fn(), lookup: vi.fn() },
   paymentsApi: { prepare: vi.fn(), confirm: vi.fn() },
+  guestPaymentsApi: { prepare: vi.fn(), confirm: vi.fn() },
   shippingApi: { quote: vi.fn().mockResolvedValue({ subtotal: 40000, zipcode: '00000', shippingFee: 0, isFreeShipping: true, isRemoteArea: false, threshold: 10, baseFee: 3000, remoteAreaSurcharge: 3000 }) },
   cartApi: { getList: vi.fn() },
   usersApi: { getAddresses: vi.fn().mockResolvedValue([]), updateAddress: vi.fn().mockResolvedValue({}) },
@@ -166,10 +173,13 @@ describe('CheckoutPage', () => {
     sessionStorage.clear();
   });
 
-  it('redirects to /login when not authenticated', async () => {
+  it('renders guest checkout without redirect when not authenticated', async () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false, token: null, user: null, isLoading: false });
+    sessionStorage.setItem('checkoutItems', JSON.stringify([sampleItem]));
     await renderCheckoutPage();
-    expect(mockReplace).toHaveBeenCalledWith('/ko/login');
+    expect(mockReplace).not.toHaveBeenCalledWith('/ko/login');
+    expect(await screen.findByLabelText(/비회원 이메일/)).toBeInTheDocument();
+    expect(screen.queryByText('쿠폰 / 적립금')).not.toBeInTheDocument();
   });
 
   it('redirects to /cart when no sessionStorage items', async () => {

--- a/src/components/__tests__/FaqPage.test.tsx
+++ b/src/components/__tests__/FaqPage.test.tsx
@@ -8,9 +8,11 @@ function makeTranslator(namespace?: string) {
     title: '자주 묻는 질문',
     loadError: 'FAQ를 불러오지 못했습니다.',
     empty: '해당 카테고리의 FAQ가 없습니다.',
-    memberOnlyOrderTitle: '주문조회는 회원 로그인 후 이용할 수 있습니다.',
-    memberOnlyOrderDescription: '옥화당은 현재 회원 주문만 지원하며, 비회원 주문조회 폼은 제공하지 않습니다.',
-    memberOnlyOrderAction: '로그인 후 마이페이지 주문 내역에서 결제 상태와 배송 상태를 확인해 주세요.',
+    orderLookupTitle: '주문 후 주문 상태는 어떻게 확인하나요?',
+    orderLookupGuestDescription: '비회원 주문은 결제 시 사용한 이메일과 주문번호로 비회원 주문조회 페이지에서 확인할 수 있습니다.',
+    orderLookupGuestAction: '비회원 주문조회로 이동',
+    orderLookupMemberDescription: '회원 주문은 로그인 후 마이페이지 주문 내역에서 계속 확인할 수 있습니다.',
+    orderLookupMemberAction: '로그인 후 주문 내역에서 결제 상태와 배송 상태를 확인해 주세요.',
     'categories.all': '전체',
     'categories.shipping': '배송',
     'categories.payment': '결제',
@@ -23,6 +25,9 @@ function makeTranslator(namespace?: string) {
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ locale: 'ko' }),
+}));
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
 }));
 
 vi.mock('next-intl', () => ({
@@ -41,12 +46,13 @@ describe('FaqPage', () => {
     vi.mocked(faqsApi.getList).mockResolvedValue({ data: [], total: 0 });
   });
 
-  it('비회원 주문조회 대신 회원 주문 전용 정책 안내를 노출한다', async () => {
+  it('guest-aware order lookup guidance is shown', async () => {
     render(<FaqPage />);
 
-    expect(await screen.findByText('주문조회는 회원 로그인 후 이용할 수 있습니다.')).toBeInTheDocument();
-    expect(screen.getByText('옥화당은 현재 회원 주문만 지원하며, 비회원 주문조회 폼은 제공하지 않습니다.')).toBeInTheDocument();
-    expect(screen.getByText(/마이페이지 주문 내역/)).toBeInTheDocument();
+    expect(await screen.findByText('주문 후 주문 상태는 어떻게 확인하나요?')).toBeInTheDocument();
+    expect(screen.getByText('비회원 주문은 결제 시 사용한 이메일과 주문번호로 비회원 주문조회 페이지에서 확인할 수 있습니다.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '비회원 주문조회로 이동' })).toHaveAttribute('href', '/ko/order/lookup');
+    expect(screen.getByText(/회원 주문은 로그인 후 마이페이지 주문 내역에서 계속 확인할 수 있습니다./)).toBeInTheDocument();
 
     await waitFor(() => expect(faqsApi.getList).toHaveBeenCalledWith(undefined, 'ko'));
   });

--- a/src/components/__tests__/OrderComplete.test.tsx
+++ b/src/components/__tests__/OrderComplete.test.tsx
@@ -1,79 +1,56 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import OrderCompletePage from '@/app/[locale]/order/complete/page';
-import { ordersApi } from '@/lib/api';
+import { ApiHttpError } from '@/lib/api-error';
+import { SESSION_KEYS } from '@/constants/storage';
+import { guestOrdersApi, ordersApi } from '@/lib/api';
+import { toast } from 'sonner';
 import koMessages from '@/i18n/messages/ko.json';
 
-// ---- next/navigation ----
 const mockReplace = vi.fn();
+const mockRouter = { replace: mockReplace };
 let mockSearchParams = new URLSearchParams('orderId=1&orderNumber=ORD-20260325-ABCDE');
+const mockUseAuth = vi.fn();
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: mockReplace }),
+  useRouter: () => mockRouter,
   useSearchParams: () => mockSearchParams,
 }));
 
+const translationCache = new Map<string, (key: string, values?: Record<string, string | number>) => string>();
+
 vi.mock('next-intl', () => ({
-  useFormatter: () => ({
-    dateTime: (date: Date) => date.toISOString(),
-  }),
-  useTranslations: (namespace: keyof typeof koMessages) => (
-    key: string,
-    values?: Record<string, string | number>,
-  ) => {
-    const messages = koMessages[namespace] as Record<string, string>;
-    let message = messages[key] ?? key;
-
-    Object.entries(values ?? {}).forEach(([name, value]) => {
-      message = message.replaceAll(`{${name}}`, String(value));
-    });
-
-    return message;
+  useFormatter: () => ({ dateTime: (date: Date) => date.toISOString() }),
+  useTranslations: (namespace: keyof typeof koMessages) => {
+    if (!translationCache.has(namespace)) {
+      translationCache.set(namespace, (key: string, values?: Record<string, string | number>) => {
+        const messages = koMessages[namespace] as Record<string, string>;
+        let message = messages[key] ?? key;
+        Object.entries(values ?? {}).forEach(([name, value]) => {
+          message = message.replaceAll(`{${name}}`, String(value));
+        });
+        return message;
+      });
+    }
+    return translationCache.get(namespace)!;
   },
 }));
 
-// ---- next/link ----
 vi.mock('next/link', () => ({
-  default: ({
-    href,
-    children,
-    className,
-  }: {
-    href: string;
-    children: React.ReactNode;
-    className?: string;
-  }) => (
-    <a href={href} className={className}>
-      {children}
-    </a>
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
   ),
 }));
 
-// ---- contexts ----
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ isAuthenticated: true, token: 'test-token', user: null }),
-  AuthContext: {},
-  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: () => mockUseAuth(),
 }));
 
-vi.mock('@/contexts/CartContext', () => ({
-  useCart: () => ({
-    items: [],
-    itemCount: 0,
-    totalAmount: 0,
-    isLoading: false,
-    addItem: vi.fn(),
-    updateQuantity: vi.fn(),
-    removeItem: vi.fn(),
-    refetch: vi.fn(),
-  }),
-  CartContext: {},
-  CartProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-
-// ---- api ----
 vi.mock('@/lib/api', () => ({
   ordersApi: { create: vi.fn(), getById: vi.fn() },
+  guestOrdersApi: { create: vi.fn(), getById: vi.fn(), lookup: vi.fn() },
   paymentsApi: { prepare: vi.fn(), confirm: vi.fn() },
   cartApi: { getList: vi.fn() },
 }));
@@ -105,21 +82,95 @@ const sampleOrder = {
   createdAt: '2026-03-25T10:00:00.000Z',
 };
 
-describe('OrderCompletePage', () => {
+describe('OrderCompletePage guest proof coverage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
     mockSearchParams = new URLSearchParams('orderId=1&orderNumber=ORD-20260325-ABCDE');
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, isLoading: false, token: 'token', user: null });
   });
 
-  it('redirects to / when no orderId in searchParams', async () => {
+  it('redirects to locale home when no orderId in searchParams', async () => {
     mockSearchParams = new URLSearchParams('');
     await act(async () => {
       render(<OrderCompletePage params={Promise.resolve({ locale: 'ko' })} />);
     });
-    expect(mockReplace).toHaveBeenCalledWith('/');
+    expect(mockReplace).toHaveBeenCalledWith('/ko/');
   });
 
-  it('renders order number text after fetching order', async () => {
+  it('loads guest order only when strong guest proof matches query params', async () => {
+    sessionStorage.setItem(
+      SESSION_KEYS.GUEST_ORDER_CONTEXT,
+      JSON.stringify({
+        orderId: 1,
+        orderNumber: 'ORD-20260325-ABCDE',
+        guestAccessToken: 'guest-token',
+        guestAccessTokenExpiresAt: '2026-08-22T00:00:00.000Z',
+      }),
+    );
+    vi.mocked(guestOrdersApi.getById).mockResolvedValue(sampleOrder);
+
+    await act(async () => {
+      render(<OrderCompletePage params={Promise.resolve({ locale: 'ko' })} />);
+    });
+
+    await waitFor(() => {
+      expect(guestOrdersApi.getById).toHaveBeenCalledWith(1, 'guest-token', 'ko');
+    });
+
+    expect(ordersApi.getById).not.toHaveBeenCalled();
+    expect(await screen.findByText('테스트 상품')).toBeInTheDocument();
+    expect(screen.getByText('주문번호와 이메일을 보관하면 비회원 주문을 다시 조회할 수 있습니다.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '비회원 주문조회' })).toHaveAttribute('href', '/ko/order/lookup');
+  });
+
+  it('treats stale guest context as invalid proof and falls back to member login recovery', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false, token: null, user: null });
+    sessionStorage.setItem(
+      SESSION_KEYS.GUEST_ORDER_CONTEXT,
+      JSON.stringify({
+        orderId: 999,
+        orderNumber: 'OTHER-ORDER',
+        guestAccessToken: 'guest-token',
+        guestAccessTokenExpiresAt: '2026-08-22T00:00:00.000Z',
+      }),
+    );
+
+    await act(async () => {
+      render(<OrderCompletePage params={Promise.resolve({ locale: 'ko' })} />);
+    });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/ko/login?redirect=%2Fko%2Forder%2Fcomplete%3ForderId%3D1%26orderNumber%3DORD-20260325-ABCDE');
+    });
+    expect(sessionStorage.getItem(SESSION_KEYS.GUEST_ORDER_CONTEXT)).toBeNull();
+    expect(guestOrdersApi.getById).not.toHaveBeenCalled();
+  });
+
+  it('clears guest proof and redirects to lookup when guest access has expired', async () => {
+    sessionStorage.setItem(
+      SESSION_KEYS.GUEST_ORDER_CONTEXT,
+      JSON.stringify({
+        orderId: 1,
+        orderNumber: 'ORD-20260325-ABCDE',
+        guestAccessToken: 'guest-token',
+        guestAccessTokenExpiresAt: '2026-08-22T00:00:00.000Z',
+      }),
+    );
+    vi.mocked(guestOrdersApi.getById).mockRejectedValue(new ApiHttpError('Unauthorized', 401));
+
+    await act(async () => {
+      render(<OrderCompletePage params={Promise.resolve({ locale: 'ko' })} />);
+    });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/ko/order/lookup');
+    });
+    expect(sessionStorage.getItem(SESSION_KEYS.GUEST_ORDER_CONTEXT)).toBeNull();
+    expect(toast.error).toHaveBeenCalledWith('비회원 주문 조회 권한이 만료되었습니다. 주문조회에서 다시 확인해 주세요.');
+  });
+
+  it('keeps member mode when no guest proof exists and user is authenticated', async () => {
     vi.mocked(ordersApi.getById).mockResolvedValue(sampleOrder);
 
     await act(async () => {
@@ -127,42 +178,9 @@ describe('OrderCompletePage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('ORD-20260325-ABCDE')).toBeInTheDocument();
+      expect(ordersApi.getById).toHaveBeenCalledWith(1);
     });
-
-    expect(screen.getByText('주문이 완료되었습니다!')).toBeInTheDocument();
-    expect(screen.getByText('테스트 상품')).toBeInTheDocument();
-  });
-
-
-  it('renders bank transfer account info when redirected from bank transfer checkout', async () => {
-    mockSearchParams = new URLSearchParams('orderId=1&orderNumber=ORD-20260325-ABCDE&payment=bank_transfer');
-    vi.mocked(ordersApi.getById).mockResolvedValue(sampleOrder);
-
-    await act(async () => {
-      render(<OrderCompletePage params={Promise.resolve({ locale: 'ko' })} />);
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('ORD-20260325-ABCDE')).toBeInTheDocument();
-    });
-
-    expect(screen.getByTestId('bank-transfer-account-info')).toBeInTheDocument();
-    expect(screen.getByText('123456-78-901234')).toBeInTheDocument();
-  });
-
-  it('renders "쇼핑 계속하기" link pointing to /', async () => {
-    vi.mocked(ordersApi.getById).mockResolvedValue(sampleOrder);
-
-    await act(async () => {
-      render(<OrderCompletePage params={Promise.resolve({ locale: 'ko' })} />);
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('쇼핑 계속하기')).toBeInTheDocument();
-    });
-
-    const link = screen.getByRole('link', { name: '쇼핑 계속하기' });
-    expect(link).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: '주문 내역 보기' })).toHaveAttribute('href', '/ko/my/orders');
+    expect(screen.getByRole('link', { name: '쇼핑 계속하기' })).toHaveAttribute('href', '/ko/');
   });
 });

--- a/src/components/shared/admin/AdminOrdersTable.tsx
+++ b/src/components/shared/admin/AdminOrdersTable.tsx
@@ -3,7 +3,7 @@
 import type { AdminOrder } from '@/lib/api';
 import { formatCurrency } from '@/utils/currency';
 import { OrderStatusSelect } from './OrderStatusSelect';
-import { ORDER_STATUS_LABELS, ORDER_STATUS_COLORS } from '@/constants/status';
+import { ORDER_STATUS_COLORS } from '@/constants/status';
 import { localMessage } from '@/utils/localMessages';
 
 interface AdminOrdersTableProps {
@@ -15,41 +15,95 @@ interface AdminOrdersTableProps {
 
 const CANCELLABLE_ORDER_STATUSES = new Set(['pending', 'paid', 'preparing']);
 
-export function AdminOrdersTable({ orders, onStatusChange, onShippingRegister, onCancelOrder }: AdminOrdersTableProps) {
+function getStatusLabel(status: string): string {
+  return localMessage(`admin.orders.status.${status}`);
+}
+
+function getProductLabel(order: AdminOrder): string {
+  if (order.items.length === 0) {
+    return '-';
+  }
+
+  if (order.items.length === 1) {
+    return order.items[0].productName;
+  }
+
+  return localMessage('admin.orders.productSummary.more', {
+    productName: order.items[0].productName,
+    count: order.items.length - 1,
+  });
+}
+
+function getCustomerEmail(order: AdminOrder): string | null {
+  return order.user?.email ?? order.guestEmailNormalized ?? null;
+}
+
+export function AdminOrdersTable({
+  orders,
+  onStatusChange,
+  onShippingRegister,
+  onCancelOrder,
+}: AdminOrdersTableProps) {
   if (orders.length === 0) {
-    return <p className="py-8 text-center text-muted-foreground">주문이 없습니다.</p>;
+    return <p className="py-8 text-center text-muted-foreground">{localMessage('admin.orders.noOrders')}</p>;
   }
 
   return (
     <>
       <div className="grid gap-3 md:hidden">
         {orders.map((order) => {
-          const productLabel = order.items.length > 0
-            ? order.items.length === 1
-              ? order.items[0].productName
-              : `${order.items[0].productName} 외 ${order.items.length - 1}건`
-            : '-';
+          const customerEmail = getCustomerEmail(order);
 
           return (
-            <article key={order.id} className="rounded-lg border bg-card p-4 shadow-sm" aria-labelledby={`order-${order.id}`}>
+            <article
+              key={order.id}
+              className="rounded-lg border bg-card p-4 shadow-sm"
+              aria-labelledby={`order-${order.id}`}
+            >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <h3 id={`order-${order.id}`} className="truncate font-mono typo-body-sm font-semibold">{order.orderNumber}</h3>
-                  <p className="typo-body-sm text-muted-foreground">{order.recipientName}</p>
+                  <h3 id={`order-${order.id}`} className="truncate font-mono typo-body-sm font-semibold">
+                    {order.orderNumber}
+                  </h3>
+                  <p className="typo-body-sm text-foreground">{order.recipientName}</p>
+                  {customerEmail && (
+                    <p className="text-xs text-muted-foreground">{customerEmail}</p>
+                  )}
                 </div>
-                <span className={`shrink-0 rounded-full px-2 py-0.5 typo-label ${ORDER_STATUS_COLORS[order.status] ?? 'bg-secondary'}`}>
-                  {ORDER_STATUS_LABELS[order.status] ?? order.status}
+                <span
+                  className={`shrink-0 rounded-full px-2 py-0.5 typo-label ${ORDER_STATUS_COLORS[order.status] ?? 'bg-secondary'}`}
+                >
+                  {getStatusLabel(order.status)}
                 </span>
               </div>
               <dl className="mt-3 grid gap-2 typo-body-sm">
-                <div className="flex justify-between gap-3"><dt className="text-muted-foreground">상품</dt><dd className="text-right">{productLabel}</dd></div>
-                <div className="flex justify-between gap-3"><dt className="text-muted-foreground">금액</dt><dd className="font-medium">{formatCurrency(order.totalAmount)}</dd></div>
-                <div className="flex justify-between gap-3"><dt className="text-muted-foreground">주문일</dt><dd>{new Date(order.createdAt).toLocaleDateString('ko-KR')}</dd></div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground">{localMessage('admin.orders.columns.product')}</dt>
+                  <dd className="text-right">{getProductLabel(order)}</dd>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground">{localMessage('admin.orders.columns.amount')}</dt>
+                  <dd className="font-medium">{formatCurrency(order.totalAmount)}</dd>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground">{localMessage('admin.orders.columns.orderDate')}</dt>
+                  <dd>{new Date(order.createdAt).toLocaleDateString()}</dd>
+                </div>
               </dl>
               <div className="mt-4 flex flex-wrap justify-end gap-2">
-                <OrderStatusSelect orderId={order.id} currentStatus={order.status} onStatusChange={onStatusChange} />
+                <OrderStatusSelect
+                  orderId={order.id}
+                  currentStatus={order.status}
+                  onStatusChange={onStatusChange}
+                />
                 {(order.status === 'preparing' || order.status === 'paid') && (
-                  <button type="button" onClick={() => onShippingRegister(order)} className="min-h-11 rounded border px-3 typo-button hover:bg-secondary">운송장</button>
+                  <button
+                    type="button"
+                    onClick={() => onShippingRegister(order)}
+                    className="min-h-11 rounded border px-3 typo-button hover:bg-secondary"
+                  >
+                    {localMessage('admin.orders.trackingSlip')}
+                  </button>
                 )}
                 {CANCELLABLE_ORDER_STATUSES.has(order.status) && (
                   <button
@@ -66,75 +120,73 @@ export function AdminOrdersTable({ orders, onStatusChange, onShippingRegister, o
         })}
       </div>
       <div className="hidden overflow-x-auto rounded-lg border md:block">
-      <table className="w-full typo-body-sm">
-        <thead className="bg-secondary">
-          <tr>
-            <th className="px-4 py-3 text-left">주문번호</th>
-            <th className="px-4 py-3 text-left">주문자</th>
-            <th className="px-4 py-3 text-left">상품</th>
-            <th className="px-4 py-3 text-right">금액</th>
-            <th className="px-4 py-3 text-left">상태</th>
-            <th className="px-4 py-3 text-left">주문일</th>
-            <th className="px-4 py-3 text-right">액션</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y">
-          {orders.map((order) => (
-            <tr key={order.id} className="hover:bg-secondary/30">
-              <td className="px-4 py-3 font-mono text-xs">{order.orderNumber}</td>
-              <td className="px-4 py-3">
-                <div className="text-sm">{order.recipientName}</div>
-                {order.user && (
-                  <div className="text-xs text-muted-foreground">{order.user.email}</div>
-                )}
-              </td>
-              <td className="max-w-48 truncate px-4 py-3">
-                {order.items.length > 0
-                  ? order.items.length === 1
-                    ? order.items[0].productName
-                    : `${order.items[0].productName} 외 ${order.items.length - 1}건`
-                  : '-'}
-              </td>
-              <td className="px-4 py-3 text-right">{formatCurrency(order.totalAmount)}</td>
-              <td className="px-4 py-3">
-                <span className={`rounded-full px-2 py-0.5 text-xs ${ORDER_STATUS_COLORS[order.status] ?? 'bg-secondary'}`}>
-                  {ORDER_STATUS_LABELS[order.status] ?? order.status}
-                </span>
-              </td>
-              <td className="px-4 py-3 text-xs text-muted-foreground">
-                {new Date(order.createdAt).toLocaleDateString('ko-KR')}
-              </td>
-              <td className="px-4 py-3 text-right">
-                <div className="flex items-center justify-end gap-2">
-                  <OrderStatusSelect
-                    orderId={order.id}
-                    currentStatus={order.status}
-                    onStatusChange={onStatusChange}
-                  />
-                  {(order.status === 'preparing' || order.status === 'paid') && (
-                    <button
-                      type="button"
-                      onClick={() => onShippingRegister(order)}
-                      className="rounded border px-2 py-1 text-xs hover:bg-secondary"
-                    >
-                      운송장
-                    </button>
-                  )}
-                  {CANCELLABLE_ORDER_STATUSES.has(order.status) && (
-                    <button
-                      type="button"
-                      onClick={() => onCancelOrder(order)}
-                      className="rounded border border-destructive px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
-                    >
-                      {localMessage('admin.orders.cancel.action')}
-                    </button>
-                  )}
-                </div>
-              </td>
+        <table className="w-full typo-body-sm">
+          <thead className="bg-secondary">
+            <tr>
+              <th className="px-4 py-3 text-left">{localMessage('admin.orders.columns.orderNumber')}</th>
+              <th className="px-4 py-3 text-left">{localMessage('admin.orders.columns.orderer')}</th>
+              <th className="px-4 py-3 text-left">{localMessage('admin.orders.columns.product')}</th>
+              <th className="px-4 py-3 text-right">{localMessage('admin.orders.columns.amount')}</th>
+              <th className="px-4 py-3 text-left">{localMessage('admin.orders.columns.status')}</th>
+              <th className="px-4 py-3 text-left">{localMessage('admin.orders.columns.orderDate')}</th>
+              <th className="px-4 py-3 text-right">{localMessage('admin.orders.columns.action')}</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="divide-y">
+            {orders.map((order) => {
+              const customerEmail = getCustomerEmail(order);
+
+              return (
+                <tr key={order.id} className="hover:bg-secondary/30">
+                  <td className="px-4 py-3 font-mono text-xs">{order.orderNumber}</td>
+                  <td className="px-4 py-3">
+                    <div className="text-sm">{order.recipientName}</div>
+                    {customerEmail && <div className="text-xs text-muted-foreground">{customerEmail}</div>}
+                  </td>
+                  <td className="max-w-48 truncate px-4 py-3">{getProductLabel(order)}</td>
+                  <td className="px-4 py-3 text-right">{formatCurrency(order.totalAmount)}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs ${ORDER_STATUS_COLORS[order.status] ?? 'bg-secondary'}`}
+                    >
+                      {getStatusLabel(order.status)}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {new Date(order.createdAt).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <OrderStatusSelect
+                        orderId={order.id}
+                        currentStatus={order.status}
+                        onStatusChange={onStatusChange}
+                      />
+                      {(order.status === 'preparing' || order.status === 'paid') && (
+                        <button
+                          type="button"
+                          onClick={() => onShippingRegister(order)}
+                          className="rounded border px-2 py-1 text-xs hover:bg-secondary"
+                        >
+                          {localMessage('admin.orders.trackingSlip')}
+                        </button>
+                      )}
+                      {CANCELLABLE_ORDER_STATUSES.has(order.status) && (
+                        <button
+                          type="button"
+                          onClick={() => onCancelOrder(order)}
+                          className="rounded border border-destructive px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                        >
+                          {localMessage('admin.orders.cancel.action')}
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
     </>
   );

--- a/src/components/shared/admin/__tests__/AdminOrdersTable.test.tsx
+++ b/src/components/shared/admin/__tests__/AdminOrdersTable.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AdminOrdersTable } from '../AdminOrdersTable';
+import type { AdminOrder } from '@/lib/api';
+
+vi.mock('../OrderStatusSelect', () => ({
+  OrderStatusSelect: ({ orderId }: { orderId: number }) => <div data-testid={`status-select-${orderId}`} />,
+}));
+
+vi.mock('@/utils/localMessages', () => ({
+  localMessage: (key: string, values?: Record<string, string | number>) => {
+    const messages: Record<string, string> = {
+      'admin.orders.noOrders': '주문이 없습니다.',
+      'admin.orders.columns.orderNumber': '주문번호',
+      'admin.orders.columns.orderer': '주문자',
+      'admin.orders.columns.product': '상품',
+      'admin.orders.columns.amount': '금액',
+      'admin.orders.columns.status': '상태',
+      'admin.orders.columns.orderDate': '주문일',
+      'admin.orders.columns.action': '액션',
+      'admin.orders.status.paid': '결제완료',
+      'admin.orders.status.preparing': '상품준비중',
+      'admin.orders.trackingSlip': '운송장',
+      'admin.orders.cancel.action': '주문 취소',
+      'admin.orders.productSummary.more': `${values?.productName} 외 ${values?.count}건`,
+    };
+    return messages[key] ?? key;
+  },
+}));
+
+const memberOrder: AdminOrder = {
+  id: 1,
+  orderNumber: 'ORD-001',
+  status: 'paid',
+  totalAmount: 40000,
+  recipientName: '회원 주문자',
+  recipientPhone: '010-1111-2222',
+  address: '서울시',
+  createdAt: '2026-07-22T00:00:00.000Z',
+  updatedAt: '2026-07-22T00:00:00.000Z',
+  customerType: 'member',
+  guestEmailNormalized: null,
+  user: { id: 1, email: 'member@example.com', name: '회원' },
+  items: [{ id: 1, productName: '회원 상품', optionName: null, price: 40000, quantity: 1 }],
+};
+
+const guestOrder: AdminOrder = {
+  id: 2,
+  orderNumber: 'ORD-002',
+  status: 'preparing',
+  totalAmount: 52000,
+  recipientName: '비회원 주문자',
+  recipientPhone: '010-2222-3333',
+  address: '부산시',
+  createdAt: '2026-07-22T00:00:00.000Z',
+  updatedAt: '2026-07-22T00:00:00.000Z',
+  customerType: 'guest',
+  guestEmailNormalized: 'guest@example.com',
+  user: null,
+  items: [
+    { id: 2, productName: '비회원 상품', optionName: null, price: 26000, quantity: 1 },
+    { id: 3, productName: '추가 상품', optionName: null, price: 26000, quantity: 1 },
+  ],
+};
+
+describe('AdminOrdersTable guest display', () => {
+  it('renders member email for member rows and guest email for guest rows', () => {
+    render(
+      <AdminOrdersTable
+        orders={[memberOrder, guestOrder]}
+        onStatusChange={vi.fn()}
+        onShippingRegister={vi.fn()}
+        onCancelOrder={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText('member@example.com').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('guest@example.com').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('비회원 상품 외 1건').length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/shared/checkout/PaymentGateway.tsx
+++ b/src/components/shared/checkout/PaymentGateway.tsx
@@ -138,14 +138,45 @@ interface PaymentGatewayProps {
   orderNumber: string;
   amount: number;
   locale: Locale;
+  guestAccessToken?: string;
+  guestAccessTokenExpiresAt?: string;
   onError: (message: string) => void;
+}
+
+function buildHostedPaymentContext({
+  orderId,
+  orderNumber,
+  amount,
+  guestAccessToken,
+  guestAccessTokenExpiresAt,
+}: Pick<
+  PaymentGatewayProps,
+  'orderId' | 'orderNumber' | 'amount' | 'guestAccessToken' | 'guestAccessTokenExpiresAt'
+>): {
+  orderId: number;
+  orderNumber: string;
+  amount: number;
+  guestAccessToken?: string;
+  guestAccessTokenExpiresAt?: string;
+} {
+  return {
+    orderId,
+    orderNumber,
+    amount,
+    ...(guestAccessToken
+      ? {
+          guestAccessToken,
+          guestAccessTokenExpiresAt,
+        }
+      : {}),
+  };
 }
 
 // ─── Toss Payments (ko) ───────────────────────────────────────────────────────
 
 const TossPaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>(
   function TossPaymentGateway(
-    { prepareResult, orderId, orderNumber, amount, locale, onError },
+    { prepareResult, orderId, orderNumber, amount, locale, guestAccessToken, guestAccessTokenExpiresAt, onError },
     ref,
   ) {
     const handlerRef = useRef<(() => Promise<void>) | null>(null);
@@ -161,7 +192,15 @@ const TossPaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>
 
           sessionStorage.setItem(
             SESSION_KEYS.TOSS_CONTEXT,
-            JSON.stringify({ orderId, orderNumber, amount }),
+            JSON.stringify(
+              buildHostedPaymentContext({
+                orderId,
+                orderNumber,
+                amount,
+                guestAccessToken,
+                guestAccessTokenExpiresAt,
+              }),
+            ),
           );
 
           await payment.requestPayment({
@@ -182,7 +221,7 @@ const TossPaymentGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>
       return () => {
         handlerRef.current = null;
       };
-    }, [prepareResult.clientKey, orderId, orderNumber, amount, locale, onError]);
+    }, [prepareResult.clientKey, orderId, orderNumber, amount, locale, guestAccessToken, guestAccessTokenExpiresAt, onError]);
 
     useImperativeHandle(ref, () => ({
       confirm: async () => {
@@ -343,7 +382,7 @@ const MockPaymentGateway = forwardRef<PaymentGatewayHandle, { locale: Locale }>(
 
 const ExternalRedirectGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayProps>(
   function ExternalRedirectGateway(
-    { prepareResult, orderId, orderNumber, amount, locale, onError },
+    { prepareResult, orderId, orderNumber, amount, locale, guestAccessToken, guestAccessTokenExpiresAt, onError },
     ref,
   ) {
     const t = useTranslations('checkout');
@@ -364,7 +403,15 @@ const ExternalRedirectGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayP
 
           sessionStorage.setItem(
             SESSION_KEYS.NAVERPAY_CONTEXT,
-            JSON.stringify({ orderId, orderNumber, amount }),
+            JSON.stringify(
+              buildHostedPaymentContext({
+                orderId,
+                orderNumber,
+                amount,
+                guestAccessToken,
+                guestAccessTokenExpiresAt,
+              }),
+            ),
           );
 
           try {
@@ -402,7 +449,15 @@ const ExternalRedirectGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayP
 
           sessionStorage.setItem(
             SESSION_KEYS.EXIMBAY_CONTEXT,
-            JSON.stringify({ orderId, orderNumber, amount }),
+            JSON.stringify(
+              buildHostedPaymentContext({
+                orderId,
+                orderNumber,
+                amount,
+                guestAccessToken,
+                guestAccessTokenExpiresAt,
+              }),
+            ),
           );
 
           try {
@@ -427,7 +482,15 @@ const ExternalRedirectGateway = forwardRef<PaymentGatewayHandle, PaymentGatewayP
 
         sessionStorage.setItem(
           SESSION_KEYS.PAYPAL_CONTEXT,
-          JSON.stringify({ orderId, orderNumber, amount }),
+          JSON.stringify(
+            buildHostedPaymentContext({
+              orderId,
+              orderNumber,
+              amount,
+              guestAccessToken,
+              guestAccessTokenExpiresAt,
+            }),
+          ),
         );
         window.location.assign(prepareResult.redirectUrl);
       },

--- a/src/components/shared/hooks/__tests__/useCheckout.test.tsx
+++ b/src/components/shared/hooks/__tests__/useCheckout.test.tsx
@@ -27,9 +27,18 @@ vi.mock('@/lib/api', () => ({
   ordersApi: {
     create: (...args: unknown[]) => mockOrdersCreate(...args),
   },
+  guestOrdersApi: {
+    create: vi.fn(),
+    getById: vi.fn(),
+    lookup: vi.fn(),
+  },
   paymentsApi: {
     prepare: (...args: unknown[]) => mockPaymentsPrepare(...args),
     confirm: (...args: unknown[]) => mockPaymentsConfirm(...args),
+  },
+  guestPaymentsApi: {
+    prepare: vi.fn(),
+    confirm: vi.fn(),
   },
 }));
 
@@ -112,6 +121,7 @@ function makeOptions(
   const options: UseCheckoutOptions = {
     checkoutItems: [mockItem],
     form: validForm,
+    guestEmail: '',
     grandTotal: 30000,
     locale: 'ko',
     paymentRef,
@@ -119,10 +129,16 @@ function makeOptions(
     selectedGateway: state.selectedGateway,
     currentOrderId: state.currentOrderId,
     currentOrderNumber: state.currentOrderNumber,
+    currentGuestAccessToken: '',
+    requiredConsent: true,
+    marketingConsent: false,
+    isGuestCheckout: false,
     setStep: vi.fn((s: PaymentStep) => { state.step = s; }),
     setPrepareResult: vi.fn((r) => { state.prepareResult = r; }),
     setCurrentOrderId: vi.fn((id) => { state.currentOrderId = id; }),
     setCurrentOrderNumber: vi.fn((n) => { state.currentOrderNumber = n; }),
+    setCurrentGuestAccessToken: vi.fn(),
+    setCurrentGuestAccessTokenExpiresAt: vi.fn(),
     setConfirmedGrandTotal: vi.fn(),
     setErrors: vi.fn(),
     refetch,

--- a/src/components/shared/hooks/useCheckout.ts
+++ b/src/components/shared/hooks/useCheckout.ts
@@ -5,18 +5,32 @@ import { useCallback } from 'react';
 import { toast } from 'sonner';
 import { handleApiError } from '@/utils/error';
 import { SESSION_KEYS } from '@/constants/storage';
-import type { CartItem, CheckoutGatewayName, PreparePaymentResponse } from '@/lib/api';
-import { ordersApi, paymentsApi } from '@/lib/api';
+import type {
+  CartItem,
+  CheckoutGatewayName,
+  GuestConfirmPaymentResponse,
+  PreparePaymentResponse,
+} from '@/lib/api';
+import { guestOrdersApi, guestPaymentsApi, ordersApi, paymentsApi } from '@/lib/api';
+
+
 import type { Locale } from '@/i18n/routing';
 import type { ShippingForm, FormErrors } from '@/app/[locale]/checkout/page';
 import type { PaymentGatewayHandle } from '@/components/shared/checkout/PaymentGateway';
+import { localMessage } from '@/utils/localMessages';
 import { toastMessage } from '@/utils/toastMessages';
 
-export type PaymentStep = 'idle' | 'creating_order' | 'preparing_payment' | 'confirming_payment' | 'success';
+export type PaymentStep =
+  | 'idle'
+  | 'creating_order'
+  | 'preparing_payment'
+  | 'confirming_payment'
+  | 'success';
 
 export interface UseCheckoutOptions {
   checkoutItems: CartItem[];
   form: ShippingForm;
+  guestEmail: string;
   grandTotal: number;
   locale: Locale;
   paymentRef: React.RefObject<PaymentGatewayHandle | null>;
@@ -24,17 +38,28 @@ export interface UseCheckoutOptions {
   selectedGateway: CheckoutGatewayName;
   currentOrderId: number | null;
   currentOrderNumber: string;
+  currentGuestAccessToken: string;
   requiredConsent?: boolean;
   marketingConsent?: boolean;
   selectedUserCouponId?: number;
   pointsUsed?: number;
+  isGuestCheckout: boolean;
   setErrors: (errors: FormErrors) => void;
   setStep: (step: PaymentStep) => void;
   setPrepareResult: (result: PreparePaymentResponse | null) => void;
   setCurrentOrderId: (id: number | null) => void;
   setCurrentOrderNumber: (orderNumber: string) => void;
+  setCurrentGuestAccessToken: (guestAccessToken: string) => void;
+  setCurrentGuestAccessTokenExpiresAt: (guestAccessTokenExpiresAt: string) => void;
   setConfirmedGrandTotal: (amount: number | null) => void;
   refetch: () => Promise<void>;
+}
+
+interface GuestOrderContext {
+  orderId: number;
+  orderNumber: string;
+  guestAccessToken: string;
+  guestAccessTokenExpiresAt: string;
 }
 
 function normalizeTextValue(value: unknown): string {
@@ -49,15 +74,30 @@ function normalizeZipcodeValue(value: unknown): string {
   return normalizeTextValue(value);
 }
 
+function clearHostedProviderContexts(): void {
+  sessionStorage.removeItem(SESSION_KEYS.TOSS_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.PAYPAL_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.NAVERPAY_CONTEXT);
+  sessionStorage.removeItem(SESSION_KEYS.EXIMBAY_CONTEXT);
+}
+
+function persistGuestOrderContext(context: GuestOrderContext): void {
+  sessionStorage.setItem(SESSION_KEYS.GUEST_ORDER_CONTEXT, JSON.stringify(context));
+}
+
+
 export function useCheckout(options: UseCheckoutOptions) {
   const { locale, grandTotal, refetch, form, checkoutItems } = options;
   const router = useRouter();
 
-  const handlePaymentError = useCallback((message: string) => {
-    toast.error(message);
-    options.setStep('idle');
-    options.setPrepareResult(null);
-  }, [options]);
+  const handlePaymentError = useCallback(
+    (message: string) => {
+      toast.error(message);
+      options.setStep('idle');
+      options.setPrepareResult(null);
+    },
+    [options],
+  );
 
   const handlePreparedGatewayFlow = useCallback(async (): Promise<void> => {
     if (!options.prepareResult || !options.paymentRef.current) return;
@@ -66,181 +106,303 @@ export function useCheckout(options: UseCheckoutOptions) {
     try {
       await options.paymentRef.current.confirm();
     } catch (err) {
-      handlePaymentError(handleApiError(err, locale === 'en' ? 'Payment failed.' : '결제에 실패했습니다.'));
+      handlePaymentError(
+        handleApiError(err, localMessage('checkout.paymentError', undefined, locale)),
+      );
     }
   }, [options, handlePaymentError, locale]);
 
-  const handleTossFlow = useCallback(async (orderId: number, orderNumber: string, result: PreparePaymentResponse): Promise<void> => {
-    options.setCurrentOrderId(orderId);
-    options.setCurrentOrderNumber(orderNumber);
-    options.setPrepareResult(result);
-    // PaymentGateway renders after state update; give it a tick before calling confirm
-    setTimeout(async () => {
-      await options.paymentRef.current?.confirm();
-    }, 100);
-  }, [options]);
+  const handleTossFlow = useCallback(
+    async (orderId: number, orderNumber: string, result: PreparePaymentResponse): Promise<void> => {
+      options.setCurrentOrderId(orderId);
+      options.setCurrentOrderNumber(orderNumber);
+      options.setPrepareResult(result);
+      setTimeout(async () => {
+        await options.paymentRef.current?.confirm();
+      }, 100);
+    },
+    [options],
+  );
 
-  const handleExternalRedirectFlow = useCallback(async (orderId: number, orderNumber: string, result: PreparePaymentResponse): Promise<void> => {
-    options.setCurrentOrderId(orderId);
-    options.setCurrentOrderNumber(orderNumber);
-    options.setPrepareResult(result);
-    options.setStep('confirming_payment');
+  const handleExternalRedirectFlow = useCallback(
+    async (orderId: number, orderNumber: string, result: PreparePaymentResponse): Promise<void> => {
+      options.setCurrentOrderId(orderId);
+      options.setCurrentOrderNumber(orderNumber);
+      options.setPrepareResult(result);
+      options.setStep('confirming_payment');
 
-    // PaymentGateway renders after state update; give it a tick before invoking the redirect/open gateway.
-    setTimeout(async () => {
-      const gateway = options.paymentRef.current;
-      if (!gateway) {
-        options.setStep('idle');
-        toast.info(toastMessage('paymentMethodPrompt'));
-        return;
-      }
+      setTimeout(async () => {
+        const gateway = options.paymentRef.current;
+        if (!gateway) {
+          options.setStep('idle');
+          toast.info(toastMessage('paymentMethodPrompt'));
+          return;
+        }
 
-      try {
-        await gateway.confirm();
-      } catch (err) {
-        handlePaymentError(handleApiError(err, locale === 'en' ? 'Payment failed.' : '결제에 실패했습니다.'));
-      }
-    }, 100);
-  }, [options, handlePaymentError, locale]);
+        try {
+          await gateway.confirm();
+        } catch (err) {
+          handlePaymentError(
+            handleApiError(err, localMessage('checkout.paymentError', undefined, locale)),
+          );
+        }
+      }, 100);
+    },
+    [options, handlePaymentError, locale],
+  );
 
-  const handleMockFlow = useCallback(async (orderId: number, orderNumber: string): Promise<void> => {
-    options.setStep('confirming_payment');
-    await paymentsApi.confirm(
-      { orderId, paymentKey: `mock-${orderNumber}`, amount: grandTotal },
-    );
+  const handleMockFlow = useCallback(
+    async (
+      orderId: number,
+      orderNumber: string,
+      guestAccessToken?: string,
+    ): Promise<void> => {
+      options.setStep('confirming_payment');
 
-    options.setStep('success');
-    toast.success(toastMessage('paymentComplete'));
-    sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
-    await refetch();
-    router.replace(`/${locale}/order/complete?orderId=${orderId}&orderNumber=${orderNumber}`);
-  }, [grandTotal, locale, refetch, router, options]);
-
-  const handleSubmit = useCallback(async (e: React.FormEvent): Promise<void> => {
-    e.preventDefault();
-
-    if (options.requiredConsent === false) {
-      toast.error(toastMessage('checkoutConsentRequired'));
-      return;
-    }
-
-    const recipientName = normalizeTextValue(form.recipientName);
-    const recipientPhone = normalizeTextValue(form.recipientPhone);
-    const zipcode = normalizeZipcodeValue(form.zipcode);
-    const address = normalizeTextValue(form.address);
-    const addressDetail = normalizeTextValue(form.addressDetail);
-    const memo = normalizeTextValue(form.memo);
-
-    // If already prepared for a user-action gateway, trigger its confirm/redirect step.
-    if (
-      options.prepareResult
-      && ['stripe', 'paypal', 'naverpay', 'eximbay'].includes(options.prepareResult.gateway)
-    ) {
-      await handlePreparedGatewayFlow();
-      return;
-    }
-
-    const errors: FormErrors = {};
-    if (recipientName.length < 2) {
-      errors.recipientName = locale === 'en' ? 'Please enter at least 2 characters for the name.' : '이름은 2자 이상 입력해주세요.';
-    }
-    if (!/^\d{3}-\d{3,4}-\d{4}$/.test(recipientPhone)) {
-      errors.recipientPhone = locale === 'en' ? 'Please enter a valid phone number. (e.g. 010-1234-5678)' : '올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)';
-    }
-    if (!/^\d{5}$/.test(zipcode)) {
-      errors.zipcode = locale === 'en' ? 'ZIP code must be 5 digits.' : '우편번호는 5자리 숫자로 입력해주세요.';
-    }
-    if (address.length === 0) {
-      errors.address = locale === 'en' ? 'Please enter your address.' : '주소를 입력해주세요.';
-    }
-    if (Object.keys(errors).length > 0) {
-      options.setErrors(errors);
-      toast.error(toastMessage('checkoutValidationError'));
-      return;
-    }
-
-    options.setErrors({});
-
-    try {
-      options.setStep('creating_order');
-      const order = await ordersApi.create(
-        {
-          items: checkoutItems.map((item) => ({
-            productId: item.productId,
-            productOptionId: item.productOptionId,
-            quantity: item.quantity,
-          })),
-          recipientName,
-          recipientPhone,
-          zipcode,
-          address,
-          addressDetail: addressDetail || null,
-          memo: memo || null,
-          marketingConsent: options.marketingConsent ?? false,
-          userCouponId: options.selectedUserCouponId,
-          pointsUsed: options.pointsUsed && options.pointsUsed > 0 ? options.pointsUsed : undefined,
-        },
-      );
-
-      const confirmedTotal = Number(order.totalAmount);
-      options.setConfirmedGrandTotal(confirmedTotal);
-
-      options.setStep('preparing_payment');
-      const result: PreparePaymentResponse = await paymentsApi.prepare(
-        { orderId: order.id, locale, gateway: options.selectedGateway },
-      );
-
-      // Toss flow
-      const isToss =
-        result.gateway === 'toss' &&
-        locale === 'ko' &&
-        result.clientKey &&
-        result.clientKey !== 'mock_client_key';
-
-      if (isToss) {
-        await handleTossFlow(order.id, order.orderNumber, result);
-        return;
-      }
-
-      // Stripe flow: render Payment Element
-      const isStripe =
-        result.gateway === 'stripe' &&
-        result.clientKey &&
-        result.clientKey !== 'mock_client_key';
-
-      if (isStripe) {
-        options.setCurrentOrderId(order.id);
-        options.setCurrentOrderNumber(order.orderNumber);
-        options.setPrepareResult(result);
-        options.setStep('idle');
-        toast.info(toastMessage('cardPaymentPrompt'));
-        return;
-      }
-
-      if (result.gateway === 'paypal' || result.gateway === 'naverpay' || result.gateway === 'eximbay') {
-        await handleExternalRedirectFlow(order.id, order.orderNumber, result);
-        return;
-      }
-
-      if (result.gateway === 'bank_transfer') {
-        options.setCurrentOrderId(order.id);
-        options.setCurrentOrderNumber(order.orderNumber);
-        options.setPrepareResult(null);
+      if (options.isGuestCheckout) {
+        if (!guestAccessToken) {
+          throw new Error('guest_access_token_missing');
+        }
+        const result: GuestConfirmPaymentResponse = await guestPaymentsApi.confirm(
+          orderId,
+          { paymentKey: `mock-${orderNumber}`, amount: grandTotal },
+          guestAccessToken,
+        );
+        const guestContext = {
+          orderId: result.orderId,
+          orderNumber: result.orderNumber,
+          guestAccessToken: result.guestAccessToken,
+          guestAccessTokenExpiresAt: result.guestAccessTokenExpiresAt,
+        };
+        persistGuestOrderContext(guestContext);
+        clearHostedProviderContexts();
         options.setStep('success');
-        toast.success(toastMessage('bankTransferOrderReceived'));
+        toast.success(toastMessage('paymentComplete'));
         sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
         await refetch();
-        router.replace(`/${locale}/order/complete?orderId=${order.id}&orderNumber=${order.orderNumber}&payment=bank_transfer`);
+        router.replace(
+          `/${locale}/order/complete?orderId=${result.orderId}&orderNumber=${result.orderNumber}&flow=guest`,
+        );
         return;
       }
 
-      // Mock flow
-      await handleMockFlow(order.id, order.orderNumber);
-    } catch (err) {
-      toast.error(handleApiError(err, toastMessage('paymentError')));
-      options.setStep('idle');
-    }
-  }, [options, form, checkoutItems, locale, refetch, router, handlePreparedGatewayFlow, handleTossFlow, handleExternalRedirectFlow, handleMockFlow]);
+      await paymentsApi.confirm({ orderId, paymentKey: `mock-${orderNumber}`, amount: grandTotal });
+      clearHostedProviderContexts();
+      options.setStep('success');
+      toast.success(toastMessage('paymentComplete'));
+      sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
+      await refetch();
+      router.replace(`/${locale}/order/complete?orderId=${orderId}&orderNumber=${orderNumber}`);
+    },
+    [grandTotal, locale, refetch, router, options],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent): Promise<void> => {
+      e.preventDefault();
+
+      if (options.requiredConsent === false) {
+        toast.error(toastMessage('checkoutConsentRequired'));
+        return;
+      }
+
+      const recipientName = normalizeTextValue(form.recipientName);
+      const recipientPhone = normalizeTextValue(form.recipientPhone);
+      const zipcode = normalizeZipcodeValue(form.zipcode);
+      const address = normalizeTextValue(form.address);
+      const addressDetail = normalizeTextValue(form.addressDetail);
+      const memo = normalizeTextValue(form.memo);
+      const normalizedGuestEmail = normalizeTextValue(options.guestEmail).toLowerCase();
+
+      if (
+        options.prepareResult &&
+        ['stripe', 'paypal', 'naverpay', 'eximbay'].includes(options.prepareResult.gateway)
+      ) {
+        await handlePreparedGatewayFlow();
+        return;
+      }
+
+      const errors: FormErrors = {};
+      if (options.isGuestCheckout && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedGuestEmail)) {
+        errors.guestEmail = localMessage('checkout.validation.guestEmailInvalid', undefined, locale);
+      }
+      if (recipientName.length < 2) {
+        errors.recipientName = localMessage('checkout.validation.recipientNameTooShort', undefined, locale);
+      }
+      if (!/^\d{3}-\d{3,4}-\d{4}$/.test(recipientPhone)) {
+        errors.recipientPhone = localMessage('checkout.validation.phoneInvalid', undefined, locale);
+      }
+      if (!/^\d{5}$/.test(zipcode)) {
+        errors.zipcode = localMessage('checkout.validation.zipcodeInvalid', undefined, locale);
+      }
+      if (address.length === 0) {
+        errors.address = localMessage('checkout.validation.addressRequired', undefined, locale);
+      }
+      if (Object.keys(errors).length > 0) {
+        options.setErrors(errors);
+        toast.error(toastMessage('checkoutValidationError'));
+        return;
+      }
+
+      options.setErrors({});
+
+      try {
+        options.setStep('creating_order');
+
+        let orderId: number;
+        let orderNumber: string;
+        let guestAccessToken = '';
+        let guestAccessTokenExpiresAt = '';
+        let confirmedTotal = grandTotal;
+
+        if (options.isGuestCheckout) {
+          const result = await guestOrdersApi.create({
+            items: checkoutItems.map((item) => ({
+              productId: item.productId,
+              productOptionId: item.productOptionId,
+              quantity: item.quantity,
+            })),
+            recipientName,
+            recipientPhone,
+            zipcode,
+            address,
+            addressDetail: addressDetail || null,
+            memo: memo || null,
+            guestEmail: normalizedGuestEmail,
+            orderLocale: locale,
+            marketingConsent: options.marketingConsent ?? false,
+          });
+
+
+
+          orderId = result.order.id;
+          orderNumber = result.order.orderNumber;
+          guestAccessToken = result.guestAccessToken;
+          guestAccessTokenExpiresAt = result.guestAccessTokenExpiresAt;
+          confirmedTotal = Number(result.order.totalAmount);
+          options.setCurrentGuestAccessToken(result.guestAccessToken);
+          options.setCurrentGuestAccessTokenExpiresAt(result.guestAccessTokenExpiresAt);
+        } else {
+          const order = await ordersApi.create({
+            items: checkoutItems.map((item) => ({
+              productId: item.productId,
+              productOptionId: item.productOptionId,
+              quantity: item.quantity,
+            })),
+            recipientName,
+            recipientPhone,
+            zipcode,
+            address,
+            addressDetail: addressDetail || null,
+            memo: memo || null,
+            orderLocale: locale,
+            marketingConsent: options.marketingConsent ?? false,
+            userCouponId: options.selectedUserCouponId,
+            pointsUsed: options.pointsUsed && options.pointsUsed > 0 ? options.pointsUsed : undefined,
+          });
+
+          orderId = order.id;
+          confirmedTotal = Number(order.totalAmount);
+          orderNumber = order.orderNumber;
+          options.setCurrentGuestAccessToken('');
+          options.setCurrentGuestAccessTokenExpiresAt('');
+        }
+
+        options.setConfirmedGrandTotal(confirmedTotal);
+        options.setStep('preparing_payment');
+
+        const result: PreparePaymentResponse = options.isGuestCheckout
+          ? await guestPaymentsApi.prepare(
+              orderId,
+              { locale, gateway: options.selectedGateway },
+              guestAccessToken,
+            )
+          : await paymentsApi.prepare({ orderId, locale, gateway: options.selectedGateway });
+
+        const isToss =
+          result.gateway === 'toss' &&
+          locale === 'ko' &&
+          result.clientKey &&
+          result.clientKey !== 'mock_client_key';
+
+        if (isToss) {
+          await handleTossFlow(orderId, orderNumber, result);
+          return;
+        }
+
+        const isStripe =
+          result.gateway === 'stripe' &&
+          result.clientKey &&
+          result.clientKey !== 'mock_client_key';
+
+        if (isStripe) {
+          options.setCurrentOrderId(orderId);
+          options.setCurrentOrderNumber(orderNumber);
+          options.setPrepareResult(result);
+          options.setStep('idle');
+          toast.info(toastMessage('cardPaymentPrompt'));
+          return;
+        }
+
+        if (
+          result.gateway === 'paypal' ||
+          result.gateway === 'naverpay' ||
+          result.gateway === 'eximbay'
+        ) {
+          await handleExternalRedirectFlow(orderId, orderNumber, result);
+          return;
+        }
+
+        if (result.gateway === 'bank_transfer') {
+          options.setCurrentOrderId(orderId);
+          options.setCurrentOrderNumber(orderNumber);
+          options.setPrepareResult(null);
+          clearHostedProviderContexts();
+          options.setStep('success');
+          toast.success(toastMessage('bankTransferOrderReceived'));
+          sessionStorage.removeItem(SESSION_KEYS.CHECKOUT_ITEMS);
+
+          if (options.isGuestCheckout) {
+            persistGuestOrderContext({
+              orderId,
+              orderNumber,
+              guestAccessToken,
+              guestAccessTokenExpiresAt,
+            });
+            await refetch();
+            router.replace(
+              `/${locale}/order/complete?orderId=${orderId}&orderNumber=${orderNumber}&payment=bank_transfer&flow=guest`,
+            );
+            return;
+          }
+
+          await refetch();
+          router.replace(
+            `/${locale}/order/complete?orderId=${orderId}&orderNumber=${orderNumber}&payment=bank_transfer`,
+          );
+          return;
+        }
+
+        await handleMockFlow(orderId, orderNumber, guestAccessToken || undefined);
+      } catch (err) {
+        toast.error(handleApiError(err, toastMessage('paymentError')));
+        options.setStep('idle');
+      }
+    },
+    [
+      options,
+      form,
+      checkoutItems,
+      locale,
+      grandTotal,
+      refetch,
+      router,
+      handlePreparedGatewayFlow,
+      handleTossFlow,
+      handleExternalRedirectFlow,
+      handleMockFlow,
+    ],
+  );
 
   return {
     handleSubmit,

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,5 +1,6 @@
 export const SESSION_KEYS = {
   CHECKOUT_ITEMS: 'checkoutItems',
+  GUEST_ORDER_CONTEXT: 'guestOrderContext',
   TOSS_CONTEXT: 'tossPaymentContext',
   PAYPAL_CONTEXT: 'paypalPaymentContext',
   NAVERPAY_CONTEXT: 'naverpayPaymentContext',

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -429,7 +429,8 @@
       "recipientNameTooShort": "Please enter at least 2 characters for the name.",
       "phoneInvalid": "Please enter a valid phone number. (e.g. 010-1234-5678)",
       "zipcodeInvalid": "ZIP code must be 5 digits.",
-      "addressRequired": "Please enter your address."
+      "addressRequired": "Please enter your address.",
+      "guestEmailInvalid": "Please enter a valid email address."
     },
     "flow": {
       "shipping": "Shipping info",
@@ -496,7 +497,12 @@
     "cardTermsAriaLabel": "Card payment terms agreement",
     "cardTermsAgreement": "I agree to the payment terms and authorize the secure card payment.",
     "payNow": "Pay now",
-    "cardSecurePageNotice": "Card number, expiry date, and CVC are never stored in Okhwadang server or browser state."
+    "cardSecurePageNotice": "Card number, expiry date, and CVC are never stored in Okhwadang server or browser state.",
+    "guestCheckoutTitle": "Guest checkout",
+    "guestCheckoutDescription": "Enter the email address used for this order. You can use it later to look up your order without logging in.",
+    "guestEmailLabel": "Guest email",
+    "guestEmailPlaceholder": "you@example.com",
+    "guestEmailDescription": "We will use this email for order updates and guest order lookup."
   },
   "order": {
     "orderHistory": "Order History",
@@ -533,7 +539,9 @@
     "discount": "Discount",
     "paymentAmount": "Payment amount",
     "viewOrders": "View order history",
-    "continueShopping": "Continue shopping"
+    "continueShopping": "Continue shopping",
+    "guestPrimaryAction": "Look up guest orders",
+    "guestAccessHint": "Save your order number and email address to look up this guest order again."
   },
   "myPage": {
     "title": "My Page",
@@ -733,7 +741,9 @@
         "shipped": "Shipped",
         "delivered": "Delivered",
         "cancelled": "Cancelled",
-        "refunded": "Refunded"
+        "refunded": "Refunded",
+        "refund_requested": "Refund Requested",
+        "completed": "Completed"
       },
       "status": {
         "pending": "Pending",
@@ -742,7 +752,9 @@
         "shipped": "Shipped",
         "delivered": "Delivered",
         "cancelled": "Cancelled",
-        "refunded": "Refunded"
+        "refunded": "Refunded",
+        "refund_requested": "Refund Requested",
+        "completed": "Completed"
       },
       "cancel": {
         "action": "Cancel order",
@@ -756,6 +768,9 @@
         "submitting": "Processing...",
         "success": "Order cancelled and customer notification was queued.",
         "error": "Failed to cancel order."
+      },
+      "productSummary": {
+        "more": "{productName} and {count} more"
       }
     },
     "products": {
@@ -1773,7 +1788,8 @@
     "back": "Back",
     "errorCode": "Error code: {code}",
     "loading": "Loading...",
-    "defaultFailMessage": "Payment failed."
+    "defaultFailMessage": "Payment failed.",
+    "guestAccessExpired": "Your guest order access expired. Look up the order again to continue."
   },
   "contact": {
     "loadError": "Failed to load page.",
@@ -1796,7 +1812,12 @@
       "exchange": "Returns/Exchanges",
       "member": "Account",
       "other": "Other"
-    }
+    },
+    "orderLookupTitle": "How do I check an order after checkout?",
+    "orderLookupGuestDescription": "Guest orders can be checked from the guest order lookup page with the order number and email used at checkout.",
+    "orderLookupGuestAction": "Go to guest order lookup",
+    "orderLookupMemberDescription": "Member orders remain available from My Page after login.",
+    "orderLookupMemberAction": "Log in and review payment and shipping updates from your order history."
   },
   "notice": {
     "title": "Notices",
@@ -1921,5 +1942,23 @@
       "edge": "Edge: Settings > Cookies and site permissions > Manage cookies and site data",
       "firefox": "Firefox: Settings > Privacy & Security > Cookies and Site Data"
     }
+  },
+  "orderLookup": {
+    "eyebrow": "Guest support",
+    "title": "Guest order lookup",
+    "description": "Enter the order number and email address used at checkout to view your guest order.",
+    "orderNumberLabel": "Order number",
+    "orderNumberPlaceholder": "ORD-000001",
+    "emailLabel": "Email",
+    "emailPlaceholder": "you@example.com",
+    "submit": "Look up order",
+    "submitting": "Looking up...",
+    "guestLookupSuccess": "Guest order found.",
+    "guestLookupNotFound": "We could not find a guest order matching that order number and email.",
+    "guestLookupValidationError": "Please check the order number and email address.",
+    "guestLookupError": "Unable to look up the guest order right now.",
+    "memberHintTitle": "Need your member order history?",
+    "memberHintDescription": "Sign in to see member orders, payment status, and shipping updates in My Page.",
+    "memberHintAction": "Go to login"
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -429,7 +429,8 @@
       "recipientNameTooShort": "이름은 2자 이상 입력해주세요.",
       "phoneInvalid": "올바른 전화번호 형식을 입력해주세요. (예: 010-1234-5678)",
       "zipcodeInvalid": "우편번호는 5자리 숫자로 입력해주세요.",
-      "addressRequired": "주소를 입력해주세요."
+      "addressRequired": "주소를 입력해주세요.",
+      "guestEmailInvalid": "올바른 이메일 주소를 입력해주세요."
     },
     "flow": {
       "shipping": "배송 정보",
@@ -496,7 +497,12 @@
     "cardTermsAriaLabel": "카드 결제 약관 동의",
     "cardTermsAgreement": "I agree to the payment terms and authorize the secure card payment.",
     "payNow": "Pay now",
-    "cardSecurePageNotice": "카드번호·유효기간·CVC는 옥화당 서버나 브라우저 상태에 저장되지 않습니다."
+    "cardSecurePageNotice": "카드번호·유효기간·CVC는 옥화당 서버나 브라우저 상태에 저장되지 않습니다.",
+    "guestCheckoutTitle": "비회원 주문",
+    "guestCheckoutDescription": "주문에 사용할 이메일을 입력해 주세요. 로그인 없이도 같은 이메일과 주문번호로 비회원 주문을 다시 조회할 수 있습니다.",
+    "guestEmailLabel": "비회원 이메일",
+    "guestEmailPlaceholder": "you@example.com",
+    "guestEmailDescription": "주문 안내와 비회원 주문조회에 사용할 이메일입니다."
   },
   "order": {
     "orderHistory": "주문 내역",
@@ -533,7 +539,9 @@
     "discount": "할인",
     "paymentAmount": "결제 금액",
     "viewOrders": "주문 내역 보기",
-    "continueShopping": "쇼핑 계속하기"
+    "continueShopping": "쇼핑 계속하기",
+    "guestPrimaryAction": "비회원 주문조회",
+    "guestAccessHint": "주문번호와 이메일을 보관하면 비회원 주문을 다시 조회할 수 있습니다."
   },
   "myPage": {
     "title": "마이페이지",
@@ -733,7 +741,9 @@
         "shipped": "배송중",
         "delivered": "배송완료",
         "cancelled": "주문취소",
-        "refunded": "환불완료"
+        "refunded": "환불완료",
+        "refund_requested": "환불요청",
+        "completed": "구매확정"
       },
       "status": {
         "pending": "결제대기",
@@ -742,7 +752,9 @@
         "shipped": "배송중",
         "delivered": "배송완료",
         "cancelled": "주문취소",
-        "refunded": "환불완료"
+        "refunded": "환불완료",
+        "refund_requested": "환불요청",
+        "completed": "구매확정"
       },
       "cancel": {
         "action": "주문 취소",
@@ -756,6 +768,9 @@
         "submitting": "처리 중...",
         "success": "주문이 취소되었고 고객 알림이 요청되었습니다.",
         "error": "주문 취소에 실패했습니다."
+      },
+      "productSummary": {
+        "more": "{productName} 외 {count}건"
       }
     },
     "products": {
@@ -1773,7 +1788,8 @@
     "back": "돌아가기",
     "errorCode": "오류 코드: {code}",
     "loading": "로딩 중...",
-    "defaultFailMessage": "결제에 실패했습니다."
+    "defaultFailMessage": "결제에 실패했습니다.",
+    "guestAccessExpired": "비회원 주문 조회 권한이 만료되었습니다. 주문조회에서 다시 확인해 주세요."
   },
   "contact": {
     "loadError": "페이지를 불러오지 못했습니다.",
@@ -1796,7 +1812,12 @@
       "exchange": "교환/반품",
       "member": "회원",
       "other": "기타"
-    }
+    },
+    "orderLookupTitle": "주문 후 주문 상태는 어떻게 확인하나요?",
+    "orderLookupGuestDescription": "비회원 주문은 결제 시 사용한 이메일과 주문번호로 비회원 주문조회 페이지에서 확인할 수 있습니다.",
+    "orderLookupGuestAction": "비회원 주문조회로 이동",
+    "orderLookupMemberDescription": "회원 주문은 로그인 후 마이페이지 주문 내역에서 계속 확인할 수 있습니다.",
+    "orderLookupMemberAction": "로그인 후 주문 내역에서 결제 상태와 배송 상태를 확인해 주세요."
   },
   "notice": {
     "title": "공지사항",
@@ -1921,5 +1942,23 @@
       "edge": "Edge: 설정 > 쿠키 및 사이트 권한 > 쿠키 및 사이트 데이터 관리",
       "firefox": "Firefox: 설정 > 개인정보 및 보안 > 쿠키와 사이트 데이터"
     }
+  },
+  "orderLookup": {
+    "eyebrow": "비회원 고객 지원",
+    "title": "비회원 주문조회",
+    "description": "결제에 사용한 주문번호와 이메일을 입력하면 비회원 주문을 확인할 수 있습니다.",
+    "orderNumberLabel": "주문번호",
+    "orderNumberPlaceholder": "ORD-000001",
+    "emailLabel": "이메일",
+    "emailPlaceholder": "you@example.com",
+    "submit": "주문조회",
+    "submitting": "조회 중...",
+    "guestLookupSuccess": "비회원 주문을 찾았습니다.",
+    "guestLookupNotFound": "주문번호와 이메일이 일치하는 비회원 주문을 찾을 수 없습니다.",
+    "guestLookupValidationError": "주문번호와 이메일을 다시 확인해 주세요.",
+    "guestLookupError": "지금은 비회원 주문을 조회할 수 없습니다.",
+    "memberHintTitle": "회원 주문 내역이 필요하신가요?",
+    "memberHintDescription": "로그인하면 마이페이지에서 회원 주문, 결제 상태, 배송 현황을 확인할 수 있습니다.",
+    "memberHintAction": "로그인으로 이동"
   }
 }

--- a/src/lib/__tests__/api-auth-skip.test.ts
+++ b/src/lib/__tests__/api-auth-skip.test.ts
@@ -1,6 +1,6 @@
 /**
- * /auth/* 엔드포인트는 401 응답 시 토큰 갱신 인터셉터를 스킵해야 한다.
- * 회귀 시 무한 refresh 루프가 발생할 수 있어 별도 회귀 가드 테스트로 분리.
+ * /auth/* 엔드포인트와 guest wrapper 요청은 401 응답 시 토큰 갱신 인터셉터를 스킵해야 한다.
+ * 회귀 시 무한 refresh 루프 또는 비회원 주문 조회 흐름의 로그인 리다이렉트가 발생할 수 있어 별도 회귀 가드 테스트로 분리.
  * (memory: feedback_api_client.md)
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -13,7 +13,7 @@ Object.defineProperty(window, 'location', {
   value: { href: '' },
 });
 
-import { apiClient, authApi } from '@/lib/api';
+import { apiClient, authApi, guestOrdersApi, guestPaymentsApi } from '@/lib/api';
 
 function makeResponse(status: number, body: unknown = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -104,6 +104,50 @@ describe('ApiClient — /auth/* 엔드포인트 401 인터셉터 스킵', () => 
     await expect(apiClient.post('/auth/google', { code: 'abc' })).rejects.toThrow();
 
     expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('guest order lookup 401 응답 시 refresh 호출이나 로그인 리다이렉트 없이 종료', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock.mockResolvedValueOnce(makeResponse(401, { message: 'Unauthorized' }));
+
+    await expect(
+      guestOrdersApi.lookup({ orderNumber: 'ORD-001', email: 'guest@example.com', locale: 'ko' }),
+    ).rejects.toThrow('Unauthorized');
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/guest/orders/lookup',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+      }),
+    );
+    expect(window.location.href).toBe('');
+  });
+
+  it('guest payment confirm 401 응답 시 refresh 재시도나 로그인 리다이렉트 없이 guest 헤더만 유지', async () => {
+    const refreshSpy = vi.spyOn(authApi, 'refresh').mockResolvedValue({ message: 'ok' });
+    fetchMock.mockResolvedValueOnce(makeResponse(401, { message: 'Unauthorized' }));
+
+    await expect(
+      guestPaymentsApi.confirm(7, { paymentKey: 'pay_123', amount: 52000 }, 'guest-token-123'),
+    ).rejects.toThrow('Unauthorized');
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/guest/orders/7/payments/confirm',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Guest-Access-Token': 'guest-token-123',
+        }),
+      }),
+    );
+    expect(window.location.href).toBe('');
   });
 
   it('/auth/* 가 아닌 경로는 401 시 refresh 호출 (대조 케이스)', async () => {

--- a/src/lib/api/admin/orders.ts
+++ b/src/lib/api/admin/orders.ts
@@ -13,7 +13,9 @@ export interface AdminOrder {
   updatedAt: string;
   cancelReason?: string | null;
   cancelledAt?: string | null;
-  user?: { id: number; email: string; name: string };
+  customerType?: 'member' | 'guest';
+  guestEmailNormalized?: string | null;
+  user: { id: number; email: string; name: string } | null;
   items: {
     id: number;
     productName: string;

--- a/src/lib/api/core.ts
+++ b/src/lib/api/core.ts
@@ -62,6 +62,7 @@ async function _ensureTokenRefreshed(): Promise<void> {
 
 export interface RequestOptions extends RequestInit {
   params?: Record<string, string | number | undefined>;
+  skipAuthRefresh?: boolean;
 }
 
 class ApiClient {
@@ -88,7 +89,7 @@ class ApiClient {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { params: _extractedParams, ...fetchOptions } = options ?? {};
+    const { params: _extractedParams, skipAuthRefresh = false, ...fetchOptions } = options ?? {};
 
     const { headers: optionHeaders, ...restFetchOptions } = fetchOptions ?? {};
     const isFormData = restFetchOptions.body instanceof FormData;
@@ -108,11 +109,10 @@ class ApiClient {
       });
 
       if (response.status === 401) {
-        if (AUTH_SKIP_REFRESH.has(endpoint)) {
+        if (skipAuthRefresh || AUTH_SKIP_REFRESH.has(endpoint)) {
           throw await createApiHttpError(response);
         }
         await _ensureTokenRefreshed();
-        // Retry original request after token refresh
         const retryResponse = await fetch(url, {
           ...restFetchOptions,
           credentials: 'include',

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -23,6 +23,8 @@ export interface OrderResponse {
   address: string;
   addressDetail: string | null;
   memo: string | null;
+  guestEmailNormalized?: string | null;
+  orderLocale?: 'ko' | 'en';
   items: OrderItemResponse[];
   createdAt: string;
 }
@@ -78,10 +80,57 @@ export interface CreateOrderBody {
   address: string;
   addressDetail?: string | null;
   memo?: string | null;
+  orderLocale: 'ko' | 'en';
   policyConsents?: PolicyConsentSnapshot[];
   marketingConsent?: boolean;
   pointsUsed?: number;
   userCouponId?: number;
+}
+
+export interface CreateGuestOrderBody {
+  items: Array<{ productId: number; productOptionId: number | null; quantity: number }>;
+  recipientName: string;
+  recipientPhone: string;
+  zipcode: string;
+  address: string;
+  addressDetail?: string | null;
+  memo?: string | null;
+  guestEmail: string;
+  orderLocale: 'ko' | 'en';
+  policyConsents?: PolicyConsentSnapshot[];
+  marketingConsent?: boolean;
+}
+
+export interface GuestOrderCreateResponse {
+  order: OrderResponse;
+  guestAccessToken: string;
+  guestAccessTokenExpiresAt: string;
+}
+
+export interface GuestOrderLookupBody {
+  orderNumber: string;
+  email: string;
+  locale?: 'ko' | 'en';
+}
+
+export interface GuestOrderLookupResponse {
+  order: OrderResponse;
+  guestAccessToken: string;
+  guestAccessTokenExpiresAt: string;
+}
+
+function createGuestRequestOptions(
+  guestAccessToken: string,
+  options?: RequestOptions,
+): RequestOptions {
+  return {
+    ...options,
+    skipAuthRefresh: true,
+    headers: {
+      ...(options?.headers as Record<string, string> | undefined),
+      'X-Guest-Access-Token': guestAccessToken,
+    },
+  };
 }
 
 export const ordersApi = {
@@ -95,4 +144,25 @@ export const ordersApi = {
     apiClient.get<OrderServiceRequest[]>(`/orders/${orderId}/service-requests`),
   createServiceRequest: (orderId: number, body: CreateOrderServiceRequestBody) =>
     apiClient.post<OrderServiceRequest>(`/orders/${orderId}/service-requests`, body),
+};
+
+export const guestOrdersApi = {
+  create: (body: CreateGuestOrderBody, options?: RequestOptions) =>
+    apiClient.post<GuestOrderCreateResponse>('/guest/orders', body, {
+      ...options,
+      skipAuthRefresh: true,
+    }),
+  getById: (id: number, guestAccessToken: string, locale?: 'ko' | 'en', options?: RequestOptions) =>
+    apiClient.get<OrderResponse>(`/guest/orders/${id}`, {
+      ...createGuestRequestOptions(guestAccessToken, options),
+      params: {
+        ...(options?.params ?? {}),
+        locale,
+      },
+    }),
+  lookup: (body: GuestOrderLookupBody, options?: RequestOptions) =>
+    apiClient.post<GuestOrderLookupResponse>('/guest/orders/lookup', body, {
+      ...options,
+      skipAuthRefresh: true,
+    }),
 };

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -24,9 +24,55 @@ export interface ConfirmPaymentResponse {
   paidAt: string;
 }
 
+export interface GuestConfirmPaymentResponse extends ConfirmPaymentResponse {
+  guestAccessToken: string;
+  guestAccessTokenExpiresAt: string;
+}
+
+function createGuestRequestOptions(
+  guestAccessToken: string,
+  options?: RequestOptions,
+): RequestOptions {
+  return {
+    ...options,
+    skipAuthRefresh: true,
+    headers: {
+      ...(options?.headers as Record<string, string> | undefined),
+      'X-Guest-Access-Token': guestAccessToken,
+    },
+  };
+}
+
 export const paymentsApi = {
-  prepare: (body: { orderId: number; locale?: string; gateway?: CheckoutGatewayName }, options?: RequestOptions) =>
-    apiClient.post<PreparePaymentResponse>('/payments/prepare', body, options),
+  prepare: (
+    body: { orderId: number; locale?: string; gateway?: CheckoutGatewayName },
+    options?: RequestOptions,
+  ) => apiClient.post<PreparePaymentResponse>('/payments/prepare', body, options),
   confirm: (body: { orderId: number; paymentKey: string; amount: number }, options?: RequestOptions) =>
     apiClient.post<ConfirmPaymentResponse>('/payments/confirm', body, options),
+};
+
+export const guestPaymentsApi = {
+  prepare: (
+    orderId: number,
+    body: { locale?: string; gateway?: CheckoutGatewayName },
+    guestAccessToken: string,
+    options?: RequestOptions,
+  ) =>
+    apiClient.post<PreparePaymentResponse>(
+      `/guest/orders/${orderId}/payments/prepare`,
+      body,
+      createGuestRequestOptions(guestAccessToken, options),
+    ),
+  confirm: (
+    orderId: number,
+    body: { paymentKey: string; amount: number },
+    guestAccessToken: string,
+    options?: RequestOptions,
+  ) =>
+    apiClient.post<GuestConfirmPaymentResponse>(
+      `/guest/orders/${orderId}/payments/confirm`,
+      body,
+      createGuestRequestOptions(guestAccessToken, options),
+    ),
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,7 +48,7 @@ function withLocaleCookie(
 }
 
 const ADMIN_ROLES = new Set(['admin', 'super_admin']);
-const MEMBER_PROTECTED_PREFIXES = ['/my', '/checkout'] as const;
+const MEMBER_PROTECTED_PREFIXES = ['/my'] as const;
 
 type JwtSessionCheckResult =
   { status: 'valid'; role: string | null } | { status: 'invalid' | 'unverified' };

--- a/src/utils/__tests__/toastMessages.test.ts
+++ b/src/utils/__tests__/toastMessages.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { toastMessage } from '@/utils/toastMessages';
+
+describe('toastMessages guest-checkout coverage', () => {
+  it('keeps checkout completion messages localized for both locales', () => {
+    expect(toastMessage('paymentComplete', undefined, 'ko')).toBe('결제가 완료되었습니다.');
+    expect(toastMessage('paymentComplete', undefined, 'en')).toBe('Payment completed.');
+    expect(toastMessage('bankTransferOrderReceived', undefined, 'ko')).toBe('주문이 접수되었습니다. 무통장입금을 진행해 주세요.');
+    expect(toastMessage('bankTransferOrderReceived', undefined, 'en')).toBe('Order received. Please complete the bank transfer.');
+  });
+
+  it('keeps hosted confirm failure messages localized for both locales', () => {
+    expect(toastMessage('paymentConfirmError', undefined, 'ko')).toBe('결제 확인 중 오류가 발생했습니다.');
+    expect(toastMessage('paymentConfirmError', undefined, 'en')).toBe('An error occurred while confirming payment.');
+    expect(toastMessage('paymentContextMissing', undefined, 'ko')).toBe('결제 컨텍스트를 찾을 수 없습니다.');
+    expect(toastMessage('paymentContextMissing', undefined, 'en')).toBe('Payment context was not found.');
+  });
+});


### PR DESCRIPTION
## 요약
- 비회원 주문 생성/조회/결제/주문완료 흐름을 추가했습니다.
- 주문/결제/동의/알림/어드민/스케줄러 경로를 guest ownership 기준까지 확장했습니다.
- 게스트 토큰 회전 및 stale token 복구, 관련 프론트/백엔드 회귀 테스트를 추가했습니다.

## 검증
- bash scripts/codex-project-guard.sh
- npm run build && npm run test:run
- cd backend && npm run build && npm run test
- bash scripts/test.sh e2e
- bash scripts/start-local.sh
- http://localhost:3000/api/health
- http://localhost:5173/ko
- http://localhost:5173/ko/checkout
- http://localhost:5173/ko/order/lookup

Closes #1137
