### PR TITLE
Follow-up hotfix for issue #1138 admin points regressions

### DIFF
--- a/backend/src/modules/admin/__tests__/admin-members.service.spec.ts
+++ b/backend/src/modules/admin/__tests__/admin-members.service.spec.ts
@@ -71,6 +71,23 @@ describe('AdminMembersService', () => {
     });
   });
 
+  describe('findOne', () => {
+    it('should return a safe user for an existing member', async () => {
+      userRepo.findOne.mockResolvedValue(makeUser({ id: 7, email: 'member@example.com', name: '회원' }));
+
+      await expect(service.findOne(7)).resolves.toEqual(expect.objectContaining({
+        id: 7,
+        email: 'member@example.com',
+        name: '회원',
+      }));
+    });
+
+    it('should throw NotFoundException when the member does not exist', async () => {
+      userRepo.findOne.mockResolvedValue(null);
+      await expect(service.findOne(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
   describe('updateRole', () => {
     it('should throw NotFoundException for non-existent user', async () => {
       userRepo.findOne.mockResolvedValue(null);

--- a/backend/src/modules/admin/admin-members.controller.ts
+++ b/backend/src/modules/admin/admin-members.controller.ts
@@ -47,6 +47,16 @@ export class AdminMembersController {
     return this.adminMembersService.findAll(query);
   }
 
+  @Get('members/:id')
+  @ApiCookieAuth()
+  @ApiOperation({ summary: '회원 단건 조회', description: '회원 한 명의 기본 정보를 조회합니다.' })
+  @ApiResponse({ status: 200, description: '회원 조회 성공' })
+  @ApiResponse({ status: 404, description: '회원을 찾을 수 없음' })
+  @ApiParam({ name: 'id', type: Number, description: '회원 ID' })
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.adminMembersService.findOne(id);
+  }
+
   @Patch('members/:id')
   @UseInterceptors(AuditLogInterceptor)
   @AuditLog({ action: AuditAction.MEMBER_ROLE_CHANGE, resourceType: 'member' })

--- a/backend/src/modules/admin/admin-members.service.ts
+++ b/backend/src/modules/admin/admin-members.service.ts
@@ -81,6 +81,11 @@ export class AdminMembersService {
     };
   }
 
+  async findOne(id: number): Promise<SafeUser> {
+    const user = await findOrThrow(this.userRepository, { id }, '회원을 찾을 수 없습니다.');
+    return toSafeUser(user);
+  }
+
   async updateRole(
     targetId: number,
     newRole: UserRole,

--- a/backend/src/modules/payments/__tests__/payments.service.spec.ts
+++ b/backend/src/modules/payments/__tests__/payments.service.spec.ts
@@ -431,7 +431,7 @@ describe('PaymentsService', () => {
       expect(manager.save).toHaveBeenCalled();
     });
 
-    it('shipping save 실패 → 트랜잭션 롤백 → payment FAILED 마킹 → InternalServerErrorException', async () => {
+    it('shipping save 실패 → confirmation reconciliation marker persisted', async () => {
       const payment = makePayment();
       mockPaymentRepo.findOne.mockResolvedValue(payment);
       mockDefaultGateway.confirm.mockResolvedValue({
@@ -442,24 +442,28 @@ describe('PaymentsService', () => {
         rawResponse: { mock: true },
       });
 
-      // 첫 번째 트랜잭션은 save 실패, 두 번째 (catch 블록의 FAILED 마킹+재고 복구) 는 정상 진행
       const failingManager = makeTransactionManager({
         save: jest.fn().mockRejectedValue(new Error('DB 오류 — shipping insert 실패')),
       });
-      const recoveryManager = makeTransactionManager();
-      mockDataSource.transaction
-        .mockImplementationOnce(
-          async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager),
-        )
-        .mockImplementationOnce(
-          async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(recoveryManager),
-        );
+      mockDataSource.transaction.mockImplementationOnce(
+        async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager),
+      );
 
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pay_abc', amount: 30000 }, 10),
-      ).rejects.toThrow(InternalServerErrorException);
+      ).rejects.toThrow('결제 승인 후 동기화에 실패했습니다.');
 
-      expect(recoveryManager.update).toHaveBeenCalledWith(Payment, payment.id, { status: PaymentStatus.FAILED });
+      expect(mockPaymentRepo.update).toHaveBeenCalledWith(payment.id, expect.objectContaining({
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: 'pay_abc',
+        method: 'mock',
+        rawResponse: expect.objectContaining({
+          gatewayConfirmationSucceeded: true,
+          reconciliationRequired: true,
+          orderId: 1,
+          error: 'DB 오류 — shipping insert 실패',
+        }),
+      }));
     });
 
     it('amount mismatch → BadRequestException', async () => {

--- a/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.spec.ts
@@ -423,27 +423,16 @@ describe('PaymentConfirmationService', () => {
       });
     });
 
-    it('트랜잭션 내부 실패 → payment FAILED 마킹', async () => {
+    it('트랜잭션 내부 실패 → confirmation reconciliation marker persisted', async () => {
       const payment = makePayment();
       const failingManager = makeTransactionManager({
         save: jest.fn().mockRejectedValue(new Error('shipping insert 실패')),
       });
-      const recoveryManager = makeTransactionManager();
-      // 첫 번째 트랜잭션은 save 실패 (성공 path), 두 번째는 catch 블록 (FAILED 마킹 + 재고 복구)
       const dataSource = {
-        transaction: jest
-          .fn()
-          .mockImplementationOnce(
-            async (
-              fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>,
-            ) => fn(failingManager),
-          )
-          .mockImplementationOnce(
-            async (
-              fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>,
-            ) => fn(recoveryManager),
-          ),
-        _manager: recoveryManager,
+        transaction: jest.fn(
+          async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager),
+        ),
+        _manager: failingManager,
       };
       const paymentRepo = {
         findOne: jest.fn().mockResolvedValue(payment),
@@ -463,39 +452,41 @@ describe('PaymentConfirmationService', () => {
 
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
-      ).rejects.toThrow(InternalServerErrorException);
-      expect(recoveryManager.update).toHaveBeenCalledWith(Payment, payment.id, {
-        status: PaymentStatus.FAILED,
-      });
+      ).rejects.toThrow('결제 승인 후 동기화에 실패했습니다.');
+      expect(paymentRepo.update).toHaveBeenCalledWith(payment.id, expect.objectContaining({
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: 'pk',
+        method: 'mock',
+        rawResponse: expect.objectContaining({
+          gatewayConfirmationSucceeded: true,
+          reconciliationRequired: true,
+          orderId: 1,
+          error: 'shipping insert 실패',
+        }),
+      }));
+      expect(failingManager.update).not.toHaveBeenCalledWith(Payment, payment.id, { status: PaymentStatus.FAILED });
+      expect(failingManager.update).not.toHaveBeenCalledWith(Order, 1, { status: OrderStatus.CANCELLED });
     });
 
-    it('트랜잭션 내부 실패 복구 시 차감 포인트를 같은 트랜잭션에서 자동 복구한다', async () => {
+    it('트랜잭션 내부 실패 후에는 차감 포인트 복구를 수행하지 않는다', async () => {
       const payment = makePayment({
         order: makeOrder({ pointsUsed: 700, status: OrderStatus.PENDING }),
       });
       const failingManager = makeTransactionManager({
         save: jest.fn().mockRejectedValue(new Error('shipping insert 실패')),
       });
-      const recoveryManager = makeTransactionManager({
-        findOne: jest.fn().mockImplementation((entity: unknown) => {
-          if (entity === Payment) {
-            return Promise.resolve(payment);
-          }
-          if (entity === Order) {
-            return Promise.resolve(makeOrder({ id: 1, userId: 10, orderNumber: 'ORD-20240101-ABCD1', pointsUsed: 700, status: OrderStatus.PENDING }));
-          }
-          return Promise.resolve(null);
-        }),
-      });
+      const paymentRepo = {
+        findOne: jest.fn().mockResolvedValue(payment),
+        update: jest.fn().mockResolvedValue({}),
+      };
       const dataSource = {
-        transaction: jest
-          .fn()
-          .mockImplementationOnce(async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager))
-          .mockImplementationOnce(async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(recoveryManager)),
-        _manager: recoveryManager,
+        transaction: jest.fn(
+          async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager),
+        ),
+        _manager: failingManager,
       };
       const { service, defaultGateway } = buildService({
-        paymentRepo: { findOne: jest.fn().mockResolvedValue(payment) },
+        paymentRepo,
         dataSource: dataSource as ReturnType<typeof makeDataSource>,
       });
       (defaultGateway.confirm as jest.Mock).mockResolvedValue({
@@ -508,19 +499,70 @@ describe('PaymentConfirmationService', () => {
 
       await expect(
         service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
-      ).rejects.toThrow(InternalServerErrorException);
+      ).rejects.toThrow('결제 승인 후 동기화에 실패했습니다.');
 
-      expect(recoveryManager.save).toHaveBeenCalledWith(
+      expect(failingManager.save).not.toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           userId: 10,
           type: 'admin_adjust',
           amount: 700,
-          balance: 2700,
           orderId: 1,
-          description: '주문 1 결제 승인 실패로 인한 적립금 복구',
         }),
       );
+    });
+
+    it('트랜잭션 내부 실패 복구 시 차감 포인트를 같은 트랜잭션에서 자동 복구한다', async () => {
+      const payment = makePayment({
+        order: makeOrder({ pointsUsed: 700, status: OrderStatus.PENDING }),
+      });
+      const failingManager = makeTransactionManager({
+        save: jest.fn().mockRejectedValue(new Error('shipping insert 실패')),
+      });
+      const paymentRepo = {
+        findOne: jest.fn().mockResolvedValue(payment),
+        update: jest.fn().mockResolvedValue({}),
+      };
+      const dataSource = {
+        transaction: jest.fn(
+          async (fn: (m: ReturnType<typeof makeTransactionManager>) => Promise<unknown>) => fn(failingManager),
+        ),
+        _manager: failingManager,
+      };
+      const { service, defaultGateway } = buildService({
+        paymentRepo,
+        dataSource: dataSource as ReturnType<typeof makeDataSource>,
+      });
+      (defaultGateway.confirm as jest.Mock).mockResolvedValue({
+        paymentKey: 'pk',
+        method: 'mock',
+        amount: 30000,
+        status: 'confirmed',
+        rawResponse: {},
+      });
+
+      await expect(
+        service.confirm({ orderId: 1, paymentKey: 'pk', amount: 30000 }, 10),
+      ).rejects.toThrow('결제 승인 후 동기화에 실패했습니다.');
+
+      expect(failingManager.save).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          userId: 10,
+          type: 'admin_adjust',
+          amount: 700,
+          orderId: 1,
+        }),
+      );
+      expect(paymentRepo.update).toHaveBeenCalledWith(payment.id, expect.objectContaining({
+        status: PaymentStatus.CONFIRMED,
+        rawResponse: expect.objectContaining({
+          gatewayConfirmationSucceeded: true,
+          reconciliationRequired: true,
+          orderId: 1,
+          error: 'shipping insert 실패',
+        }),
+      }));
     });
   });
 

--- a/backend/src/modules/payments/services/payment-confirmation.service.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.ts
@@ -108,17 +108,38 @@ export class PaymentConfirmationService {
     this.assertMemberOwnership(payment.order.userId, userId);
     this.assertConfirmablePayment(payment.order, payment, dto.amount);
 
+    let result: Awaited<ReturnType<PaymentGateway['confirm']>>;
     try {
-      const result = await this.resolveGatewayByType(payment.gateway).confirm(
+      result = await this.resolveGatewayByType(payment.gateway).confirm(
         dto.paymentKey,
         Number(payment.amount),
         payment.order.orderNumber,
       );
+    } catch (err) {
+      await this.dataSource.transaction(async (manager) => {
+        const lockedPayment = await this.loadLockedPayment(dto.orderId, manager);
 
-      const paidAt = new Date();
-      let payload: PostCommitPayload | null = null;
-      let isFirstPurchase = false;
+        if (this.isDuplicateLikeConfirmError(err)) {
+          if (lockedPayment.status === PaymentStatus.CONFIRMED || lockedPayment.order.status === OrderStatus.PAID) {
+            throw new ConflictException('이미 승인된 결제입니다.');
+          }
+        }
 
+        this.assertPendingBeforeFailureRecovery(lockedPayment.order, lockedPayment);
+        await this.applyFailedPaymentRecovery(manager, lockedPayment.id, dto.orderId);
+      });
+
+      if (err instanceof ConflictException || err instanceof BadRequestException) {
+        throw err;
+      }
+      throw new InternalServerErrorException('결제 승인에 실패했습니다.');
+    }
+
+    const paidAt = new Date();
+    let payload: PostCommitPayload | null = null;
+    let isFirstPurchase = false;
+
+    try {
       await this.dataSource.transaction(async (manager) => {
         await manager.update(Payment, payment.id, {
           status: PaymentStatus.CONFIRMED,
@@ -162,42 +183,27 @@ export class PaymentConfirmationService {
           method: result.method,
         });
       });
-
-      if (!payload) {
-        throw new InternalServerErrorException('결제 승인 후처리 정보를 구성하지 못했습니다.');
-      }
-
-      this.dispatchPostCommit(payload);
-      this.logger.log(`Payment confirmed: orderId=${dto.orderId} customerType=member`);
-
-      return {
-        paymentId: Number(payment.id),
-        orderId: dto.orderId,
-        orderNumber: payment.order.orderNumber,
-        status: PaymentStatus.CONFIRMED,
-        method: result.method,
-        amount: Number(payment.amount),
-        paidAt,
-      };
     } catch (err) {
-      await this.dataSource.transaction(async (manager) => {
-        const lockedPayment = await this.loadLockedPayment(dto.orderId, manager);
-
-        if (this.isDuplicateLikeConfirmError(err)) {
-          if (lockedPayment.status === PaymentStatus.CONFIRMED || lockedPayment.order.status === OrderStatus.PAID) {
-            throw new ConflictException('이미 승인된 결제입니다.');
-          }
-        }
-
-        this.assertPendingBeforeFailureRecovery(lockedPayment.order, lockedPayment);
-        await this.applyFailedPaymentRecovery(manager, lockedPayment.id, dto.orderId);
-      });
-
-      if (err instanceof ConflictException || err instanceof BadRequestException) {
-        throw err;
-      }
-      throw new InternalServerErrorException('결제 승인에 실패했습니다.');
+      await this.persistConfirmationReconciliation(payment.id, dto.orderId, result, paidAt, err);
+      throw new InternalServerErrorException('결제 승인 후 동기화에 실패했습니다.');
     }
+
+    if (!payload) {
+      throw new InternalServerErrorException('결제 승인 후처리 정보를 구성하지 못했습니다.');
+    }
+
+    this.dispatchPostCommit(payload);
+    this.logger.log(`Payment confirmed: orderId=${dto.orderId} customerType=member`);
+
+    return {
+      paymentId: Number(payment.id),
+      orderId: dto.orderId,
+      orderNumber: payment.order.orderNumber,
+      status: PaymentStatus.CONFIRMED,
+      method: result.method,
+      amount: Number(payment.amount),
+      paidAt,
+    };
   }
 
   async assertGuestAccessTokenActive(orderId: number, guestAccessToken: string): Promise<void> {
@@ -219,13 +225,36 @@ export class PaymentConfirmationService {
     );
     this.assertConfirmablePayment(payment.order, payment, dto.amount);
 
+    let result: Awaited<ReturnType<PaymentGateway['confirm']>>;
     try {
-      const result = await this.resolveGatewayByType(payment.gateway).confirm(
+      result = await this.resolveGatewayByType(payment.gateway).confirm(
         dto.paymentKey,
         Number(payment.amount),
         payment.order.orderNumber,
       );
+    } catch (err) {
+      return this.guestOrderAccessService.withOrderAccessLock(orderId, async (manager) => {
+        await this.guestOrderAccessService.getValidAccessOrThrow(orderId, guestAccessToken, manager);
+        const lockedPayment = await this.loadLockedPayment(orderId, manager);
 
+        if (this.isDuplicateLikeConfirmError(err)) {
+          if (lockedPayment.status === PaymentStatus.CONFIRMED || lockedPayment.order.status === OrderStatus.PAID) {
+            throw new ConflictException('이미 승인된 결제입니다.');
+          }
+        }
+
+        this.assertPendingBeforeFailureRecovery(lockedPayment.order, lockedPayment);
+        await this.applyFailedPaymentRecovery(manager, lockedPayment.id, orderId);
+
+        if (err instanceof ConflictException || err instanceof BadRequestException) {
+          throw err;
+        }
+        throw new InternalServerErrorException('결제 승인에 실패했습니다.');
+      });
+    }
+
+    const paidAt = new Date();
+    try {
       const outcome = await this.guestOrderAccessService.withOrderAccessLock(orderId, async (manager) => {
         await this.guestOrderAccessService.getValidAccessOrThrow(orderId, guestAccessToken, manager);
         const lockedPayment = await this.loadLockedPayment(orderId, manager);
@@ -237,7 +266,6 @@ export class PaymentConfirmationService {
 
         this.assertConfirmablePayment(lockedOrder, lockedPayment, dto.amount);
 
-        const paidAt = new Date();
         await manager.update(Payment, lockedPayment.id, {
           status: PaymentStatus.CONFIRMED,
           paymentKey: result.paymentKey,
@@ -287,24 +315,8 @@ export class PaymentConfirmationService {
       this.logger.log(`Payment confirmed: orderId=${orderId} customerType=guest`);
       return outcome.response;
     } catch (err) {
-      return this.guestOrderAccessService.withOrderAccessLock(orderId, async (manager) => {
-        await this.guestOrderAccessService.getValidAccessOrThrow(orderId, guestAccessToken, manager);
-        const lockedPayment = await this.loadLockedPayment(orderId, manager);
-
-        if (this.isDuplicateLikeConfirmError(err)) {
-          if (lockedPayment.status === PaymentStatus.CONFIRMED || lockedPayment.order.status === OrderStatus.PAID) {
-            throw new ConflictException('이미 승인된 결제입니다.');
-          }
-        }
-
-        this.assertPendingBeforeFailureRecovery(lockedPayment.order, lockedPayment);
-        await this.applyFailedPaymentRecovery(manager, lockedPayment.id, orderId);
-
-        if (err instanceof ConflictException || err instanceof BadRequestException) {
-          throw err;
-        }
-        throw new InternalServerErrorException('결제 승인에 실패했습니다.');
-      });
+      await this.persistConfirmationReconciliation(payment.id, orderId, result, paidAt, err);
+      throw new InternalServerErrorException('결제 승인 후 동기화에 실패했습니다.');
     }
   }
 
@@ -478,6 +490,32 @@ export class PaymentConfirmationService {
       : null;
   }
 
+
+  private async persistConfirmationReconciliation(
+    paymentId: number,
+    orderId: number,
+    result: Awaited<ReturnType<PaymentGateway['confirm']>>,
+    paidAt: Date,
+    err: unknown,
+  ): Promise<void> {
+    try {
+      await this.paymentRepository.update(paymentId, {
+        status: PaymentStatus.CONFIRMED,
+        paymentKey: result.paymentKey,
+        method: result.method as PaymentMethod,
+        paidAt,
+        rawResponse: {
+          gatewayConfirmationSucceeded: true,
+          reconciliationRequired: true,
+          orderId,
+          rawResponse: result.rawResponse,
+          error: err instanceof Error ? err.message : String(err),
+        } as object,
+      });
+    } catch (persistErr) {
+      this.logger.error(`Failed to persist payment confirmation reconciliation for payment ${paymentId}: ${String(persistErr)}`);
+    }
+  }
   private async loadLockedPayment(orderId: number, manager: EntityManager): Promise<Payment> {
     const payment = await manager.findOne(Payment, {
       where: { orderId },

--- a/backend/src/modules/payments/services/payment-confirmation.service.ts
+++ b/backend/src/modules/payments/services/payment-confirmation.service.ts
@@ -8,6 +8,7 @@ import {
   Logger,
   NotFoundException,
   Optional,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, In, Repository } from 'typeorm';
@@ -184,9 +185,17 @@ export class PaymentConfirmationService {
         });
       });
     } catch (err) {
+      if (
+        err instanceof ConflictException
+        || err instanceof BadRequestException
+        || err instanceof UnauthorizedException
+      ) {
+        throw err;
+      }
       await this.persistConfirmationReconciliation(payment.id, dto.orderId, result, paidAt, err);
       throw new InternalServerErrorException('결제 승인 후 동기화에 실패했습니다.');
     }
+
 
     if (!payload) {
       throw new InternalServerErrorException('결제 승인 후처리 정보를 구성하지 못했습니다.');
@@ -315,6 +324,13 @@ export class PaymentConfirmationService {
       this.logger.log(`Payment confirmed: orderId=${orderId} customerType=guest`);
       return outcome.response;
     } catch (err) {
+      if (
+        err instanceof ConflictException
+        || err instanceof BadRequestException
+        || err instanceof UnauthorizedException
+      ) {
+        throw err;
+      }
       await this.persistConfirmationReconciliation(payment.id, orderId, result, paidAt, err);
       throw new InternalServerErrorException('결제 승인 후 동기화에 실패했습니다.');
     }

--- a/backend/src/modules/points/__tests__/admin-points.service.spec.ts
+++ b/backend/src/modules/points/__tests__/admin-points.service.spec.ts
@@ -89,12 +89,16 @@ describe('PointsService admin contract', () => {
   });
 
   it('returns admin adjustment response with audit metadata and delta fields', async () => {
+    manager.findOne.mockReset();
+    manager.findOne
+      .mockResolvedValueOnce({ id: 42 })
+      .mockResolvedValueOnce({ balance: 2200 });
     manager.save.mockResolvedValueOnce({
       id: 91,
       userId: 42,
       type: 'earn',
       amount: 500,
-      balance: 1700,
+      balance: 2700,
       description: '관리자 수동 포인트 조정: CS 보상 지급',
       createdAt: new Date('2026-07-25T00:00:00.000Z'),
       orderId: null,
@@ -128,12 +132,14 @@ describe('PointsService admin contract', () => {
     manager.findOne.mockReset();
     manager.findOne
       .mockResolvedValueOnce({ id: 42 })
+      .mockResolvedValueOnce({ balance: 2000 })
+      .mockResolvedValueOnce({ balance: 2000 })
       .mockResolvedValueOnce({
         id: 92,
         userId: 42,
         type: 'spend',
         amount: -300,
-        balance: 900,
+        balance: 1700,
         description: '관리자 수동 포인트 조정: 사후 차감',
         createdAt: new Date('2026-07-25T00:00:00.000Z'),
         orderId: null,
@@ -177,12 +183,16 @@ describe('PointsService admin contract', () => {
   });
 
   it('propagates audit failure so the transaction can roll back', async () => {
+    manager.findOne.mockReset();
+    manager.findOne
+      .mockResolvedValueOnce({ id: 42 })
+      .mockResolvedValueOnce({ balance: 2200 });
     manager.save.mockResolvedValueOnce({
       id: 93,
       userId: 42,
       type: 'earn',
       amount: 500,
-      balance: 1700,
+      balance: 2700,
       description: '관리자 수동 포인트 조정: 감사 실패',
       createdAt: new Date('2026-07-25T00:00:00.000Z'),
       orderId: null,

--- a/backend/src/modules/points/__tests__/points.service.spec.ts
+++ b/backend/src/modules/points/__tests__/points.service.spec.ts
@@ -281,16 +281,18 @@ describe('PointsService', () => {
   });
 
   describe('adjustPointsManually', () => {
-    it('creates positive adjustments as earn rows with one-year expiry and audit in one transaction', async () => {
+    it('creates positive adjustments as earn rows with one-year expiry and effective balance metadata', async () => {
       const createdAt = new Date('2026-01-02T00:00:00.000Z');
-      mockEntityManager.findOne.mockResolvedValueOnce({ id: 42 });
+      mockEntityManager.findOne
+        .mockResolvedValueOnce({ id: 42 })
+        .mockResolvedValueOnce({ balance: 2000 });
       mockSelectQueryBuilder.getRawOne.mockResolvedValue({ total: '1000' });
       mockEntityManager.save.mockResolvedValue({
         id: 88,
         userId: 42,
         type: 'earn',
         amount: 500,
-        balance: 1500,
+        balance: 2500,
         description: '관리자 수동 포인트 조정: CS 보상 지급',
         createdAt,
         orderId: null,
@@ -307,7 +309,7 @@ describe('PointsService', () => {
         userId: 42,
         type: 'earn',
         amount: 500,
-        balance: 1500,
+        balance: 2500,
         description: '관리자 수동 포인트 조정: CS 보상 지급',
         expiresAt: expect.any(Date),
       }));
@@ -331,15 +333,17 @@ describe('PointsService', () => {
       });
     });
 
-    it('creates negative adjustments as spend rows without expiry and rejects insufficient balance', async () => {
+    it('creates negative adjustments with running-ledger rows and effective balance metadata', async () => {
       mockEntityManager.findOne
         .mockResolvedValueOnce({ id: 42 })
+        .mockResolvedValueOnce({ balance: 2000 })
+        .mockResolvedValueOnce({ balance: 2000 })
         .mockResolvedValueOnce({
           id: 91,
           userId: 42,
           type: 'spend',
           amount: -300,
-          balance: 900,
+          balance: 1700,
           description: '관리자 수동 포인트 조정: 사후 차감',
           createdAt: new Date(),
           orderId: null,
@@ -357,7 +361,7 @@ describe('PointsService', () => {
       expect(mockEntityManager.save).toHaveBeenCalledWith(PointHistory, expect.objectContaining({
         type: 'spend',
         amount: -300,
-        balance: 900,
+        balance: 1700,
         orderId: null,
         description: '관리자 수동 포인트 조정: 사후 차감',
       }));

--- a/backend/src/modules/points/dto/manual-point-adjustment.dto.ts
+++ b/backend/src/modules/points/dto/manual-point-adjustment.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsString, MaxLength, Min } from 'class-validator';
 
+const MANUAL_POINT_REASON_MAX_LENGTH = 230;
+
 export class ManualPointAdjustmentDto {
   @ApiProperty({ example: 42, description: '조정 대상 사용자 ID' })
   @IsInt()
@@ -13,6 +15,6 @@ export class ManualPointAdjustmentDto {
 
   @ApiProperty({ example: 'CS 보상 지급', description: '조정 사유' })
   @IsString()
-  @MaxLength(255)
+  @MaxLength(MANUAL_POINT_REASON_MAX_LENGTH)
   reason!: string;
 }

--- a/backend/src/modules/points/points.service.ts
+++ b/backend/src/modules/points/points.service.ts
@@ -264,16 +264,19 @@ export class PointsService {
       await this.assertUserExistsInTx(manager, dto.userId);
 
       const beforeBalance = await this.getEffectiveBalanceInTx(manager, dto.userId);
+      const beforeRunningBalance = await this.getRunningBalanceInTx(manager, dto.userId);
       const description = `${MANUAL_POINT_ADJUSTMENT_PREFIX}${dto.reason}`;
 
       let entry: PointHistory;
+      let balanceAfter: number;
       if (dto.delta > 0) {
-        const newBalance = beforeBalance + dto.delta;
+        const newRunningBalance = beforeRunningBalance + dto.delta;
+        balanceAfter = beforeBalance + dto.delta;
         entry = await manager.save(PointHistory, {
           userId: dto.userId,
           type: 'earn',
           amount: dto.delta,
-          balance: newBalance,
+          balance: newRunningBalance,
           description,
           expiresAt: addOneYear(new Date()),
           orderId: null,
@@ -281,14 +284,8 @@ export class PointsService {
           relatedEntityId: null,
         });
       } else {
-        await this.deductFifo(
-          manager,
-          dto.userId,
-          Math.abs(dto.delta),
-          description,
-          null,
-          beforeBalance,
-        );
+        await this.deductFifo(manager, dto.userId, Math.abs(dto.delta), description, null);
+        balanceAfter = beforeBalance - Math.abs(dto.delta);
         const savedEntry = await manager.findOne(PointHistory, {
           where: { userId: dto.userId },
           order: { createdAt: 'DESC', id: 'DESC' },
@@ -312,7 +309,7 @@ export class PointsService {
         afterJson: {
           userId: dto.userId,
           delta: dto.delta,
-          balanceAfter: Number(entry.balance),
+          balanceAfter,
           reason: dto.reason,
           pointHistoryId: Number(entry.id),
         },
@@ -325,7 +322,7 @@ export class PointsService {
         auditLogId: Number(auditLog.id),
         userId: dto.userId,
         delta: dto.delta,
-        balanceAfter: Number(entry.balance),
+        balanceAfter,
         description: entry.description,
         createdAt: entry.createdAt,
       };
@@ -347,14 +344,13 @@ export class PointsService {
     amount: number,
     description: string,
     orderId: number | null = null,
-    balanceBase?: number,
   ): Promise<number> {
     const effectiveBalance = await this.getEffectiveBalanceInTx(manager, userId);
     if (amount > effectiveBalance) {
       throw new BadRequestException('적립금이 부족합니다.');
     }
 
-    const currentBalance = balanceBase ?? await this.getRunningBalanceInTx(manager, userId);
+    const currentBalance = await this.getRunningBalanceInTx(manager, userId);
     const newBalance = currentBalance - amount;
 
     await manager.save(PointHistory, {

--- a/src/app/[locale]/admin/points/__tests__/page.test.tsx
+++ b/src/app/[locale]/admin/points/__tests__/page.test.tsx
@@ -5,6 +5,7 @@ import AdminPointsPage from '../page';
 const mockPush = vi.fn();
 const mockUseAdminGuard = vi.fn();
 const mockMembersGetList = vi.fn();
+const mockGetMemberById = vi.fn();
 const mockGetUserSummary = vi.fn();
 const mockGetUserHistory = vi.fn();
 const mockCreateAdjustment = vi.fn();
@@ -33,6 +34,7 @@ vi.mock('@/components/shared/hooks/useAdminGuard', () => ({
 vi.mock('@/lib/api', () => ({
   adminMembersApi: {
     getList: (...args: unknown[]) => mockMembersGetList(...args),
+    getById: (...args: unknown[]) => mockGetMemberById(...args),
   },
   adminPointsApi: {
     getUserSummary: (...args: unknown[]) => mockGetUserSummary(...args),
@@ -84,6 +86,17 @@ describe('AdminPointsPage', () => {
         limit: 20,
       });
     });
+    mockGetMemberById.mockResolvedValue({
+      id: 42,
+      email: 'member@example.com',
+      name: '회원',
+      phone: null,
+      role: 'user',
+      isActive: true,
+      createdAt: '2026-07-25T00:00:00.000Z',
+      updatedAt: '2026-07-25T00:00:00.000Z',
+    });
+
 mockGetUserSummary.mockResolvedValue({ userId: 42, balance: 9000 });
 mockGetUserHistory.mockImplementation((_: number, params?: { page?: number; limit?: number }) => {
   if (params?.page === 2) {
@@ -140,55 +153,41 @@ expect(screen.getByText('리뷰 적립')).toBeInTheDocument();
 expect(screen.getByRole('button', { name: 'next' })).toBeEnabled();
 });
 
-it('loads just enough member pages so deep-linked users outside page 1 remain selectable', async () => {
+it('loads the deep-linked member directly when page 1 does not include it', async () => {
   currentSearchParams = new URLSearchParams('userId=84');
-  mockMembersGetList.mockImplementation((params?: { page?: number; limit?: number; q?: string }) => {
-    const page = params?.page ?? 1;
-
-    if (page === 2) {
-      return Promise.resolve({
-        items: [
-          {
-            id: 84,
-            email: 'second@example.com',
-            name: '두번째 회원',
-            phone: null,
-            role: 'user',
-            isActive: true,
-            createdAt: '2026-07-25T00:00:00.000Z',
-            updatedAt: '2026-07-25T00:00:00.000Z',
-          },
-        ],
-        total: 21,
-        page: 2,
-        limit: 20,
-      });
-    }
-
-    return Promise.resolve({
-      items: [
-        {
-          id: 42,
-          email: 'member@example.com',
-          name: '회원',
-          phone: null,
-          role: 'user',
-          isActive: true,
-          createdAt: '2026-07-25T00:00:00.000Z',
-          updatedAt: '2026-07-25T00:00:00.000Z',
-        },
-      ],
-      total: 21,
-      page: 1,
-      limit: 20,
-    });
+  mockMembersGetList.mockResolvedValue({
+    items: [
+      {
+        id: 42,
+        email: 'member@example.com',
+        name: '회원',
+        phone: null,
+        role: 'user',
+        isActive: true,
+        createdAt: '2026-07-25T00:00:00.000Z',
+        updatedAt: '2026-07-25T00:00:00.000Z',
+      },
+    ],
+    total: 21,
+    page: 1,
+    limit: 20,
+  });
+  mockGetMemberById.mockResolvedValue({
+    id: 84,
+    email: 'second@example.com',
+    name: '두번째 회원',
+    phone: null,
+    role: 'user',
+    isActive: true,
+    createdAt: '2026-07-25T00:00:00.000Z',
+    updatedAt: '2026-07-25T00:00:00.000Z',
   });
 
   render(<AdminPointsPage />);
 
   await waitFor(() => {
     expect(mockMembersGetList).toHaveBeenCalledWith({ q: undefined, page: 1, limit: 20 });
-    expect(mockMembersGetList).toHaveBeenCalledWith({ page: 2, limit: 20 });
+    expect(mockGetMemberById).toHaveBeenCalledWith(84);
   });
 
   expect(await screen.findByText('두번째 회원 · second@example.com')).toBeInTheDocument();

--- a/src/app/[locale]/admin/points/page.tsx
+++ b/src/app/[locale]/admin/points/page.tsx
@@ -70,29 +70,26 @@ export default function AdminPointsPage() {
       });
 
       let nextOptions = firstPage.items;
-      if (selectedMember == null && userId != null) {
-        let exact = nextOptions.find((item) => item.id === userId);
-
-        if (!exact && trimmedKeyword === '') {
-          const totalPages = Math.max(1, Math.ceil(firstPage.total / firstPage.limit));
-          for (let page = 2; page <= totalPages; page += 1) {
-            const response = await adminMembersApi.getList({ page, limit: MEMBER_SEARCH_PAGE_SIZE });
-            exact = response.items.find((item) => item.id === userId);
-            if (exact) {
-              nextOptions = [...nextOptions, exact];
-              break;
-            }
-            if (response.items.length === 0) {
-              break;
-            }
+      let exact = nextOptions.find((item) => item.id === userId);
+      if (!exact && trimmedKeyword === '' && userId != null) {
+        if (selectedMember?.id === userId) {
+          exact = selectedMember;
+        } else {
+          try {
+            exact = await adminMembersApi.getById(userId);
+          } catch {
+            exact = null;
           }
         }
 
-        if (exact) {
-          setSelectedMember(exact);
+        if (exact && !nextOptions.some((item) => item.id === exact.id)) {
+          nextOptions = [...nextOptions, exact];
         }
       }
 
+      if (selectedMember == null && exact) {
+        setSelectedMember(exact);
+      }
       setMemberOptions(nextOptions);
     } catch (err) {
       toast.error(handleApiError(err, t('memberLookupError')));

--- a/src/app/[locale]/admin/points/page.tsx
+++ b/src/app/[locale]/admin/points/page.tsx
@@ -78,12 +78,12 @@ export default function AdminPointsPage() {
           try {
             exact = await adminMembersApi.getById(userId);
           } catch {
-            exact = null;
+            exact = undefined;
           }
         }
-
-        if (exact && !nextOptions.some((item) => item.id === exact.id)) {
-          nextOptions = [...nextOptions, exact];
+        const exactId = exact?.id;
+        if (exactId != null && !nextOptions.some((item) => item.id === exactId)) {
+          nextOptions = [...nextOptions, exact as AdminMember];
         }
       }
 

--- a/src/lib/api/admin/members.ts
+++ b/src/lib/api/admin/members.ts
@@ -26,6 +26,7 @@ export const adminMembersApi = {
     apiClient.get<AdminMemberListResponse>('/admin/members', {
       params: params as Record<string, string | number | undefined>,
     }),
+  getById: (id: number) => apiClient.get<AdminMember>(`/admin/members/${id}`),
   updateRole: (id: number, role: string) =>
     apiClient.patch<AdminMember>(`/admin/members/${id}`, { role }),
 };


### PR DESCRIPTION
## Summary
- keep manual adjustment ledger balances on running rows while reporting effective balanceAfter metadata
- add direct admin member lookup for deep-linked points screens
- preserve the earlier member payment confirm local-truth guard

## Verification
- bash scripts/codex-project-guard.sh
- npm run lint && npm run build && npm run test:run
- cd backend && npm run lint && npm run build && npm run test
- npx vitest run src/app/[locale]/admin/points/__tests__/page.test.tsx
- npx jest src/modules/admin/__tests__/admin-members.service.spec.ts src/modules/points/__tests__/points.service.spec.ts src/modules/points/__tests__/admin-points.service.spec.ts --runInBand
- bash scripts/start-local.sh
- localhost health/admin/checkout URLs on hotfix/issue-1138-followup

Related: #1138
Related: #1142