### PR TITLE
Hotfix post-merge issue #1138 payment and points regressions

### DIFF
--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -49,6 +49,9 @@ const makePayment = (overrides: Partial<Payment> = {}): Payment =>
 const makeTransactionManager = (overrides: Record<string, jest.Mock> = {}) => ({
   update: jest.fn().mockResolvedValue({}),
   findOne: jest.fn().mockImplementation((entity: unknown) => {
+    if (entity === Payment) {
+      return Promise.resolve(makePayment());
+    }
     if (entity === Order) {
       return Promise.resolve(makeOrder({ pointsUsed: 0 }));
     }

--- a/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
@@ -55,6 +55,9 @@ const makePayment = (overrides: Partial<Payment> = {}): Payment =>
 const makeTransactionManager = (overrides: Record<string, jest.Mock> = {}) => ({
   update: jest.fn().mockResolvedValue({}),
   findOne: jest.fn().mockImplementation((entity: unknown) => {
+    if (entity === Payment) {
+      return Promise.resolve(makePayment());
+    }
     if (entity === Order) {
       return Promise.resolve(makeOrder({ pointsUsed: 0 }));
     }
@@ -475,6 +478,9 @@ describe('PaymentConfirmationService', () => {
       });
       const recoveryManager = makeTransactionManager({
         findOne: jest.fn().mockImplementation((entity: unknown) => {
+          if (entity === Payment) {
+            return Promise.resolve(payment);
+          }
           if (entity === Order) {
             return Promise.resolve(makeOrder({ id: 1, userId: 10, orderNumber: 'ORD-20240101-ABCD1', pointsUsed: 700, status: OrderStatus.PENDING }));
           }
@@ -515,6 +521,31 @@ describe('PaymentConfirmationService', () => {
           description: '주문 1 결제 승인 실패로 인한 적립금 복구',
         }),
       );
+    });
+  });
+
+  describe('confirm() — duplicate loser local-truth handling', () => {
+    it('duplicate-like provider error + authoritative confirmed state → 409 without FAILED/CANCELLED recovery', async () => {
+      const payment = makePayment();
+      const lockedPayment = makePayment({
+        status: PaymentStatus.CONFIRMED,
+        order: makeOrder({ status: OrderStatus.PAID }),
+      });
+      const manager = makeTransactionManager({
+        findOne: jest.fn().mockResolvedValue(lockedPayment),
+      });
+      const dataSource = makeDataSource(manager);
+      const { service, defaultGateway } = buildService({
+        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+        dataSource,
+      });
+      (defaultGateway.confirm as jest.Mock).mockRejectedValue(new Error('already captured by provider'));
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pay_dup', amount: 30000 }, 10),
+      ).rejects.toThrow(ConflictException);
+      expect(manager.update).not.toHaveBeenCalledWith(Payment, lockedPayment.id, { status: PaymentStatus.FAILED });
+      expect(manager.update).not.toHaveBeenCalledWith(Order, 1, { status: OrderStatus.CANCELLED });
     });
   });
 

--- a/backend/src/modules/payments/services/payment-confirmation.service.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.ts
@@ -181,7 +181,16 @@ export class PaymentConfirmationService {
       };
     } catch (err) {
       await this.dataSource.transaction(async (manager) => {
-        await this.applyFailedPaymentRecovery(manager, payment.id, dto.orderId);
+        const lockedPayment = await this.loadLockedPayment(dto.orderId, manager);
+
+        if (this.isDuplicateLikeConfirmError(err)) {
+          if (lockedPayment.status === PaymentStatus.CONFIRMED || lockedPayment.order.status === OrderStatus.PAID) {
+            throw new ConflictException('이미 승인된 결제입니다.');
+          }
+        }
+
+        this.assertPendingBeforeFailureRecovery(lockedPayment.order, lockedPayment);
+        await this.applyFailedPaymentRecovery(manager, lockedPayment.id, dto.orderId);
       });
 
       if (err instanceof ConflictException || err instanceof BadRequestException) {
@@ -282,7 +291,7 @@ export class PaymentConfirmationService {
         await this.guestOrderAccessService.getValidAccessOrThrow(orderId, guestAccessToken, manager);
         const lockedPayment = await this.loadLockedPayment(orderId, manager);
 
-        if (this.isDuplicateLikeGuestConfirmError(err)) {
+        if (this.isDuplicateLikeConfirmError(err)) {
           if (lockedPayment.status === PaymentStatus.CONFIRMED || lockedPayment.order.status === OrderStatus.PAID) {
             throw new ConflictException('이미 승인된 결제입니다.');
           }
@@ -328,7 +337,7 @@ export class PaymentConfirmationService {
     }
   }
 
-  private isDuplicateLikeGuestConfirmError(err: unknown): boolean {
+  private isDuplicateLikeConfirmError(err: unknown): boolean {
     if (err instanceof ConflictException) {
       return true;
     }

--- a/backend/src/modules/points/__tests__/admin-points.service.spec.ts
+++ b/backend/src/modules/points/__tests__/admin-points.service.spec.ts
@@ -128,8 +128,6 @@ describe('PointsService admin contract', () => {
     manager.findOne.mockReset();
     manager.findOne
       .mockResolvedValueOnce({ id: 42 })
-      .mockResolvedValueOnce({ balance: 1200 })
-      .mockResolvedValueOnce({ balance: 1200 })
       .mockResolvedValueOnce({
         id: 92,
         userId: 42,

--- a/backend/src/modules/points/__tests__/points.service.spec.ts
+++ b/backend/src/modules/points/__tests__/points.service.spec.ts
@@ -283,9 +283,8 @@ describe('PointsService', () => {
   describe('adjustPointsManually', () => {
     it('creates positive adjustments as earn rows with one-year expiry and audit in one transaction', async () => {
       const createdAt = new Date('2026-01-02T00:00:00.000Z');
-      mockEntityManager.findOne
-        .mockResolvedValueOnce({ id: 42 })
-        .mockResolvedValueOnce({ balance: 1000 });
+      mockEntityManager.findOne.mockResolvedValueOnce({ id: 42 });
+      mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '1000' });
       mockEntityManager.save.mockResolvedValue({
         id: 88,
         userId: 42,
@@ -335,8 +334,6 @@ describe('PointsService', () => {
     it('creates negative adjustments as spend rows without expiry and rejects insufficient balance', async () => {
       mockEntityManager.findOne
         .mockResolvedValueOnce({ id: 42 })
-        .mockResolvedValueOnce({ balance: 1200 })
-        .mockResolvedValueOnce({ balance: 1200 })
         .mockResolvedValueOnce({
           id: 91,
           userId: 42,
@@ -366,6 +363,7 @@ describe('PointsService', () => {
       }));
       expect(result).toMatchObject({ pointHistoryId: 91, auditLogId: 501, balanceAfter: 900, delta: -300 });
     });
+
 
     it('rejects zero adjustments', async () => {
       await expect(
@@ -404,6 +402,10 @@ describe('PointsService', () => {
   });
 
   describe('deductFifo', () => {
+
+  beforeEach(() => {
+    mockEntityManager.findOne.mockReset();
+  });
     it('should create a spend record with correct balance and return new balance', async () => {
       mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '5000' });
       mockEntityManager.findOne.mockResolvedValue({ balance: 5000 });

--- a/backend/src/modules/points/points.service.ts
+++ b/backend/src/modules/points/points.service.ts
@@ -263,7 +263,7 @@ export class PointsService {
     return this.dataSource.transaction(async (manager) => {
       await this.assertUserExistsInTx(manager, dto.userId);
 
-      const beforeBalance = await this.getRunningBalanceInTx(manager, dto.userId);
+      const beforeBalance = await this.getEffectiveBalanceInTx(manager, dto.userId);
       const description = `${MANUAL_POINT_ADJUSTMENT_PREFIX}${dto.reason}`;
 
       let entry: PointHistory;
@@ -281,7 +281,14 @@ export class PointsService {
           relatedEntityId: null,
         });
       } else {
-        await this.deductFifo(manager, dto.userId, Math.abs(dto.delta), description, null);
+        await this.deductFifo(
+          manager,
+          dto.userId,
+          Math.abs(dto.delta),
+          description,
+          null,
+          beforeBalance,
+        );
         const savedEntry = await manager.findOne(PointHistory, {
           where: { userId: dto.userId },
           order: { createdAt: 'DESC', id: 'DESC' },
@@ -340,13 +347,14 @@ export class PointsService {
     amount: number,
     description: string,
     orderId: number | null = null,
+    balanceBase?: number,
   ): Promise<number> {
     const effectiveBalance = await this.getEffectiveBalanceInTx(manager, userId);
     if (amount > effectiveBalance) {
       throw new BadRequestException('적립금이 부족합니다.');
     }
 
-    const currentBalance = await this.getRunningBalanceInTx(manager, userId);
+    const currentBalance = balanceBase ?? await this.getRunningBalanceInTx(manager, userId);
     const newBalance = currentBalance - amount;
 
     await manager.save(PointHistory, {

--- a/src/app/[locale]/admin/points/__tests__/page.test.tsx
+++ b/src/app/[locale]/admin/points/__tests__/page.test.tsx
@@ -54,7 +54,7 @@ describe('AdminPointsPage', () => {
       isLoading: false,
       isAdmin: true,
     });
-    mockMembersGetList.mockImplementation((params?: { page?: number; limit?: number }) => {
+    mockMembersGetList.mockImplementation((params?: { page?: number; limit?: number; q?: string }) => {
       const page = params?.page ?? 1;
 
       if (page === 2) {
@@ -62,7 +62,7 @@ describe('AdminPointsPage', () => {
           items: [],
           total: 1,
           page: 2,
-          limit: 100,
+          limit: 20,
         });
       }
 
@@ -81,7 +81,7 @@ describe('AdminPointsPage', () => {
         ],
         total: 1,
         page: 1,
-        limit: 100,
+        limit: 20,
       });
     });
 mockGetUserSummary.mockResolvedValue({ userId: 42, balance: 9000 });
@@ -140,9 +140,9 @@ expect(screen.getByText('리뷰 적립')).toBeInTheDocument();
 expect(screen.getByRole('button', { name: 'next' })).toBeEnabled();
 });
 
-it('loads every member page so deep-linked users outside page 1 remain selectable', async () => {
+it('loads just enough member pages so deep-linked users outside page 1 remain selectable', async () => {
   currentSearchParams = new URLSearchParams('userId=84');
-  mockMembersGetList.mockImplementation((params?: { page?: number; limit?: number }) => {
+  mockMembersGetList.mockImplementation((params?: { page?: number; limit?: number; q?: string }) => {
     const page = params?.page ?? 1;
 
     if (page === 2) {
@@ -159,9 +159,9 @@ it('loads every member page so deep-linked users outside page 1 remain selectabl
             updatedAt: '2026-07-25T00:00:00.000Z',
           },
         ],
-        total: 2,
+        total: 21,
         page: 2,
-        limit: 100,
+        limit: 20,
       });
     }
 
@@ -178,21 +178,31 @@ it('loads every member page so deep-linked users outside page 1 remain selectabl
           updatedAt: '2026-07-25T00:00:00.000Z',
         },
       ],
-      total: 2,
+      total: 21,
       page: 1,
-      limit: 100,
+      limit: 20,
     });
   });
 
   render(<AdminPointsPage />);
 
   await waitFor(() => {
-    expect(mockMembersGetList).toHaveBeenCalledWith({ q: undefined, page: 1, limit: 100 });
-    expect(mockMembersGetList).toHaveBeenCalledWith({ q: undefined, page: 2, limit: 100 });
+    expect(mockMembersGetList).toHaveBeenCalledWith({ q: undefined, page: 1, limit: 20 });
+    expect(mockMembersGetList).toHaveBeenCalledWith({ page: 2, limit: 20 });
   });
 
-  expect(await screen.findByText('두번째 회원')).toBeInTheDocument();
-  expect(screen.getByText('second@example.com')).toBeInTheDocument();
+  expect(await screen.findByText('두번째 회원 · second@example.com')).toBeInTheDocument();
+});
+
+it('keeps member search to the first result page per keystroke', async () => {
+  render(<AdminPointsPage />);
+
+  fireEvent.change(screen.getByLabelText('memberSearchLabel'), { target: { value: '두번째' } });
+
+  await waitFor(() => {
+    expect(mockMembersGetList).toHaveBeenCalledWith({ q: '두번째', page: 1, limit: 20 });
+  });
+  expect(mockMembersGetList).not.toHaveBeenCalledWith({ q: '두번째', page: 2, limit: 20 });
 });
 
 it('navigates point history pages for the selected member', async () => {

--- a/src/app/[locale]/admin/points/page.tsx
+++ b/src/app/[locale]/admin/points/page.tsx
@@ -31,7 +31,7 @@ const SOURCE_KIND_TONES: Record<AdminPointSourceKind, string> = {
 };
 
 const HISTORY_PAGE_SIZE = 50;
-const MEMBER_PAGE_SIZE = 100;
+const MEMBER_SEARCH_PAGE_SIZE = 20;
 
 function parseUserId(value: string | null): number | null {
   if (!value) return null;
@@ -62,30 +62,38 @@ export default function AdminPointsPage() {
 
   const loadMembers = useCallback(async (keyword: string) => {
     try {
-      const allMembers: AdminMember[] = [];
-      let page = 1;
-      let total = 0;
+      const trimmedKeyword = keyword.trim();
+      const firstPage = await adminMembersApi.getList({
+        q: trimmedKeyword || undefined,
+        page: 1,
+        limit: MEMBER_SEARCH_PAGE_SIZE,
+      });
 
-      do {
-        const response = await adminMembersApi.getList({
-          q: keyword || undefined,
-          page,
-          limit: MEMBER_PAGE_SIZE,
-        });
-        allMembers.push(...response.items);
-        total = response.total;
-        page += 1;
-
-        if (response.items.length === 0) {
-          break;
-        }
-      } while (allMembers.length < total);
-
-      setMemberOptions(allMembers);
+      let nextOptions = firstPage.items;
       if (selectedMember == null && userId != null) {
-        const exact = allMembers.find((item) => item.id === userId);
-        if (exact) setSelectedMember(exact);
+        let exact = nextOptions.find((item) => item.id === userId);
+
+        if (!exact && trimmedKeyword === '') {
+          const totalPages = Math.max(1, Math.ceil(firstPage.total / firstPage.limit));
+          for (let page = 2; page <= totalPages; page += 1) {
+            const response = await adminMembersApi.getList({ page, limit: MEMBER_SEARCH_PAGE_SIZE });
+            exact = response.items.find((item) => item.id === userId);
+            if (exact) {
+              nextOptions = [...nextOptions, exact];
+              break;
+            }
+            if (response.items.length === 0) {
+              break;
+            }
+          }
+        }
+
+        if (exact) {
+          setSelectedMember(exact);
+        }
       }
+
+      setMemberOptions(nextOptions);
     } catch (err) {
       toast.error(handleApiError(err, t('memberLookupError')));
     }


### PR DESCRIPTION
## Summary
- re-check member payment confirm local truth before failed-payment recovery
- write manual point adjustment balances from effective balances
- bound admin points member search to a first-page query plus deep-link fallback

## Verification
- bash scripts/codex-project-guard.sh
- npm run lint && npm run build && npm run test:run
- cd backend && npm run lint && npm run build && npm run test
- npx vitest run src/app/[locale]/admin/points/__tests__/page.test.tsx
- npx jest src/modules/payments/services/payment-confirmation.service.spec.ts src/modules/points/__tests__/points.service.spec.ts src/modules/points/__tests__/admin-points.service.spec.ts --runInBand
- bash scripts/start-local.sh
- localhost health/admin/checkout URLs on hotfix/issue-1138-postmerge

Related: #1138